### PR TITLE
chore(sage): bump SAGE sidecar/SDK 6.6.5 -> 8.4.2 + fix 8.4.x integration drift

### DIFF
--- a/core/sage/client.py
+++ b/core/sage/client.py
@@ -198,12 +198,28 @@ class SageClient:
             # Dict-keyed by the canonical lower-case name so a typo
             # surfaces as an explicit "unknown memory_type ..." log
             # and the call falls back deliberately, not by accident.
+            #
+            # SAGE 8.4.2 MemoryType enum = {fact, observation,
+            # inference, task} (docs/reference/python-sdk.md). The
+            # 6.6.x extras RAPTOR used to reference (hypothesis,
+            # evidence, decision, lesson) no longer exist on the
+            # enum. We keep accepting those legacy names as inputs
+            # and fold them onto the nearest surviving member so any
+            # caller still passing them degrades sensibly instead of
+            # silently collapsing to "observation":
+            #   hypothesis -> inference (a drawn conclusion)
+            #   evidence/decision/lesson -> observation (recorded fact
+            #     about what happened)
             allowed = {
+                "fact": _MemoryType.fact,
                 "observation": _MemoryType.observation,
-                "hypothesis": getattr(_MemoryType, "hypothesis", None),
-                "evidence": getattr(_MemoryType, "evidence", None),
-                "decision": getattr(_MemoryType, "decision", None),
-                "lesson": getattr(_MemoryType, "lesson", None),
+                "inference": _MemoryType.inference,
+                "task": _MemoryType.task,
+                # Legacy 6.6.x aliases, mapped onto the 8.4.2 enum.
+                "hypothesis": _MemoryType.inference,
+                "evidence": _MemoryType.observation,
+                "decision": _MemoryType.observation,
+                "lesson": _MemoryType.observation,
             }
             mt = allowed.get(memory_type)
             if mt is None:

--- a/core/sage/docker-compose.yml
+++ b/core/sage/docker-compose.yml
@@ -40,7 +40,7 @@ services:
       - OLLAMA_HOST=http://ollama:11434
 
   sage:
-    image: ghcr.io/l33tdawg/sage:6.6.5
+    image: ghcr.io/l33tdawg/sage:8.4.2
     ports:
       - "8090:8080"
     volumes:

--- a/core/sage/scripts/_common.py
+++ b/core/sage/scripts/_common.py
@@ -6,8 +6,11 @@ a SAGE volume reset, or when the setup script is re-invoked) creates
 duplicates in the SAGE consensus store.
 
 `async_memory_exists` lets callers skip the propose step for items
-already stored, keyed by a stable per-memory tag that SAGE's 6.6.0
-tags-as-first-class feature makes queryable.
+already stored, keyed by a stable per-memory tag that SAGE's
+tags-as-first-class feature makes queryable. (Introduced in SAGE
+6.6.0; still present in 8.4.2 — `list_memories(domain, tag, limit=1)`
+remains the supported exact-filter lookup, verified against
+docs/reference/python-sdk.md.)
 
 Caveat: SAGE stores tags as **node-local metadata** (not part of the
 on-chain consensus tx). On a single-node deployment — which is what

--- a/core/sage/scripts/register_agents.py
+++ b/core/sage/scripts/register_agents.py
@@ -392,6 +392,8 @@ async def register_agents(sage_url: str, dry_run: bool = False, force: bool = Fa
         # AgentRegistration.on_chain_height (int64) was renamed from
         # `registered_at` in SAGE 6.6.0 to fix a 3-way type mismatch
         # (Go int64 vs OpenAPI date-time string vs SDK `str | None`).
+        # Still the field name as of SAGE 8.4.2 (AgentRegistration
+        # exposes on_chain_height — docs/reference/python-sdk.md).
         # Surface it so a grep for "raptor-registrar" in debug logs
         # confirms the registration actually landed on-chain.
         reg = await client.register_agent("raptor-registrar")

--- a/core/sage/scripts/seed_sage_knowledge.py
+++ b/core/sage/scripts/seed_sage_knowledge.py
@@ -429,7 +429,8 @@ async def seed(sage_url: str, dry_run: bool = False, force: bool = False):
     # Register as raptor-seed agent
     try:
         # See register_agents.py for on_chain_height rationale — same
-        # SAGE 6.6.0 type-mismatch fix.
+        # SAGE 6.6.0 type-mismatch fix; on_chain_height still present
+        # on AgentRegistration as of SAGE 8.4.2.
         reg = await client.register_agent("raptor-seed")
         height = getattr(reg, "on_chain_height", None)
         print(f"Registered as raptor-seed (on-chain height {height})")

--- a/core/sage/tests/test_sage_client.py
+++ b/core/sage/tests/test_sage_client.py
@@ -93,8 +93,15 @@ def _install_mock_sdk(client_mod):
     client_mod._SAGE_SDK_AVAILABLE = True
     client_mod._SyncSageClient = mock_cls
     client_mod._AgentIdentity = mock_identity_cls
+    # Mirror the SAGE 8.4.2 MemoryType enum: fact | observation |
+    # inference | task (docs/reference/python-sdk.md). client.propose's
+    # allowlist references all four members directly, so the mock must
+    # expose them all or the allowlist build raises AttributeError.
     client_mod._MemoryType = SimpleNamespace(
-        observation="observation", fact="fact", inference="inference"
+        observation="observation",
+        fact="fact",
+        inference="inference",
+        task="task",
     )
     return mock_cls, mock_instance
 

--- a/libexec/raptor-sage-setup
+++ b/libexec/raptor-sage-setup
@@ -254,10 +254,13 @@ wait_health() {
         # then failed in confusing ways (404 from the wrong
         # backend, JSON parse error on HTML response).
         # SAGE's /health endpoint returns a JSON `{"status":
-        # "ok", ...}` body; confirm the "ok" sentinel is
-        # present before trusting the response.
+        # "healthy", "version": ...}` body (SAGE 8.4.x; earlier
+        # 6.6.x returned `{"status": "ok", ...}`). Match on the
+        # `"status"` key — present in every SAGE version's health
+        # body and absent from the proxy/ingress default-backend
+        # responses we are guarding against — before trusting it.
         if response=$(curl -sf "$SAGE_URL/health" 2>/dev/null); then
-            if printf '%s' "$response" | grep -q '"ok"'; then
+            if printf '%s' "$response" | grep -q '"status"'; then
                 printf " — ready.\n"
                 return 0
             fi

--- a/requirements.txt
+++ b/requirements.txt
@@ -71,7 +71,7 @@ packaging==25.0
 # https://ollama.ai
 
 # SAGE persistent memory (consensus-validated knowledge)
-# pip install sage-agent-sdk==6.6.5 httpx==0.28.1
+# pip install sage-agent-sdk==8.4.2 httpx==0.28.1
 
 # SCA hard deps (defusedxml, packaging, pyyaml) are pinned above. The
 # only remaining optional one:


### PR DESCRIPTION
## What & why

RAPTOR's optional SAGE cross-repo recall layer was pinned to SAGE **6.6.5** — roughly **12 minor versions** behind SAGE's current `8.4.2`. This PR tracks the sidecar/SDK up to 8.4.2 and fixes the API drift that accumulated across that jump.

SAGE here is an **optional, additive** cross-repo recall layer on top of RAPTOR's local `FuzzingMemory`, not a replacement. None of these changes make RAPTOR hard-depend on a running SAGE node: `core/sage/memory.py` still keeps the JSON file as the local cache and fallback, every SAGE call stays wrapped in try/except, and with no SDK / no node the layer degrades to a no-op and the fuzzer runs exactly as before. The diff touches only the 8 files under the SAGE integration surface — **zero changes to RAPTOR's core orchestration or the local FuzzingMemory write path.**

## Two drift fixes that matter (the bump would be broken without them)

- **Health check would hang.** SAGE's `/health` body changed from `{"status":"ok",...}` (6.6.x) to `{"status":"healthy",...}` (8.4.x; `rest-api.md:1083`). `raptor-sage-setup`'s `wait_health()` grepped for `"ok"`, which an 8.4.2 node never emits — so setup would time out forever. Now greps `"status"` (present in every SAGE version's health body, absent from the proxy/ingress default-backend responses the trust-marker guards against, and consistent with `client.py`'s own check).
- **Latent `propose()` bug fixed.** 8.4.2's `MemoryType` enum narrowed to `{fact, observation, inference, task}` (`python-sdk.md:1051`). RAPTOR's `propose()` allowlist referenced 6.6 members that no longer exist (`hypothesis`/`evidence`/`decision`/`lesson`) **and was missing `fact` — which `hooks.py` actually passes**, so `fact` proposals were silently failing. Rebuilt the allowlist to the real 8.4.2 enum and kept the legacy names as accepted **input aliases** folded onto the nearest surviving member (`hypothesis → inference`; `evidence`/`decision`/`lesson → observation`).

## What RAPTOR gains from 6.6 → 8.4

- **Hybrid recall / RRF** — `POST /v1/memory/hybrid` fuses FTS5 keyword + vector cosine via Reciprocal Rank Fusion in one round-trip, with multi-variant query expansions. Much better "have we seen this crash/primitive before" cross-repo recall than the pure-vector path on 6.6.
- **First-class, queryable tags** — OR-semantics tag filtering, exactly what RAPTOR's domain+tag scoping and the dedup-on-reseed lookup (`async_memory_exists`) rely on. (Tags landed in 6.6.0; confirmed still present on 8.4.2.)
- **OAuth 2.0 + PKCE** — full DCR flow for MCP bearer tokens, if RAPTOR ever wires recall through the MCP connector path.
- **v8 Proof-of-Experience (PoE) consensus** — PoE-weighted quorum (app-v3/v8.2), real verdict-correctness accuracy + corroboration (app-v4/v8.3), real domain factor (app-v5/v8.4). Committed cross-repo memories carry more trustworthy confidence.

## Version pins changed

- `core/sage/docker-compose.yml`: sidecar image `ghcr.io/l33tdawg/sage` `6.6.5 → 8.4.2` (the only running-version reference).
- `requirements.txt`: commented SDK install hint `sage-agent-sdk 6.6.5 → 8.4.2` (`httpx==0.28.1` left as-is; the 8.4.2 SDK needs no newer httpx). Still a comment, not an active dependency — SAGE stays optional.

Doc/comment version annotations in `scripts/_common.py`, `register_agents.py`, `seed_sage_knowledge.py` were re-verified still accurate on 8.4.2 (tags-as-first-class; `AgentRegistration.on_chain_height`, `python-sdk.md:437`) and annotated rather than rewritten.

## Validation performed

**Mocked unit suite:** `pytest core/sage/tests/` — **67/67 pass** (1 unrelated upstream Pydantic deprecation warning). Re-confirmed 67/67 in an isolated venv carrying the real `sage-agent-sdk==8.4.2`.

**Live 8.4.2 node** (standalone `docker run ghcr.io/l33tdawg/sage:8.4.2`, fresh throwaway volume, driven by RAPTOR's own scripts + `SageClient`):
- `register_agents.py` → **16/16 agents stored, 0 failed**; registrar at `on_chain_height=70` (confirms the field is present + populated on 8.4.2).
- `seed_sage_knowledge.py` → **84/84 memories stored, 0 failed**; re-run idempotent (**0 stored / 84 skipped**), proving `async_memory_exists → list_memories(domain, tag, limit=1)` tag lookup works on 8.4.2.
- `SageClient.propose` smoke across all four 8.4.2 enum members + legacy aliases → all return `True` (incl. the now-fixed `fact`); `query` returns the proposed memories end-to-end.
- Resilience: with SAGE disabled **and** with the node unreachable, `is_available()→False`, `propose()→False`, `query()→[]`, no exceptions — local FuzzingMemory path intact.

Every drift claim was cross-checked against SAGE's code-verified `docs/reference/` (`rest-api.md:1083`, `python-sdk.md:1051/:437`).

### Recommended final smoke before merge

The live validation above used a standalone `docker run` of the 8.4.2 node image (the documented full-stack `docker compose -f core/sage/docker-compose.yml up` wasn't run end-to-end here — the test host's `:8090` was occupied and the compose `ollama:0.21.0` image wasn't cached; compose wiring was validated via `docker compose config`). Before merge, one full `raptor-sage-setup` run against the composed stack is worth doing to confirm the ollama-embedding path and port/volume wiring.

## Migration note

The 6.6 → 8.4 jump is a **sidecar chain rebuild** — the consensus/PoE state format moved across the version span, so an existing 6.6.x SAGE volume should be re-initialized rather than upgraded in place. Fine for RAPTOR: its SAGE store is an ephemeral, re-seedable cross-repo cache (authoritative fuzzing knowledge lives in the local `FuzzingMemory` JSON). Path: reset the SAGE volume, bring up the 8.4.2 sidecar, re-run `raptor-sage-setup` to re-seed. No RAPTOR-side data loss.
