### PR TITLE
feat(scorecard): freshness weighting + cost/usage/schema visibility

### DIFF
--- a/.claude/commands/scorecard.md
+++ b/.claude/commands/scorecard.md
@@ -12,15 +12,19 @@ The slash command is for **research and ops**, not a routing API. The actual rou
 
 ```
 /scorecard                              # default: list all cells with derived columns
-/scorecard list [flags]                 # filtered / sorted views
+/scorecard list [flags]                 # filtered / sorted views (--recency N adds a recency view + impact footer)
 /scorecard compare <model-a> <model-b>  # side-by-side on shared decision_classes
 /scorecard samples <decision_class>     # disagreement-reasoning samples (the "why was it wrong?" view)
-/scorecard pin <decision_class> --model <m> --as <override>
+/scorecard pin <decision_class> --model <m> --as <short-circuit|fall-through|auto>
 /scorecard unpin <decision_class> --model <m>
 /scorecard reset [<decision_class>] [--model <m>] [--older-than-days <n>] [--all]
 ```
 
-`list` flags: `--by-savings` `--by-miss-rate` `--untrusted` `--learning` `--consumer <prefix>` `--since <Nd|Nh>`.
+**On a bare `/scorecard` (no args), run `libexec/raptor-llm-scorecard` directly — the CLI now defaults to `list`. Do NOT deliberate or interpret; treat the input as a natural-language question only when the user actually types one.** (Keeps `/scorecard` instant instead of pausing on an LLM round-trip.)
+
+`list` flags: `--by-savings` `--by-miss-rate` `--untrusted` `--learning` `--prefix <prefix>` (filter by decision_class prefix) `--since <Nd|Nh>` `--recency <days>` (weight the policy/wilson/calls columns toward recent behaviour).
+
+A `calls` column shows per-model usage volume. Models appear here once used — even before any reliability outcome is scored — via the run-end usage flush; a `_usage` decision_class row is the pure usage signal (no reliability data yet).
 
 The CLI lives at `libexec/raptor-llm-scorecard`. Output is markdown so it pastes cleanly into notebooks / issues / chat.
 

--- a/core/llm/client.py
+++ b/core/llm/client.py
@@ -473,6 +473,7 @@ class LLMClient:
                 retain_samples=self.config.scorecard_retain_samples,
                 shadow_rate=self.config.scorecard_shadow_rate,
                 keep_models=keep_models or None,
+                freshness_half_life_days=self.config.scorecard_freshness_half_life_days,
             )
         return self._scorecard
 
@@ -579,8 +580,196 @@ class LLMClient:
                 if fired is None:
                     fired = self._fired_models = {}
                 fired[key] = fired.get(key, 0) + 1
+            # Lazily arm the run-end usage flush — only on the FIRST real fire,
+            # so mocked/cached clients that never call a provider never register
+            # an atexit handler or write to the scorecard.
+            self._arm_usage_flush()
         except Exception:
             pass
+
+    def _record_usage(
+        self, alias: str, *, cost: float = 0.0, tokens: int = 0,
+        input_tokens: int = 0, output_tokens: int = 0,
+        duration_s: float = 0.0,
+    ) -> None:
+        """Accumulate per-alias cost / tokens / latency for the run-end flush
+        into the scorecard. Cheap dict update under ``_stats_lock`` — zero new
+        I/O on the hot path; the batched write happens once at lifecycle end.
+        Never raises (best-effort, like ``_record_fired_model``)."""
+        try:
+            ms = int(max(0.0, duration_s) * 1000)
+            with self._stats_lock:
+                usage = getattr(self, "_fired_usage", None)
+                if usage is None:
+                    usage = self._fired_usage = {}
+                cur = usage.setdefault(alias, {
+                    "cost_usd": 0.0, "tokens": 0,
+                    "input_tokens": 0, "output_tokens": 0,
+                    "latency_ms_sum": 0, "latency_ms_max": 0,
+                })
+                cur["cost_usd"] += float(cost or 0.0)
+                cur["tokens"] += int(tokens or 0)
+                cur["input_tokens"] += int(input_tokens or 0)
+                cur["output_tokens"] += int(output_tokens or 0)
+                cur["latency_ms_sum"] += ms
+                if ms > cur["latency_ms_max"]:
+                    cur["latency_ms_max"] = ms
+        except Exception:
+            pass
+
+    def _record_schema_validity(self, alias: str, *, success: bool) -> None:
+        """Accumulate per-alias schema-validation outcomes for the run-end
+        flush — one ``correct`` per structured call whose response parsed and
+        matched the schema, one ``incorrect`` per call that didn't.
+
+        Recorded under the ``_structured`` decision_class at flush time so it
+        becomes a universal "how reliably does this model follow the schema"
+        signal across every ``generate_structured`` use. Cheap dict update
+        under ``_stats_lock``; never raises."""
+        try:
+            with self._stats_lock:
+                schema = getattr(self, "_fired_schema", None)
+                if schema is None:
+                    schema = self._fired_schema = {}
+                cur = schema.setdefault(alias, {"pass": 0, "fail": 0})
+                if success:
+                    cur["pass"] += 1
+                else:
+                    cur["fail"] += 1
+        except Exception:
+            pass
+
+    def _arm_usage_flush(self) -> None:
+        """Register the run-end usage flush exactly once, the first time a real
+        provider call fires. Guarded so it's a no-op when the scorecard is
+        disabled."""
+        if getattr(self, "_usage_flush_armed", False):
+            return
+        self._usage_flush_armed = True
+        try:
+            if not getattr(self.config, "scorecard_enabled", True):
+                return
+            import atexit
+            atexit.register(self.flush_usage_to_scorecard)
+        except Exception:
+            pass
+
+    def _snapshot_and_clear_fired(self) -> tuple:
+        """Atomically copy + clear ``_fired_models`` / ``_fired_usage`` /
+        ``_fired_schema`` under a single ``_stats_lock``. Used by
+        :meth:`flush_usage_to_scorecard` to (1) tighten the snapshot the
+        adversarial review flagged — previously the flush re-acquired the lock
+        between the three reads, allowing an in-flight ``_record_*`` to land in
+        an inconsistent snapshot; and (2) let subsequent fires accumulate into a
+        fresh window so a manual mid-run flush isn't a one-shot."""
+        with self._stats_lock:
+            fm = dict(getattr(self, "_fired_models", {}) or {})
+            fu = {
+                k: dict(v)
+                for k, v in (getattr(self, "_fired_usage", {}) or {}).items()
+            }
+            fs = {
+                k: dict(v)
+                for k, v in (getattr(self, "_fired_schema", {}) or {}).items()
+            }
+            self._fired_models = {}
+            self._fired_usage = {}
+            self._fired_schema = {}
+        return fm, fu, fs
+
+    def flush_usage_to_scorecard(self) -> None:
+        """Flush this run's per-model usage into the scorecard — at run end
+        (armed lazily on first fire via :meth:`_arm_usage_flush`). Aggregates
+        per-alias call counts + cost / tokens / latency + schema validity, and
+        records them under the ``_usage`` (volume) and ``_structured`` (schema)
+        decision classes so a model that was *used* but never *scored* against
+        an oracle still appears in the scorecard.
+
+        Uses :meth:`_snapshot_and_clear_fired` so repeated flushes (atexit +
+        any explicit caller) each process a fresh window — no double-count, no
+        lost data after the first flush. Best-effort; never raises."""
+        try:
+            if not getattr(self.config, "scorecard_enabled", True):
+                return
+            fired_dict, usage_metrics, schema_dict = self._snapshot_and_clear_fired()
+            if not fired_dict:
+                return
+            # Build the same list shape get_fired_models() returns, from the
+            # snapshot. (provider, alias, resolved, role) -> count.
+            fired = [
+                {"provider": p, "alias": a, "resolved": r,
+                 "role": role, "calls": int(n)}
+                for (p, a, r, role), n in fired_dict.items()
+            ]
+            agg: Dict[str, Dict[str, Any]] = {}
+            for f in fired:
+                alias = f.get("alias")
+                if not alias:
+                    continue
+                cur = agg.setdefault(alias, {"calls": 0, "resolved": None})
+                cur["calls"] += int(f.get("calls", 0)) or 1
+                if f.get("resolved"):
+                    cur["resolved"] = f["resolved"]
+            uses = []
+            tot_calls = 0
+            tot_cost = 0.0
+            tot_lat_ms = 0
+            for a, v in agg.items():
+                m = usage_metrics.get(a, {})
+                calls = int(v["calls"])
+                cost = float(m.get("cost_usd", 0.0))
+                lat_sum = int(m.get("latency_ms_sum", 0))
+                tot_calls += calls
+                tot_cost += cost
+                tot_lat_ms += lat_sum
+                uses.append({
+                    "model": a, "decision_class": "_usage",
+                    "calls": calls, "model_version": v["resolved"],
+                    "cost_usd": cost,
+                    "tokens": int(m.get("tokens", 0)),
+                    "input_tokens": int(m.get("input_tokens", 0)),
+                    "output_tokens": int(m.get("output_tokens", 0)),
+                    "latency_ms_sum": lat_sum,
+                    "latency_ms_max": int(m.get("latency_ms_max", 0)),
+                })
+            # Append _structured entries for schema-validity outcomes. Different
+            # decision_class from _usage so the schema reliability signal is
+            # cleanly separable in `list` views and consumes the standard
+            # Wilson-over-events machinery on the schema_valid slot.
+            for alias, counts in schema_dict.items():
+                if not alias:
+                    continue
+                p = int(counts.get("pass", 0))
+                f = int(counts.get("fail", 0))
+                if not (p or f):
+                    continue
+                uses.append({
+                    "model": alias, "decision_class": "_structured",
+                    "calls": p + f,
+                    "schema_valid_pass": p, "schema_valid_fail": f,
+                })
+            self.scorecard.register_uses(uses)
+            # Per-run scorecard delta — the discoverability lever. One line at
+            # process end so every command's user sees the scorecard active
+            # and learns the command exists. Best-effort print to stderr.
+            try:
+                import sys as _sys
+                avg_ms = (tot_lat_ms // tot_calls) if tot_calls else 0
+                cost_s = f"${tot_cost:.4f}" if tot_cost else "$0"
+                models_s = ", ".join(
+                    f"{a} {agg[a]['calls']}c"
+                    for a in sorted(agg, key=lambda k: -agg[k]['calls'])
+                )
+                print(
+                    f"scorecard: {tot_calls} calls across {len(agg)} model(s) "
+                    f"[{models_s}] · {cost_s} · avg {avg_ms}ms — "
+                    f"`raptor-llm-scorecard` for details",
+                    file=_sys.stderr,
+                )
+            except Exception:
+                pass
+        except Exception as e:  # pragma: no cover - shutdown-path best effort
+            logger.debug("scorecard usage flush failed: %s", e)
 
     def get_fired_models(self) -> list:
         """Distinct models invoked during this run (cache hits excluded).
@@ -1008,6 +1197,14 @@ class LLMClient:
                             response.resolved_model,
                             "primary" if model_idx == 0 else "fallback",
                         )
+                        self._record_usage(
+                            model.model_name,
+                            cost=response.cost,
+                            tokens=response.tokens_used,
+                            input_tokens=response.input_tokens,
+                            output_tokens=response.output_tokens,
+                            duration_s=duration,
+                        )
 
                         logger.debug(f"Generation successful: {model.provider}/{model.model_name} "
                                     f"(tokens: {response.tokens_used}, cost: ${response.cost:.4f}, "
@@ -1255,6 +1452,16 @@ class LLMClient:
                             model.provider, model.model_name, resolved,
                             "primary" if model_idx == 0 else "fallback",
                         )
+                        self._record_usage(
+                            model.model_name,
+                            cost=cost_delta,
+                            tokens=tokens_delta,
+                            duration_s=duration,
+                        )
+                        # Schema reliability signal — the response parsed and
+                        # matched the schema (otherwise we'd be in the except
+                        # branch). Recorded under _structured at flush time.
+                        self._record_schema_validity(model.model_name, success=True)
                         # Cache before returning so repeated identical calls
                         # short-circuit the provider entirely. Cache key is
                         # tied to model_config (the first-choice model), so
@@ -1265,6 +1472,15 @@ class LLMClient:
 
                     except Exception as e:
                         last_error = e
+                        # Schema reliability signal — only record the model as
+                        # schema-failing when the error class points at a
+                        # response-shape problem (parse / schema-mismatch /
+                        # validation), not at infra (network 5xx, timeouts,
+                        # quota). Otherwise we'd attribute provider flakes as
+                        # this model's schema unreliability and the SCHEMA_VALID
+                        # cell would drift to nonsense.
+                        if not (_is_quota_error(e) or _is_retryable_error(e)):
+                            self._record_schema_validity(model.model_name, success=False)
 
                         if _is_quota_error(e):
                             quota_guidance = _get_quota_guidance(model.model_name, model.provider)

--- a/core/llm/config.py
+++ b/core/llm/config.py
@@ -973,6 +973,16 @@ class LLMConfig:
     # reset); set higher to validate more aggressively.
     scorecard_shadow_rate: float = 0.05
 
+    # Freshness half-life (days) for age-weighting scorecard reliability counts at
+    # verdict time. Recent observations dominate stale ones, so a model that
+    # regressed behind a floating alias (notably Gemini, which exposes no
+    # version signal) surfaces instead of being averaged against its own past.
+    # ``None`` (default) DISABLES weighting — counts are summed unweighted,
+    # identical to the pre-freshness behaviour. Enabling lowers the effective
+    # sample size, so confirm the cold-start impact with the offline measurement
+    # before turning it on by default. See ~/design/scorecard-model-versioning.md.
+    scorecard_freshness_half_life_days: Optional[float] = None
+
     def __post_init__(self) -> None:
         """Seed ``specialized_models`` with same-provider fast-tier
         defaults for routing-light task types (binary verdicts,

--- a/core/llm/scorecard/cli.py
+++ b/core/llm/scorecard/cli.py
@@ -21,7 +21,7 @@ import datetime as _dt
 import re
 import sys
 from pathlib import Path
-from typing import List, Optional
+from typing import Any, Dict, List, Optional
 
 from .scorecard import (
     ALL_EVENT_TYPES,
@@ -74,6 +74,26 @@ def _format_policy(policy: str, n: int, sample_size_floor: int = 10) -> str:
     if policy == Policy.FALL_THROUGH:
         return "fall-through"
     return f"learning (n<{sample_size_floor})"
+
+
+def _drift_marker(baseline: str, current: str) -> str:
+    """Prefix the policy column with a drift indicator when the freshness-weighted
+    verdict differs from the unweighted baseline. Surfaces silent regressions
+    (or improvements) in the `list` view when `--freshness` is used.
+
+      * ``↓`` — was trusted (short-circuit), recent data says otherwise (the
+        actionable signal — the model regressed in the recent window).
+      * ``↑`` — was distrusted, recent data trusts (the recovery signal).
+      * ``*`` — any other verdict change (fall-through ↔ learning).
+      * ``""`` — no drift.
+    """
+    if baseline == current:
+        return ""
+    if baseline == Policy.SHORT_CIRCUIT and current != Policy.SHORT_CIRCUIT:
+        return "↓ "
+    if current == Policy.SHORT_CIRCUIT and baseline != Policy.SHORT_CIRCUIT:
+        return "↑ "
+    return "* "
 
 
 def _wilson_ub_pct(
@@ -231,6 +251,8 @@ def _sort_stats(
             ),
             reverse=True,
         )
+    if sort_key == "cost":
+        return sorted(stats, key=lambda s: s.cost_usd, reverse=True)
     return sorted(stats, key=lambda s: (s.decision_class, s.model))
 
 
@@ -239,9 +261,38 @@ def _sort_stats(
 # ---------------------------------------------------------------------------
 
 
+def _stats_to_json(s: DecisionClassStats) -> Dict[str, Any]:
+    """JSON-shape dict for a single cell — used by every command's --json
+    output. Keeps the shape stable so scripts / dashboards / CI gates can
+    depend on it (vs scraping the markdown table)."""
+    ev = s.events[EventType.CHEAP_SHORT_CIRCUIT]
+    return {
+        "decision_class": s.decision_class,
+        "model": s.model,
+        "model_version": s.model_version,
+        "policy": _policy_for_stats(s),
+        "policy_override": s.policy_override,
+        "n": ev.correct + ev.incorrect,
+        "max_miss_pct": _wilson_ub_pct(s, EventType.CHEAP_SHORT_CIRCUIT),
+        "cheap_correct": ev.correct,
+        "cheap_incorrect": ev.incorrect,
+        "calls": s.calls,
+        "cost_usd": s.cost_usd,
+        "tokens": s.tokens,
+        "input_tokens": s.input_tokens,
+        "output_tokens": s.output_tokens,
+        "latency_ms_sum": s.latency_ms_sum,
+        "latency_ms_max": s.latency_ms_max,
+        "first_seen_at": s.first_seen_at,
+        "last_seen_at": s.last_seen_at,
+    }
+
+
 def _render_table(
     stats: List[DecisionClassStats],
     event_type: str = EventType.CHEAP_SHORT_CIRCUIT,
+    *,
+    drift_map: Optional[Dict[Any, str]] = None,
 ) -> str:
     """Markdown table of cell summary lines. Columns are chosen for
     "what is this model good at?" research questions.
@@ -261,20 +312,29 @@ def _render_table(
         ev = s.events[event_type]
         n = ev.correct + ev.incorrect
         policy = _policy_for_stats(s)
+        # Drift marker is prepended to the policy column when the freshness-
+        # weighted verdict differs from the unweighted baseline — surfaces
+        # silent regressions/recoveries directly in the list view.
+        marker = ""
+        if drift_map is not None:
+            baseline = drift_map.get((s.decision_class, s.model), policy)
+            marker = _drift_marker(baseline, policy)
         rows.append((
             s.decision_class,
             s.model,
             n,
             _format_wilson(s, event_type),
-            _format_policy(policy, s.events[
+            marker + _format_policy(policy, s.events[
                 EventType.CHEAP_SHORT_CIRCUIT].correct + s.events[
                 EventType.CHEAP_SHORT_CIRCUIT].incorrect),
             _event_correct_count(s, event_type),
             _humanise_age(s.last_seen_at),
+            s.calls,
+            f"${s.cost_usd:.4f}" if s.cost_usd else "$0",
         ))
     headers = (
-        "decision_class", "model", "n", "wilson_ub%",
-        "policy", correct_col, "last_seen",
+        "decision_class", "model", "n", "max_miss%",
+        "policy", correct_col, "last_seen", "calls", "$$",
     )
     widths = [
         max(len(headers[i]), max((len(str(r[i])) for r in rows), default=0))
@@ -305,6 +365,9 @@ def _render_compare(
             f"_(no decision_classes seen by both {model_a} and "
             f"{model_b})_"
         )
+    def _cost(s: DecisionClassStats) -> str:
+        return f"${s.cost_usd:.4f}" if s.cost_usd else "$0"
+
     rows = []
     for dc in shared:
         a, b = by_dc_a[dc], by_dc_b[dc]
@@ -316,15 +379,19 @@ def _render_compare(
             _format_wilson(a),
             _format_policy(_policy_for_stats(a),
                            a_ev.correct + a_ev.incorrect),
+            str(a.calls), _cost(a),
             f"{b_ev.correct + b_ev.incorrect}",
             _format_wilson(b),
             _format_policy(_policy_for_stats(b),
                            b_ev.correct + b_ev.incorrect),
+            str(b.calls), _cost(b),
         ))
     headers = (
         "decision_class",
-        f"{model_a} n", f"{model_a} wilson%", f"{model_a} policy",
-        f"{model_b} n", f"{model_b} wilson%", f"{model_b} policy",
+        f"{model_a} n", f"{model_a} max_miss%", f"{model_a} policy",
+        f"{model_a} calls", f"{model_a} $$",
+        f"{model_b} n", f"{model_b} max_miss%", f"{model_b} policy",
+        f"{model_b} calls", f"{model_b} $$",
     )
     widths = [
         max(len(headers[i]), max((len(str(r[i])) for r in rows), default=0))
@@ -383,7 +450,18 @@ def _render_samples(stat: DecisionClassStats) -> str:
 
 def cmd_list(args: argparse.Namespace) -> int:
     sc = ModelScorecard(args.path)
-    stats = sc.get_stats()
+    hl = getattr(args, "freshness_half_life_days", None)
+    stats = sc.get_stats(freshness_half_life_days=hl)
+    # Drift map: when freshness is on, compute the unweighted baseline policy
+    # per (dc, model) so the render can flag cells whose verdict changed under
+    # freshness — the silent-regression / silent-recovery signal.
+    drift_map: Optional[Dict[Any, str]] = None
+    if hl:
+        baseline = sc.get_stats()
+        drift_map = {
+            (s.decision_class, s.model): _policy_for_stats(s)
+            for s in baseline
+        }
     since = _parse_since(args.since) if args.since else None
     stats = _filter_stats(
         stats,
@@ -397,15 +475,255 @@ def cmd_list(args: argparse.Namespace) -> int:
         sort_key = "savings"
     elif args.by_miss_rate:
         sort_key = "miss-rate"
+    elif getattr(args, "by_cost", False):
+        sort_key = "cost"
     event_type = getattr(args, "event_type", EventType.CHEAP_SHORT_CIRCUIT)
     stats = _sort_stats(stats, sort_key=sort_key, event_type=event_type)
-    print(_render_table(stats, event_type=event_type))
+    if getattr(args, "json", False):
+        import json as _json
+        cells = []
+        for s in stats:
+            d = _stats_to_json(s)
+            if drift_map:
+                baseline = drift_map.get((s.decision_class, s.model))
+                if baseline and baseline != d["policy"]:
+                    d["freshness_drift"] = {"baseline_policy": baseline}
+            cells.append(d)
+        out: Dict[str, Any] = {"cells": cells}
+        if hl:
+            out["freshness_half_life_days"] = hl
+            out["freshness_impact"] = sc.measure_freshness_impact(hl)
+        print(_json.dumps(out, indent=2, default=str))
+        return 0
+    print(_render_table(stats, event_type=event_type, drift_map=drift_map))
+    if hl:
+        # When the freshness view is on, summarise its impact inline: how many
+        # currently-trusted cells would change verdict under this half-life —
+        # the cold-start signal to weigh before enabling freshness by default.
+        imp = sc.measure_freshness_impact(hl)
+        extra = f", +{imp['flipped_in']} newly trusted" if imp["flipped_in"] else ""
+        print(
+            f"\nfreshness @{hl:g}d: {imp['flipped_out']} of "
+            f"{imp['short_circuit_baseline']} trusted cells fall out of "
+            f"short-circuit{extra}"
+        )
+    return 0
+
+
+def cmd_summary(args: argparse.Namespace) -> int:
+    """One-shot dashboard: totals, policy breakdown, spend, most-used model,
+    cheapest-reliable, recent activity. The "open this every morning" view."""
+    sc = ModelScorecard(args.path)
+    stats = sc.get_stats()
+    if not stats:
+        print("scorecard is empty — no LLM calls recorded yet.")
+        return 0
+
+    models = set()
+    trusted = learning = fall_through = 0
+    total_cost = 0.0
+    cost_per_model: Dict[str, float] = {}
+    calls_per_model: Dict[str, int] = {}
+    usage_cell_by_model: Dict[str, DecisionClassStats] = {}
+    trusted_models_by_dc: Dict[str, str] = {}   # for cheapest-trusted picking
+
+    for s in stats:
+        models.add(s.model)
+        p = _policy_for_stats(s)
+        if s.decision_class == "_usage":
+            usage_cell_by_model[s.model] = s
+        if p == Policy.SHORT_CIRCUIT:
+            trusted += 1
+            trusted_models_by_dc[(s.decision_class, s.model)] = s.model
+        elif p == Policy.LEARNING:
+            learning += 1
+        elif p == Policy.FALL_THROUGH:
+            fall_through += 1
+        total_cost += s.cost_usd
+        cost_per_model[s.model] = cost_per_model.get(s.model, 0.0) + s.cost_usd
+        calls_per_model[s.model] = calls_per_model.get(s.model, 0) + s.calls
+
+    # Cheapest trusted (lowest $/call from each trusted model's _usage cell).
+    cheapest: Optional[tuple] = None
+    trusted_aliases = {m for (_, m) in trusted_models_by_dc.keys()}
+    for m in trusted_aliases:
+        u = usage_cell_by_model.get(m)
+        if u and u.calls > 0:
+            cpc = u.cost_usd / u.calls
+            if cheapest is None or cpc < cheapest[1]:
+                cheapest = (m, cpc)
+
+    # Recent activity — cells touched in the last 7 days.
+    threshold = _dt.datetime.now(_dt.timezone.utc) - _dt.timedelta(days=7)
+    recent = 0
+    for s in stats:
+        try:
+            t = _dt.datetime.fromisoformat(s.last_seen_at)
+            if t.tzinfo is None:
+                t = t.replace(tzinfo=_dt.timezone.utc)
+            if t > threshold:
+                recent += 1
+        except (ValueError, TypeError):
+            pass
+
+    most_used = max(calls_per_model.items(), key=lambda x: x[1], default=(None, 0))
+
+    if getattr(args, "json", False):
+        import json as _json
+        out = {
+            "cells_total": len(stats),
+            "models_total": len(models),
+            "policy_breakdown": {
+                "trusted": trusted, "learning": learning, "fall_through": fall_through,
+            },
+            "total_spend_usd": total_cost,
+            "spend_by_model": dict(cost_per_model),
+            "calls_by_model": dict(calls_per_model),
+            "most_used": (
+                {"model": most_used[0], "calls": most_used[1]}
+                if most_used[0] else None
+            ),
+            "cheapest_trusted": (
+                {"model": cheapest[0], "cost_per_call": cheapest[1]}
+                if cheapest else None
+            ),
+            "recent_cells_7d": recent,
+        }
+        print(_json.dumps(out, indent=2, default=str))
+        return 0
+
+    print(f"scorecard summary ({args.path}):")
+    print(f"  cells: {len(stats)} across {len(models)} model(s)")
+    print(f"  policy: {trusted} trusted · {learning} learning · {fall_through} fall-through")
+    cost_lines = [f"{m} ${c:.4f}" for m, c in sorted(
+        cost_per_model.items(), key=lambda x: -x[1]) if c > 0]
+    cost_break = " (" + ", ".join(cost_lines) + ")" if cost_lines else ""
+    print(f"  total spend: ${total_cost:.4f}{cost_break}")
+    if most_used[0] and most_used[1] > 0:
+        print(f"  most-used: {most_used[0]} ({most_used[1]} calls)")
+    if cheapest:
+        print(f"  cheapest trusted: {cheapest[0]} @ ${cheapest[1]:.4f}/call")
+    print(f"  recent activity: {recent} cells last seen in last 7d")
+    return 0
+
+
+def cmd_recommend(args: argparse.Namespace) -> int:
+    """Pick the model an operator should route a `decision_class` to: cheapest
+    trusted-by-the-data, with the runners-up listed. Combines per-(model, dc)
+    reliability (max_miss% from the cheap-tier slot) with the model's overall
+    cost-per-call from its `_usage` cell. The actionable payoff of the whole
+    scorecard system."""
+    sc = ModelScorecard(args.path)
+    target_dc = args.decision_class
+    stats = sc.get_stats(
+        freshness_half_life_days=getattr(args, "freshness_half_life_days", None))
+    candidates = []
+    usage_by_model = {}
+    for s in stats:
+        if s.decision_class == "_usage":
+            usage_by_model[s.model] = s
+        elif s.decision_class == target_dc:
+            candidates.append(s)
+    if not candidates:
+        print(
+            f"no scorecard data for decision_class {target_dc!r} — nothing to "
+            f"recommend. Use `list --prefix {target_dc.split(':')[0]}` to "
+            f"survey what's available.",
+            file=sys.stderr,
+        )
+        return 0
+
+    # (model, max_miss_pct_or_None, cost_per_call_or_None, policy, n)
+    rows = []
+    for c in candidates:
+        ub = _wilson_ub_pct(c, EventType.CHEAP_SHORT_CIRCUIT)
+        u = usage_by_model.get(c.model)
+        cpc = (u.cost_usd / u.calls) if u and u.calls else None
+        ev = c.events[EventType.CHEAP_SHORT_CIRCUIT]
+        rows.append((c.model, ub, cpc, _policy_for_stats(c), ev.correct + ev.incorrect))
+
+    trusted = sorted(
+        (r for r in rows if r[3] == Policy.SHORT_CIRCUIT),
+        key=lambda r: r[2] if r[2] is not None else float("inf"),
+    )
+    learning = [r for r in rows if r[3] == Policy.LEARNING]
+    fall_through = sorted(
+        (r for r in rows if r[3] == Policy.FALL_THROUGH),
+        key=lambda r: r[1] if r[1] is not None else float("inf"),
+    )
+
+    hl = getattr(args, "freshness_half_life_days", None)
+
+    if getattr(args, "json", False):
+        import json as _json
+        def _r(row):
+            m, ub, cpc, _pol, n = row
+            return {"model": m, "max_miss_pct": ub, "cost_per_call": cpc, "n": n}
+        out = {
+            "decision_class": target_dc,
+            "freshness_half_life_days": hl,
+            "trusted": [_r(r) for r in trusted],
+            "learning": [r[0] for r in learning],
+            "fall_through": [_r(r) for r in fall_through],
+            "recommendation": (
+                {"model": trusted[0][0], "reason": "cheapest trusted"}
+                if trusted else None
+            ),
+        }
+        if not trusted and fall_through:
+            out["least_bad"] = {"model": fall_through[0][0]}
+        print(_json.dumps(out, indent=2, default=str))
+        return 0
+
+    # Freshness banner — when an operator passes --freshness, surface that the
+    # ranking reflects weighted (recent-dominant) data so a different answer
+    # than unweighted has a visible breadcrumb.
+    suffix = f" (freshness half-life {hl:g}d)" if hl else ""
+    print(f"recommendation for {target_dc}{suffix}:")
+
+    def _fmt_ub(x):
+        return f"{x:.1f}% max_miss" if x is not None else "max_miss=n/a"
+
+    def _fmt_cpc(x):
+        return f"${x:.4f}/call" if x is not None else "no cost data"
+
+    if trusted:
+        m, ub, cpc, _, n = trusted[0]
+        cpc_note = " — cheapest trusted" if cpc is not None else " — trusted (no cost data to rank by)"
+        print(f"  use: {m}  ({_fmt_ub(ub)} · n={n} · {_fmt_cpc(cpc)}){cpc_note}")
+        for m2, ub2, cpc2, _, _n2 in trusted[1:]:
+            print(f"  also trusted: {m2} ({_fmt_ub(ub2)} · {_fmt_cpc(cpc2)})")
+    else:
+        print("  no trusted model — none meet the miss-rate ceiling")
+        if fall_through:
+            m, ub, cpc, _, n = fall_through[0]
+            print(f"  least-bad option: {m} ({_fmt_ub(ub)} · n={n} · {_fmt_cpc(cpc)})")
+    if learning:
+        names = ", ".join(r[0] for r in learning)
+        print(f"  still learning (insufficient data): {names}")
     return 0
 
 
 def cmd_compare(args: argparse.Namespace) -> int:
     sc = ModelScorecard(args.path)
     all_stats = sc.get_stats()
+    if getattr(args, "json", False):
+        import json as _json
+        by_dc_a = {s.decision_class: s for s in all_stats if s.model == args.model_a}
+        by_dc_b = {s.decision_class: s for s in all_stats if s.model == args.model_b}
+        out = {
+            "model_a": args.model_a, "model_b": args.model_b,
+            "shared": [
+                {
+                    "decision_class": dc,
+                    "model_a": _stats_to_json(by_dc_a[dc]),
+                    "model_b": _stats_to_json(by_dc_b[dc]),
+                }
+                for dc in sorted(set(by_dc_a) & set(by_dc_b))
+            ],
+        }
+        print(_json.dumps(out, indent=2, default=str))
+        return 0
     print(_render_compare(
         all_stats, all_stats,
         model_a=args.model_a, model_b=args.model_b,
@@ -435,9 +753,21 @@ def cmd_samples(args: argparse.Namespace) -> int:
     return 0
 
 
+# Friendly CLI policy words -> the internal policy_override storage values
+# (kept verbose for an explicit on-disk format + unchanged verdict comparisons).
+# The CLI words match the `policy` column `list` prints, so the vocab is
+# consistent end to end.
+_PIN_VALUE_MAP = {
+    "short-circuit": "force_short_circuit",
+    "fall-through": "force_fall_through",
+    "auto": "auto",
+}
+
+
 def cmd_pin(args: argparse.Namespace) -> int:
     sc = ModelScorecard(args.path)
-    sc.set_policy_override(args.decision_class, args.model, args.as_)
+    override = _PIN_VALUE_MAP.get(args.as_, args.as_)
+    sc.set_policy_override(args.decision_class, args.model, override)
     print(
         f"Pinned {args.decision_class} on {args.model} as "
         f"{args.as_}.",
@@ -625,7 +955,17 @@ def _build_parser() -> argparse.ArgumentParser:
         "--path", type=Path, default=DEFAULT_PATH,
         help=f"sidecar path (default: {DEFAULT_PATH})",
     )
-    sub = p.add_subparsers(dest="subcommand", required=True)
+    p.add_argument(
+        "--json", action="store_true",
+        help=(
+            "emit machine-parseable JSON instead of the markdown table — "
+            "applies to list / compare / recommend / summary. Lets scripts, "
+            "dashboards, and CI gates consume scorecard data directly."
+        ),
+    )
+    # Not required: a bare invocation defaults to `list` (see main()). Keeps
+    # `/scorecard` fast and useful instead of erroring on a missing subcommand.
+    sub = p.add_subparsers(dest="subcommand", required=False)
 
     # list
     p_list = sub.add_parser(
@@ -644,10 +984,15 @@ def _build_parser() -> argparse.ArgumentParser:
     p_list.add_argument(
         "--by-miss-rate", action="store_true",
         help=(
-            "sort by Wilson upper-95%% miss-rate (descending). For "
-            "non-cheap event slots, sorts by the wilson upper bound "
-            "on that slot's incorrect-rate."
+            "sort by worst-case miss-rate (descending) — the conservative "
+            "95%%-confidence upper bound shown in the max_miss%% column. For "
+            "non-cheap event slots, sorts by that slot's worst-case "
+            "incorrect-rate."
         ),
+    )
+    p_list.add_argument(
+        "--by-cost", action="store_true",
+        help="sort by total spend on this cell (descending) — the $$ column.",
     )
     p_list.add_argument(
         "--untrusted", action="store_true",
@@ -658,7 +1003,7 @@ def _build_parser() -> argparse.ArgumentParser:
         help="show only cells still in learning mode (n<floor)",
     )
     p_list.add_argument(
-        "--consumer", type=str, default=None,
+        "--prefix", type=str, default=None, dest="consumer", metavar="PREFIX",
         help=(
             "filter by decision_class prefix "
             "(e.g. 'codeql' matches codeql:py/sql-injection etc.)"
@@ -672,7 +1017,7 @@ def _build_parser() -> argparse.ArgumentParser:
         "--event-type", type=str, default=EventType.CHEAP_SHORT_CIRCUIT,
         choices=list(ALL_EVENT_TYPES),
         help=(
-            "reframe n / wilson_ub%% / correct columns around the "
+            "reframe n / max_miss%% / correct columns around the "
             "chosen event slot. Default 'cheap_short_circuit' "
             "preserves the auto-policy view; pass "
             "'reasoning_divergence' / 'multi_model_consensus' / "
@@ -681,7 +1026,49 @@ def _build_parser() -> argparse.ArgumentParser:
             "column is always cheap-derived."
         ),
     )
+    p_list.add_argument(
+        "--freshness", dest="freshness_half_life_days",
+        type=float, default=None, metavar="DAYS",
+        help=(
+            "weight recent behaviour more heavily, halving an observation's "
+            "weight every DAYS days (exponential half-life), so the policy / "
+            "max_miss%% / calls columns reflect recent over stale history — "
+            "the same weighting the live gate applies when "
+            "scorecard_freshness_half_life_days is configured. Default: "
+            "unweighted (all-time)."
+        ),
+    )
     p_list.set_defaults(handler=cmd_list)
+
+    # summary — the daily-driver dashboard
+    p_sum = sub.add_parser(
+        "summary",
+        help=(
+            "one-shot dashboard: cell totals, policy breakdown, total spend, "
+            "most-used model, cheapest trusted, recent activity"
+        ),
+    )
+    p_sum.set_defaults(handler=cmd_summary)
+
+    # recommend — the actionable payoff
+    p_rec = sub.add_parser(
+        "recommend",
+        help=(
+            "pick the model to route a given decision_class to — cheapest "
+            "trusted (max_miss%% ≤ ceiling), with runners-up listed. The "
+            "operator-facing payoff of the whole scorecard."
+        ),
+    )
+    p_rec.add_argument(
+        "decision_class", type=str,
+        help="decision_class to recommend for (e.g. codeql:py/sql-injection)",
+    )
+    p_rec.add_argument(
+        "--freshness", dest="freshness_half_life_days",
+        type=float, default=None, metavar="DAYS",
+        help="weight recent behaviour (half-life in days); same as `list --freshness`",
+    )
+    p_rec.set_defaults(handler=cmd_recommend)
 
     # compare
     p_cmp = sub.add_parser(
@@ -716,8 +1103,9 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     p_pin.add_argument(
         "--as", type=str, dest="as_", required=True,
-        choices=("force_short_circuit", "force_fall_through", "auto"),
-        help="override value to set",
+        choices=("short-circuit", "fall-through", "auto"),
+        help=("policy to pin: short-circuit (always trust this cell) / "
+              "fall-through (never trust) / auto (back to data-driven)"),
     )
     p_pin.set_defaults(handler=cmd_pin)
 
@@ -818,8 +1206,22 @@ def _build_parser() -> argparse.ArgumentParser:
 
 
 def main(argv: Optional[List[str]] = None) -> int:
+    import sys as _sys
+    argv = list(_sys.argv[1:] if argv is None else argv)
     parser = _build_parser()
     args = parser.parse_args(argv)
+    if getattr(args, "handler", None) is None:
+        # No subcommand given -> default to `list` (top-level optionals like
+        # --path stay before the appended subcommand, which argparse accepts).
+        # Print a discoverability footer so the operator still learns the other
+        # subcommands now that a bare invocation no longer errors into usage.
+        args = parser.parse_args([*argv, "list"])
+        rc = args.handler(args)
+        # Suppress the discoverability footer when --json is on so the
+        # emitted output stays valid JSON for downstream parsers.
+        if not getattr(args, "json", False):
+            print("\n(more subcommands: run `raptor-llm-scorecard -h`)")
+        return rc
     return args.handler(args)
 
 

--- a/core/llm/scorecard/cli.py
+++ b/core/llm/scorecard/cli.py
@@ -520,12 +520,12 @@ def cmd_summary(args: argparse.Namespace) -> int:
         return 0
 
     models = set()
-    trusted = learning = fall_through = 0
+    short_circuit = learning = fall_through = 0
     total_cost = 0.0
     cost_per_model: Dict[str, float] = {}
     calls_per_model: Dict[str, int] = {}
     usage_cell_by_model: Dict[str, DecisionClassStats] = {}
-    trusted_models_by_dc: Dict[str, str] = {}   # for cheapest-trusted picking
+    sc_models_by_dc: Dict[str, str] = {}   # for cheapest-trusted picking
 
     for s in stats:
         models.add(s.model)
@@ -533,8 +533,8 @@ def cmd_summary(args: argparse.Namespace) -> int:
         if s.decision_class == "_usage":
             usage_cell_by_model[s.model] = s
         if p == Policy.SHORT_CIRCUIT:
-            trusted += 1
-            trusted_models_by_dc[(s.decision_class, s.model)] = s.model
+            short_circuit += 1
+            sc_models_by_dc[(s.decision_class, s.model)] = s.model
         elif p == Policy.LEARNING:
             learning += 1
         elif p == Policy.FALL_THROUGH:
@@ -543,10 +543,10 @@ def cmd_summary(args: argparse.Namespace) -> int:
         cost_per_model[s.model] = cost_per_model.get(s.model, 0.0) + s.cost_usd
         calls_per_model[s.model] = calls_per_model.get(s.model, 0) + s.calls
 
-    # Cheapest trusted (lowest $/call from each trusted model's _usage cell).
+    # Cheapest short-circuit (lowest $/call from each cell's _usage row).
     cheapest: Optional[tuple] = None
-    trusted_aliases = {m for (_, m) in trusted_models_by_dc.keys()}
-    for m in trusted_aliases:
+    sc_aliases = {m for (_, m) in sc_models_by_dc.keys()}
+    for m in sc_aliases:
         u = usage_cell_by_model.get(m)
         if u and u.calls > 0:
             cpc = u.cost_usd / u.calls
@@ -574,7 +574,7 @@ def cmd_summary(args: argparse.Namespace) -> int:
             "cells_total": len(stats),
             "models_total": len(models),
             "policy_breakdown": {
-                "trusted": trusted, "learning": learning, "fall_through": fall_through,
+                "short_circuit": short_circuit, "learning": learning, "fall_through": fall_through,
             },
             "total_spend_usd": total_cost,
             "spend_by_model": dict(cost_per_model),
@@ -583,7 +583,7 @@ def cmd_summary(args: argparse.Namespace) -> int:
                 {"model": most_used[0], "calls": most_used[1]}
                 if most_used[0] else None
             ),
-            "cheapest_trusted": (
+            "cheapest_short_circuit": (
                 {"model": cheapest[0], "cost_per_call": cheapest[1]}
                 if cheapest else None
             ),
@@ -594,7 +594,7 @@ def cmd_summary(args: argparse.Namespace) -> int:
 
     print(f"scorecard summary ({args.path}):")
     print(f"  cells: {len(stats)} across {len(models)} model(s)")
-    print(f"  policy: {trusted} trusted · {learning} learning · {fall_through} fall-through")
+    print(f"  policy: {short_circuit} trusted · {learning} learning · {fall_through} fall-through")
     cost_lines = [f"{m} ${c:.4f}" for m, c in sorted(
         cost_per_model.items(), key=lambda x: -x[1]) if c > 0]
     cost_break = " (" + ", ".join(cost_lines) + ")" if cost_lines else ""
@@ -642,7 +642,7 @@ def cmd_recommend(args: argparse.Namespace) -> int:
         ev = c.events[EventType.CHEAP_SHORT_CIRCUIT]
         rows.append((c.model, ub, cpc, _policy_for_stats(c), ev.correct + ev.incorrect))
 
-    trusted = sorted(
+    sc_rows = sorted(
         (r for r in rows if r[3] == Policy.SHORT_CIRCUIT),
         key=lambda r: r[2] if r[2] is not None else float("inf"),
     )
@@ -662,15 +662,15 @@ def cmd_recommend(args: argparse.Namespace) -> int:
         out = {
             "decision_class": target_dc,
             "freshness_half_life_days": hl,
-            "trusted": [_r(r) for r in trusted],
+            "short_circuit": [_r(r) for r in sc_rows],
             "learning": [r[0] for r in learning],
             "fall_through": [_r(r) for r in fall_through],
             "recommendation": (
-                {"model": trusted[0][0], "reason": "cheapest trusted"}
-                if trusted else None
+                {"model": sc_rows[0][0], "reason": "cheapest short-circuit"}
+                if sc_rows else None
             ),
         }
-        if not trusted and fall_through:
+        if not sc_rows and fall_through:
             out["least_bad"] = {"model": fall_through[0][0]}
         print(_json.dumps(out, indent=2, default=str))
         return 0
@@ -687,11 +687,11 @@ def cmd_recommend(args: argparse.Namespace) -> int:
     def _fmt_cpc(x):
         return f"${x:.4f}/call" if x is not None else "no cost data"
 
-    if trusted:
-        m, ub, cpc, _, n = trusted[0]
+    if sc_rows:
+        m, ub, cpc, _, n = sc_rows[0]
         cpc_note = " — cheapest trusted" if cpc is not None else " — trusted (no cost data to rank by)"
         print(f"  use: {m}  ({_fmt_ub(ub)} · n={n} · {_fmt_cpc(cpc)}){cpc_note}")
-        for m2, ub2, cpc2, _, _n2 in trusted[1:]:
+        for m2, ub2, cpc2, _, _n2 in sc_rows[1:]:
             print(f"  also trusted: {m2} ({_fmt_ub(ub2)} · {_fmt_cpc(cpc2)})")
     else:
         print("  no trusted model — none meet the miss-rate ceiling")

--- a/core/llm/scorecard/freshness.py
+++ b/core/llm/scorecard/freshness.py
@@ -1,0 +1,135 @@
+"""Freshness-weighting core for the model scorecard.
+
+The scorecard accumulates correct/incorrect counts per
+``(model, decision_class, event_type)``. To let a model's *recent* reliability
+dominate its stale history — model aliases float behind unchanged names
+(notably Gemini, which exposes no version signal at all), so a cell silently
+blends reliability across whatever versions the provider served over time — the
+counts are stratified into **monthly age buckets** and weighted by an
+exponential decay at *read* time. Read-time means the half-life can be set
+conservatively now and re-tuned once real drift data exists, without reprocessing
+(an EMA baked at write time could not).
+
+This module is pure: no I/O, no scorecard state. ``scorecard.py`` wires these
+into the bucketed ``events`` shape and the Wilson verdict. ``half_life_days``
+of ``None``/``<=0`` means decay is DISABLED — every bucket counts fully, which
+is exactly the pre-freshness behaviour (back-compat by construction).
+
+Bucket key format: ``"YYYY-MM"``. Age is measured from the bucket's first day.
+See ``~/design/scorecard-model-versioning.md``.
+"""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Mapping, Tuple, Union
+
+# A very large age (days) assigned to an unparseable bucket key so it decays to
+# ~0 under any positive half-life rather than raising. Defensive: a hand-edited
+# or corrupt key must never crash the verdict path.
+_UNPARSEABLE_AGE_DAYS = 1.0e9
+
+# Mean Gregorian month length — converts whole-month bucket differences to days
+# so the half-life (expressed in days) applies uniformly.
+_MEAN_MONTH_DAYS = 30.44
+
+
+def bucket_key(when: Union[str, datetime]) -> str:
+    """Return the ``"YYYY-MM"`` bucket for an ISO-8601 timestamp or datetime.
+
+    A bare ``str`` is parsed as ISO-8601; anything unparseable falls back to
+    its first 7 chars if they look like ``YYYY-MM`` (ISO timestamps start that
+    way), else raises ``ValueError`` (callers pass ``_now_iso()`` output, which
+    is always well-formed).
+    """
+    if isinstance(when, datetime):
+        dt = when
+    else:
+        try:
+            dt = datetime.fromisoformat(when)
+        except (ValueError, TypeError):
+            s = str(when)
+            if len(s) >= 7 and s[4] == "-" and s[:4].isdigit() and s[5:7].isdigit():
+                return s[:7]
+            raise ValueError(f"unparseable timestamp for bucket_key: {when!r}")
+    return f"{dt.year:04d}-{dt.month:02d}"
+
+
+def bucket_age_days(bucket: str, now: datetime) -> float:
+    """Age in days of a ``"YYYY-MM"`` bucket relative to ``now``, computed as the
+    whole-month difference × the mean month length — so the *current* month is
+    age 0 (fully weighted) and last month ≈ 30 days. Floored at 0 (future
+    buckets → 0). Unparseable → a huge age so it decays away rather than
+    crashing the verdict path."""
+    try:
+        year_s, month_s = bucket.split("-", 1)
+        by, bm = int(year_s), int(month_s)
+    except (ValueError, IndexError):
+        return _UNPARSEABLE_AGE_DAYS
+    months = (now.year - by) * 12 + (now.month - bm)
+    if months <= 0:
+        return 0.0
+    return months * _MEAN_MONTH_DAYS
+
+
+def decay_weight(age_days: float, half_life_days: Union[float, None]) -> float:
+    """Exponential decay ``0.5 ** (age_days / half_life_days)``.
+
+    ``half_life_days`` of ``None`` or ``<= 0`` disables decay (returns 1.0):
+    every bucket counts fully, i.e. the pre-freshness behaviour.
+    """
+    if not half_life_days or half_life_days <= 0:
+        return 1.0
+    if age_days <= 0:
+        return 1.0
+    return 0.5 ** (age_days / half_life_days)
+
+
+def flatten_counts(
+    buckets: Mapping[str, object],
+) -> Tuple[int, int]:
+    """Sum ``(correct, incorrect)`` across all buckets, unweighted. The
+    decay-disabled / back-compat read path. Defensive: a flat v1-shaped
+    ``{"correct", "incorrect"}`` that slips past migration is returned as-is
+    (treated as a single bucket) rather than crashing."""
+    if not is_bucketed(buckets):
+        return int(buckets.get("correct", 0)), int(buckets.get("incorrect", 0))
+    correct = 0
+    incorrect = 0
+    for counts in buckets.values():
+        correct += int(counts.get("correct", 0))
+        incorrect += int(counts.get("incorrect", 0))
+    return correct, incorrect
+
+
+def weighted_counts(
+    buckets: Mapping[str, Mapping[str, int]],
+    half_life_days: Union[float, None],
+    now: datetime,
+) -> Tuple[float, float]:
+    """Decay-weighted ``(correct, incorrect)`` sums over age buckets.
+
+    With ``half_life_days`` None/<=0 this equals :func:`flatten_counts` (every
+    weight is 1.0), so the verdict path is identical to today when decay is off.
+    Returns floats — Wilson's interval is valid for a fractional effective
+    sample size.
+    """
+    if not half_life_days or half_life_days <= 0 or not is_bucketed(buckets):
+        # Decay disabled, or a flat (ageless) entry → no decay possible.
+        c, i = flatten_counts(buckets)
+        return float(c), float(i)
+    correct = 0.0
+    incorrect = 0.0
+    for bucket, counts in buckets.items():
+        w = decay_weight(bucket_age_days(bucket, now), half_life_days)
+        correct += w * int(counts.get("correct", 0))
+        incorrect += w * int(counts.get("incorrect", 0))
+    return correct, incorrect
+
+
+def is_bucketed(event_counts: Mapping[str, object]) -> bool:
+    """True if an event-type entry is the v2 bucketed shape
+    (``{"YYYY-MM": {...}}``) rather than the v1 flat
+    ``{"correct": int, "incorrect": int}``. Used by the migration."""
+    if not event_counts:
+        return True  # empty {} is a valid (empty) bucketed shape
+    return "correct" not in event_counts and "incorrect" not in event_counts

--- a/core/llm/scorecard/scorecard.py
+++ b/core/llm/scorecard/scorecard.py
@@ -15,12 +15,15 @@ Persistence shape (JSON, ``out/llm_scorecard.json`` by default)::
             "last_seen_at":  "2026-05-06T...",
             "model_version": "claude-haiku-4-5-20251001",
             "policy_override": "auto",          // auto | force_short_circuit | force_fall_through
-            "events": {
-              "cheap_short_circuit":   {"correct": 47, "incorrect": 1},
-              "multi_model_consensus": {"correct":  0, "incorrect": 0},
-              "judge_review":          {"correct":  0, "incorrect": 0},
-              "tool_evidence":         {"correct":  0, "incorrect": 0},
-              "operator_feedback":     {"correct":  0, "incorrect": 0}
+            "events": {                            // v2: per-type "YYYY-MM" age buckets
+              "cheap_short_circuit": {
+                "2026-05": {"correct": 30, "incorrect": 1},
+                "2026-04": {"correct": 17, "incorrect": 0}
+              },
+              "multi_model_consensus": {},
+              "judge_review":          {},
+              "tool_evidence":         {},
+              "operator_feedback":     {}
             },
             "disagreement_samples": [
               {
@@ -54,12 +57,23 @@ from pathlib import Path
 from typing import Dict, List, Literal, Optional, Set, Tuple
 
 from core.json import save_json
+from core.llm.scorecard.freshness import (
+    bucket_key,
+    flatten_counts,
+    is_bucketed,
+    weighted_counts,
+)
 from core.logging import get_logger
 
 logger = get_logger()
 
 
-SCHEMA_VERSION = 1
+# v2 (2026-05): per-event-type counts are stratified into "YYYY-MM" age buckets
+# (``events[type] = {"2026-05": {"correct", "incorrect"}, ...}``) instead of a
+# flat ``{"correct", "incorrect"}``, so reads can freshness-weight by bucket age.
+# Migration from v1 folds the flat counts into a single bucket keyed by the
+# cell's last-seen month. See ``freshness.py`` + ``~/design/scorecard-model-versioning.md``.
+SCHEMA_VERSION = 2
 
 # Wilson 95% upper bound is the gate; this many failures (or failure
 # rate, computed by Wilson on the success/failure split) above this
@@ -128,6 +142,14 @@ class EventType:
     # heuristic-first with a 2-step LLM tiebreak, no ground-truth
     # calibration.
     EXPLOIT_INTENT_MATCH = "exploit_intent_match"
+    # Per-call structured-output validity: did the response parse + match the
+    # schema. ``correct`` = passed first time, ``incorrect`` = failed (the
+    # provider may retry internally; this records the externally-observable
+    # outcome only). Producer: ``LLMClient.generate_structured`` via the
+    # run-end lifecycle flush. Recorded under the ``_structured`` decision
+    # class so it's a universal "how often does this model follow the schema"
+    # axis, decoupled from any task-specific reliability cell.
+    SCHEMA_VALID = "schema_valid"
 
 
 ALL_EVENT_TYPES: Tuple[str, ...] = (
@@ -138,6 +160,7 @@ ALL_EVENT_TYPES: Tuple[str, ...] = (
     EventType.OPERATOR_FEEDBACK,
     EventType.REASONING_DIVERGENCE,
     EventType.EXPLOIT_INTENT_MATCH,
+    EventType.SCHEMA_VALID,
 )
 
 
@@ -195,6 +218,17 @@ class DecisionClassStats:
     policy_override: PolicyOverride
     events: Dict[str, _EventCounts]
     disagreement_samples: List[Dict[str, str]] = field(default_factory=list)
+    # Lifecycle metrics — a volume/cost/speed signal, separate from the
+    # correct/incorrect reliability events. Bumped by register_uses once per
+    # run lifecycle; never affects the Wilson verdict. The cost + tokens are
+    # the "did I get value for money" axis every operator cares about.
+    calls: int = 0
+    cost_usd: float = 0.0
+    tokens: int = 0
+    input_tokens: int = 0
+    output_tokens: int = 0
+    latency_ms_sum: int = 0
+    latency_ms_max: int = 0
 
 def _wilson_upper_bound(successes: int, failures: int, *,
                          z: float = 1.96) -> float:
@@ -234,13 +268,72 @@ def _now_iso() -> str:
     return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
 
 
-def _empty_events() -> Dict[str, Dict[str, int]]:
-    """A fresh ``events`` dict with all known event types initialised
-    to zero counts. Ensures the JSON shape is identical for cells
-    that have only seen one event type vs cells that have seen all
-    five — operators don't have to wonder "why is this key missing?"
-    when scanning the file."""
-    return {et: {"correct": 0, "incorrect": 0} for et in ALL_EVENT_TYPES}
+def _safe_int(v, default: int = 0) -> int:
+    """Coerce to ``int`` defensively — wrong-type/malformed cell fields
+    (a hand-edited ``"calls": "abc"``, a JSON list slipped in, ``None``) coerce
+    to the default rather than raising out of the locked context and aborting
+    the whole write."""
+    try:
+        return int(v) if v is not None else default
+    except (TypeError, ValueError):
+        return default
+
+
+def _safe_float(v, default: float = 0.0) -> float:
+    """Float counterpart to :func:`_safe_int`. Wrong-type values → default."""
+    try:
+        return float(v) if v is not None else default
+    except (TypeError, ValueError):
+        return default
+
+
+def _empty_events() -> Dict[str, Dict[str, Dict[str, int]]]:
+    """A fresh ``events`` dict: every known event type present, each mapped to
+    an empty age-bucket map (``{}``). Buckets (``"YYYY-MM" -> {correct,
+    incorrect}``) are added lazily by :meth:`ModelScorecard.record_event`. All
+    event types are present so the JSON shape is identical across cells."""
+    return {et: {} for et in ALL_EVENT_TYPES}
+
+
+def _migrate_events_v1_to_v2(cell: Dict) -> None:
+    """In place: convert a cell's flat v1 ``events[type] = {correct, incorrect}``
+    to v2 age-bucketed ``events[type] = {month: {correct, incorrect}}``.
+
+    Flat counts fold into ONE bucket keyed by the cell's last-seen month (the
+    best-known freshness for that aggregate); zero-count types become empty
+    ``{}``. Idempotent — already-bucketed entries are left untouched, so this is
+    also safe as the ``_ensure_cell`` defensive backfill."""
+    events = cell.get("events")
+    if not isinstance(events, dict):
+        cell["events"] = _empty_events()
+        return
+    ts = cell.get("last_seen_at") or cell.get("first_seen_at") or _now_iso()
+    try:
+        month = bucket_key(ts)
+    except ValueError:
+        month = bucket_key(_now_iso())
+    for et, counts in list(events.items()):
+        if is_bucketed(counts):
+            continue
+        c = _safe_int(counts.get("correct"), 0)
+        i = _safe_int(counts.get("incorrect"), 0)
+        events[et] = {month: {"correct": c, "incorrect": i}} if (c or i) else {}
+
+
+def _migrate(data: Dict, from_version) -> bool:
+    """Migrate ``data`` in place from ``from_version`` to ``SCHEMA_VERSION``.
+    Returns True on success, False for an unknown version (caller raises rather
+    than silently corrupting). Currently: v1 -> v2 (flat -> bucketed events)."""
+    if from_version == 1:
+        for by_dc in data.get("models", {}).values():
+            if not isinstance(by_dc, dict):
+                continue
+            for cell in by_dc.values():
+                if isinstance(cell, dict):
+                    _migrate_events_v1_to_v2(cell)
+        data["version"] = SCHEMA_VERSION
+        return True
+    return False
 
 
 # ---------------------------------------------------------------------------
@@ -272,6 +365,7 @@ class ModelScorecard:
         auto_gc_after_days: Optional[int] = DEFAULT_AUTO_GC_AFTER_DAYS,
         auto_gc_interval_seconds: float = _AUTO_GC_INTERVAL_SECONDS,
         keep_models: Optional[Set[str]] = None,
+        freshness_half_life_days: Optional[float] = None,
         rng=None,
     ):
         """``shadow_rate`` is the probability (0-1) that a call to a
@@ -297,6 +391,10 @@ class ModelScorecard:
         self.shadow_rate = shadow_rate
         self.auto_gc_after_days = auto_gc_after_days
         self.auto_gc_interval_seconds = auto_gc_interval_seconds
+        # Freshness half-life (days) for age-weighting the cell counts at verdict
+        # time. None / <=0 = disabled → counts are summed unweighted (identical
+        # to pre-v2 behaviour). See freshness.py.
+        self.freshness_half_life_days = freshness_half_life_days
         # Cells whose ``model`` is in ``keep_models`` are protected
         # from auto-GC regardless of last_seen_at age. Intent: an
         # operator who configures a model in models.json but takes
@@ -345,8 +443,12 @@ class ModelScorecard:
             )
         with self._with_lock() as data:
             cell = self._ensure_cell(data, model, decision_class)
-            cell["events"][event_type][outcome] += 1
-            cell["last_seen_at"] = _now_iso()
+            now_iso = _now_iso()
+            bucket = cell["events"][event_type].setdefault(
+                bucket_key(now_iso), {"correct": 0, "incorrect": 0}
+            )
+            bucket[outcome] += 1
+            cell["last_seen_at"] = now_iso
             if model_version:
                 cell["model_version"] = model_version
             if (outcome == "incorrect"
@@ -366,6 +468,60 @@ class ModelScorecard:
                     cell["disagreement_samples"] = (
                         samples[-MAX_DISAGREEMENT_SAMPLES:]
                     )
+
+    def register_uses(self, uses: List[Dict]) -> None:
+        """Record per-(model, decision_class) USAGE — a volume/presence signal,
+        not a reliability outcome. Bumps each cell's ``calls`` counter and
+        last_seen; never touches the correct/incorrect events, so it cannot
+        affect the Wilson verdict or routing.
+
+        Intended to be flushed ONCE per run lifecycle (e.g. from ``LLMClient``
+        at process exit over ``get_fired_models()``) — so the per-call cost is
+        zero and a model that was *used* but not yet *scored* against an oracle
+        still shows up in the scorecard. One batched write for the whole list.
+
+        Each entry: ``{"model": str, "decision_class": str, "calls": int,
+        "model_version": Optional[str]}`` plus optional lifecycle metrics —
+        ``cost_usd``, ``tokens``, ``input_tokens``, ``output_tokens``,
+        ``latency_ms_sum``, ``latency_ms_max``. Missing metrics are treated as
+        0 (so callers can opt in to richer enrichment without changing the
+        signature)."""
+        if not uses:
+            return
+        with self._with_lock() as data:
+            for u in uses:
+                model = u.get("model")
+                dc = u.get("decision_class")
+                if not model or not dc:
+                    continue
+                cell = self._ensure_cell(data, model, dc)
+                cell["calls"] = _safe_int(cell.get("calls"), 0) + _safe_int(u.get("calls"), 1)
+                cell["cost_usd"] = _safe_float(cell.get("cost_usd"), 0.0) + _safe_float(u.get("cost_usd"), 0.0)
+                cell["tokens"] = _safe_int(cell.get("tokens"), 0) + _safe_int(u.get("tokens"), 0)
+                cell["input_tokens"] = _safe_int(cell.get("input_tokens"), 0) + _safe_int(u.get("input_tokens"), 0)
+                cell["output_tokens"] = _safe_int(cell.get("output_tokens"), 0) + _safe_int(u.get("output_tokens"), 0)
+                cell["latency_ms_sum"] = _safe_int(cell.get("latency_ms_sum"), 0) + _safe_int(u.get("latency_ms_sum"), 0)
+                u_max = _safe_int(u.get("latency_ms_max"), 0)
+                if u_max > _safe_int(cell.get("latency_ms_max"), 0):
+                    cell["latency_ms_max"] = u_max
+                # Optional batched schema-validity outcomes for this cell:
+                # accumulate into the current-month bucket of the SCHEMA_VALID
+                # event so the result counts towards the standard Wilson view
+                # over that slot. correct = response parsed + matched schema;
+                # incorrect = it didn't.
+                pass_n = int(u.get("schema_valid_pass", 0))
+                fail_n = int(u.get("schema_valid_fail", 0))
+                if pass_n or fail_n:
+                    now_iso = _now_iso()
+                    sv = cell["events"].setdefault(EventType.SCHEMA_VALID, {})
+                    bucket = sv.setdefault(
+                        bucket_key(now_iso), {"correct": 0, "incorrect": 0})
+                    bucket["correct"] += pass_n
+                    bucket["incorrect"] += fail_n
+                cell["last_seen_at"] = _now_iso()
+                mv = u.get("model_version")
+                if mv:
+                    cell["model_version"] = mv
 
     def should_short_circuit(
         self,
@@ -402,15 +558,12 @@ class ModelScorecard:
             return Policy.FALL_THROUGH
 
         ev = cell["events"].get(EventType.CHEAP_SHORT_CIRCUIT, {})
-        correct = int(ev.get("correct", 0))
-        incorrect = int(ev.get("incorrect", 0))
-        n = correct + incorrect
-        if n < sample_size_floor:
-            return Policy.LEARNING
-
-        upper = _wilson_upper_bound(correct, incorrect)
-        if upper > self.miss_rate_ceiling:
-            return Policy.FALL_THROUGH
+        policy = self._measured_policy(
+            ev, self.freshness_half_life_days,
+            sample_size_floor=sample_size_floor,
+        )
+        if policy != Policy.SHORT_CIRCUIT:
+            return policy
         # Cell is short-circuit-worthy. Roll the re-shadowing dice:
         # with probability ``shadow_rate`` we run full anyway so the
         # cell keeps accumulating fresh ground-truth signal and we
@@ -420,6 +573,80 @@ class ModelScorecard:
         if self.shadow_rate > 0 and self._rng() < self.shadow_rate:
             return Policy.SHADOW
         return Policy.SHORT_CIRCUIT
+
+    def _measured_policy(
+        self, ev: Dict, half_life_days: Optional[float],
+        *, sample_size_floor: int = 10,
+    ) -> str:
+        """The measured short-circuit policy for one cell's
+        ``cheap_short_circuit`` buckets — SHORT_CIRCUIT / FALL_THROUGH /
+        LEARNING — ignoring operator pins and shadow sampling.
+
+        With ``half_life_days`` set, counts are freshness-weighted (recent
+        observations dominate stale ones, so a model that regressed behind a
+        floating alias surfaces instead of being averaged against its own past);
+        ``n`` is then the fractional effective sample size, for which Wilson's
+        interval is valid. With it ``None``/<=0 the counts are summed unweighted
+        (pre-freshness behaviour). Shared by :meth:`should_short_circuit` and
+        :meth:`measure_freshness_impact` so both judge identically."""
+        if half_life_days:
+            correct, incorrect = weighted_counts(
+                ev, half_life_days, datetime.now(timezone.utc),
+            )
+        else:
+            correct, incorrect = flatten_counts(ev)
+        if correct + incorrect < sample_size_floor:
+            return Policy.LEARNING
+        if _wilson_upper_bound(correct, incorrect) > self.miss_rate_ceiling:
+            return Policy.FALL_THROUGH
+        return Policy.SHORT_CIRCUIT
+
+    def measure_freshness_impact(
+        self, half_life_days: float, *, sample_size_floor: int = 10,
+    ) -> Dict[str, int]:
+        """Offline gate: compare the cheap-short-circuit verdict for every cell
+        with decay OFF (baseline) vs ON at ``half_life_days``, and tally how
+        many trusted cells would FALL OUT of SHORT_CIRCUIT (and to which
+        policy). Run this before enabling freshness by default — freshness lowers
+        the effective sample size, and this quantifies the cold-start hit.
+        Read-only; ignores operator pins and shadow sampling (measures the
+        underlying drift signal)."""
+        out = {
+            "cells": 0,
+            "short_circuit_baseline": 0,
+            "short_circuit_weighted": 0,
+            "flipped_out": 0,
+            "flipped_out_to_learning": 0,
+            "flipped_out_to_fall_through": 0,
+            "flipped_in": 0,
+        }
+        with self._with_lock(write=False) as data:
+            for by_dc in (data.get("models") or {}).values():
+                if not isinstance(by_dc, dict):
+                    continue
+                for cell in by_dc.values():
+                    if not isinstance(cell, dict):
+                        continue
+                    ev = (cell.get("events") or {}).get(
+                        EventType.CHEAP_SHORT_CIRCUIT, {})
+                    base = self._measured_policy(
+                        ev, None, sample_size_floor=sample_size_floor)
+                    wgt = self._measured_policy(
+                        ev, half_life_days, sample_size_floor=sample_size_floor)
+                    out["cells"] += 1
+                    base_sc = base == Policy.SHORT_CIRCUIT
+                    wgt_sc = wgt == Policy.SHORT_CIRCUIT
+                    out["short_circuit_baseline"] += int(base_sc)
+                    out["short_circuit_weighted"] += int(wgt_sc)
+                    if base_sc and not wgt_sc:
+                        out["flipped_out"] += 1
+                        if wgt == Policy.LEARNING:
+                            out["flipped_out_to_learning"] += 1
+                        else:
+                            out["flipped_out_to_fall_through"] += 1
+                    elif not base_sc and wgt_sc:
+                        out["flipped_in"] += 1
+        return out
 
     def claim_and_record_tool_evidence(
         self,
@@ -466,8 +693,12 @@ class ModelScorecard:
             if finding_id in seen:
                 return False
             seen.append(finding_id)
-            cell["events"][EventType.TOOL_EVIDENCE][outcome] += 1
-            cell["last_seen_at"] = _now_iso()
+            now_iso = _now_iso()
+            bucket = cell["events"][EventType.TOOL_EVIDENCE].setdefault(
+                bucket_key(now_iso), {"correct": 0, "incorrect": 0}
+            )
+            bucket[outcome] += 1
+            cell["last_seen_at"] = now_iso
             if model_version:
                 cell["model_version"] = model_version
             if (outcome == "incorrect"
@@ -503,14 +734,24 @@ class ModelScorecard:
             cell = self._ensure_cell(data, model, decision_class)
             cell["policy_override"] = policy_override
 
-    def get_stats(self) -> List[DecisionClassStats]:
+    def get_stats(
+        self, *, freshness_half_life_days: Optional[float] = None,
+    ) -> List[DecisionClassStats]:
         """Materialise every cell as :class:`DecisionClassStats`.
-        Used by the CLI; not the hot path."""
+        Used by the CLI; not the hot path.
+
+        ``freshness_half_life_days`` (None = unweighted, the default) age-weights
+        each cell's counts so the materialised view — and every column the CLI
+        derives from it (policy / wilson-UB / calls-saved) — reflects the same
+        freshness the live gate would apply. Weighted counts are rounded for a
+        clean integer display."""
         out: List[DecisionClassStats] = []
         with self._with_lock(write=False) as data:
             for model, by_dc in (data.get("models") or {}).items():
                 for dc, cell in by_dc.items():
-                    out.append(self._cell_to_stats(model, dc, cell))
+                    out.append(self._cell_to_stats(
+                        model, dc, cell,
+                        freshness_half_life_days=freshness_half_life_days))
         return out
 
     def get_stat(
@@ -613,6 +854,13 @@ class ModelScorecard:
                 "policy_override": "auto",
                 "events": _empty_events(),
                 "disagreement_samples": [],
+                "calls": 0,
+                "cost_usd": 0.0,
+                "tokens": 0,
+                "input_tokens": 0,
+                "output_tokens": 0,
+                "latency_ms_sum": 0,
+                "latency_ms_max": 0,
             }
             by_dc[decision_class] = cell
         else:
@@ -623,21 +871,34 @@ class ModelScorecard:
             cell.setdefault("model_version", "")
             cell.setdefault("policy_override", "auto")
             cell.setdefault("disagreement_samples", [])
-            events = cell.setdefault("events", {})
+            cell.setdefault("calls", 0)
+            cell.setdefault("cost_usd", 0.0)
+            cell.setdefault("tokens", 0)
+            cell.setdefault("input_tokens", 0)
+            cell.setdefault("output_tokens", 0)
+            cell.setdefault("latency_ms_sum", 0)
+            cell.setdefault("latency_ms_max", 0)
+            cell.setdefault("events", {})
+            _migrate_events_v1_to_v2(cell)  # idempotent: convert any flat entries
             for et in ALL_EVENT_TYPES:
-                events.setdefault(et, {"correct": 0, "incorrect": 0})
+                cell["events"].setdefault(et, {})  # all types present, empty bucketed
         return cell
 
     def _cell_to_stats(
         self, model: str, decision_class: str, cell: Dict,
+        *, freshness_half_life_days: Optional[float] = None,
     ) -> DecisionClassStats:
-        events = {
-            et: _EventCounts(
-                correct=int(cell["events"].get(et, {}).get("correct", 0)),
-                incorrect=int(cell["events"].get(et, {}).get("incorrect", 0)),
-            )
-            for et in ALL_EVENT_TYPES
-        }
+        events = {}
+        for et in ALL_EVENT_TYPES:
+            buckets = cell["events"].get(et, {})
+            if freshness_half_life_days:
+                wc, wi = weighted_counts(
+                    buckets, freshness_half_life_days,
+                    datetime.now(timezone.utc))
+                c, i = round(wc), round(wi)
+            else:
+                c, i = flatten_counts(buckets)
+            events[et] = _EventCounts(correct=c, incorrect=i)
         return DecisionClassStats(
             decision_class=decision_class,
             model=model,
@@ -647,6 +908,13 @@ class ModelScorecard:
             policy_override=cell.get("policy_override", "auto"),
             events=events,
             disagreement_samples=list(cell.get("disagreement_samples", [])),
+            calls=_safe_int(cell.get("calls"), 0),
+            cost_usd=_safe_float(cell.get("cost_usd"), 0.0),
+            tokens=_safe_int(cell.get("tokens"), 0),
+            input_tokens=_safe_int(cell.get("input_tokens"), 0),
+            output_tokens=_safe_int(cell.get("output_tokens"), 0),
+            latency_ms_sum=_safe_int(cell.get("latency_ms_sum"), 0),
+            latency_ms_max=_safe_int(cell.get("latency_ms_max"), 0),
         )
 
     # ----- locked read-modify-write helper -----
@@ -722,15 +990,26 @@ class ModelScorecard:
             # silently downgrade.
             existing_version = self.data.get("version")
             if existing_version is None:
-                # Cold-start file or hand-edited — accept and stamp.
+                # Cold-start / hand-edited / aborted-prior-migration file — a
+                # missing version key may hide either v1 (flat events) or v2
+                # (bucketed) contents. Defensively run the v1→v2 migration
+                # before stamping: it's idempotent (already-bucketed cells are
+                # skipped per `is_bucketed`), so it's a no-op when the file is
+                # genuinely v2-shaped. Without this, a v1-shaped file would
+                # get the v2 banner with its cells still flat and only
+                # self-heal lazily as `_ensure_cell` touched each cell.
+                _migrate(self.data, 1)
                 self.data["version"] = SCHEMA_VERSION
             elif existing_version != SCHEMA_VERSION:
-                raise RuntimeError(
-                    f"scorecard: schema version mismatch at {path}: "
-                    f"file has version={existing_version}, code "
-                    f"expects {SCHEMA_VERSION}. Migrate or delete "
-                    f"the sidecar to continue."
-                )
+                # Forward-migrate known older versions in memory; the migrated
+                # data is persisted on the next write under the lock we hold.
+                if not _migrate(self.data, existing_version):
+                    raise RuntimeError(
+                        f"scorecard: schema version mismatch at {path}: "
+                        f"file has version={existing_version}, code "
+                        f"expects {SCHEMA_VERSION} and has no migration "
+                        f"path. Migrate or delete the sidecar to continue."
+                    )
             self.data.setdefault("models", {})
             return self.data
 
@@ -841,12 +1120,12 @@ class ModelScorecard:
                 seen = cell.get("last_seen_at", "")
                 if seen and seen < cutoff_iso:
                     # Tally before deletion so the log line is
-                    # informative without a separate scan.
+                    # informative without a separate scan. Counts are
+                    # age-bucketed (v2) — flatten across buckets.
                     for et_counts in (cell.get("events") or {}).values():
-                        events_correct += int(
-                            et_counts.get("correct", 0))
-                        events_incorrect += int(
-                            et_counts.get("incorrect", 0))
+                        c, i = flatten_counts(et_counts)
+                        events_correct += c
+                        events_incorrect += i
                     del by_dc[dc_key]
                     per_model_counts[m_key] = (
                         per_model_counts.get(m_key, 0) + 1)

--- a/core/llm/scorecard/tests/test_cli.py
+++ b/core/llm/scorecard/tests/test_cli.py
@@ -76,13 +76,15 @@ def _make_args(**kwargs):
     """Build a Namespace with the union of all defaults the CLI
     handlers expect; tests override specific fields."""
     base = dict(
-        path=None, by_savings=False, by_miss_rate=False,
+        path=None, by_savings=False, by_miss_rate=False, by_cost=False,
         untrusted=False, learning=False, consumer=None, since=None,
         model_a=None, model_b=None,
         decision_class=None, model=None, as_=None,
         older_than_days=None, all=False,
         outcome=None, note=None,
         event_type=EventType.CHEAP_SHORT_CIRCUIT,
+        freshness_half_life_days=None, half_life_days=None,
+        json=False,
     )
     base.update(kwargs)
     return SimpleNamespace(**base)
@@ -345,6 +347,29 @@ def test_pin_sets_policy_override(seeded_scorecard):
     assert stat.policy_override == "force_fall_through"
 
 
+def test_pin_friendly_value_maps_to_storage(seeded_scorecard):
+    """The ergonomic `--as short-circuit` (matching the `list` policy vocab)
+    maps to the internal `force_short_circuit` storage value — on-disk format
+    and verdict comparisons are unchanged."""
+    args = _make_args(
+        path=seeded_scorecard,
+        decision_class="codeql:py/sql-injection",
+        model="claude-haiku-4-5",
+        as_="short-circuit",
+    )
+    _capture(cli_mod.cmd_pin, args)
+    sc = ModelScorecard(seeded_scorecard)
+    stat = sc.get_stat("codeql:py/sql-injection", "claude-haiku-4-5")
+    assert stat.policy_override == "force_short_circuit"
+
+
+def test_prefix_filters_by_decision_class():
+    """`--prefix` is the decision_class prefix filter (renamed from the jargon
+    `--consumer`)."""
+    parser = cli_mod._build_parser()
+    assert parser.parse_args(["list", "--prefix", "codeql"]).consumer == "codeql"
+
+
 def test_unpin_releases_to_auto(seeded_scorecard):
     sc = ModelScorecard(seeded_scorecard)
     sc.set_policy_override(
@@ -602,3 +627,276 @@ def test_humanise_age_days():
     now = _dt.datetime(2026, 5, 6, 12, 0, 0, tzinfo=_dt.timezone.utc)
     three_days_ago = (now - _dt.timedelta(days=3, hours=2)).isoformat()
     assert cli_mod._humanise_age(three_days_ago, now=now) == "3d ago"
+
+
+# ---------------------------------------------------------------------------
+# freshness
+# ---------------------------------------------------------------------------
+
+
+def _write_freshness_fixture(path):
+    """A cell trusted unweighted (stale correct dominates) but untrusted under
+    freshness (recent failures dominate)."""
+    import json
+
+    from core.llm.scorecard.freshness import bucket_key
+
+    now = _dt.datetime.now(_dt.timezone.utc)
+    cur = bucket_key(now)
+    stale = f"{now.year - 2:04d}-{now.month:02d}"
+    fixture = {"version": 2, "models": {"haiku": {"codeql:py/sqli": {
+        "first_seen_at": f"{stale}-01T00:00:00+00:00",
+        "last_seen_at": f"{cur}-01T00:00:00+00:00",
+        "model_version": "", "policy_override": "auto",
+        "events": {
+            "cheap_short_circuit": {cur: {"correct": 0, "incorrect": 18},
+                                    stale: {"correct": 4000, "incorrect": 0}},
+            "multi_model_consensus": {}, "judge_review": {},
+            "tool_evidence": {}, "operator_feedback": {},
+        },
+        "disagreement_samples": [],
+    }}}}
+    path.write_text(json.dumps(fixture), encoding="utf-8")
+    return path
+
+
+def test_list_freshness_flag_reweights_policy(tmp_path):
+    """`list --freshness-half-life-days` reflects recent behaviour: the cell is
+    trusted unweighted but falls through once the stale data decays away."""
+    path = _write_freshness_fixture(tmp_path / "sc.json")
+    _, out_off, _ = _capture(cli_mod.cmd_list, _make_args(path=path))
+    assert "short-circuit" in out_off
+    _, out_on, _ = _capture(
+        cli_mod.cmd_list, _make_args(path=path, freshness_half_life_days=30))
+    assert "fall-through" in out_on
+    # the freshness view appends an inline impact footer (folded-in what-if)
+    assert "fall out of short-circuit" in out_on
+
+
+def test_list_shows_calls_column(tmp_path):
+    """`list` surfaces the per-model usage count, so a used-but-unscored model
+    is visible with its call volume."""
+    sc = ModelScorecard(tmp_path / "sc.json")
+    sc.register_uses([{"model": "haiku", "decision_class": "_usage", "calls": 7}])
+    rc, out, _ = _capture(cli_mod.cmd_list, _make_args(path=tmp_path / "sc.json"))
+    assert rc == 0
+    assert "calls" in out                          # the new column header
+    assert "_usage" in out and "haiku" in out and "7" in out
+
+
+def test_list_freshness_shows_drift_marker_on_regression(tmp_path):
+    """When --freshness flips a cell from short-circuit -> fall-through, the
+    policy column gets a ↓ drift marker — the silent-regression signal."""
+    path = _write_freshness_fixture(tmp_path / "sc.json")
+    _, out, _ = _capture(
+        cli_mod.cmd_list, _make_args(path=path, freshness_half_life_days=30))
+    assert "↓ fall-through" in out
+
+
+def test_list_no_drift_marker_without_freshness(tmp_path):
+    """No drift markers in the default unweighted view (markers only make
+    sense when comparing weighted vs baseline)."""
+    path = _write_freshness_fixture(tmp_path / "sc.json")
+    _, out, _ = _capture(cli_mod.cmd_list, _make_args(path=path))
+    assert "↓" not in out and "↑" not in out
+
+
+def test_recommend_picks_cheapest_trusted(tmp_path):
+    """`recommend` ranks trusted models for a decision_class by cost-per-call
+    and surfaces the cheapest — the actionable payoff of the scorecard."""
+    sc = ModelScorecard(tmp_path / "sc.json", shadow_rate=0.0)
+    # both models earn trust on codeql:py/sqli (n >= 73 clean keeps Wilson UB <= 5%)
+    for _ in range(80):
+        sc.record_event("codeql:py/sqli", "haiku",
+                        EventType.CHEAP_SHORT_CIRCUIT, "correct")
+        sc.record_event("codeql:py/sqli", "sonnet",
+                        EventType.CHEAP_SHORT_CIRCUIT, "correct")
+    # _usage cells set per-model spend (haiku cheap, sonnet 12x more)
+    sc.register_uses([
+        {"model": "haiku", "decision_class": "_usage",
+         "calls": 100, "cost_usd": 0.10},
+        {"model": "sonnet", "decision_class": "_usage",
+         "calls": 100, "cost_usd": 1.20},
+    ])
+    rc, out, _ = _capture(
+        cli_mod.cmd_recommend,
+        _make_args(path=tmp_path / "sc.json",
+                   decision_class="codeql:py/sqli"))
+    assert rc == 0
+    assert "use: haiku" in out                      # cheapest trusted wins
+    assert "also trusted: sonnet" in out
+
+
+def test_recommend_no_data_reports_clearly(tmp_path):
+    """Unknown decision_class -> clear message, exit 0 (informational, not
+    an error to operator scripts)."""
+    sc = ModelScorecard(tmp_path / "sc.json")
+    sc.register_uses([{"model": "haiku", "decision_class": "_usage",
+                       "calls": 1, "cost_usd": 0.001}])
+    rc, _, err = _capture(
+        cli_mod.cmd_recommend,
+        _make_args(path=tmp_path / "sc.json",
+                   decision_class="codeql:py/unknown"))
+    assert rc == 0
+    assert "no scorecard data" in err
+
+
+def test_recommend_handles_pinned_trusted_with_no_events(tmp_path):
+    """A `force_short_circuit` pin with NO cheap_short_circuit events makes
+    max_miss% None for a SHORT_CIRCUIT cell; recommend must format it
+    gracefully (`max_miss=n/a`), not crash on `None.__format__`."""
+    sc = ModelScorecard(tmp_path / "sc.json", shadow_rate=0.0)
+    sc.set_policy_override("codeql:py/sqli", "haiku", "force_short_circuit")
+    rc, out, _ = _capture(
+        cli_mod.cmd_recommend,
+        _make_args(path=tmp_path / "sc.json",
+                   decision_class="codeql:py/sqli"))
+    assert rc == 0
+    assert "use: haiku" in out
+    assert "max_miss=n/a" in out
+
+
+def test_recommend_freshness_shows_banner(tmp_path):
+    """When --freshness is set, the output header carries the half-life so a
+    different recommendation than unweighted has a visible breadcrumb."""
+    sc = ModelScorecard(tmp_path / "sc.json", shadow_rate=0.0)
+    for _ in range(80):
+        sc.record_event("codeql:py/sqli", "haiku",
+                        EventType.CHEAP_SHORT_CIRCUIT, "correct")
+    rc, out, _ = _capture(
+        cli_mod.cmd_recommend,
+        _make_args(path=tmp_path / "sc.json",
+                   decision_class="codeql:py/sqli",
+                   freshness_half_life_days=30))
+    assert rc == 0
+    assert "freshness half-life 30d" in out
+
+
+def test_list_shows_cost_column_and_by_cost_sorts(tmp_path):
+    """`list` surfaces per-cell spend in the $$ column, and `--by-cost` ranks
+    by it. The cost data is the universal 'did I get value for money' axis."""
+    sc = ModelScorecard(tmp_path / "sc.json")
+    sc.register_uses([
+        {"model": "haiku", "decision_class": "_usage",
+         "calls": 10, "cost_usd": 0.05},
+        {"model": "sonnet", "decision_class": "_usage",
+         "calls": 4, "cost_usd": 0.40},
+    ])
+    rc, out, _ = _capture(cli_mod.cmd_list, _make_args(path=tmp_path / "sc.json"))
+    assert rc == 0
+    assert "$$" in out                              # the cost column header
+    assert "$0.40" in out and "$0.05" in out        # both cells render their spend
+    # --by-cost ranks sonnet ($0.40) above haiku ($0.05)
+    rc2, out2, _ = _capture(
+        cli_mod.cmd_list, _make_args(path=tmp_path / "sc.json", by_cost=True))
+    assert rc2 == 0
+    assert out2.index("sonnet") < out2.index("haiku")
+
+
+def test_bare_invocation_defaults_to_list(seeded_scorecard):
+    """A bare `raptor-llm-scorecard` (no subcommand) runs `list` instead of
+    erroring — so `/scorecard` is fast and useful by default."""
+    out, err = io.StringIO(), io.StringIO()
+    with redirect_stdout(out), redirect_stderr(err):
+        rc = cli_mod.main(["--path", str(seeded_scorecard)])
+    assert rc == 0
+    text = out.getvalue()
+    assert "decision_class" in text                 # the list-table header rendered
+    assert "-h" in text                             # discoverability footer -> -h
+
+
+# ---------------------------------------------------------------------------
+# enhancements (--json, summary, compare extension)
+# ---------------------------------------------------------------------------
+
+
+def _seed_minimal(path):
+    """A small scorecard fixture: trusted haiku on codeql:py/sqli + usage cell
+    + an untrusted sonnet cell — enough to exercise summary/recommend/list."""
+    sc = ModelScorecard(path, shadow_rate=0.0)
+    for _ in range(80):
+        sc.record_event("codeql:py/sqli", "haiku",
+                        EventType.CHEAP_SHORT_CIRCUIT, "correct")
+    sc.register_uses([
+        {"model": "haiku", "decision_class": "_usage",
+         "calls": 100, "cost_usd": 0.10},
+        {"model": "sonnet", "decision_class": "_usage",
+         "calls": 5, "cost_usd": 0.50},
+    ])
+    return path
+
+
+def test_list_json_emits_parseable_array(tmp_path):
+    """`list --json` emits JSON that downstream scripts can parse — and the
+    cells carry every field we render in the table (n / max_miss / cost / etc.)."""
+    import json as _json
+    _seed_minimal(tmp_path / "sc.json")
+    rc, out, _ = _capture(
+        cli_mod.cmd_list, _make_args(path=tmp_path / "sc.json", json=True))
+    assert rc == 0
+    parsed = _json.loads(out)
+    assert isinstance(parsed.get("cells"), list) and parsed["cells"]
+    sample = parsed["cells"][0]
+    for required in (
+        "decision_class", "model", "policy", "n",
+        "calls", "cost_usd", "max_miss_pct", "last_seen_at",
+    ):
+        assert required in sample, f"missing {required} in {sample}"
+
+
+def test_recommend_json_emits_recommendation(tmp_path):
+    """`recommend --json` emits the structured recommendation + trusted list."""
+    import json as _json
+    _seed_minimal(tmp_path / "sc.json")
+    rc, out, _ = _capture(
+        cli_mod.cmd_recommend,
+        _make_args(path=tmp_path / "sc.json",
+                   decision_class="codeql:py/sqli", json=True))
+    assert rc == 0
+    parsed = _json.loads(out)
+    assert parsed["decision_class"] == "codeql:py/sqli"
+    assert parsed["recommendation"]["model"] == "haiku"
+    assert any(t["model"] == "haiku" for t in parsed["trusted"])
+
+
+def test_summary_text_dashboard(tmp_path):
+    """The text summary surfaces total cells, policy breakdown, spend, and the
+    cheapest-trusted line — the daily-driver view."""
+    _seed_minimal(tmp_path / "sc.json")
+    rc, out, _ = _capture(
+        cli_mod.cmd_summary, _make_args(path=tmp_path / "sc.json"))
+    assert rc == 0
+    assert "cells:" in out and "trusted" in out
+    assert "total spend:" in out
+    assert "cheapest trusted: haiku" in out
+
+
+def test_summary_json_dashboard(tmp_path):
+    """`summary --json` shape: cells_total / policy_breakdown / spend_by_model /
+    cheapest_trusted — parseable for dashboards."""
+    import json as _json
+    _seed_minimal(tmp_path / "sc.json")
+    rc, out, _ = _capture(
+        cli_mod.cmd_summary, _make_args(path=tmp_path / "sc.json", json=True))
+    assert rc == 0
+    parsed = _json.loads(out)
+    assert parsed["cells_total"] > 0
+    assert parsed["policy_breakdown"]["trusted"] >= 1
+    assert parsed["cheapest_trusted"]["model"] == "haiku"
+
+
+def test_compare_text_includes_cost_and_calls(tmp_path):
+    """Extended `compare` shows $$ + calls per side, not just reliability."""
+    _seed_minimal(tmp_path / "sc.json")
+    # need a shared decision_class for both models — give sonnet a sql cell too
+    sc = ModelScorecard(tmp_path / "sc.json", shadow_rate=0.0)
+    for _ in range(80):
+        sc.record_event("codeql:py/sqli", "sonnet",
+                        EventType.CHEAP_SHORT_CIRCUIT, "correct")
+    rc, out, _ = _capture(
+        cli_mod.cmd_compare,
+        _make_args(path=tmp_path / "sc.json",
+                   model_a="haiku", model_b="sonnet"))
+    assert rc == 0
+    assert "haiku $$" in out and "sonnet $$" in out
+    assert "haiku calls" in out and "sonnet calls" in out

--- a/core/llm/scorecard/tests/test_cli.py
+++ b/core/llm/scorecard/tests/test_cli.py
@@ -856,7 +856,7 @@ def test_recommend_json_emits_recommendation(tmp_path):
     parsed = _json.loads(out)
     assert parsed["decision_class"] == "codeql:py/sqli"
     assert parsed["recommendation"]["model"] == "haiku"
-    assert any(t["model"] == "haiku" for t in parsed["trusted"])
+    assert any(t["model"] == "haiku" for t in parsed["short_circuit"])
 
 
 def test_summary_text_dashboard(tmp_path):
@@ -881,8 +881,8 @@ def test_summary_json_dashboard(tmp_path):
     assert rc == 0
     parsed = _json.loads(out)
     assert parsed["cells_total"] > 0
-    assert parsed["policy_breakdown"]["trusted"] >= 1
-    assert parsed["cheapest_trusted"]["model"] == "haiku"
+    assert parsed["policy_breakdown"]["short_circuit"] >= 1
+    assert parsed["cheapest_short_circuit"]["model"] == "haiku"
 
 
 def test_compare_text_includes_cost_and_calls(tmp_path):

--- a/core/llm/scorecard/tests/test_freshness.py
+++ b/core/llm/scorecard/tests/test_freshness.py
@@ -1,0 +1,81 @@
+"""Unit tests for the scorecard freshness-weighting core (pure functions)."""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from core.llm.scorecard.freshness import (
+    bucket_age_days,
+    bucket_key,
+    decay_weight,
+    flatten_counts,
+    is_bucketed,
+    weighted_counts,
+)
+
+NOW = datetime(2026, 5, 29, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def test_bucket_key_from_iso_and_datetime():
+    assert bucket_key("2026-05-29T12:00:00+00:00") == "2026-05"
+    assert bucket_key(datetime(2026, 1, 3, tzinfo=timezone.utc)) == "2026-01"
+    # Degraded-but-parseable prefix.
+    assert bucket_key("2026-05-29 weird") == "2026-05"
+
+
+def test_bucket_age_days():
+    assert bucket_age_days("2026-05", NOW) == 0.0          # current month = 0
+    assert round(bucket_age_days("2026-04", NOW)) == 30    # one month ≈ 30d
+    assert round(bucket_age_days("2025-05", NOW)) == 365   # one year ≈ 365d
+    assert bucket_age_days("2026-06", NOW) == 0.0          # future floors to 0
+    # Unparseable -> huge age (decays away, never raises).
+    assert bucket_age_days("garbage", NOW) > 1e8
+
+
+def test_decay_weight():
+    assert decay_weight(0, 90) == 1.0
+    assert decay_weight(90, 90) == 0.5                      # one half-life
+    assert decay_weight(180, 90) == 0.25                    # two half-lives
+    # Disabled forms all return 1.0 (no decay).
+    assert decay_weight(1000, None) == 1.0
+    assert decay_weight(1000, 0) == 1.0
+    assert decay_weight(1000, -5) == 1.0
+
+
+def test_flatten_counts_sums_all_buckets():
+    buckets = {
+        "2026-05": {"correct": 10, "incorrect": 1},
+        "2026-04": {"correct": 5, "incorrect": 2},
+    }
+    assert flatten_counts(buckets) == (15, 3)
+    assert flatten_counts({}) == (0, 0)
+
+
+def test_weighted_disabled_equals_flatten():
+    buckets = {
+        "2026-05": {"correct": 10, "incorrect": 1},
+        "2026-01": {"correct": 5, "incorrect": 2},
+    }
+    assert weighted_counts(buckets, None, NOW) == (15.0, 3.0)
+    assert weighted_counts(buckets, 0, NOW) == (15.0, 3.0)
+
+
+def test_weighted_recent_dominates():
+    # Old data is mostly-correct; recent data is mostly-incorrect. With a short
+    # half-life, the weighted miss-rate should be driven by the recent bucket.
+    buckets = {
+        "2026-05": {"correct": 0, "incorrect": 10},   # recent: all wrong
+        "2025-05": {"correct": 100, "incorrect": 0},  # a year stale: all right
+    }
+    # Unweighted: miss-rate = 10/110 ≈ 0.09 (stale data dilutes the regression).
+    c0, i0 = flatten_counts(buckets)
+    assert i0 / (c0 + i0) < 0.10
+    # Weighted (30-day half-life): the year-old correct counts decay to ~0,
+    # so the weighted miss-rate is dominated by the recent failures.
+    c, i = weighted_counts(buckets, 30, NOW)
+    assert i / (c + i) > 0.90
+
+
+def test_is_bucketed_discriminates_v1_v2():
+    assert is_bucketed({"2026-05": {"correct": 1, "incorrect": 0}}) is True
+    assert is_bucketed({}) is True                          # empty == empty buckets
+    assert is_bucketed({"correct": 5, "incorrect": 1}) is False  # v1 flat shape

--- a/core/llm/scorecard/tests/test_scorecard.py
+++ b/core/llm/scorecard/tests/test_scorecard.py
@@ -198,10 +198,12 @@ def test_schema_includes_version_field(tmp_path):
 
 
 def test_all_event_types_present_in_cells(tmp_path):
-    """A cell that's only seen ``cheap_short_circuit`` still has
-    zero-counts for the other 4 event types so operators inspecting
-    the JSON see a uniform shape, not 'why is `tool_evidence`
-    missing?'"""
+    """A cell that's only seen ``cheap_short_circuit`` still has every event
+    type present (v2: each as an age-bucket map) so operators inspecting the
+    JSON see a uniform shape, not 'why is `tool_evidence` missing?'. Untouched
+    types are empty ``{}``; the touched type has a current-month bucket."""
+    from core.llm.scorecard.freshness import flatten_counts
+
     path = tmp_path / "sc.json"
     sc = ModelScorecard(path)
     sc.record_event(
@@ -210,9 +212,237 @@ def test_all_event_types_present_in_cells(tmp_path):
     on_disk = json.loads(path.read_text(encoding="utf-8"))
     cell = on_disk["models"]["m"]["x:y"]
     for et in ALL_EVENT_TYPES:
-        assert et in cell["events"]
-        assert "correct" in cell["events"][et]
-        assert "incorrect" in cell["events"][et]
+        assert et in cell["events"]              # uniform shape: all types present
+    # Untouched types are empty bucket maps.
+    assert cell["events"][EventType.MULTI_MODEL_CONSENSUS] == {}
+    # The touched type has a single current-month "YYYY-MM" bucket.
+    cheap = cell["events"][EventType.CHEAP_SHORT_CIRCUIT]
+    assert flatten_counts(cheap) == (1, 0)
+    assert all(len(k) == 7 and k[4] == "-" for k in cheap)
+
+
+def test_v1_file_migrates_to_v2_buckets(tmp_path):
+    """A v1 (flat-events) scorecard file loads, migrates to v2 age-bucketed
+    shape keyed by the cell's last-seen month, preserves counts (so the verdict
+    is unchanged), and bumps the persisted version on the next write."""
+    path = tmp_path / "sc.json"
+    v1 = {
+        "version": 1,
+        "models": {"m": {"x:y": {
+            "first_seen_at": "2026-03-01T00:00:00+00:00",
+            "last_seen_at": "2026-04-15T00:00:00+00:00",
+            "model_version": "",
+            "policy_override": "auto",
+            "events": {
+                "cheap_short_circuit":   {"correct": 47, "incorrect": 1},
+                "multi_model_consensus": {"correct": 0, "incorrect": 0},
+                "judge_review":          {"correct": 0, "incorrect": 0},
+                "tool_evidence":         {"correct": 0, "incorrect": 0},
+                "operator_feedback":     {"correct": 0, "incorrect": 0},
+            },
+            "disagreement_samples": [],
+        }}},
+    }
+    path.write_text(json.dumps(v1), encoding="utf-8")
+
+    sc = ModelScorecard(path)
+    # In-memory migration preserves counts on the read path.
+    stats = {(s.model, s.decision_class): s for s in sc.get_stats()}
+    cheap_stat = stats[("m", "x:y")].events[EventType.CHEAP_SHORT_CIRCUIT]
+    assert (cheap_stat.correct, cheap_stat.incorrect) == (47, 1)
+
+    # A write persists the migrated v2 shape.
+    sc.record_event("x:y", "m", EventType.JUDGE_REVIEW, "correct")
+    on_disk = json.loads(path.read_text(encoding="utf-8"))
+    assert on_disk["version"] == 2
+    cell = on_disk["models"]["m"]["x:y"]
+    # Flat counts folded into the last-seen month bucket (2026-04), untouched.
+    assert cell["events"]["cheap_short_circuit"] == {"2026-04": {"correct": 47, "incorrect": 1}}
+    # Zero-count types became empty bucket maps.
+    assert cell["events"]["multi_model_consensus"] == {}
+
+
+def test_version_less_v1_file_gets_migrated_on_load(tmp_path):
+    """Adversarial: a version-LESS file with v1-shaped flat events must NOT be
+    silently stamped v2 while the events stay flat (which would only self-heal
+    lazily as cells are touched). __enter__ now defensively runs v1->v2 even
+    when no version key is present."""
+    path = tmp_path / "sc.json"
+    path.write_text(json.dumps({
+        # NO `version` key
+        "models": {"m": {"x:y": {
+            "first_seen_at": "2026-04-01T00:00:00+00:00",
+            "last_seen_at": "2026-04-15T00:00:00+00:00",
+            "model_version": "", "policy_override": "auto",
+            "events": {
+                "cheap_short_circuit": {"correct": 50, "incorrect": 1},
+                "multi_model_consensus": {"correct": 0, "incorrect": 0},
+                "judge_review": {"correct": 0, "incorrect": 0},
+                "tool_evidence": {"correct": 0, "incorrect": 0},
+                "operator_feedback": {"correct": 0, "incorrect": 0},
+            },
+            "disagreement_samples": [],
+        }}},
+    }))
+    sc = ModelScorecard(path)
+    # Trigger a write so the migrated shape persists.
+    sc.record_event("x:y", "m", EventType.JUDGE_REVIEW, "correct")
+    on_disk = json.loads(path.read_text())
+    assert on_disk["version"] == 2
+    # Cheap counts must be bucketed under last_seen month (not still flat).
+    cheap = on_disk["models"]["m"]["x:y"]["events"]["cheap_short_circuit"]
+    assert cheap == {"2026-04": {"correct": 50, "incorrect": 1}}
+
+
+def test_freshness_weighting_flips_verdict_on_recent_regression(tmp_path):
+    """A model that was reliable long ago but regressed recently: unweighted,
+    the stale correct counts dilute the recent failures and the cell stays
+    trusted; freshness-weighted, the 2-year-old data decays away and the recent
+    regression flips the verdict to FALL_THROUGH. This is the whole point."""
+    from datetime import datetime, timezone
+
+    from core.llm.scorecard.freshness import bucket_key
+
+    now = datetime.now(timezone.utc)
+    cur = bucket_key(now)
+    stale = f"{now.year - 2:04d}-{now.month:02d}"   # ~24 months ago
+    fixture = {
+        "version": 2,
+        "models": {"m": {"x:y": {
+            "first_seen_at": f"{stale}-01T00:00:00+00:00",
+            "last_seen_at": f"{cur}-01T00:00:00+00:00",
+            "model_version": "",
+            "policy_override": "auto",
+            "events": {
+                "cheap_short_circuit": {
+                    cur:   {"correct": 0, "incorrect": 15},     # recent: all wrong
+                    stale: {"correct": 2000, "incorrect": 0},   # 2y stale: all right
+                },
+                "multi_model_consensus": {},
+                "judge_review": {},
+                "tool_evidence": {},
+                "operator_feedback": {},
+            },
+            "disagreement_samples": [],
+        }}},
+    }
+    path = tmp_path / "sc.json"
+    path.write_text(json.dumps(fixture), encoding="utf-8")
+
+    # Decay OFF: 15/2015 ≈ 0.7% miss-rate → trusted.
+    off = ModelScorecard(path)
+    assert off.should_short_circuit("x:y", "m") == Policy.SHORT_CIRCUIT
+    # Decay ON (30-day half-life): the 2-year-stale correct counts decay to ~0,
+    # the recent failures dominate → fall through (regression surfaces).
+    on = ModelScorecard(path, freshness_half_life_days=30)
+    assert on.should_short_circuit("x:y", "m") == Policy.FALL_THROUGH
+
+
+def test_measure_freshness_impact_counts_flips(tmp_path):
+    """The offline gate reports how many trusted cells fall out of SHORT_CIRCUIT
+    under a candidate half-life — the cold-start check before enabling decay."""
+    from datetime import datetime, timezone
+
+    from core.llm.scorecard.freshness import bucket_key
+
+    now = datetime.now(timezone.utc)
+    cur = bucket_key(now)
+    stale = f"{now.year - 2:04d}-{now.month:02d}"
+
+    def _cell(cheap_buckets, seen_month):
+        return {
+            "first_seen_at": f"{stale}-01T00:00:00+00:00",
+            "last_seen_at": f"{seen_month}-01T00:00:00+00:00",
+            "model_version": "", "policy_override": "auto",
+            "events": {
+                "cheap_short_circuit": cheap_buckets,
+                "multi_model_consensus": {}, "judge_review": {},
+                "tool_evidence": {}, "operator_feedback": {},
+            },
+            "disagreement_samples": [],
+        }
+
+    fixture = {"version": 2, "models": {"m": {
+        # regresses recently → flips OUT of short-circuit under decay
+        "x:y": _cell({cur: {"correct": 0, "incorrect": 15},
+                      stale: {"correct": 2000, "incorrect": 0}}, cur),
+        # consistently good recently → stays trusted (≥73 clean obs needed for
+        # Wilson UB ≤ ceiling with zero failures)
+        "x:z": _cell({cur: {"correct": 100, "incorrect": 0}}, cur),
+    }}}
+    path = tmp_path / "sc.json"
+    path.write_text(json.dumps(fixture), encoding="utf-8")
+
+    out = ModelScorecard(path).measure_freshness_impact(30)
+    assert out["cells"] == 2
+    assert out["short_circuit_baseline"] == 2     # both trusted unweighted
+    assert out["short_circuit_weighted"] == 1     # only the stable one survives
+    assert out["flipped_out"] == 1
+    assert out["flipped_out_to_fall_through"] == 1
+    assert out["flipped_in"] == 0
+
+
+def test_register_uses_records_calls_without_touching_verdict(tmp_path):
+    """Usage registration is a volume/presence signal: it bumps `calls` +
+    last_seen and makes a used-but-unscored model APPEAR, without creating
+    reliability outcomes (verdict stays LEARNING)."""
+    sc = ModelScorecard(tmp_path / "sc.json")
+    sc.register_uses([
+        {"model": "haiku", "decision_class": "_usage", "calls": 3,
+         "model_version": "haiku-20251001"},
+        {"model": "haiku", "decision_class": "_usage", "calls": 2},
+    ])
+    stats = {(s.model, s.decision_class): s for s in sc.get_stats()}
+    assert ("haiku", "_usage") in stats           # the model now appears
+    cell = stats[("haiku", "_usage")]
+    assert cell.calls == 5                         # 3 + 2 accumulated
+    assert cell.model_version == "haiku-20251001"
+    # No reliability outcomes recorded → verdict is LEARNING, routing unaffected.
+    assert sc.should_short_circuit("_usage", "haiku") == Policy.LEARNING
+    assert cell.events[EventType.CHEAP_SHORT_CIRCUIT].total() == 0
+
+
+def test_register_uses_aggregates_cost_and_tokens(tmp_path):
+    """Lifecycle enrichment: register_uses sums cost / tokens / latency_sum and
+    takes the MAX of latency_max — the 'did I get value for money' axis."""
+    sc = ModelScorecard(tmp_path / "sc.json")
+    sc.register_uses([{
+        "model": "haiku", "decision_class": "_usage",
+        "calls": 3, "cost_usd": 0.05, "tokens": 1200,
+        "input_tokens": 1000, "output_tokens": 200,
+        "latency_ms_sum": 4500, "latency_ms_max": 1800,
+    }])
+    sc.register_uses([{
+        "model": "haiku", "decision_class": "_usage",
+        "calls": 2, "cost_usd": 0.02, "tokens": 400,
+        "input_tokens": 350, "output_tokens": 50,
+        "latency_ms_sum": 2200, "latency_ms_max": 1300,
+    }])
+    cell = {(s.model, s.decision_class): s for s in sc.get_stats()}[("haiku", "_usage")]
+    assert cell.calls == 5
+    assert abs(cell.cost_usd - 0.07) < 1e-9
+    assert cell.tokens == 1600
+    assert cell.input_tokens == 1350
+    assert cell.output_tokens == 250
+    assert cell.latency_ms_sum == 6700
+    assert cell.latency_ms_max == 1800           # max, not sum
+
+
+def test_register_uses_records_schema_valid_events(tmp_path):
+    """Lifecycle batched-write for schema validity: register_uses with
+    schema_valid_pass / schema_valid_fail bumps the SCHEMA_VALID event slot
+    in the current-month bucket — the universal "does this model follow the
+    schema" axis fed by every generate_structured call."""
+    sc = ModelScorecard(tmp_path / "sc.json")
+    sc.register_uses([{
+        "model": "haiku", "decision_class": "_structured",
+        "calls": 5, "schema_valid_pass": 4, "schema_valid_fail": 1,
+    }])
+    cell = sc.get_stat("_structured", "haiku")
+    assert cell is not None
+    ev = cell.events[EventType.SCHEMA_VALID]
+    assert (ev.correct, ev.incorrect) == (4, 1)
+    assert cell.calls == 5
 
 
 def test_model_first_layout(tmp_path):
@@ -852,3 +1082,33 @@ class TestAutoGc:
             assert data.get("last_gc_at"), (
                 "last_gc_at must be stamped after first auto-GC pass"
             )
+
+
+def test_safe_coercion_tolerates_wrong_type_scalar_cell_fields(tmp_path):
+    """Adversarial: hand-edited cells with wrong-type scalar fields
+    (e.g. ``"calls": "abc"``, ``"cost_usd": None``) must NOT abort the
+    read/write — `_safe_int`/`_safe_float` coerce to 0 instead. Subsequent
+    `register_uses` then bumps from the coerced default."""
+    path = tmp_path / "sc.json"
+    path.write_text(json.dumps({"version": 2, "models": {"m": {"x:y": {
+        "first_seen_at": "2026-05-01T00:00:00+00:00",
+        "last_seen_at": "2026-05-01T00:00:00+00:00",
+        "model_version": "", "policy_override": "auto",
+        "events": {et: {} for et in ALL_EVENT_TYPES},
+        "disagreement_samples": [],
+        # garbage scalar fields:
+        "calls": "abc",
+        "cost_usd": None,
+        "tokens": "garbage",
+        "latency_ms_sum": [1, 2, 3],
+    }}}}))
+    sc = ModelScorecard(path)
+    stats = {(s.model, s.decision_class): s for s in sc.get_stats()}
+    cell = stats[("m", "x:y")]
+    assert cell.calls == 0 and cell.cost_usd == 0.0 and cell.tokens == 0
+    assert cell.latency_ms_sum == 0
+    # And a register_uses bumps cleanly from the defaults
+    sc.register_uses([{"model": "m", "decision_class": "x:y",
+                       "calls": 2, "cost_usd": 0.5}])
+    after = sc.get_stat("x:y", "m")
+    assert after.calls == 2 and abs(after.cost_usd - 0.5) < 1e-9

--- a/core/llm/scorecard/tests/test_tool_evidence.py
+++ b/core/llm/scorecard/tests/test_tool_evidence.py
@@ -19,6 +19,7 @@ import pytest
 from core.llm.scorecard import cli as cli_mod
 from core.llm.scorecard.scorecard import EventType, ModelScorecard
 from core.llm.scorecard.tool_evidence import (
+    auto_back_prop_from_validate_run,
     record_tool_evidence_outcome,
     record_tool_evidence_outcomes,
 )
@@ -355,3 +356,108 @@ class TestCLIToolEvidence:
             EventType.CHEAP_SHORT_CIRCUIT
         ]
         assert (before.correct, before.incorrect) == (after.correct, after.incorrect)
+
+
+# ---------------------------------------------------------------------------
+# Auto back-prop from /validate run-end
+# ---------------------------------------------------------------------------
+
+
+class TestAutoBackPropFromValidateRun:
+    """`/validate` writes its report and then auto-feeds the scorecard: a
+    co-located orchestrated_report.json + findings.json get joined by
+    finding_id and one TOOL_EVIDENCE event lands per concluded verdict."""
+
+    def _write_run(self, run: Path, analysis_records, validation_findings):
+        run.mkdir(parents=True, exist_ok=True)
+        (run / "orchestrated_report.json").write_text(
+            json.dumps({"results": analysis_records}), encoding="utf-8")
+        (run / "findings.json").write_text(
+            json.dumps({"findings": validation_findings}), encoding="utf-8")
+
+    def test_join_emits_one_event_per_concluded_finding(self, tmp_path, scorecard):
+        run = tmp_path / "validate-run"
+        self._write_run(
+            run,
+            analysis_records=[
+                {"finding_id": "f-1", "rule_id": "py/sqli",
+                 "analysed_by": "claude-opus", "is_exploitable": True},
+                {"finding_id": "f-2", "rule_id": "py/xss",
+                 "analysed_by": "haiku", "is_exploitable": True},
+            ],
+            validation_findings=[
+                {"finding_id": "f-1", "is_exploitable": True},   # agree
+                {"finding_id": "f-2", "is_exploitable": False},  # disagree
+            ],
+        )
+        n = auto_back_prop_from_validate_run(run, scorecard=scorecard)
+        assert n == 2
+        # f-1: agree -> correct on the opus cell
+        opus = _stat(scorecard, "agentic:py/sqli", "claude-opus")
+        assert opus == (1, 0)
+        # f-2: disagree -> incorrect on the haiku cell
+        haiku = _stat(scorecard, "agentic:py/xss", "haiku")
+        assert haiku == (0, 1)
+
+    def test_inconclusive_skipped(self, tmp_path, scorecard):
+        run = tmp_path / "v"
+        self._write_run(
+            run,
+            analysis_records=[{"finding_id": "f", "rule_id": "r",
+                               "analysed_by": "m", "is_exploitable": True}],
+            validation_findings=[{"finding_id": "f", "is_exploitable": None}],
+        )
+        assert auto_back_prop_from_validate_run(run, scorecard=scorecard) == 0
+
+    def test_missing_files_returns_zero(self, tmp_path, scorecard):
+        """No orchestrated_report.json (standalone /validate) → silent 0."""
+        run = tmp_path / "empty"
+        run.mkdir()
+        (run / "findings.json").write_text("{}")
+        assert auto_back_prop_from_validate_run(run, scorecard=scorecard) == 0
+
+    def test_no_attributable_model_skipped(self, tmp_path, scorecard):
+        run = tmp_path / "v"
+        self._write_run(
+            run,
+            analysis_records=[{"finding_id": "f", "rule_id": "r",
+                               "is_exploitable": True}],   # no analysed_by
+            validation_findings=[{"finding_id": "f", "is_exploitable": True}],
+        )
+        assert auto_back_prop_from_validate_run(run, scorecard=scorecard) == 0
+
+    def test_top_level_non_dict_does_not_crash(self, tmp_path, scorecard):
+        """List / scalar JSON in either report → 0 (no AttributeError on
+        `.get`). Adversarial: hand-edits or upstream corruption mustn't crash."""
+        run = tmp_path / "v"
+        run.mkdir()
+        (run / "orchestrated_report.json").write_text("[]")        # list
+        (run / "findings.json").write_text('{"findings": []}')
+        assert auto_back_prop_from_validate_run(run, scorecard=scorecard) == 0
+        (run / "orchestrated_report.json").write_text("42")        # scalar
+        assert auto_back_prop_from_validate_run(run, scorecard=scorecard) == 0
+
+    def test_rejects_non_str_analysed_by(self, tmp_path, scorecard):
+        """`analysed_by` must be a non-empty string — a list/dict would
+        stringify to nonsense and silently mangle attribution."""
+        run = tmp_path / "v"
+        self._write_run(
+            run,
+            analysis_records=[{"finding_id": "f", "rule_id": "r",
+                               "analysed_by": ["a", "b"],          # bad shape
+                               "is_exploitable": True}],
+            validation_findings=[{"finding_id": "f", "is_exploitable": True}],
+        )
+        assert auto_back_prop_from_validate_run(run, scorecard=scorecard) == 0
+
+    def test_rejects_non_bool_is_exploitable(self, tmp_path, scorecard):
+        """A stringy verdict ('yes') shouldn't be silently truthy-coerced —
+        JSON spec says bool; anything else is a corrupt upstream record."""
+        run = tmp_path / "v"
+        self._write_run(
+            run,
+            analysis_records=[{"finding_id": "f", "rule_id": "r",
+                               "analysed_by": "m", "is_exploitable": True}],
+            validation_findings=[{"finding_id": "f", "is_exploitable": "yes"}],
+        )
+        assert auto_back_prop_from_validate_run(run, scorecard=scorecard) == 0

--- a/core/llm/scorecard/tool_evidence.py
+++ b/core/llm/scorecard/tool_evidence.py
@@ -29,7 +29,9 @@ auto-policy gate (Wilson over ``CHEAP_SHORT_CIRCUIT``) is unaffected.
 
 from __future__ import annotations
 
+import json
 import logging
+from pathlib import Path
 from typing import Any, Dict, Iterable, Optional
 
 from . import _MAX_REASONING_CHARS
@@ -188,4 +190,113 @@ def record_tool_evidence_outcomes(
 __all__ = [
     "record_tool_evidence_outcome",
     "record_tool_evidence_outcomes",
+    "auto_back_prop_from_validate_run",
 ]
+
+
+# -----------------------------------------------------------------------------
+# Auto back-prop from /validate run-end (no operator action required)
+# -----------------------------------------------------------------------------
+
+
+def auto_back_prop_from_validate_run(
+    validate_output_dir: Any,
+    *,
+    scorecard: Optional[ModelScorecard] = None,
+    decision_class_prefix: str = "agentic",
+) -> int:
+    """Auto-record ``TOOL_EVIDENCE`` outcomes from a completed ``/validate``
+    run by joining a co-located ``orchestrated_report.json`` (the upstream
+    ``/agentic`` analysis) with the run's ``findings.json`` (carrying the
+    validator's ``is_exploitable`` verdicts) on ``finding_id``.
+
+    Best-effort: missing files / no concluded verdicts / no scorecard path →
+    returns 0 without raising. Intended to be called from
+    ``write_validation_report`` so every ``/validate`` run feeds the scorecard
+    with downstream-truth signal — the biggest unwired reliability source
+    today. Mirrors the join logic of the operator-driven ``tool-evidence``
+    CLI subcommand."""
+    out = Path(validate_output_dir)
+    orch_path = out / "orchestrated_report.json"
+    findings_path = out / "findings.json"
+    if not orch_path.exists() or not findings_path.exists():
+        return 0
+    try:
+        analysis = json.loads(orch_path.read_text(encoding="utf-8"))
+        validation = json.loads(findings_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError) as e:
+        logger.debug("auto_back_prop: cannot read reports under %s: %s", out, e)
+        return 0
+    # Top-level shape guard — a hand-edited or upstream-corrupted list/scalar
+    # would AttributeError on `.get(...)` later.
+    if not isinstance(analysis, dict) or not isinstance(validation, dict):
+        logger.debug(
+            "auto_back_prop: non-dict top-level in reports under %s "
+            "(analysis=%s validation=%s)",
+            out, type(analysis).__name__, type(validation).__name__,
+        )
+        return 0
+
+    # Build {finding_id: validation_verdict_bool}; inconclusive → skip.
+    val_by_id: Dict[str, bool] = {}
+    for vf in (validation.get("findings") or validation.get("results") or []):
+        if not isinstance(vf, dict):
+            continue
+        fid = vf.get("finding_id")
+        verdict = vf.get("is_exploitable")
+        # Tighten: a finding_id must be a non-empty str/int (a list/dict in
+        # that slot would stringify to nonsense and miscount silently).
+        if not isinstance(fid, (str, int)) or fid == "":
+            continue
+        # Tighten: is_exploitable must be a real bool — JSON spec says bool;
+        # a stringy "true"/"false" or "yes" shouldn't be quietly coerced.
+        if not isinstance(verdict, bool):
+            continue
+        val_by_id[str(fid)] = verdict
+    if not val_by_id:
+        return 0
+
+    # Walk analysis records and emit one tool-evidence dict per finding the
+    # validator concluded on. Skip records missing an attributable model
+    # (same rationale as ``cmd_tool_evidence``).
+    records = []
+    for r in (analysis.get("results") or []):
+        if not isinstance(r, dict):
+            continue
+        fid = r.get("finding_id")
+        model = r.get("analysed_by")
+        if not isinstance(fid, (str, int)) or str(fid) not in val_by_id:
+            continue
+        # Tighten: analysed_by must be a str (a list / dict / int would land
+        # under a stringified key and silently mangle attribution).
+        if not isinstance(model, str) or not model:
+            continue
+        analysis_verdict = r.get("is_exploitable", False)
+        if not isinstance(analysis_verdict, bool):
+            continue
+        records.append({
+            "model": model,
+            "rule_id": r.get("rule_id") or "unknown",
+            "analysis_verdict": analysis_verdict,
+            "validation_verdict": val_by_id[str(fid)],
+            "finding_id": fid,
+            "analysis_reasoning": r.get("reasoning") or "",
+        })
+    if not records:
+        return 0
+
+    if scorecard is None:
+        # Resolve the scorecard path via RAPTOR_DIR so /validate run from
+        # any cwd writes to the same sidecar the rest of RAPTOR uses,
+        # not a stray ./out/llm_scorecard.json next to the target repo.
+        import os
+        raptor_dir = os.environ.get("RAPTOR_DIR")
+        if raptor_dir:
+            default_path = Path(raptor_dir) / "out" / "llm_scorecard.json"
+        else:
+            default_path = Path("out/llm_scorecard.json")
+        scorecard = ModelScorecard(default_path)
+    return record_tool_evidence_outcomes(
+        scorecard, records=records,
+        decision_class_prefix=decision_class_prefix,
+    )

--- a/packages/exploitability_validation/report.py
+++ b/packages/exploitability_validation/report.py
@@ -280,6 +280,31 @@ def write_validation_report(output_dir: str, target: Optional[str] = None) -> Pa
     summary = generate_summary(output_dir)
     _atomic_write_text(out / "summary.txt", summary + "\n")
 
+    # Auto back-prop /validate verdicts onto the scorecard's TOOL_EVIDENCE
+    # event slot — the biggest unwired reliability signal. Joins a co-located
+    # orchestrated_report.json with this run's findings.json by finding_id.
+    # Best-effort: missing inputs or any error → silent no-op, never breaks
+    # /validate. Surfaces a one-line scorecard delta when records land, so
+    # operators see /validate feeding the scorecard at run-end.
+    try:
+        from core.llm.scorecard.tool_evidence import auto_back_prop_from_validate_run
+        n = auto_back_prop_from_validate_run(out)
+        if n:
+            import sys as _sys
+            print(
+                f"scorecard: recorded {n} tool_evidence outcome(s) from "
+                f"/validate — `raptor-llm-scorecard list "
+                f"--event-type tool_evidence`",
+                file=_sys.stderr,
+            )
+    except Exception as e:  # noqa: BLE001 — never break /validate, but log
+        # at debug so substrate rot (ImportError, signature drift, permissions)
+        # surfaces under `--verbose` instead of silently decaying for months.
+        import logging as _logging
+        _logging.getLogger(__name__).debug(
+            "scorecard back-prop skipped: %s: %s", type(e).__name__, e,
+        )
+
     return report_path
 
 


### PR DESCRIPTION
Substrate for an ops-grade scorecard, building on the per-cell reliability counts already in place.

- Freshness weighting: configurable half-life decays old observations so a regression two weeks ago isn't diluted by a year of clean history. v1 (flat) → v2 (age-bucketed) migrates on first write.
- Usage / cost / token / latency accumulators flushed atexit (and mid-run via snapshot-and-clear) into `_usage` + `_structured` cells, attributed per model.
- schema_valid event type: structured-call hits/misses per model; failure attribution gated on non-retryable, non-quota errors so infra flakes don't pollute the reliability signal.
- /validate auto-wires tool_evidence back at report time with defensive isinstance gates (RAPTOR_DIR-relative path).
- CLI: new `summary` dashboard, new `recommend` (cheapest trusted), `compare` extended with $$ and calls per side, `list` marks freshness drift, `--json` on every read command, `--freshness` flag exposed.

200 scorecard tests + 1028 broader pass; ruff clean; E2E (scorecard_e2e.py, 20 checks) covers mid-run flush and v1→v2 migration through real writes.