### PR TITLE
feat(understand): mechanical shared_state site enrichment for --map

### DIFF
--- a/.claude/skills/code-understanding/map.md
+++ b/.claude/skills/code-understanding/map.md
@@ -248,12 +248,25 @@ the function *is*) alongside the LLM's narrative (what the function
 this without re-parsing source. Idempotent. Skip if
 `$WORKDIR/checklist.json` doesn't exist or doesn't carry `target_path`.
 
-**[MAP-5d] Enrich with ownership / privilege sites (C/C++)**
+**[MAP-5d] Enrich with ownership / privilege / shared-state sites (C/C++)**
 
 After normalisation, run the site enricher. Uses `source_intel` (cocci) to
-attach `ownership_model` (alloc / checked-alloc / paired-free / double-free
-sites) and `privilege_model` (capability-check / LSM-hook sites) sections,
-each entry carrying `kind`, `file`, `line`, and `function`.
+attach three Phase B sections, each entry carrying `kind`, `file`, `line`,
+and `function`:
+
+* `ownership_model` — alloc / checked-alloc / paired-free / double-free sites
+  (extras: `allocator`, `free_fn`, `role`)
+* `privilege_model` — capability-check / LSM-hook sites
+  (extras: `name`, `grade`)
+* `shared_state` — lock acquire/release sites covering kernel spinlock /
+  mutex / rwlock and POSIX `pthread_mutex` (kernel: variants `_irq`,
+  `_irqsave`, `_bh`, `_interruptible`, `_killable`, `_trylock`; rw: read /
+  write variants). Entry `kind` is the compound `<lock_kind>_<op>`
+  (e.g. `spin_acquire`, `mutex_release`); extras: `fn` (concrete function
+  matched, e.g. `spin_lock_irqsave`), `lock_var` (first-arg expression,
+  whitespace-normalised). Atomics, RCU, and C++ scope-based locks
+  (`std::lock_guard`) are intentionally out of scope here — each has
+  semantics worth its own evidence shape and is deferred.
 
 ```bash
 libexec/raptor-enrich-context-map-sites "$WORKDIR"
@@ -261,10 +274,13 @@ libexec/raptor-enrich-context-map-sites "$WORKDIR"
 
 These are the *mechanical* halves of those sections — deterministic call
 sites, no LLM. (Semantic analysis — refcount-protocol anomalies, ownership
-transfers, privilege bypass paths — is the LLM's job when you populate the
-narrative.) Skip-silent: no-ops on non-C/C++ targets or when `spatch` isn't
-on PATH, so it only adds a cocci pass where it has something to find.
-Idempotent. Skip if `$WORKDIR/checklist.json` lacks `target_path`.
+transfers, privilege bypass paths, lock imbalance — is the LLM's job when
+you populate the narrative. Lock *imbalance* specifically has its own
+finding-style cocci at `engine/coccinelle/rules/lock_imbalance.cocci` for
+the bug-shape; this enrichment is enumeration only.) Skip-silent: no-ops on
+non-C/C++ targets or when `spatch` isn't on PATH, so it only adds a cocci
+pass where it has something to find. Idempotent. Skip if
+`$WORKDIR/checklist.json` lacks `target_path`.
 
 **[MAP-6] Record Coverage**
 

--- a/engine/coccinelle/rules/lock_imbalance.cocci
+++ b/engine/coccinelle/rules/lock_imbalance.cocci
@@ -3,6 +3,14 @@
 //
 // Catches the CVE-2022-2602 / CVE-2023-4622 class: lock acquired,
 // error path returns without unlock. Covers common kernel lock variants.
+//
+// Coverage tracks engine/coccinelle/source_intel/concurrency/lock_sites.cocci
+// (the enumeration counterpart) for the subset where imbalance semantics
+// apply. Trylock variants are intentionally excluded — the lock may not be
+// held on the failure path, so "return with trylock-held" would FP. Userspace
+// pthread mutex is enumerated by lock_sites.cocci but not bug-detected here;
+// this rule remains kernel-focused. Keep the two files' kernel-locking name
+// sets aligned when extending.
 
 // Spinlock: error return with lock held
 @spin_held@
@@ -11,8 +19,8 @@ position p;
 constant C;
 @@
 
-\(spin_lock\|spin_lock_irq\|spin_lock_bh\)(&L);
-... when != \(spin_unlock\|spin_unlock_irq\|spin_unlock_bh\)(&L)
+\(spin_lock\|spin_lock_irq\|spin_lock_bh\|raw_spin_lock\|raw_spin_lock_irq\|raw_spin_lock_bh\)(&L);
+... when != \(spin_unlock\|spin_unlock_irq\|spin_unlock_bh\|raw_spin_unlock\|raw_spin_unlock_irq\|raw_spin_unlock_bh\)(&L)
 (
 * return@p -C;
 |
@@ -65,8 +73,8 @@ position p;
 constant C;
 @@
 
-spin_lock_irqsave(&L, F);
-... when != spin_unlock_irqrestore(&L, F)
+\(spin_lock_irqsave\|raw_spin_lock_irqsave\)(&L, F);
+... when != \(spin_unlock_irqrestore\|raw_spin_unlock_irqrestore\)(&L, F)
 (
 * return@p -C;
 |
@@ -83,6 +91,33 @@ L << irqsave_held.L;
 import json, sys
 for _p in p:
     _m = {"file": _p.file, "line": int(_p.line), "col": int(_p.column), "line_end": int(_p.line_end), "col_end": int(_p.column_end), "rule": "lock_imbalance", "message": "Return with spin_lock_irqsave held on %s" % L}
+    sys.stderr.write("COCCIRESULT:" + json.dumps(_m) + "\n")
+
+// RW lock irqsave: error return with lock held (two-arg variant)
+@rw_irqsave_held@
+expression L, F;
+position p;
+constant C;
+@@
+
+\(read_lock_irqsave\|write_lock_irqsave\)(&L, F);
+... when != \(read_unlock_irqrestore\|write_unlock_irqrestore\)(&L, F)
+(
+* return@p -C;
+|
+* return@p NULL;
+|
+* return@p;
+)
+
+@script:python@
+p << rw_irqsave_held.p;
+L << rw_irqsave_held.L;
+@@
+
+import json, sys
+for _p in p:
+    _m = {"file": _p.file, "line": int(_p.line), "col": int(_p.column), "line_end": int(_p.line_end), "col_end": int(_p.column_end), "rule": "lock_imbalance", "message": "Return with rw_lock_irqsave held on %s" % L}
     sys.stderr.write("COCCIRESULT:" + json.dumps(_m) + "\n")
 
 // RW lock: error return with lock held

--- a/engine/coccinelle/source_intel/concurrency/lock_sites.cocci
+++ b/engine/coccinelle/source_intel/concurrency/lock_sites.cocci
@@ -1,0 +1,239 @@
+// lock_sites.cocci — enumerate lock acquire/release sites for the
+// Phase B `shared_state` /understand --map section.
+//
+// NOT a bug detector — that's lock_imbalance.cocci's job. Pure
+// enumeration. One COCCIRESULT per call:
+//
+//   lock_site:<op>:<kind>:<fn>:<lock_var>
+//
+// op       ∈ acquire | release
+// kind     ∈ spin | mutex | rw | pthread_mutex
+// fn       = the concrete function name matched
+// lock_var = the expression in the first arg position, rendered by
+//            spatch (may contain whitespace, e.g. ``& sl``). Consumers
+//            should normalise (e.g. collapse ``& `` → ``&``).
+//
+// Coverage:
+//   * Kernel spinlock variants (incl. irq/bh/irqsave/trylock)
+//   * Kernel mutex (lock/lock_interruptible/lock_killable/trylock/unlock)
+//   * Kernel rwlock (read/write variants + irq/bh)
+//   * POSIX pthread mutex (lock/trylock/unlock)
+//
+// Out of scope (deferred): atomic_*, READ_ONCE/WRITE_ONCE, RCU,
+// futex, std::mutex / std::lock_guard (C++ scope-based). Each has
+// distinct semantics worth its own evidence shape.
+//
+// Known limitations consumers should be aware of:
+//
+//   * trylock variants (`spin_trylock`, `mutex_trylock`,
+//     `pthread_mutex_trylock`, `read_trylock`, `write_trylock`) emit
+//     ``op=acquire`` because that's the *intent*, but the lock is
+//     only HELD when the return value is checked-zero. Pure
+//     enumeration is correct; pairing/imbalance reasoning must
+//     account for the failure path.
+//
+//   * Identifier matching is name-only. A non-kernel project that
+//     defines `void read_lock(int fd)` (e.g. file-lock wrapper) WILL
+//     fire as kind=`rw`. Short names like `read_lock` / `write_lock`
+//     are the highest collision risk. The shared_state section is
+//     informational; downstream LLM analysis can disambiguate from
+//     surrounding code. Match by signature/header file would tighten
+//     this but isn't worth the complexity for v1.
+//
+// Consumed by packages/source_intel/analyze.py:_collect_lock_sites
+// → LockSiteEvidence tuples → SourceIntelResult.lock_sites →
+// context_map_sites.build_shared_state → cmap["shared_state"].
+
+
+// === Kernel spinlocks ===
+
+@spin_acq@
+position p;
+expression L;
+identifier fn = {
+    spin_lock, spin_lock_irq, spin_lock_bh, spin_lock_irqsave,
+    spin_trylock, spin_trylock_irq, spin_trylock_bh, spin_trylock_irqsave,
+    raw_spin_lock, raw_spin_lock_irq, raw_spin_lock_bh, raw_spin_lock_irqsave,
+    raw_spin_trylock
+};
+@@
+fn@p(L, ...)
+
+@script:python depends on spin_acq@
+p << spin_acq.p;
+fn << spin_acq.fn;
+L << spin_acq.L;
+@@
+import json, sys
+for _p in p:
+    sys.stderr.write("COCCIRESULT:" + json.dumps({
+        "file": _p.file, "line": int(_p.line),
+        "rule": "lock_sites",
+        "message": "lock_site:acquire:spin:" + str(fn) + ":" + str(L),
+    }) + "\n")
+
+
+@spin_rel@
+position p;
+expression L;
+identifier fn = {
+    spin_unlock, spin_unlock_irq, spin_unlock_bh, spin_unlock_irqrestore,
+    raw_spin_unlock, raw_spin_unlock_irq, raw_spin_unlock_bh, raw_spin_unlock_irqrestore
+};
+@@
+fn@p(L, ...)
+
+@script:python depends on spin_rel@
+p << spin_rel.p;
+fn << spin_rel.fn;
+L << spin_rel.L;
+@@
+import json, sys
+for _p in p:
+    sys.stderr.write("COCCIRESULT:" + json.dumps({
+        "file": _p.file, "line": int(_p.line),
+        "rule": "lock_sites",
+        "message": "lock_site:release:spin:" + str(fn) + ":" + str(L),
+    }) + "\n")
+
+
+// === Kernel mutex ===
+
+@mutex_acq@
+position p;
+expression L;
+identifier fn = {
+    mutex_lock, mutex_lock_interruptible, mutex_lock_killable,
+    mutex_trylock
+};
+@@
+fn@p(L, ...)
+
+@script:python depends on mutex_acq@
+p << mutex_acq.p;
+fn << mutex_acq.fn;
+L << mutex_acq.L;
+@@
+import json, sys
+for _p in p:
+    sys.stderr.write("COCCIRESULT:" + json.dumps({
+        "file": _p.file, "line": int(_p.line),
+        "rule": "lock_sites",
+        "message": "lock_site:acquire:mutex:" + str(fn) + ":" + str(L),
+    }) + "\n")
+
+
+@mutex_rel@
+position p;
+expression L;
+identifier fn = { mutex_unlock };
+@@
+fn@p(L, ...)
+
+@script:python depends on mutex_rel@
+p << mutex_rel.p;
+fn << mutex_rel.fn;
+L << mutex_rel.L;
+@@
+import json, sys
+for _p in p:
+    sys.stderr.write("COCCIRESULT:" + json.dumps({
+        "file": _p.file, "line": int(_p.line),
+        "rule": "lock_sites",
+        "message": "lock_site:release:mutex:" + str(fn) + ":" + str(L),
+    }) + "\n")
+
+
+// === Kernel rwlock ===
+
+@rw_acq@
+position p;
+expression L;
+identifier fn = {
+    read_lock, read_lock_irq, read_lock_bh, read_lock_irqsave,
+    write_lock, write_lock_irq, write_lock_bh, write_lock_irqsave,
+    read_trylock, write_trylock
+};
+@@
+fn@p(L, ...)
+
+@script:python depends on rw_acq@
+p << rw_acq.p;
+fn << rw_acq.fn;
+L << rw_acq.L;
+@@
+import json, sys
+for _p in p:
+    sys.stderr.write("COCCIRESULT:" + json.dumps({
+        "file": _p.file, "line": int(_p.line),
+        "rule": "lock_sites",
+        "message": "lock_site:acquire:rw:" + str(fn) + ":" + str(L),
+    }) + "\n")
+
+
+@rw_rel@
+position p;
+expression L;
+identifier fn = {
+    read_unlock, read_unlock_irq, read_unlock_bh, read_unlock_irqrestore,
+    write_unlock, write_unlock_irq, write_unlock_bh, write_unlock_irqrestore
+};
+@@
+fn@p(L, ...)
+
+@script:python depends on rw_rel@
+p << rw_rel.p;
+fn << rw_rel.fn;
+L << rw_rel.L;
+@@
+import json, sys
+for _p in p:
+    sys.stderr.write("COCCIRESULT:" + json.dumps({
+        "file": _p.file, "line": int(_p.line),
+        "rule": "lock_sites",
+        "message": "lock_site:release:rw:" + str(fn) + ":" + str(L),
+    }) + "\n")
+
+
+// === POSIX pthread mutex (userspace) ===
+
+@pthread_acq@
+position p;
+expression L;
+identifier fn = { pthread_mutex_lock, pthread_mutex_trylock };
+@@
+fn@p(L, ...)
+
+@script:python depends on pthread_acq@
+p << pthread_acq.p;
+fn << pthread_acq.fn;
+L << pthread_acq.L;
+@@
+import json, sys
+for _p in p:
+    sys.stderr.write("COCCIRESULT:" + json.dumps({
+        "file": _p.file, "line": int(_p.line),
+        "rule": "lock_sites",
+        "message": "lock_site:acquire:pthread_mutex:" + str(fn) + ":" + str(L),
+    }) + "\n")
+
+
+@pthread_rel@
+position p;
+expression L;
+identifier fn = { pthread_mutex_unlock };
+@@
+fn@p(L, ...)
+
+@script:python depends on pthread_rel@
+p << pthread_rel.p;
+fn << pthread_rel.fn;
+L << pthread_rel.L;
+@@
+import json, sys
+for _p in p:
+    sys.stderr.write("COCCIRESULT:" + json.dumps({
+        "file": _p.file, "line": int(_p.line),
+        "rule": "lock_sites",
+        "message": "lock_site:release:pthread_mutex:" + str(fn) + ":" + str(L),
+    }) + "\n")

--- a/packages/code_understanding/annotation_synth.py
+++ b/packages/code_understanding/annotation_synth.py
@@ -203,20 +203,22 @@ def _emit_site_annotations(
     counts: SynthCounts,
 ) -> None:
     """Emit ONE annotation per function aggregating its mechanically-detected
-    ownership + privilege sites (from ``context_map_sites``).
+    ownership / privilege / shared-state sites (from ``context_map_sites``).
 
     Aggregation is mandatory: annotations key on ``(file, function)`` and a
     function commonly holds several sites (e.g. alloc + double-free, or
-    ownership *and* a capability check), so a per-site write would clobber
-    down to the last one. Each site already carries its ``function``
-    (source_intel's enclosing function); checklist resolution is a fallback so
-    coverage survives an inventory miss. Source is ``source_intel`` and the
-    substrate's ``respect-manual`` write never clobbers an operator note.
+    ownership *and* a capability check, or many lock acquire/release pairs),
+    so a per-site write would clobber down to the last one. Each site already
+    carries its ``function`` (source_intel's enclosing function); checklist
+    resolution is a fallback so coverage survives an inventory miss. Source is
+    ``source_intel`` and the substrate's ``respect-manual`` write never
+    clobbers an operator note.
     """
     groups: Dict[tuple, Dict[str, Any]] = {}
     for category, section_key in (
         ("ownership", "ownership_model"),
         ("privilege", "privilege_model"),
+        ("shared_state", "shared_state"),
     ):
         for item in _safe_list_of_dicts(cmap, section_key):
             file_path = item.get("file")
@@ -241,7 +243,8 @@ def _emit_site_annotations(
             if line:
                 head += f" (line {line})"
             detail = [head]
-            for k in ("allocator", "free_fn", "name", "grade", "role"):
+            for k in ("allocator", "free_fn", "name", "grade", "role",
+                      "fn", "lock_var"):
                 if item.get(k):
                     detail.append(f"  {k}: {item[k]}")
             g["lines"].append("\n".join(detail))

--- a/packages/code_understanding/context_map_sites.py
+++ b/packages/code_understanding/context_map_sites.py
@@ -106,6 +106,24 @@ def build_privilege_model(si: "SourceIntelResult") -> List[Dict[str, Any]]:
     return out
 
 
+def build_shared_state(si: "SourceIntelResult") -> List[Dict[str, Any]]:
+    """Lock acquire / release sites — spin / mutex / rw / pthread.
+
+    Site `kind` is `<lock_kind>_<op>` (e.g. `spin_acquire`, `mutex_release`)
+    so consumers can filter on a single field. The concrete function
+    (`fn`) and lock expression (`lock_var`) ride alongside.
+    """
+    out: List[Dict[str, Any]] = []
+    for ls in getattr(si, "lock_sites", ()) or ():
+        kind = f"{getattr(ls, 'kind', '')}_{getattr(ls, 'op', '')}"
+        out.append(_site(
+            kind, ls,
+            fn=getattr(ls, "fn", None),
+            lock_var=getattr(ls, "lock_var", None),
+        ))
+    return out
+
+
 def enrich_context_map_with_sites(
     cmap: Dict[str, Any], si: "SourceIntelResult",
     *, repo_root: Optional[Union[str, Path]] = None,
@@ -129,13 +147,14 @@ def enrich_context_map_with_sites(
     merge-vs-replace decision — resolve it then, against that layer's design
     (the intended flow is mechanical-sites-first, LLM-enriches-on-top).
     """
-    counts = {"ownership_model": 0, "privilege_model": 0}
+    counts = {"ownership_model": 0, "privilege_model": 0, "shared_state": 0}
     if not isinstance(cmap, dict):
         return counts
     root = Path(repo_root) if repo_root is not None else None
     for key, builder in (
         ("ownership_model", build_ownership_model),
         ("privilege_model", build_privilege_model),
+        ("shared_state", build_shared_state),
     ):
         try:
             sites = builder(si)

--- a/packages/code_understanding/tests/test_context_map_sites.py
+++ b/packages/code_understanding/tests/test_context_map_sites.py
@@ -37,7 +37,7 @@ class _SI:
 
     _FIELDS = (
         "allocations", "checked_allocations", "paired_frees",
-        "double_frees", "capabilities", "lsm_hooks",
+        "double_frees", "capabilities", "lsm_hooks", "lock_sites",
     )
 
     def __init__(self, **kw):
@@ -88,10 +88,53 @@ def test_privilege_sites():
     assert cap["name"] == "capable" and cap["grade"] == "same_function"
 
 
+def test_shared_state_sites_aggregated_with_kind_op_compound():
+    # Coverage: every (op × kind) pair carries fn + lock_var alongside.
+    si = _SI(lock_sites=[
+        _Ev(location=("d.c", 11), enclosing_function="do_work",
+            op="acquire", kind="spin", fn="spin_lock", lock_var="&sl"),
+        _Ev(location=("d.c", 14), enclosing_function="do_work",
+            op="release", kind="spin", fn="spin_unlock", lock_var="&sl"),
+        _Ev(location=("d.c", 22), enclosing_function="do_work",
+            op="acquire", kind="mutex", fn="mutex_lock_interruptible",
+            lock_var="&m"),
+        _Ev(location=("d.c", 25), enclosing_function="do_work",
+            op="release", kind="mutex", fn="mutex_unlock", lock_var="&m"),
+        _Ev(location=("e.c", 3), enclosing_function="thread_fn",
+            op="acquire", kind="pthread_mutex", fn="pthread_mutex_lock",
+            lock_var="&pm"),
+    ])
+    cmap: dict = {}
+    counts = enrich_context_map_with_sites(cmap, si)
+    assert counts["shared_state"] == 5
+    ss = cmap["shared_state"]
+    # compound kind = <lock_kind>_<op>; fn + lock_var preserved.
+    assert {e["kind"] for e in ss} == {
+        "spin_acquire", "spin_release",
+        "mutex_acquire", "mutex_release",
+        "pthread_mutex_acquire",
+    }
+    spin_acq = next(e for e in ss if e["kind"] == "spin_acquire")
+    assert spin_acq == {
+        "kind": "spin_acquire", "file": "d.c", "line": 11,
+        "function": "do_work", "fn": "spin_lock", "lock_var": "&sl",
+    }
+
+
+def test_shared_state_section_omitted_when_empty():
+    # No lock_sites → no shared_state key written (mirrors the
+    # ownership_model / privilege_model contract: never shadow an LLM
+    # populator with an empty list).
+    cmap: dict = {}
+    counts = enrich_context_map_with_sites(cmap, _SI())
+    assert counts["shared_state"] == 0
+    assert "shared_state" not in cmap
+
+
 def test_empty_result_writes_no_keys():
     cmap = {"entry_points": []}
     counts = enrich_context_map_with_sites(cmap, _SI())
-    assert counts == {"ownership_model": 0, "privilege_model": 0}
+    assert counts == {"ownership_model": 0, "privilege_model": 0, "shared_state": 0}
     assert "ownership_model" not in cmap and "privilege_model" not in cmap
 
 
@@ -116,7 +159,7 @@ def test_best_effort_on_malformed_evidence():
 
 def test_non_dict_cmap_is_noop():
     assert enrich_context_map_with_sites(None, _SI()) == {
-        "ownership_model": 0, "privilege_model": 0,
+        "ownership_model": 0, "privilege_model": 0, "shared_state": 0,
     }
 
 
@@ -152,7 +195,7 @@ def test_degrades_gracefully_without_spatch(monkeypatch):
 
     cmap = {"entry_points": []}
     counts = enrich_context_map_with_sites(cmap, si)
-    assert counts == {"ownership_model": 0, "privilege_model": 0}
+    assert counts == {"ownership_model": 0, "privilege_model": 0, "shared_state": 0}
     assert "ownership_model" not in cmap and "privilege_model" not in cmap
 
 
@@ -217,6 +260,50 @@ def test_synth_aggregates_multiple_sites_per_function(tmp_path):
     assert body.count("site:") == 3  # all three sites survive
     assert "line 9" in body and "line 10" in body and "line 7" in body
     assert "site_categories=ownership,privilege" in body
+
+
+def test_synth_aggregates_all_three_categories_with_shared_state(tmp_path):
+    # Same regression class as the ownership+privilege test above, extended
+    # to verify shared_state (Phase B concurrency axis) joins the dispatch
+    # tuple cleanly. A function with ownership + privilege + multiple lock
+    # sites must yield ONE annotation carrying every site, with
+    # site_categories listing all three. Regression risk: if the synth
+    # category tuple isn't extended, shared_state sites silently drop and
+    # site_categories degrades to ownership,privilege.
+    out = tmp_path / "run"
+    out.mkdir()
+    (out / "checklist.json").write_text(
+        json.dumps({"target_path": str(tmp_path / "repo")}), encoding="utf-8",
+    )
+    cmap = {
+        "ownership_model": [
+            {"kind": "alloc", "file": "k.c", "line": 5,
+             "function": "handler", "allocator": "kmalloc"},
+        ],
+        "privilege_model": [
+            {"kind": "capability", "file": "k.c", "line": 7,
+             "function": "handler", "name": "capable"},
+        ],
+        "shared_state": [
+            {"kind": "spin_acquire", "file": "k.c", "line": 11,
+             "function": "handler", "fn": "spin_lock", "lock_var": "&sl"},
+            {"kind": "spin_release", "file": "k.c", "line": 14,
+             "function": "handler", "fn": "spin_unlock", "lock_var": "&sl"},
+            {"kind": "mutex_acquire", "file": "k.c", "line": 18,
+             "function": "handler", "fn": "mutex_lock", "lock_var": "&m"},
+        ],
+    }
+    (out / "context-map.json").write_text(json.dumps(cmap), encoding="utf-8")
+
+    counts = synthesise_from_understand_output(out)
+    assert counts.emitted == 1  # one annotation per (file, function)
+    body = (out / "annotations" / "k.c.md").read_text(encoding="utf-8")
+    assert body.count("site:") == 5  # 1 ownership + 1 privilege + 3 shared
+    # shared_state-specific extras land in the body
+    assert "fn: spin_lock" in body and "lock_var: &sl" in body
+    assert "fn: mutex_lock" in body and "lock_var: &m" in body
+    # all three categories appear in the metadata header
+    assert "site_categories=ownership,privilege,shared_state" in body
 
 
 # --- producer shim --------------------------------------------------------

--- a/packages/source_intel/analyze.py
+++ b/packages/source_intel/analyze.py
@@ -273,6 +273,23 @@ class LsmEvidence:
 
 
 @dataclass(frozen=True)
+class LockSiteEvidence:
+    """A single lock acquire or release site (spin/mutex/rw/pthread).
+
+    Enumeration only — does NOT imply imbalance or bug. Populated from
+    engine/coccinelle/source_intel/concurrency/lock_sites.cocci output.
+    Feeds the Phase B `shared_state` /understand --map section.
+    """
+
+    op: str                                       # "acquire" | "release"
+    kind: str                                     # "spin" | "mutex" | "rw" | "pthread_mutex"
+    fn: str                                       # concrete function name (e.g. "spin_lock_irqsave")
+    lock_var: str                                 # first-arg expression, normalised
+    location: Tuple[str, int]
+    enclosing_function: Optional[str] = None
+
+
+@dataclass(frozen=True)
 class WarnEvidence:
     """A single observation of a non-aborting runtime-warning call
     (WARN_ON / pr_warn / KASAN_REPORT etc.).
@@ -544,6 +561,13 @@ class SourceIntelResult:
     #: Informational — feeds Stage D LLM as memory-leak corroboration.
     paired_frees: Tuple[PairedFreeEvidence, ...] = ()
 
+    #: Phase B (concurrency axis): lock acquire/release sites
+    #: enumerated by lock_sites.cocci. Informational; feeds the
+    #: shared_state /understand --map section + per-function
+    #: annotations. No verdict policy attached — pairing/imbalance
+    #: detection is lock_imbalance.cocci's job.
+    lock_sites: Tuple[LockSiteEvidence, ...] = ()
+
     #: Axis 6 consumer: build-hardening flags observed in the target's
     #: build configuration. Populated from core.build.build_flags when
     #: signal exists; otherwise default BuildFlagsContext() (all None,
@@ -809,6 +833,7 @@ def analyze(
     c_level_source_observations: List[CLevelSourceEvidence] = []
     double_free_observations: List[DoubleFreeEvidence] = []
     paired_free_observations: List[PairedFreeEvidence] = []
+    lock_site_observations: List[LockSiteEvidence] = []
 
     # spatch invocation per axis. ``no_includes=True`` matches the
     # existing PR-3 scan + PR-4 prereqs untrusted-target posture;
@@ -864,6 +889,9 @@ def analyze(
                 paired_free_observations.extend(
                     _parse_match_to_paired_free(match)
                 )
+                lock_site_observations.extend(
+                    _parse_match_to_lock_site(match)
+                )
 
     # Project-specific alias discovery: walk target headers, classify
     # `#define MACRO __attribute__((...))` patterns by family, count
@@ -909,6 +937,7 @@ def analyze(
         lsm_hooks=tuple(lsm_observations),
         double_frees=tuple(double_free_observations),
         paired_frees=tuple(paired_free_observations),
+        lock_sites=tuple(lock_site_observations),
         build_flags=extract_flags(target),
     )
 
@@ -1401,6 +1430,45 @@ def _parse_match_to_lsm(match: Any) -> List[LsmEvidence]:
     )
     return [LsmEvidence(
         hook_name=hook,
+        location=(file_path, line_no),
+        enclosing_function=enclosing_fn,
+    )]
+
+
+_LOCK_SITE_KINDS = frozenset({"spin", "mutex", "rw", "pthread_mutex"})
+_LOCK_SITE_OPS = frozenset({"acquire", "release"})
+
+
+def _parse_match_to_lock_site(match: Any) -> List[LockSiteEvidence]:
+    """Convert a cocci SpatchMatch from lock_sites.cocci into a
+    LockSiteEvidence record. Message: ``lock_site:<op>:<kind>:<fn>:<lock_var>``.
+    The lock_var segment can contain ``:`` if the expression uses scope
+    resolution etc. — only the first 4 segments are structural; the
+    rest is rejoined as the lock_var."""
+    msg = (getattr(match, "message", "") or "").strip()
+    if not msg.startswith("lock_site:"):
+        return []
+    parts = msg.split(":", 4)
+    if len(parts) < 5:
+        return []
+    _prefix, op, kind, fn, lock_var = parts
+    if op not in _LOCK_SITE_OPS or kind not in _LOCK_SITE_KINDS:
+        return []
+    if not fn:
+        return []
+    # spatch renders `&foo` as `& foo`; normalise the common cases so
+    # downstream consumers can group by lock_var without re-parsing.
+    lock_var = lock_var.strip().replace("& ", "&")
+    file_path = getattr(match, "file", "")
+    line_no = int(getattr(match, "line", 0))
+    enclosing_fn = (
+        _enclosing_function(file_path, line_no) if file_path else None
+    )
+    return [LockSiteEvidence(
+        op=op,
+        kind=kind,
+        fn=fn,
+        lock_var=lock_var,
         location=(file_path, line_no),
         enclosing_function=enclosing_fn,
     )]

--- a/packages/source_intel/tests/test_lock_sites.py
+++ b/packages/source_intel/tests/test_lock_sites.py
@@ -1,0 +1,217 @@
+"""Tests for the concurrency axis — lock_sites.cocci + LockSiteEvidence.
+
+Two layers:
+  * Unit: the message parser (`_parse_match_to_lock_site`) — deterministic,
+    no spatch. Pins the COCCIRESULT shape, the kind/op enums, the
+    `& foo` → `&foo` normalisation, and the structural-segment guard.
+  * Real-spatch E2E: gated on spatch availability. Smoke fixture with
+    every covered family fires; out-of-axis primitives (cpu_relax,
+    atomic_inc, futex) do NOT fire.
+"""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+import pytest
+
+from packages.source_intel.analyze import (
+    LockSiteEvidence,
+    SourceIntelResult,
+    _parse_match_to_lock_site,
+    analyze,
+)
+
+
+class _Match:
+    """Shape-compatible stand-in for coccinelle.runner.SpatchMatch."""
+
+    def __init__(self, message: str, file: str = "x.c", line: int = 1) -> None:
+        self.message = message
+        self.file = file
+        self.line = line
+
+
+# --- parser unit tests ----------------------------------------------------
+
+
+def test_parser_accepts_canonical_message():
+    out = _parse_match_to_lock_site(_Match(
+        "lock_site:acquire:spin:spin_lock:&sl", file="d.c", line=12,
+    ))
+    assert out == [LockSiteEvidence(
+        op="acquire", kind="spin", fn="spin_lock", lock_var="&sl",
+        location=("d.c", 12), enclosing_function=None,
+    )]
+
+
+def test_parser_normalises_spatch_amp_spacing():
+    # spatch renders `&sl` as `& sl`; consumers must see the normalised form
+    # so grouping by lock_var doesn't fragment on whitespace artefacts.
+    out = _parse_match_to_lock_site(_Match(
+        "lock_site:acquire:mutex:mutex_lock:& m",
+    ))
+    assert out[0].lock_var == "&m"
+
+
+def test_parser_rejects_unknown_op():
+    assert _parse_match_to_lock_site(_Match(
+        "lock_site:downgrade:spin:spin_lock:&sl",
+    )) == []
+
+
+def test_parser_rejects_unknown_kind():
+    assert _parse_match_to_lock_site(_Match(
+        "lock_site:acquire:rcu:rcu_read_lock:&p",
+    )) == []
+
+
+def test_parser_rejects_truncated_message():
+    # Missing the lock_var segment — only 4 parts.
+    assert _parse_match_to_lock_site(_Match(
+        "lock_site:acquire:spin:spin_lock",
+    )) == []
+
+
+def test_parser_rejects_empty_fn():
+    assert _parse_match_to_lock_site(_Match(
+        "lock_site:acquire:spin::&sl",
+    )) == []
+
+
+def test_parser_ignores_other_rules():
+    # A neighbouring rule's COCCIRESULT mustn't leak through the dispatch.
+    assert _parse_match_to_lock_site(_Match("lsm:security_inode_permission")) == []
+    assert _parse_match_to_lock_site(_Match("paired_free:kmalloc:kfree")) == []
+
+
+def test_parser_preserves_colons_in_lock_var():
+    # If a future C++ extension emits a scoped name (`Class::member`),
+    # the colons in lock_var must survive the 4-way split.
+    out = _parse_match_to_lock_site(_Match(
+        "lock_site:acquire:pthread_mutex:pthread_mutex_lock:&Foo::Bar::m",
+    ))
+    assert out[0].lock_var == "&Foo::Bar::m"
+
+
+def test_lock_sites_default_empty_on_bare_result():
+    r = SourceIntelResult()
+    assert r.lock_sites == ()
+
+
+# --- real-spatch E2E (skipped in CI; runs locally) ------------------------
+
+
+_LOCK_FIXTURE_HEADER = """\
+typedef int spinlock_t;
+typedef int rwlock_t;
+typedef int pthread_mutex_t;
+struct mutex { int x; };
+
+void spin_lock(spinlock_t *l);
+void spin_unlock(spinlock_t *l);
+void spin_lock_irqsave(spinlock_t *l, unsigned long f);
+void spin_unlock_irqrestore(spinlock_t *l, unsigned long f);
+void mutex_lock(struct mutex *m);
+int mutex_lock_interruptible(struct mutex *m);
+void mutex_unlock(struct mutex *m);
+void read_lock(rwlock_t *l);
+void write_lock(rwlock_t *l);
+void read_unlock(rwlock_t *l);
+void write_unlock(rwlock_t *l);
+int pthread_mutex_lock(pthread_mutex_t *m);
+int pthread_mutex_unlock(pthread_mutex_t *m);
+
+/* deliberately NOT covered by lock_sites.cocci */
+void cpu_relax(void);
+void atomic_inc(int *v);
+int futex(int *uaddr, int futex_op);
+"""
+
+_LOCK_FIXTURE_BODY = """\
+static spinlock_t sl;
+static struct mutex m;
+static rwlock_t rl;
+static pthread_mutex_t pm;
+
+int driver(void) {
+    unsigned long flags;
+    spin_lock(&sl);
+    spin_unlock(&sl);
+    spin_lock_irqsave(&sl, flags);
+    spin_unlock_irqrestore(&sl, flags);
+    mutex_lock(&m);
+    mutex_unlock(&m);
+    if (mutex_lock_interruptible(&m)) return -1;
+    mutex_unlock(&m);
+    read_lock(&rl); read_unlock(&rl);
+    write_lock(&rl); write_unlock(&rl);
+    pthread_mutex_lock(&pm);
+    pthread_mutex_unlock(&pm);
+
+    /* Out-of-axis primitives — must NOT appear in lock_sites. */
+    cpu_relax();
+    atomic_inc(&flags);
+    futex((int *)&sl, 0);
+    return 0;
+}
+"""
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(
+    not shutil.which("spatch"), reason="spatch not installed",
+)
+def test_e2e_lock_sites_covers_every_family(tmp_path: Path) -> None:
+    (tmp_path / "lk.c").write_text(_LOCK_FIXTURE_HEADER + _LOCK_FIXTURE_BODY)
+    r = analyze(tmp_path)
+
+    # Every covered family fires at least once on the fixture.
+    triples = {(s.kind, s.op, s.fn) for s in r.lock_sites}
+    expected = {
+        ("spin", "acquire", "spin_lock"),
+        ("spin", "release", "spin_unlock"),
+        ("spin", "acquire", "spin_lock_irqsave"),
+        ("spin", "release", "spin_unlock_irqrestore"),
+        ("mutex", "acquire", "mutex_lock"),
+        ("mutex", "release", "mutex_unlock"),
+        ("mutex", "acquire", "mutex_lock_interruptible"),
+        ("rw", "acquire", "read_lock"),
+        ("rw", "release", "read_unlock"),
+        ("rw", "acquire", "write_lock"),
+        ("rw", "release", "write_unlock"),
+        ("pthread_mutex", "acquire", "pthread_mutex_lock"),
+        ("pthread_mutex", "release", "pthread_mutex_unlock"),
+    }
+    missing = expected - triples
+    assert not missing, f"families not captured: {sorted(missing)}"
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(
+    not shutil.which("spatch"), reason="spatch not installed",
+)
+def test_e2e_lock_sites_skips_out_of_axis_primitives(tmp_path: Path) -> None:
+    # Atomics / CPU hints / futex aren't lock sites; they belong to other
+    # axes (deferred). If they appear in lock_sites, our cocci is too broad.
+    (tmp_path / "lk.c").write_text(_LOCK_FIXTURE_HEADER + _LOCK_FIXTURE_BODY)
+    r = analyze(tmp_path)
+
+    fns = {s.fn for s in r.lock_sites}
+    assert "cpu_relax" not in fns
+    assert "atomic_inc" not in fns
+    assert "futex" not in fns
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(
+    not shutil.which("spatch"), reason="spatch not installed",
+)
+def test_e2e_lock_sites_carry_enclosing_function(tmp_path: Path) -> None:
+    (tmp_path / "lk.c").write_text(_LOCK_FIXTURE_HEADER + _LOCK_FIXTURE_BODY)
+    r = analyze(tmp_path)
+
+    fns = {s.enclosing_function for s in r.lock_sites}
+    # Every site comes from `driver` — no stray attributions.
+    assert fns == {"driver"}, f"unexpected enclosing functions: {fns}"

--- a/packages/source_intel/tests/test_rule_integrity.py
+++ b/packages/source_intel/tests/test_rule_integrity.py
@@ -49,6 +49,9 @@ EXPECTED_RULES = {
     "compile_time": {
         "no_sanitize_attr.cocci",
     },
+    "concurrency": {
+        "lock_sites.cocci",
+    },
     "hazards": {
         "deprecated_functions.cocci",
         "signed_alloc.cocci",


### PR DESCRIPTION
Phase B sister to ownership_model / privilege_model (#689). Adds a `shared_state` section to context-map.json listing every lock acquire/release site so operators and downstream LLM analysis see concurrency surface without hallucinating call sites.

- New cocci axis engine/coccinelle/source_intel/concurrency/lock_sites.cocci: enumeration-only (NOT a bug detector — that's lock_imbalance.cocci). Covers kernel spinlock (incl. _irq / _irqsave / _bh / _trylock / raw_*), kernel mutex (lock / _interruptible / _killable / _trylock / unlock), kernel rwlock (read/write variants + _irq / _bh), and POSIX pthread mutex. Atomics, RCU, futex, and C++ scope-based locks (std::lock_guard) deliberately out of scope — each has distinct semantics worth its own evidence shape.
- New LockSiteEvidence + lock_sites field on SourceIntelResult; cocci output flows through _parse_match_to_lock_site with trylock / short-name collision risks documented in the cocci header.
- build_shared_state in context_map_sites projects evidence as a flat list of site dicts (kind=<lock_kind>_<op>, fn, lock_var), matching the shipped ownership_model / privilege_model shape; future pairing can land as an additive pair_id without schema break.
- annotation_synth aggregates shared_state alongside the two existing categories — ONE annotation per (file, function) carrying every site. Multi-category test added against the per-site-clobber regression class #689 surfaced.
- map.md MAP-5d extended; rule-integrity test registers the new axis.

Also closes coverage gaps in the sister bug-detector engine/coccinelle/rules/lock_imbalance.cocci so its kernel-locking name set tracks lock_sites for the subset where imbalance semantics apply: adds raw_spin_lock / _irq / _bh / _irqsave (identical semantics to non-raw, previously missed) and a new rw_irqsave_held rule covering read_lock_irqsave / write_lock_irqsave (the rwlock version of the 2-arg irqsave pattern lock_imbalance had for spin only). Trylock variants and userspace pthread stay out of lock_imbalance intentionally — documented in its header. Smoke-validated: 3 new variants fire, balanced control case does not.

8 unit + 3 real-spatch E2E (skip-silent on CI without spatch). Full suite (706 → 707 pass) + ruff clean.