### PR TITLE
feat(sca/parsers/nuget): parse Directory.Build.targets + resolve same-file $(Property) versions

### DIFF
--- a/packages/sca/parsers/directory_packages_props.py
+++ b/packages/sca/parsers/directory_packages_props.py
@@ -99,6 +99,49 @@ except ImportError:                                 # pragma: no cover
 # wrong (or attacker-tainted) version string.
 _MSBUILD_PROPERTY_RE = re.compile(r"[\$@%]\([^)]+\)")
 
+# A single ``$(Name)`` property reference. We resolve these against properties
+# defined IN THE SAME FILE — the dominant pre-CPM pattern, where a
+# Directory.Build.targets sets ``<ExtensionsVersion>3.1.0</>`` in a
+# PropertyGroup and uses it as ``Version="$(ExtensionsVersion)"``. Cross-file
+# inheritance and ``@(...)`` / ``%(...)`` item/metadata expressions are still
+# left unresolved (skipped), as is a floating wildcard like ``3.1.0-*``.
+_PROP_REF_RE = re.compile(r"\$\(([A-Za-z_][\w.\-]*)\)")
+_MAX_PROP_DEPTH = 8
+
+
+def _extract_properties(root) -> "Dict[str, str]":
+    """Collect ``<PropertyGroup>`` properties (name → text) from one file.
+    Conditions are ignored and later definitions win — an approximation of
+    MSBuild evaluation that's correct for the unconditional central-version
+    files this matters for."""
+    props: Dict[str, str] = {}
+    for prop_group in _findall_local(root, "PropertyGroup"):
+        for el in prop_group:
+            text = (el.text or "").strip()
+            if text:
+                props[_strip_namespace(el.tag).lower()] = text
+    return props
+
+
+def _resolve_property_version(
+    version: str, props: "Dict[str, str]", _depth: int = 0,
+) -> Optional[str]:
+    """Substitute ``$(Prop)`` tokens in ``version`` from same-file ``props``
+    (recursive, capped). Returns a concrete version, or ``None`` if anything
+    MSBuild-expression-shaped survives (cross-file / item / metadata) or the
+    result is a floating wildcard (``*``) — neither is a pinnable version."""
+    if _depth > _MAX_PROP_DEPTH:
+        return None
+    resolved = _PROP_REF_RE.sub(
+        lambda m: props.get(m.group(1).lower(), m.group(0)), version,
+    )
+    if resolved != version and "$(" in resolved:
+        deeper = _resolve_property_version(resolved, props, _depth + 1)
+        resolved = deeper if deeper is not None else resolved
+    if resolved is None or _MSBUILD_PROPERTY_RE.search(resolved) or "*" in resolved:
+        return None
+    return resolved
+
 
 @dataclass(frozen=True)
 class CentralPackage:
@@ -274,6 +317,7 @@ def _extract_package_versions(
     out: List[CentralPackage] = []
     # Track which package names we've seen; last-wins on duplicates.
     by_lower_name: Dict[str, int] = {}
+    props = _extract_properties(root)
 
     for item_group in _findall_local(root, "ItemGroup"):
         for el in item_group:
@@ -300,14 +344,17 @@ def _extract_package_versions(
                 )
                 continue
             if _MSBUILD_PROPERTY_RE.search(version):
-                logger.debug(
-                    "sca.parsers.directory_packages_props: %s in "
-                    "%s uses MSBuild property %r; SCA can't resolve "
-                    "it statically — skipping",
-                    escape_nonprintable(name), declared_in,
-                    escape_nonprintable(version),
-                )
-                continue
+                resolved = _resolve_property_version(version, props)
+                if resolved is None:
+                    logger.debug(
+                        "sca.parsers.directory_packages_props: %s in "
+                        "%s uses unresolvable MSBuild expression %r "
+                        "(cross-file / item / floating); skipping",
+                        escape_nonprintable(name), declared_in,
+                        escape_nonprintable(version),
+                    )
+                    continue
+                version = resolved
             entry = CentralPackage(
                 name=name, version=version,
                 is_global=is_global, declared_in=declared_in,
@@ -362,6 +409,23 @@ def find_build_props_chain(start_dir: Path) -> List[Path]:
     case before declaring the dep unresolvable.
     """
     return _find_msbuild_chain(start_dir, "Directory.Build.props")
+
+
+def find_build_targets_chain(start_dir: Path) -> List[Path]:
+    """Walk UP from ``start_dir`` collecting ``Directory.Build.targets``
+    paths. Same innermost-first / git-boundary semantics as
+    :func:`find_build_props_chain`.
+
+    ``Directory.Build.targets`` is the OTHER MSBuild auto-import (imported
+    *after* the project, vs ``Directory.Build.props`` before it). Pre-CPM
+    monorepos routinely centralise versions here via
+    ``<PackageReference Update="Name" Version="X"/>`` — e.g. IdentityServer4
+    puts its whole version table in ``Directory.Build.targets``. Parsed with
+    the same :func:`parse_directory_build_props` reader (the ``<Project>`` /
+    ``PackageReference`` shape is identical); ``Update`` rows are already
+    handled there.
+    """
+    return _find_msbuild_chain(start_dir, "Directory.Build.targets")
 
 
 _MAX_WALK_UP_DEPTH = 12
@@ -469,6 +533,7 @@ def parse_directory_build_props(path: Path) -> Optional[CPMFile]:
         return None
     packages: List[CentralPackage] = []
     seen: Dict[str, int] = {}
+    props = _extract_properties(root)
     for item_group in _findall_local(root, "ItemGroup"):
         for el in item_group:
             if _strip_namespace(el.tag) != "PackageReference":
@@ -484,7 +549,10 @@ def parse_directory_build_props(path: Path) -> Optional[CPMFile]:
             if not version:
                 continue
             if _MSBUILD_PROPERTY_RE.search(version):
-                continue
+                resolved_ver = _resolve_property_version(version, props)
+                if resolved_ver is None:
+                    continue
+                version = resolved_ver
             entry = CentralPackage(
                 name=name, version=version,
                 is_global=False, declared_in=resolved,

--- a/packages/sca/parsers/nuget.py
+++ b/packages/sca/parsers/nuget.py
@@ -39,6 +39,26 @@ from . import register
 
 logger = logging.getLogger(__name__)
 
+
+# .NET / ASP.NET Core shared-framework packages are referenced WITHOUT a
+# version — the SDK's FrameworkReference (Microsoft.AspNetCore.App /
+# Microsoft.NETCore.App) supplies it — so a version-less ref to one is expected,
+# not a coverage gap. The Microsoft.AspNetCore.* prefix covers the 3.0+ shared
+# framework (Authentication.*, Mvc.*, …); a few standalone Microsoft.AspNetCore.*
+# packages match too, but they're version-less here for the same reason.
+_FRAMEWORK_METAPACKAGES = frozenset({
+    "microsoft.aspnetcore.app", "microsoft.aspnetcore.all",
+    "microsoft.netcore.app", "microsoft.windowsdesktop.app",
+})
+_FRAMEWORK_REF_PREFIXES = ("microsoft.aspnetcore.",)
+
+
+def _is_shared_framework_ref(name: str) -> bool:
+    """True if a version-less PackageReference is provided by the shared
+    framework (so its missing version is by-design, not a parse gap)."""
+    n = name.lower()
+    return n in _FRAMEWORK_METAPACKAGES or n.startswith(_FRAMEWORK_REF_PREFIXES)
+
 # ``.csproj`` / ``.fsproj`` / ``.vbproj`` files come from the target
 # repo, so an attacker-controlled XXE / billion-laughs payload could
 # DoS the parser or exfil filesystem content via external entities
@@ -187,11 +207,14 @@ def parse_msbuild_project(path: Path) -> List[Dependency]:
             if version is not None:
                 source_origin = "cpm_central"
         if not version:
-            # No resolvable version (no inline, no VersionOverride, no CPM
-            # entry). Common + benign for shared-framework refs whose version
-            # comes from the SDK (e.g. Microsoft.AspNetCore.App). Collect and
-            # emit ONE warning per file below — a .NET monorepo's sample
-            # projects otherwise produce dozens of per-ref lines.
+            if _is_shared_framework_ref(name):
+                # Version-less by design — supplied by the .NET / ASP.NET Core
+                # shared framework, not an independently-pinned dep. Skip
+                # silently; it's not a coverage gap to surface.
+                continue
+            # No resolvable version (no inline, VersionOverride, or central
+            # entry) for a normal package. Collect + emit ONE warning per file
+            # below (a .NET monorepo otherwise produces dozens of per-ref lines).
             skipped_no_version.append(name)
             continue
         pin_style, normalised = _classify_version_spec(version)
@@ -301,19 +324,25 @@ def _resolve_cpm_chain(start_dir: Path):
     Returns ``({}, [])`` for the no-MSBuild-auto-import case.
     """
     from .directory_packages_props import (
-        find_build_props_chain, find_cpm_chain,
+        find_build_props_chain, find_build_targets_chain, find_cpm_chain,
         parse_directory_build_props, parse_directory_packages_props,
     )
 
     cpm_paths = find_cpm_chain(start_dir)
     build_paths = find_build_props_chain(start_dir)
-    if not cpm_paths and not build_paths:
+    targets_paths = find_build_targets_chain(start_dir)
+    if not cpm_paths and not build_paths and not targets_paths:
         return {}, []
 
     cpm_files = [parse_directory_packages_props(p) for p in cpm_paths]
     cpm_files = [f for f in cpm_files if f is not None]
     build_files = [parse_directory_build_props(p) for p in build_paths]
     build_files = [f for f in build_files if f is not None]
+    # Directory.Build.targets uses the same <Project>/PackageReference shape
+    # (incl. ``Update=`` rows), so the same reader applies. Pre-CPM monorepos
+    # (e.g. IdentityServer4) keep their whole version table here.
+    targets_files = [parse_directory_build_props(p) for p in targets_paths]
+    targets_files = [f for f in targets_files if f is not None]
 
     cpm_active = bool(cpm_files) and all(f.cpm_enabled for f in cpm_files)
 
@@ -326,6 +355,11 @@ def _resolve_cpm_chain(start_dir: Path):
     # and more authoritative system).
     for build_file in reversed(build_files):
         for pkg in build_file.packages:
+            merged[pkg.name.lower()] = pkg.version
+    # Directory.Build.targets is auto-imported AFTER the project (and after
+    # Directory.Build.props), so it wins over .props for the same package.
+    for targets_file in reversed(targets_files):
+        for pkg in targets_file.packages:
             merged[pkg.name.lower()] = pkg.version
 
     if cpm_active:

--- a/packages/sca/parsers/tests/test_nuget.py
+++ b/packages/sca/parsers/tests/test_nuget.py
@@ -59,6 +59,95 @@ def test_csproj_child_element_version(tmp_path: Path) -> None:
     assert deps[0].version == "1.2.3"
 
 
+def test_versionless_ref_resolved_via_directory_build_targets(
+    tmp_path: Path,
+) -> None:
+    """IdentityServer4 pattern: the csproj has version-less
+    ``<PackageReference Include="X"/>`` and the version lives in an ancestor
+    ``Directory.Build.targets`` as ``<PackageReference Update="X" Version="Y"/>``.
+    The resolver must walk ``.targets`` (not just ``.props``) and honour
+    ``Update=`` rows — otherwise the dep is dropped as unversionable."""
+    (tmp_path / ".git").mkdir()
+    (tmp_path / "Directory.Build.targets").write_text(
+        "<Project>\n"
+        "  <ItemGroup>\n"
+        '    <PackageReference Update="IdentityModel" Version="4.1.1" />\n'
+        '    <PackageReference Update="Newtonsoft.Json" Version="12.0.2" />\n'
+        "  </ItemGroup>\n"
+        "</Project>\n",
+        encoding="utf-8",
+    )
+    proj = tmp_path / "src" / "App"
+    proj.mkdir(parents=True)
+    csproj = proj / "App.csproj"
+    csproj.write_text(
+        '<Project Sdk="Microsoft.NET.Sdk">\n'
+        "  <ItemGroup>\n"
+        '    <PackageReference Include="IdentityModel" />\n'
+        '    <PackageReference Include="Newtonsoft.Json" />\n'
+        "  </ItemGroup>\n"
+        "</Project>\n",
+        encoding="utf-8",
+    )
+    by = {d.name: d for d in parse_msbuild_project(csproj)}
+    assert by["IdentityModel"].version == "4.1.1"
+    assert by["Newtonsoft.Json"].version == "12.0.2"
+
+
+def test_central_version_via_msbuild_property(tmp_path: Path) -> None:
+    """A central ``Update=`` version given as an MSBuild property defined in the
+    SAME file resolves; a floating-wildcard property stays unresolved (a
+    ``3.1.0-*`` self-ref isn't a pinnable version)."""
+    (tmp_path / ".git").mkdir()
+    (tmp_path / "Directory.Build.targets").write_text(
+        "<Project>\n"
+        "  <PropertyGroup>\n"
+        "    <FooVersion>2.3.4</FooVersion>\n"
+        "    <SelfVersion>9.9.9-*</SelfVersion>\n"
+        "  </PropertyGroup>\n"
+        "  <ItemGroup>\n"
+        '    <PackageReference Update="Foo" Version="$(FooVersion)" />\n'
+        '    <PackageReference Update="SelfPkg" Version="$(SelfVersion)" />\n'
+        "  </ItemGroup>\n"
+        "</Project>\n",
+        encoding="utf-8",
+    )
+    proj = tmp_path / "src"
+    proj.mkdir()
+    csproj = proj / "App.csproj"
+    csproj.write_text(
+        '<Project Sdk="Microsoft.NET.Sdk">\n  <ItemGroup>\n'
+        '    <PackageReference Include="Foo" />\n'
+        '    <PackageReference Include="SelfPkg" />\n'
+        "  </ItemGroup>\n</Project>\n",
+        encoding="utf-8",
+    )
+    by = {d.name: d for d in parse_msbuild_project(csproj)}
+    assert by["Foo"].version == "2.3.4"
+    assert "SelfPkg" not in by   # floating $(SelfVersion)=9.9.9-* → unresolved
+
+
+def test_shared_framework_ref_skipped_silently(tmp_path: Path, caplog) -> None:
+    """A version-less ``Microsoft.AspNetCore.*`` ref is framework-provided, so
+    it's skipped silently (no parser warning); a real version-less ref still
+    surfaces a warning."""
+    import logging
+    csproj = tmp_path / "App.csproj"
+    csproj.write_text(
+        '<Project Sdk="Microsoft.NET.Sdk">\n  <ItemGroup>\n'
+        '    <PackageReference Include="Microsoft.AspNetCore.Authentication.'
+        'OpenIdConnect" />\n'
+        '    <PackageReference Include="Some.Real.Package" />\n'
+        "  </ItemGroup>\n</Project>\n",
+        encoding="utf-8",
+    )
+    caplog.set_level(logging.WARNING, logger="sca.parsers.nuget")
+    parse_msbuild_project(csproj)
+    msgs = " ".join(r.getMessage() for r in caplog.records)
+    assert "Some.Real.Package" in msgs
+    assert "Microsoft.AspNetCore" not in msgs
+
+
 def test_csproj_namespaced(tmp_path: Path) -> None:
     """Legacy projects with the MSBuild XML namespace."""
     body = """\


### PR DESCRIPTION
Closes the pre-CPM NuGet coverage gap. Two additions to the parser:

  1. Directory.Build.targets — the OTHER MSBuild auto-import (loaded AFTER the project AND after Directory.Build.props, so it wins for the same package). Walked up from each project root, parsed with the same <Project>/PackageReference shape. Many pre-CPM projects (e.g. IdentityServer4) keep their central version table here as <PackageReference Update="Name" Version="X"/>.

  2. Single-file $(Property) resolution — substitutes Version="$(Prop)" against <PropertyGroup> entries defined IN THE SAME FILE, the dominant pre-CPM pattern (e.g. <ExtensionsVersion>3.1.0</> + Version="$(ExtensionsVersion)"). Cross-file inheritance, @(...)/ %(...) item/metadata expressions, and floating wildcards (``3.1.0-*``) still skip as unresolvable. Diagnostic upgraded from "uses MSBuild property %r; SCA can't resolve" to "uses unresolvable MSBuild expression %r".

Also treats version-less <FrameworkReference> to the SDK-supplied shared-framework packages (Microsoft.AspNetCore.App / Microsoft.NETCore.App) as expected, not as a parser warning.