### PR TITLE
fix(sca): route central-version-table NuGet deps to the file that owns the version

### DIFF
--- a/packages/sca/harden.py
+++ b/packages/sca/harden.py
@@ -145,6 +145,14 @@ class HardenCandidate:
     selection: str = "highest_safe"
     # Reserved: the LLM impact analysis (Follow-up #7) populates this.
     impact_analysis: Optional[Dict[str, Any]] = None
+    # When the dep's version is owned by a *central* file (CPM
+    # Directory.Packages.props or pre-CPM Directory.Build.targets/props),
+    # ``manifest`` points at the csproj where the PackageReference is
+    # *declared* but the patch must go to the file that owns the version.
+    # Set from ``dep.source_extra['resolved_in']`` by the parser; consumed
+    # by ``_apply`` when building the ``_PlanEntry`` so the rewrite is
+    # routed to the right file. ``None`` for inline / non-central deps.
+    resolved_in: Optional[str] = None
 
 
 # ---------------------------------------------------------------------------
@@ -480,6 +488,13 @@ def _plan_one(
     platform_matrix=None,
     library_mode: bool = False,
 ) -> HardenCandidate:
+    # The parser annotates a dep whose version is owned by a *central* file
+    # (CPM Directory.Packages.props, pre-CPM Directory.Build.targets/props)
+    # with ``source_extra['resolved_in']`` pointing at that file. Carry it on
+    # the candidate so ``_apply`` routes the rewrite there — without it the
+    # patch would target the csproj where the PackageReference is *declared*,
+    # which holds no Version to update.
+    resolved_in = (dep.source_extra or {}).get("resolved_in")
     cand = HardenCandidate(
         ecosystem=dep.ecosystem,
         name=dep.name,
@@ -488,6 +503,7 @@ def _plan_one(
         from_version=dep.version,
         to_version=None,
         crosses_major=False,
+        resolved_in=resolved_in,
     )
 
     # ``--pin-only``: skip loose pins entirely (don't convert ``>=X`` to
@@ -1374,13 +1390,21 @@ def _apply(
         # inline-install) still work; the ones that do (pom.xml,
         # package.json) refuse with a clear reason.
         installed = cand.from_version or ""
-        key = (cand.ecosystem, cand.name, cand.manifest)
+        # Route the rewrite to the file that OWNS the version. For CPM /
+        # pre-CPM central-version deps the parser set ``resolved_in`` to the
+        # central file (Directory.Packages.props / Directory.Build.targets /
+        # Directory.Build.props); fall back to ``manifest`` (the csproj where
+        # the dep is declared) for inline / non-central deps.
+        write_path = Path(cand.resolved_in) if cand.resolved_in else Path(cand.manifest)
+        # Dedup key by (eco, name, write_path) — two csprojs both inheriting
+        # the same central version collapse to one patch on the central file.
+        key = (cand.ecosystem, cand.name, str(write_path))
         plans[key] = _PlanEntry(
             ecosystem=cand.ecosystem,
             name=cand.name,
             installed=installed,
             target=cand.to_version,
-            manifest=Path(cand.manifest),
+            manifest=write_path,
             advisory_ids=[],
             # Library posture: the rewriter raises the floor to a range
             # (``>=target``) instead of corridor-pinning ``==target``.

--- a/packages/sca/parsers/nuget.py
+++ b/packages/sca/parsers/nuget.py
@@ -172,6 +172,7 @@ def parse_msbuild_project(path: Path) -> List[Dependency]:
             declared_in=path,
             source_extra=source_extra,
             source_origin="cpm_global",
+            resolved_in=global_pkg.declared_in,
         )
         if dep.key() in seen_keys:
             continue
@@ -200,11 +201,15 @@ def parse_msbuild_project(path: Path) -> List[Dependency]:
             if override:
                 version = override.strip()
                 source_origin = "version_override"
+        cpm_resolved_in: Optional[Path] = None
         if not version and cpm_map:
             # Fall through to the CPM map walked from the
-            # csproj's directory.
-            version = cpm_map.get(name.lower())
-            if version is not None:
+            # csproj's directory. ``cpm_map`` carries (version, central_file)
+            # — the central file owns the version so harden/bumper can route
+            # the patch there instead of the csproj.
+            hit = cpm_map.get(name.lower())
+            if hit is not None:
+                version, cpm_resolved_in = hit
                 source_origin = "cpm_central"
         if not version:
             if _is_shared_framework_ref(name):
@@ -229,6 +234,7 @@ def parse_msbuild_project(path: Path) -> List[Dependency]:
             source_extra=source_extra,
             source_origin=source_origin,
             pin_style=pin_style,
+            resolved_in=cpm_resolved_in,
         )
         if dep.key() in seen_keys:
             continue
@@ -255,6 +261,7 @@ def _build_msbuild_dep(
     source_extra: Optional[dict] = None,
     source_origin: str = "inline_version",
     pin_style: PinStyle = PinStyle.EXACT,
+    resolved_in: Optional[Path] = None,
 ) -> Dependency:
     """Construct a Dependency carrying the MSBuild source-origin
     annotation. ``source_origin`` records where the version came
@@ -264,14 +271,26 @@ def _build_msbuild_dep(
       * ``inline_version_child`` — csproj ``<Version>`` child
       * ``version_override`` — csproj ``VersionOverride=``
       * ``cpm_central`` — Directory.Packages.props PackageVersion
+                          OR Directory.Build.targets PackageReference Update=
       * ``cpm_global`` — Directory.Packages.props GlobalPackageReference
 
     Bumper consumers read this off ``dep.source_extra["origin"]`` to
     pick the rewriter target.
+
+    ``resolved_in`` carries the absolute path of the central file the
+    version was actually read from (Directory.Packages.props /
+    Directory.Build.targets / Directory.Build.props), exposed as
+    ``source_extra["resolved_in"]``. Patch-emitters (harden / bumper) use
+    this to write the new version to the file that owns it, instead of the
+    csproj that ``declared_in`` points at — without it, ``cpm_central`` /
+    ``cpm_global`` deps round-trip through the csproj rewriter, which
+    finds no ``Version=`` attribute and emits no patch.
     """
     purl = _build_purl(name, version)
     extra = dict(source_extra) if source_extra else {}
     extra["origin"] = source_origin
+    if resolved_in is not None:
+        extra["resolved_in"] = str(resolved_in)
     return Dependency(
         ecosystem=ECOSYSTEM,
         name=name,
@@ -346,6 +365,10 @@ def _resolve_cpm_chain(start_dir: Path):
 
     cpm_active = bool(cpm_files) and all(f.cpm_enabled for f in cpm_files)
 
+    # ``merged`` carries (version, central_file_path) per package — the path
+    # is the file that ACTUALLY owns the version (vs the csproj that
+    # references the package), so patch-emitters can route writes to the
+    # right place. See ``_build_msbuild_dep(resolved_in=)``.
     merged: dict = {}
     globals_by_name: dict = {}
 
@@ -355,17 +378,17 @@ def _resolve_cpm_chain(start_dir: Path):
     # and more authoritative system).
     for build_file in reversed(build_files):
         for pkg in build_file.packages:
-            merged[pkg.name.lower()] = pkg.version
+            merged[pkg.name.lower()] = (pkg.version, pkg.declared_in)
     # Directory.Build.targets is auto-imported AFTER the project (and after
     # Directory.Build.props), so it wins over .props for the same package.
     for targets_file in reversed(targets_files):
         for pkg in targets_file.packages:
-            merged[pkg.name.lower()] = pkg.version
+            merged[pkg.name.lower()] = (pkg.version, pkg.declared_in)
 
     if cpm_active:
         for cpm_file in reversed(cpm_files):
             for pkg in cpm_file.packages:
-                merged[pkg.name.lower()] = pkg.version
+                merged[pkg.name.lower()] = (pkg.version, pkg.declared_in)
                 if pkg.is_global:
                     globals_by_name[pkg.name.lower()] = pkg
                 elif pkg.name.lower() in globals_by_name:

--- a/packages/sca/parsers/tests/test_nuget.py
+++ b/packages/sca/parsers/tests/test_nuget.py
@@ -92,6 +92,117 @@ def test_versionless_ref_resolved_via_directory_build_targets(
     by = {d.name: d for d in parse_msbuild_project(csproj)}
     assert by["IdentityModel"].version == "4.1.1"
     assert by["Newtonsoft.Json"].version == "12.0.2"
+    # source_extra['resolved_in'] tells harden / bumper where the version
+    # actually lives so the patch is routed to the .targets file, not the
+    # csproj (which holds no Version to update).
+    targets = str(tmp_path / "Directory.Build.targets")
+    assert by["IdentityModel"].source_extra["resolved_in"] == targets
+    assert by["Newtonsoft.Json"].source_extra["resolved_in"] == targets
+
+
+def test_cpm_central_dep_records_resolved_in(tmp_path: Path) -> None:
+    """A CPM dep resolved from Directory.Packages.props records that file in
+    source_extra['resolved_in'] so harden routes the patch there."""
+    (tmp_path / ".git").mkdir()
+    (tmp_path / "Directory.Packages.props").write_text(
+        '<Project>\n'
+        '  <PropertyGroup>'
+        '<ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>'
+        '</PropertyGroup>\n'
+        '  <ItemGroup>'
+        '<PackageVersion Include="Newtonsoft.Json" Version="13.0.1" />'
+        '</ItemGroup>\n'
+        '</Project>\n',
+        encoding="utf-8",
+    )
+    proj = tmp_path / "src" / "App"
+    proj.mkdir(parents=True)
+    csproj = proj / "App.csproj"
+    csproj.write_text(
+        '<Project Sdk="Microsoft.NET.Sdk">\n'
+        '  <PropertyGroup>'
+        '<ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>'
+        '</PropertyGroup>\n'
+        '  <ItemGroup>'
+        '<PackageReference Include="Newtonsoft.Json" />'
+        '</ItemGroup>\n'
+        '</Project>\n',
+        encoding="utf-8",
+    )
+    deps = list(parse_msbuild_project(csproj))
+    nj = next(d for d in deps if d.name == "Newtonsoft.Json")
+    assert nj.source_extra["origin"] == "cpm_central"
+    assert nj.source_extra["resolved_in"] == str(tmp_path / "Directory.Packages.props")
+
+
+def test_inline_dep_has_no_resolved_in(tmp_path: Path) -> None:
+    """A normal inline ``<PackageReference Include="X" Version="Y"/>`` dep
+    does NOT set resolved_in — its version lives in the csproj itself."""
+    (tmp_path / ".git").mkdir()
+    csproj = tmp_path / "App.csproj"
+    csproj.write_text(
+        '<Project Sdk="Microsoft.NET.Sdk">\n'
+        '  <ItemGroup>'
+        '<PackageReference Include="Newtonsoft.Json" Version="13.0.1"/>'
+        '</ItemGroup>\n'
+        '</Project>\n',
+        encoding="utf-8",
+    )
+    nj = next(d for d in parse_msbuild_project(csproj))
+    assert nj.source_extra["origin"] == "inline_version"
+    assert "resolved_in" not in nj.source_extra
+
+
+def test_cpm_global_dep_records_resolved_in(tmp_path: Path) -> None:
+    """GlobalPackageReference (cpm_global) deps also need resolved_in so
+    harden routes the patch to Directory.Packages.props, not the csproj."""
+    (tmp_path / ".git").mkdir()
+    (tmp_path / "Directory.Packages.props").write_text(
+        '<Project>\n'
+        '  <PropertyGroup>'
+        '<ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>'
+        '</PropertyGroup>\n'
+        '  <ItemGroup>'
+        '<GlobalPackageReference Include="Newtonsoft.Json" Version="13.0.1"/>'
+        '</ItemGroup>\n'
+        '</Project>\n', encoding="utf-8")
+    proj = tmp_path / "src" / "App"
+    proj.mkdir(parents=True)
+    csproj = proj / "App.csproj"
+    csproj.write_text(
+        '<Project Sdk="Microsoft.NET.Sdk">\n'
+        '  <PropertyGroup>'
+        '<ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>'
+        '</PropertyGroup>\n'
+        '</Project>\n', encoding="utf-8")
+    nj = next(d for d in parse_msbuild_project(csproj) if d.name == "Newtonsoft.Json")
+    assert nj.source_extra["origin"] == "cpm_global"
+    assert nj.source_extra["resolved_in"] == str(tmp_path / "Directory.Packages.props")
+
+
+def test_directory_build_targets_wins_over_props(tmp_path: Path) -> None:
+    """MSBuild import order: Directory.Build.targets is auto-imported AFTER
+    the project AND after Directory.Build.props, so it wins for the same
+    package — resolved_in must point at .targets, not .props."""
+    (tmp_path / ".git").mkdir()
+    (tmp_path / "Directory.Build.props").write_text(
+        '<Project><ItemGroup>'
+        '<PackageReference Update="X" Version="1.0.0"/>'
+        '</ItemGroup></Project>\n', encoding="utf-8")
+    (tmp_path / "Directory.Build.targets").write_text(
+        '<Project><ItemGroup>'
+        '<PackageReference Update="X" Version="2.0.0"/>'
+        '</ItemGroup></Project>\n', encoding="utf-8")
+    proj = tmp_path / "src" / "App"
+    proj.mkdir(parents=True)
+    csproj = proj / "App.csproj"
+    csproj.write_text(
+        '<Project Sdk="Microsoft.NET.Sdk"><ItemGroup>'
+        '<PackageReference Include="X"/></ItemGroup></Project>\n',
+        encoding="utf-8")
+    x = next(d for d in parse_msbuild_project(csproj) if d.name == "X")
+    assert x.version == "2.0.0", f"targets value must win, got {x.version}"
+    assert x.source_extra["resolved_in"] == str(tmp_path / "Directory.Build.targets")
 
 
 def test_central_version_via_msbuild_property(tmp_path: Path) -> None:

--- a/packages/sca/tests/test_harden_planner.py
+++ b/packages/sca/tests/test_harden_planner.py
@@ -1062,6 +1062,68 @@ def test_supports_library_floor_raise_matrix(manifest, supported) -> None:
     assert _supports_library_floor_raise(dep) is supported
 
 
+def test_two_csprojs_sharing_central_dep_collapse_to_one_patch(tmp_path) -> None:
+    """Two csprojs both inheriting one central PackageVersion must produce
+    a SINGLE patch on the central file, not one per csproj. The dedup key in
+    _apply uses the write-path (cand.resolved_in) for exactly this."""
+    from packages.sca.harden import _apply
+    props = tmp_path / "Directory.Packages.props"
+    props.write_text(
+        '<Project><ItemGroup>'
+        '<PackageVersion Include="X" Version="1.0.0"/></ItemGroup></Project>')
+    cands = []
+    for sub in ("A", "B"):
+        (tmp_path / sub).mkdir()
+        csp = tmp_path / sub / f"{sub}.csproj"
+        csp.write_text('<Project/>')
+        cands.append(HardenCandidate(
+            ecosystem="NuGet", name="X", manifest=str(csp),
+            pin_style="exact", from_version="1.0.0", to_version="1.0.1",
+            crosses_major=False, status="promoted",
+            resolved_in=str(props),
+        ))
+    out = tmp_path / "out"
+    _apply(cands, target=tmp_path, out_dir=out,
+           allow_major_without_review=False, allow_degraded=False,
+           ecosystem_allowlist=None)
+    patched = list((out / "proposed").rglob("*"))
+    csproj_patches = [p for p in patched if p.is_file() and p.suffix == ".csproj"]
+    props_patches = [p for p in patched if p.is_file() and p.name == "Directory.Packages.props"]
+    assert len(props_patches) == 1, f"expected ONE .props patch, got {len(props_patches)}"
+    assert csproj_patches == [], f"no csproj should be patched, got {csproj_patches}"
+
+
+def test_central_version_dep_routes_apply_to_resolved_in(tmp_path) -> None:
+    """A dep whose version is owned by a central file (CPM Directory.Packages
+    .props or pre-CPM Directory.Build.targets) must have its PATCH routed to
+    THAT file by _apply — not to the csproj where the PackageReference is
+    declared (the csproj holds no Version attribute to update). Carried via
+    HardenCandidate.resolved_in, set from dep.source_extra['resolved_in']."""
+    from packages.sca.harden import _apply
+    csproj = tmp_path / "App.csproj"
+    csproj.write_text(
+        '<Project Sdk="Microsoft.NET.Sdk">'
+        '<ItemGroup><PackageReference Include="X"/></ItemGroup></Project>')
+    props = tmp_path / "Directory.Packages.props"
+    props.write_text(
+        '<Project><ItemGroup>'
+        '<PackageVersion Include="X" Version="1.0.0"/></ItemGroup></Project>')
+    cand = HardenCandidate(
+        ecosystem="NuGet", name="X", manifest=str(csproj),
+        pin_style="exact", from_version="1.0.0", to_version="1.0.1",
+        crosses_major=False, status="promoted",
+        resolved_in=str(props),         # parser-set: version lives in props
+    )
+    out = tmp_path / "out"
+    _apply([cand], target=tmp_path, out_dir=out,
+           allow_major_without_review=False, allow_degraded=False,
+           ecosystem_allowlist=None)
+    proposed_props = out / "proposed" / "Directory.Packages.props"
+    proposed_csproj = out / "proposed" / "App.csproj"
+    assert proposed_props.exists() and 'Version="1.0.1"' in proposed_props.read_text()
+    assert not proposed_csproj.exists()
+
+
 def test_library_mode_directory_build_targets_no_longer_unsupported() -> None:
     """Directory.Build.targets was rejected as unsupported_manifest by the
     pre-follow-up harden._has_rewriter. With the new rewriter + dispatch +


### PR DESCRIPTION
Closes a latent end-to-end gap that has affected CPM users since Directory.Packages.props support landed AND a fresh gap that would have affected the just-added Directory.Build.targets path. A dep whose version is owned by a central file (CPM Directory.Packages.props, pre-CPM Directory.Build.targets, Directory.Build.props) was attributed by the parser to the csproj where its <PackageReference> is *declared* — so harden's _apply tried to rewrite the csproj, which holds no Version attribute, and silently emitted no patch.

Parser (packages/sca/parsers/nuget.py)
- _resolve_cpm_chain now carries (version, central_file_path) per package instead of just the version, so the file the version was actually read from survives the merge of the .props/.targets chain.
- _build_msbuild_dep gains a resolved_in kwarg that stamps the central file path onto source_extra['resolved_in'] for cpm_central + cpm_global deps. Inline / VersionOverride / non-central deps are unchanged (no resolved_in set).

Harden (packages/sca/harden.py)
- HardenCandidate gains an optional resolved_in field, populated from dep.source_extra['resolved_in'] in _plan_one.
- _apply routes the _PlanEntry's manifest to resolved_in when set (falling back to cand.manifest for inline / non-central deps). The dedup key uses the write-path, so two csprojs both inheriting one central PackageVersion collapse to a single patch on the central file.

Tests
- Parser unit: cpm_central, cpm_global, and Directory.Build.targets deps all stamp resolved_in; inline deps leave it absent; Directory.Build .targets wins over Directory.Build.props for the same package (MSBuild post-import order).
- Harden integration: a central-version-table dep's patch lands on the central file (not the csproj); two csprojs sharing one central dep collapse to ONE patch on the .props.