### PR TITLE
 fix(llm): pinned model bypasses auto-resolution + accurate banner

### DIFF
--- a/core/llm/client.py
+++ b/core/llm/client.py
@@ -292,11 +292,73 @@ def _ollama_check_url() -> str:
     return f"{base}/api/tags"
 
 
+def _pinned_llm_config(model_name: str) -> 'LLMConfig':
+    """Build a minimal :class:`LLMConfig` for a caller-pinned model.
+
+    Bypasses the auto-resolution path entirely — no thinking-model
+    scoring, no fallback chain.  Calls the inferred provider's builder
+    directly via ``_PROVIDER_BUILDERS``, so the resolver's lenient
+    "fall through to whatever provider IS configured" behaviour can't
+    substitute a different provider for the one the caller pinned.
+
+    Provider inference: explicit ``provider/model`` syntax beats inference;
+    otherwise infer from the model-name prefix (``claude*`` -> anthropic,
+    ``gpt*`` -> openai, anything containing ``gemini`` -> gemini; default
+    anthropic).  When the inferred provider has no credentials configured,
+    returns a bare uncredentialed ``ModelConfig`` — callers that
+    authenticate by other means (e.g. Bedrock with AWS env credentials)
+    can still construct a working request; pure-key-auth callers will
+    hit the same auth error they would have at call time anyway.
+    """
+    from dataclasses import replace
+    from core.llm.config import ModelConfig, _PROVIDER_BUILDERS
+
+    if "/" in model_name:
+        provider, model_name = model_name.split("/", 1)
+    elif model_name.startswith("claude"):
+        provider = "anthropic"
+    elif "gemini" in model_name:
+        provider = "gemini"
+    elif model_name.startswith("gpt"):
+        provider = "openai"
+    else:
+        provider = "anthropic"
+
+    builder = _PROVIDER_BUILDERS.get(provider)
+    base = builder() if builder is not None else None
+    if base is None:
+        primary = ModelConfig(provider=provider, model_name=model_name, role="code")
+    else:
+        primary = replace(base, model_name=model_name, role="code")
+    return LLMConfig(primary_model=primary, fallback_models=[])
+
+
 class LLMClient:
     """Unified LLM client with multi-provider support and fallback."""
 
-    def __init__(self, config: Optional[LLMConfig] = None):
-        self.config = config or LLMConfig()
+    def __init__(self, config: Optional[LLMConfig] = None,
+                 *, pinned_model: Optional[str] = None):
+        """Construct the LLM client.
+
+        When ``pinned_model`` is set the caller commits to overriding the
+        model on every call.  We then BUILD a minimal :class:`LLMConfig`
+        targeted at the inferred provider — short-circuiting Step 1 of
+        ``_get_default_primary_model`` (env-var probe for that provider)
+        and skipping the thinking-model scoring path AND the fallback
+        chain entirely.  The previous behaviour resolved both, then
+        ignored them and logged a misleading "Primary model:
+        gemini-2.5-pro" banner; this skips the resolution at the source.
+
+        ``config`` takes precedence over ``pinned_model`` when both are
+        passed (caller knows what they want).
+        """
+        if config is not None:
+            self.config = config
+        elif pinned_model is not None:
+            self.config = _pinned_llm_config(pinned_model)
+        else:
+            self.config = LLMConfig()
+        self._pinned_model = pinned_model
         self.providers: Dict[str, LLMProvider] = {}
         self.total_cost = 0.0
         self.request_count = 0
@@ -380,12 +442,22 @@ class LLMClient:
         self._cache_write_failures = 0
 
         logger.info("LLM Client initialized")
-        if self.config.primary_model:
+        if self._pinned_model:
+            # Caller has signalled it will override the model on every call.
+            # Suppress the misleading "Primary: <auto-selected>" and
+            # "Fallback models: N" lines — those reflect the operator's
+            # default config, but none of them will actually fire in this
+            # run.  Log what WILL fire instead.
+            logger.info(
+                f"Pinned model: {self._pinned_model} "
+                f"(caller override; RAPTOR config defaults bypassed)"
+            )
+        elif self.config.primary_model:
             logger.info(f"Primary model: {self.config.primary_model.provider}/{self.config.primary_model.model_name}")
+            if self.config.enable_fallback:
+                logger.info(f"Fallback models: {len(self.config.fallback_models)}")
         else:
             logger.warning("LLM Client initialized with no primary model — all calls will fail")
-        if self.config.enable_fallback:
-            logger.info(f"Fallback models: {len(self.config.fallback_models)}")
 
         # Warn if using Ollama for exploit generation
         if self.config.primary_model and self.config.primary_model.provider.lower() == "ollama":

--- a/core/llm/tests/test_pinned_model.py
+++ b/core/llm/tests/test_pinned_model.py
@@ -1,0 +1,120 @@
+"""Tests for ``LLMClient(pinned_model=…)`` — caller-pinned model mode.
+
+When a caller signals it will override the model on every ``generate()``
+call (via ``model_config=``), the previous code path resolved + advertised
+the operator's default ``primary_model`` anyway.  The log read
+``Primary model: gemini-2.5-pro`` even when every call would actually hit
+Anthropic, plus the upstream thinking-model auto-resolution path fired
+its own misleading ``Auto-selected thinking model: gemini…`` line.
+
+Pinned mode short-circuits both: ``_pinned_llm_config`` calls the inferred
+provider's builder directly (so the resolver's lenient fall-through to
+"whatever provider IS configured" can't substitute a different provider
+for the pinned one), the fallback chain is empty, and the banner reflects
+what's actually going to fire.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from core.llm.client import LLMClient, _pinned_llm_config
+
+
+class _RaptorLogCapture:
+    """Capture records sent to the ``raptor`` logger.
+
+    RAPTOR's :class:`RaptorLogger` sets ``propagate=False`` on the
+    ``raptor`` logger, so pytest's ``caplog`` (which hooks the root
+    logger) never sees these records — attaching a handler directly
+    is the workaround used throughout ``core/llm/tests/``.
+    """
+
+    def __enter__(self):
+        self.records: list = []
+        self._h = logging.Handler()
+        self._h.handle = lambda r: (self.records.append(r), True)[1]
+        self._lg = logging.getLogger("raptor")
+        self._lg.addHandler(self._h)
+        return self
+
+    def __exit__(self, *exc):
+        self._lg.removeHandler(self._h)
+        return False
+
+    def messages(self) -> list:
+        return [r.getMessage() for r in self.records]
+
+
+def test_pinned_llm_config_anthropic_inference_from_claude_prefix(monkeypatch):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-fake-key")
+    cfg = _pinned_llm_config("claude-opus-4-8")
+    assert cfg.primary_model.provider == "anthropic"
+    assert cfg.primary_model.model_name == "claude-opus-4-8"
+    assert cfg.primary_model.role == "code"
+    assert cfg.fallback_models == []
+
+
+def test_pinned_llm_config_explicit_provider_slash_model(monkeypatch):
+    """``provider/model`` syntax strips the prefix and is authoritative."""
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-fake-key")
+    cfg = _pinned_llm_config("anthropic/claude-sonnet-4-6")
+    assert cfg.primary_model.provider == "anthropic"
+    assert cfg.primary_model.model_name == "claude-sonnet-4-6"
+
+
+def test_pinned_llm_config_inference_table(monkeypatch):
+    """Bare-name inference: claude*→anthropic, gpt*→openai, *gemini*→gemini,
+    everything else→anthropic (conservative default)."""
+    # Make every provider's env-key probe succeed so the builder doesn't
+    # influence the resolved provider.
+    for v in ("ANTHROPIC_API_KEY", "OPENAI_API_KEY", "GEMINI_API_KEY"):
+        monkeypatch.setenv(v, "test-fake-key")
+    cases = [
+        ("claude-opus-4-8",        "anthropic"),
+        ("claude-haiku-4-5",       "anthropic"),
+        ("gpt-4o-mini",            "openai"),
+        ("gemini-2.5-pro",         "gemini"),
+        ("anthropic/claude-opus",  "anthropic"),
+        ("openai/gpt-5",           "openai"),
+    ]
+    for name, expected in cases:
+        cfg = _pinned_llm_config(name)
+        assert cfg.primary_model.provider == expected, name
+
+
+def test_pinned_llm_config_no_credentials_returns_bare_config():
+    """When the inferred provider has no env credentials, returns a bare
+    uncredentialed ModelConfig with the pinned name (does NOT fall through
+    to a different provider — that lenient behaviour is what caused the
+    misleading gemini banner the fix is removing)."""
+    cfg = _pinned_llm_config("anthropic/claude-opus-4-8")  # explicit pin, no key
+    assert cfg.primary_model.provider == "anthropic"
+    assert cfg.primary_model.model_name == "claude-opus-4-8"
+    assert cfg.fallback_models == []
+
+
+def test_llmclient_pinned_banner_suppresses_default_primary(monkeypatch):
+    """With ``pinned_model``, banner reports the pin instead of the
+    operator's auto-resolved primary, and skips the misleading "Primary
+    model:" / "Fallback models:" lines."""
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-fake-key")
+    with _RaptorLogCapture() as cap:
+        LLMClient(pinned_model="claude-opus-4-8")
+    msgs = cap.messages()
+    assert any("Pinned model: claude-opus-4-8" in m for m in msgs), msgs
+    # The two lines that the fix is removing for pinned mode:
+    assert not any(m.startswith("Primary model:") for m in msgs), msgs
+    assert not any(m.startswith("Fallback models:") for m in msgs), msgs
+
+
+def test_llmclient_default_banner_unchanged(monkeypatch):
+    """Without ``pinned_model``, banner behaviour is unchanged — the fix is
+    additive (no regression for callers that don't opt in)."""
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-fake-key")
+    with _RaptorLogCapture() as cap:
+        LLMClient()
+    msgs = cap.messages()
+    # At least one of these fires in default mode (the existing banner).
+    assert (any(m.startswith("Primary model:") for m in msgs)
+            or any("no primary model" in m for m in msgs)), msgs


### PR DESCRIPTION
 LLMClient(pinned_model=X) callers override the model on every
 generate() call via model_config=, but the previous code still
 resolved the operator's default chain and logged its auto-selected
 primary + thinking model — e.g. "Primary model: gemini-2.5-pro" with
 an Anthropic pin in effect. A reader of the log naturally concluded
 RAPTOR was talking to gemini.

 Fix at the source, not the log: _pinned_llm_config(X) infers the
 provider from the model name, calls that provider's builder DIRECTLY
 (not the lenient resolver that falls through to other providers when
 credentials are missing — that fall-through caused the misleading
 banner), and returns a minimal LLMConfig with empty fallbacks.
 _get_best_thinking_model is never entered, so its log lines never
 fire. Banner reads "Pinned model: X (caller override; RAPTOR config
 defaults bypassed)" instead.

 Default-mode behaviour unchanged (additive fix). 6 new tests cover
 provider inference, strict-provider semantics, empty fallback chain,
 banner content for both modes. 542 LLM tests pass; ruff clean.