### PR TITLE
feat(sca/rewriters): Directory.Build.targets <PackageReference Update...> rewriter

### DIFF
--- a/packages/sca/harden.py
+++ b/packages/sca/harden.py
@@ -440,7 +440,7 @@ def _supports_library_floor_raise(dep: Dependency) -> bool:
         floor/preferred and are fine for libraries."""
     n = dep.declared_in.name
     if n in ("pyproject.toml", "package.json", "Directory.Packages.props",
-             "libs.versions.toml", "pom.xml"):
+             "Directory.Build.targets", "libs.versions.toml", "pom.xml"):
         return True
     if n.startswith("requirements") and n.endswith(".txt"):
         return True
@@ -795,7 +795,8 @@ def _has_rewriter(manifest: Path) -> bool:
     """
     name = manifest.name
     if name in ("pom.xml", "package.json", "pyproject.toml",
-                "Directory.Packages.props", "libs.versions.toml"):
+                "Directory.Packages.props", "Directory.Build.targets",
+                "libs.versions.toml"):
         return True
     if name.startswith("requirements") and name.endswith(".txt"):
         return True

--- a/packages/sca/rewriters/__init__.py
+++ b/packages/sca/rewriters/__init__.py
@@ -168,6 +168,7 @@ from . import yaml_image              # noqa: E402,F401
 # ``parsers/gradle_version_catalog`` for the read-side.
 from . import csproj                              # noqa: E402,F401
 from . import directory_packages_props            # noqa: E402,F401
+from . import directory_build_targets             # noqa: E402,F401
 from . import gradle_version_catalog              # noqa: E402,F401
 
 

--- a/packages/sca/rewriters/directory_build_targets.py
+++ b/packages/sca/rewriters/directory_build_targets.py
@@ -1,0 +1,152 @@
+"""``Directory.Build.targets`` ``<PackageReference Update=...>`` rewriter.
+
+Pre-CPM central-version pattern: Directory.Build.targets is an MSBuild
+auto-import loaded AFTER each project, where many projects keep their
+version table as ``<PackageReference Update="Name" Version="X"/>`` — the
+``Update`` attribute *overrides* a transitively-inherited reference's
+version (vs ``Include`` which adds a new one). Parser support landed in
+``parsers/nuget.py``; this is the matching rewriter.
+
+Mirrors :mod:`packages.sca.rewriters.csproj` exactly, with one swap:
+``Update=`` in place of ``Include=`` on every pattern. Same three shapes
+(inline ``Version=`` / ``VersionOverride=`` / child ``<Version>`` element),
+same locator semantics (case-insensitive NuGet package name), same
+preference order.
+
+Dispatched from ``packages/sca/rewriters/__init__.py`` by filename
+(registered for ``Directory.Build.targets``); from harden / update via
+``update._rewrite_one``.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from pathlib import Path
+from typing import List, Tuple
+
+from . import RewriteEdit, RewriteResult, register
+
+logger = logging.getLogger(__name__)
+
+
+def _build_targets_predicate(path: Path) -> bool:
+    return path.name == "Directory.Build.targets"
+
+
+def _build_inline_version_pattern(update_name: str) -> "re.Pattern":
+    """``<PackageReference Update="X" Version="OLD" />`` — central-version
+    override shape."""
+    upd = re.escape(update_name)
+    return re.compile(
+        r"""(?P<open><PackageReference\b)"""
+        r"""(?P<prefix>[^>]*?Update\s*=\s*['"])"""
+        rf"""(?P<upd>{upd})"""
+        r"""(?P<upd_close>['"])"""
+        r"""(?P<mid>[^>]*?Version\s*=\s*['"])"""
+        r"""(?P<version>[^'"]*)"""
+        r"""(?P<ver_close>['"])""",
+        re.IGNORECASE,
+    )
+
+
+def _build_version_override_pattern(update_name: str) -> "re.Pattern":
+    """``<PackageReference Update="X" VersionOverride="OLD" />``."""
+    upd = re.escape(update_name)
+    return re.compile(
+        r"""(?P<open><PackageReference\b)"""
+        r"""(?P<prefix>[^>]*?Update\s*=\s*['"])"""
+        rf"""(?P<upd>{upd})"""
+        r"""(?P<upd_close>['"])"""
+        r"""(?P<mid>[^>]*?VersionOverride\s*=\s*['"])"""
+        r"""(?P<version>[^'"]*)"""
+        r"""(?P<ver_close>['"])""",
+        re.IGNORECASE,
+    )
+
+
+def _build_child_version_pattern(update_name: str) -> "re.Pattern":
+    """``<PackageReference Update="X"><Version>OLD</Version></PackageReference>``
+    — older child-element shape."""
+    upd = re.escape(update_name)
+    return re.compile(
+        r"""(?P<open><PackageReference\b)"""
+        r"""(?P<prefix>[^>]*?Update\s*=\s*['"])"""
+        rf"""(?P<upd>{upd})"""
+        r"""(?P<upd_close>['"])"""
+        r"""(?P<gap>[^>]*>\s*<Version>\s*)"""
+        r"""(?P<version>[^<]*?)"""
+        r"""(?P<post>\s*</Version>\s*</PackageReference>)""",
+        re.IGNORECASE,
+    )
+
+
+@register(predicate=_build_targets_predicate)
+def rewrite_directory_build_targets(
+    path: Path, edits: List[RewriteEdit],
+) -> List[RewriteResult]:
+    """Apply ``<PackageReference Update=...>`` Version / VersionOverride
+    edits to a Directory.Build.targets file. Preference order per edit:
+    inline ``Version=`` → ``VersionOverride=`` → child ``<Version>`` element."""
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError as e:
+        return [RewriteResult(edit=ed, applied=False,
+                              reason=f"error: read failed: {e}")
+                for ed in edits]
+
+    new_text = text
+    results: List[RewriteResult] = []
+    for edit in edits:
+        new_text, result = _apply_one(new_text, edit)
+        results.append(result)
+
+    if any(r.applied for r in results):
+        try:
+            _atomic_write(path, new_text)
+        except OSError as e:
+            return [RewriteResult(
+                edit=r.edit, applied=False,
+                reason=f"error: write failed: {e}",
+            ) for r in results]
+    return results
+
+
+def _apply_one(text: str, edit: RewriteEdit) -> Tuple[str, RewriteResult]:
+    for pattern_builder in (
+        _build_inline_version_pattern,
+        _build_version_override_pattern,
+        _build_child_version_pattern,
+    ):
+        pat = pattern_builder(edit.locator)
+        match = pat.search(text)
+        if match is None:
+            continue
+        current = match.group("version")
+        if current != edit.old_value:
+            return text, RewriteResult(
+                edit=edit, applied=False,
+                reason=(
+                    f"value_mismatch: file has version={current!r}, "
+                    f"edit expected {edit.old_value!r}"
+                ),
+            )
+        new_text = (
+            text[:match.start("version")]
+            + edit.new_value
+            + text[match.end("version"):]
+        )
+        return new_text, RewriteResult(
+            edit=edit, applied=True, reason="",
+        )
+    return text, RewriteResult(
+        edit=edit, applied=False, reason="not_found",
+    )
+
+
+def _atomic_write(path: Path, content: str) -> None:
+    from packages.sca._atomic import atomic_write_text
+    atomic_write_text(path, content)
+
+
+__all__ = ["rewrite_directory_build_targets"]

--- a/packages/sca/rewriters/tests/test_directory_build_targets.py
+++ b/packages/sca/rewriters/tests/test_directory_build_targets.py
@@ -1,0 +1,125 @@
+"""Tests for the Directory.Build.targets <PackageReference Update=...>
+rewriter — the pre-CPM central-version pattern."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from packages.sca.rewriters import RewriteEdit
+from packages.sca.rewriters.directory_build_targets import (
+    rewrite_directory_build_targets,
+)
+
+
+def _write(tmp_path: Path, body: str) -> Path:
+    p = tmp_path / "Directory.Build.targets"
+    p.write_text(body, encoding="utf-8")
+    return p
+
+
+def test_rewrites_inline_version_attribute(tmp_path: Path):
+    """The central-version table form: <PackageReference Update="X"
+    Version="Y"/>. This is the dominant pre-CPM shape."""
+    p = _write(tmp_path, """\
+<Project>
+  <ItemGroup>
+    <PackageReference Update="IdentityServer4" Version="3.1.0" />
+  </ItemGroup>
+</Project>
+""")
+    results = rewrite_directory_build_targets(p, [RewriteEdit(
+        locator="IdentityServer4",
+        old_value="3.1.0", new_value="4.1.2",
+    )])
+    assert results[0].applied is True
+    assert 'Version="4.1.2"' in p.read_text()
+
+
+def test_case_insensitive_locator(tmp_path: Path):
+    """NuGet package names are case-insensitive — the locator should match
+    regardless of casing in the file."""
+    p = _write(tmp_path, """\
+<Project>
+  <ItemGroup>
+    <PackageReference Update="NEWTONSOFT.JSON" Version="13.0.1" />
+  </ItemGroup>
+</Project>
+""")
+    results = rewrite_directory_build_targets(p, [RewriteEdit(
+        locator="Newtonsoft.Json",
+        old_value="13.0.1", new_value="13.0.3",
+    )])
+    assert results[0].applied is True
+
+
+def test_value_mismatch_does_not_rewrite(tmp_path: Path):
+    """If the file's current version differs from the edit's old_value,
+    refuse rather than blind-overwrite (prevents stomping on out-of-date
+    plans)."""
+    p = _write(tmp_path, """\
+<Project>
+  <ItemGroup>
+    <PackageReference Update="X" Version="2.0.0" />
+  </ItemGroup>
+</Project>
+""")
+    body_before = p.read_text()
+    results = rewrite_directory_build_targets(p, [RewriteEdit(
+        locator="X", old_value="1.0.0", new_value="3.0.0",
+    )])
+    assert results[0].applied is False
+    assert "value_mismatch" in (results[0].reason or "")
+    assert p.read_text() == body_before
+
+
+def test_unknown_package_is_not_found(tmp_path: Path):
+    p = _write(tmp_path, """\
+<Project>
+  <ItemGroup>
+    <PackageReference Update="Foo" Version="1.0.0" />
+  </ItemGroup>
+</Project>
+""")
+    results = rewrite_directory_build_targets(p, [RewriteEdit(
+        locator="Bar", old_value="1.0.0", new_value="2.0.0",
+    )])
+    assert results[0].applied is False
+    assert (results[0].reason or "") == "not_found"
+
+
+def test_include_attribute_is_not_matched(tmp_path: Path):
+    """Update= and Include= are SEMANTICALLY different (override vs add).
+    This rewriter must match Update= only — an Include= reference is the
+    csproj rewriter's job."""
+    p = _write(tmp_path, """\
+<Project>
+  <ItemGroup>
+    <PackageReference Include="X" Version="1.0.0" />
+  </ItemGroup>
+</Project>
+""")
+    body_before = p.read_text()
+    results = rewrite_directory_build_targets(p, [RewriteEdit(
+        locator="X", old_value="1.0.0", new_value="2.0.0",
+    )])
+    assert results[0].applied is False
+    assert p.read_text() == body_before
+
+
+def test_child_version_element_shape(tmp_path: Path):
+    """Older child-element shape: <PackageReference Update="X">
+    <Version>OLD</Version></PackageReference>."""
+    p = _write(tmp_path, """\
+<Project>
+  <ItemGroup>
+    <PackageReference Update="X">
+      <Version>1.0.0</Version>
+    </PackageReference>
+  </ItemGroup>
+</Project>
+""")
+    results = rewrite_directory_build_targets(p, [RewriteEdit(
+        locator="X", old_value="1.0.0", new_value="2.0.0",
+    )])
+    assert results[0].applied is True
+    assert "<Version>2.0.0</Version>" in p.read_text()

--- a/packages/sca/tests/test_harden_planner.py
+++ b/packages/sca/tests/test_harden_planner.py
@@ -1052,6 +1052,7 @@ def test_library_mode_inline_install_is_unsupported_not_pinned() -> None:
     ("requirements.txt", True), ("requirements-dev.txt", True),
     ("pyproject.toml", True), ("package.json", True),
     ("App.csproj", True), ("Directory.Packages.props", True),
+    ("Directory.Build.targets", True),   # pre-CPM central-version table
     ("libs.versions.toml", True), ("pom.xml", True),
     ("Dockerfile", False), ("install.sh", False), ("setup.cfg", False),
 ])
@@ -1059,6 +1060,24 @@ def test_supports_library_floor_raise_matrix(manifest, supported) -> None:
     from packages.sca.harden import _supports_library_floor_raise
     dep = replace(_dep(), declared_in=Path("/x") / manifest)
     assert _supports_library_floor_raise(dep) is supported
+
+
+def test_library_mode_directory_build_targets_no_longer_unsupported() -> None:
+    """Directory.Build.targets was rejected as unsupported_manifest by the
+    pre-follow-up harden._has_rewriter. With the new rewriter + dispatch +
+    gate entries, deps attributed to that file flow through the planner
+    cleanly (status driven by the registry/OSV result, not by the gate)."""
+    dep = replace(_dep(ecosystem="NuGet", name="IdentityServer4",
+                       version="3.1.0", pin_style=PinStyle.RANGE),
+                  declared_in=Path("/x/Directory.Build.targets"))
+    osv = _FakeOsv({"3.1.0": [_adv("C")]})
+    cand = _plan_one(
+        dep, registries={"NuGet": _FakeRegistry(["4.2.0", "4.1.2", "3.1.0"],
+                                                ecosystem="NuGet")},
+        osv=osv, offline=False, allow_major=False, library_mode=True,
+    )
+    assert cand.status != "unsupported_manifest"
+    assert cand.status != "library_floor_raise_unsupported"
 
 
 def test_library_mode_no_clean_version_refuses_to_pin() -> None:

--- a/packages/sca/update.py
+++ b/packages/sca/update.py
@@ -813,6 +813,12 @@ def _rewrite_one(
     # match the dep's source-origin field).
     if name == "Directory.Packages.props":
         return _rewrite_via_registry(manifest, text, plan)
+    # Pre-CPM central-version table: <PackageReference Update="X" Version="Y"/>
+    # in Directory.Build.targets. Same registry dispatch — the dedicated
+    # rewriter (rewriters/directory_build_targets.py) matches Update= rather
+    # than Include=.
+    if name == "Directory.Build.targets":
+        return _rewrite_via_registry(manifest, text, plan)
     if suffix in (".csproj", ".fsproj", ".vbproj"):
         return _rewrite_via_registry(manifest, text, plan)
     # Gradle write surface — libs.versions.toml. Inline


### PR DESCRIPTION
Closes the rewriter side of the nuget-targets parser improvement: pre-CPM projects keep their central version table as <PackageReference Update="X" Version="Y"/> in Directory.Build.targets, which the new directory_build_targets rewriter handles (mirrors csproj.py with Update= in place of Include=). Routes through _rewrite_via_registry and expands harden's _has_rewriter + _supports_library_floor_raise gates so the filename is no longer rejected as unsupported_manifest.

Note: a pre-existing harden routing gap (HardenCandidate doesn't carry source_extra, so _apply can't re-route cpm_central-origin deps from the csproj they're declared in to the actual version-table file) prevents end-to-end patching today for BOTH CPM and Directory.Build.targets. This follow-up is the rewriter + gate piece; the routing fix is separate.