### PR TITLE
feat(understand): mechanical crypto_inventory site enrichment for --map

### DIFF
--- a/.claude/skills/code-understanding/map.md
+++ b/.claude/skills/code-understanding/map.md
@@ -248,10 +248,10 @@ the function *is*) alongside the LLM's narrative (what the function
 this without re-parsing source. Idempotent. Skip if
 `$WORKDIR/checklist.json` doesn't exist or doesn't carry `target_path`.
 
-**[MAP-5d] Enrich with ownership / privilege / shared-state sites (C/C++)**
+**[MAP-5d] Enrich with ownership / privilege / shared-state / crypto sites (C/C++)**
 
 After normalisation, run the site enricher. Uses `source_intel` (cocci) to
-attach three Phase B sections, each entry carrying `kind`, `file`, `line`,
+attach four Phase B sections, each entry carrying `kind`, `file`, `line`,
 and `function`:
 
 * `ownership_model` — alloc / checked-alloc / paired-free / double-free sites
@@ -267,6 +267,21 @@ and `function`:
   whitespace-normalised). Atomics, RCU, and C++ scope-based locks
   (`std::lock_guard`) are intentionally out of scope here — each has
   semantics worth its own evidence shape and is deferred.
+* `crypto_inventory` — cryptographic primitive calls + RNG sources. Entry
+  `kind` is the call kind (`primitive_call` or `rng_source`); extras:
+  `api` (`openssl` / `kernel` / `libsodium` / `libc`) and `fn` (concrete
+  function matched, e.g. `EVP_EncryptInit_ex`). Covers OpenSSL modern EVP
+  + legacy primitives (AES_/SHA_/HMAC_/DES_/RC4_/MD5_/BF_), Linux kernel
+  crypto API (`crypto_alloc_*`, `crypto_skcipher_*`, `crypto_shash_*`,
+  `crypto_ahash_*`, `crypto_aead_*`), libsodium (`crypto_secretbox_*`,
+  `crypto_box_*`, `crypto_sign_*`, `crypto_aead_*`, `crypto_pwhash_*`),
+  and RNG sources (`RAND_bytes`, `randombytes_buf`, `getrandom`,
+  `get_random_bytes`, libc `rand`/`random`). MbedTLS, Windows BCrypt,
+  Bouncy Castle / Java crypto, and C++ wrappers (Botan, Crypto++) are
+  intentionally out of scope here — add as separate rules when target
+  corpus shows demand. **Soundness**: identifier matching is name-only;
+  a non-crypto project that defines its own `SHA256_Update` will fire.
+  Short names (`rand`, `random`) have highest collision risk.
 
 ```bash
 libexec/raptor-enrich-context-map-sites "$WORKDIR"

--- a/engine/coccinelle/source_intel/crypto/crypto_calls.cocci
+++ b/engine/coccinelle/source_intel/crypto/crypto_calls.cocci
@@ -1,0 +1,285 @@
+// crypto_calls.cocci — enumerate cryptographic primitive call sites + RNG
+// sources for the Phase B `crypto_inventory` /understand --map section.
+//
+// NOT a "is this crypto broken" detector — pure enumeration. One
+// COCCIRESULT per call:
+//
+//   crypto:<kind>:<api>:<fn>
+//
+// kind ∈ primitive_call | rng_source
+// api  ∈ openssl | kernel | libsodium | libc
+// fn   = the concrete function name matched
+//
+// Coverage (v1):
+//   * OpenSSL — modern EVP_* (Init/Update/Final + key/cipher mgmt),
+//     legacy AES_/SHA*_/HMAC_/DES_/RC4_/MD5_/BF_ primitives.
+//   * Linux kernel crypto API — crypto_alloc_*, crypto_skcipher_*,
+//     crypto_shash_*, crypto_ahash_*, crypto_aead_*.
+//   * libsodium — crypto_secretbox_*, crypto_box_*, crypto_sign_*,
+//     crypto_aead_*, crypto_auth_*, crypto_pwhash_*.
+//   * RNG sources — OpenSSL RAND_bytes/RAND_priv_bytes, libsodium
+//     randombytes_buf, Linux getrandom, libc rand/random.
+//
+// Out of scope (deferred): MbedTLS, Windows BCrypt, Bouncy
+// Castle/Java crypto, C++ wrappers (Botan, Crypto++). Add as separate
+// rules / axes when target corpus shows demand.
+//
+// Known limitations (documented for downstream consumers):
+//   * Name-only matching. A non-crypto project that defines
+//     `int SHA256_Update(state *, void *, size_t)` (rare but possible
+//     for educational code or replacements) will fire. Short names
+//     like `rand` have HIGH collision risk in pure-userspace code;
+//     consumers should disambiguate using surrounding context.
+//   * `rand()` and `random()` are categorised as `rng_source` here
+//     because that is their advertised purpose, even though they are
+//     cryptographically broken. The Phase B section is enumeration;
+//     "broken RNG used in crypto context" reasoning belongs to a
+//     separate finding-style rule.
+//
+// Consumed by packages/source_intel/analyze.py:_parse_match_to_crypto_call
+// → CryptoCallEvidence tuples → SourceIntelResult.crypto_calls →
+// context_map_sites.build_crypto_inventory → cmap["crypto_inventory"].
+
+
+// =====================================================================
+// OpenSSL — modern EVP_* surface
+// =====================================================================
+
+@evp_calls@
+position p;
+identifier fn = {
+    EVP_EncryptInit, EVP_EncryptInit_ex, EVP_EncryptUpdate, EVP_EncryptFinal,
+    EVP_EncryptFinal_ex,
+    EVP_DecryptInit, EVP_DecryptInit_ex, EVP_DecryptUpdate, EVP_DecryptFinal,
+    EVP_DecryptFinal_ex,
+    EVP_CipherInit, EVP_CipherInit_ex, EVP_CipherUpdate, EVP_CipherFinal,
+    EVP_CipherFinal_ex,
+    EVP_DigestInit, EVP_DigestInit_ex, EVP_DigestUpdate, EVP_DigestFinal,
+    EVP_DigestFinal_ex, EVP_Digest,
+    EVP_DigestSignInit, EVP_DigestSignUpdate, EVP_DigestSignFinal,
+    EVP_DigestVerifyInit, EVP_DigestVerifyUpdate, EVP_DigestVerifyFinal,
+    EVP_PKEY_encrypt, EVP_PKEY_decrypt,
+    EVP_PKEY_sign, EVP_PKEY_verify,
+    EVP_PKEY_derive,
+    HMAC_Init, HMAC_Init_ex, HMAC_Update, HMAC_Final, HMAC
+};
+@@
+fn@p(...)
+
+@script:python depends on evp_calls@
+p << evp_calls.p;
+fn << evp_calls.fn;
+@@
+import json, sys
+for _p in p:
+    sys.stderr.write("COCCIRESULT:" + json.dumps({
+        "file": _p.file, "line": int(_p.line),
+        "rule": "crypto_calls",
+        "message": "crypto:primitive_call:openssl:" + str(fn),
+    }) + "\n")
+
+
+// =====================================================================
+// OpenSSL — legacy / per-algorithm primitives
+// =====================================================================
+
+@openssl_legacy@
+position p;
+identifier fn = {
+    AES_encrypt, AES_decrypt, AES_set_encrypt_key, AES_set_decrypt_key,
+    AES_cbc_encrypt, AES_ctr128_encrypt, AES_ecb_encrypt, AES_ofb128_encrypt,
+    DES_encrypt1, DES_encrypt2, DES_encrypt3, DES_ecb_encrypt,
+    DES_ncbc_encrypt, DES_cbc_encrypt, DES_set_key, DES_set_odd_parity,
+    RC4, RC4_set_key,
+    MD5_Init, MD5_Update, MD5_Final, MD5,
+    SHA1_Init, SHA1_Update, SHA1_Final, SHA1,
+    SHA224_Init, SHA224_Update, SHA224_Final, SHA224,
+    SHA256_Init, SHA256_Update, SHA256_Final, SHA256,
+    SHA384_Init, SHA384_Update, SHA384_Final, SHA384,
+    SHA512_Init, SHA512_Update, SHA512_Final, SHA512,
+    BF_set_key, BF_encrypt, BF_decrypt, BF_cbc_encrypt, BF_ecb_encrypt
+};
+@@
+fn@p(...)
+
+@script:python depends on openssl_legacy@
+p << openssl_legacy.p;
+fn << openssl_legacy.fn;
+@@
+import json, sys
+for _p in p:
+    sys.stderr.write("COCCIRESULT:" + json.dumps({
+        "file": _p.file, "line": int(_p.line),
+        "rule": "crypto_calls",
+        "message": "crypto:primitive_call:openssl:" + str(fn),
+    }) + "\n")
+
+
+// =====================================================================
+// Linux kernel crypto API
+// =====================================================================
+
+@kernel_crypto@
+position p;
+identifier fn = {
+    crypto_alloc_skcipher, crypto_alloc_cipher, crypto_alloc_shash,
+    crypto_alloc_ahash, crypto_alloc_aead, crypto_alloc_akcipher,
+    crypto_alloc_kpp, crypto_alloc_rng,
+    crypto_skcipher_encrypt, crypto_skcipher_decrypt,
+    crypto_skcipher_setkey,
+    crypto_aead_encrypt, crypto_aead_decrypt, crypto_aead_setkey,
+    crypto_aead_setauthsize,
+    crypto_shash_init, crypto_shash_update, crypto_shash_final,
+    crypto_shash_digest, crypto_shash_setkey,
+    crypto_ahash_init, crypto_ahash_update, crypto_ahash_final,
+    crypto_ahash_digest, crypto_ahash_setkey,
+    crypto_akcipher_encrypt, crypto_akcipher_decrypt,
+    crypto_akcipher_sign, crypto_akcipher_verify
+};
+@@
+fn@p(...)
+
+@script:python depends on kernel_crypto@
+p << kernel_crypto.p;
+fn << kernel_crypto.fn;
+@@
+import json, sys
+for _p in p:
+    sys.stderr.write("COCCIRESULT:" + json.dumps({
+        "file": _p.file, "line": int(_p.line),
+        "rule": "crypto_calls",
+        "message": "crypto:primitive_call:kernel:" + str(fn),
+    }) + "\n")
+
+
+// =====================================================================
+// libsodium
+// =====================================================================
+
+@libsodium_crypto@
+position p;
+identifier fn = {
+    crypto_secretbox, crypto_secretbox_open,
+    crypto_secretbox_easy, crypto_secretbox_open_easy,
+    crypto_secretbox_detached, crypto_secretbox_open_detached,
+    crypto_box, crypto_box_open, crypto_box_easy, crypto_box_open_easy,
+    crypto_box_detached, crypto_box_open_detached,
+    crypto_box_keypair, crypto_box_seed_keypair,
+    crypto_sign, crypto_sign_open, crypto_sign_detached,
+    crypto_sign_verify_detached, crypto_sign_keypair,
+    crypto_sign_seed_keypair,
+    crypto_aead_chacha20poly1305_encrypt,
+    crypto_aead_chacha20poly1305_decrypt,
+    crypto_aead_chacha20poly1305_ietf_encrypt,
+    crypto_aead_chacha20poly1305_ietf_decrypt,
+    crypto_aead_xchacha20poly1305_ietf_encrypt,
+    crypto_aead_xchacha20poly1305_ietf_decrypt,
+    crypto_auth, crypto_auth_verify,
+    crypto_pwhash, crypto_pwhash_str, crypto_pwhash_str_verify,
+    crypto_generichash, crypto_generichash_init, crypto_generichash_update,
+    crypto_generichash_final,
+    crypto_hash_sha256, crypto_hash_sha512
+};
+@@
+fn@p(...)
+
+@script:python depends on libsodium_crypto@
+p << libsodium_crypto.p;
+fn << libsodium_crypto.fn;
+@@
+import json, sys
+for _p in p:
+    sys.stderr.write("COCCIRESULT:" + json.dumps({
+        "file": _p.file, "line": int(_p.line),
+        "rule": "crypto_calls",
+        "message": "crypto:primitive_call:libsodium:" + str(fn),
+    }) + "\n")
+
+
+// =====================================================================
+// RNG sources — every API consumed for entropy/randomness
+// =====================================================================
+
+@openssl_rng@
+position p;
+identifier fn = {
+    RAND_bytes, RAND_priv_bytes, RAND_pseudo_bytes, RAND_seed, RAND_add
+};
+@@
+fn@p(...)
+
+@script:python depends on openssl_rng@
+p << openssl_rng.p;
+fn << openssl_rng.fn;
+@@
+import json, sys
+for _p in p:
+    sys.stderr.write("COCCIRESULT:" + json.dumps({
+        "file": _p.file, "line": int(_p.line),
+        "rule": "crypto_calls",
+        "message": "crypto:rng_source:openssl:" + str(fn),
+    }) + "\n")
+
+
+@libsodium_rng@
+position p;
+identifier fn = {
+    randombytes_buf, randombytes_buf_deterministic,
+    randombytes_random, randombytes_uniform, randombytes
+};
+@@
+fn@p(...)
+
+@script:python depends on libsodium_rng@
+p << libsodium_rng.p;
+fn << libsodium_rng.fn;
+@@
+import json, sys
+for _p in p:
+    sys.stderr.write("COCCIRESULT:" + json.dumps({
+        "file": _p.file, "line": int(_p.line),
+        "rule": "crypto_calls",
+        "message": "crypto:rng_source:libsodium:" + str(fn),
+    }) + "\n")
+
+
+@kernel_rng@
+position p;
+identifier fn = {
+    get_random_bytes, get_random_u32, get_random_u64,
+    get_random_long, prandom_u32, prandom_bytes,
+    getrandom
+};
+@@
+fn@p(...)
+
+@script:python depends on kernel_rng@
+p << kernel_rng.p;
+fn << kernel_rng.fn;
+@@
+import json, sys
+for _p in p:
+    sys.stderr.write("COCCIRESULT:" + json.dumps({
+        "file": _p.file, "line": int(_p.line),
+        "rule": "crypto_calls",
+        "message": "crypto:rng_source:kernel:" + str(fn),
+    }) + "\n")
+
+
+@libc_rng@
+position p;
+identifier fn = { rand, random, srand, srandom, drand48, lrand48, mrand48 };
+@@
+fn@p(...)
+
+@script:python depends on libc_rng@
+p << libc_rng.p;
+fn << libc_rng.fn;
+@@
+import json, sys
+for _p in p:
+    sys.stderr.write("COCCIRESULT:" + json.dumps({
+        "file": _p.file, "line": int(_p.line),
+        "rule": "crypto_calls",
+        "message": "crypto:rng_source:libc:" + str(fn),
+    }) + "\n")

--- a/packages/code_understanding/annotation_synth.py
+++ b/packages/code_understanding/annotation_synth.py
@@ -203,14 +203,16 @@ def _emit_site_annotations(
     counts: SynthCounts,
 ) -> None:
     """Emit ONE annotation per function aggregating its mechanically-detected
-    ownership / privilege / shared-state sites (from ``context_map_sites``).
+    ownership / privilege / shared-state / crypto sites (from
+    ``context_map_sites``).
 
     Aggregation is mandatory: annotations key on ``(file, function)`` and a
     function commonly holds several sites (e.g. alloc + double-free, or
-    ownership *and* a capability check, or many lock acquire/release pairs),
-    so a per-site write would clobber down to the last one. Each site already
-    carries its ``function`` (source_intel's enclosing function); checklist
-    resolution is a fallback so coverage survives an inventory miss. Source is
+    ownership *and* a capability check, or many lock acquire/release pairs,
+    or a crypto primitive call alongside an RNG source), so a per-site write
+    would clobber down to the last one. Each site already carries its
+    ``function`` (source_intel's enclosing function); checklist resolution is
+    a fallback so coverage survives an inventory miss. Source is
     ``source_intel`` and the substrate's ``respect-manual`` write never
     clobbers an operator note.
     """
@@ -219,6 +221,7 @@ def _emit_site_annotations(
         ("ownership", "ownership_model"),
         ("privilege", "privilege_model"),
         ("shared_state", "shared_state"),
+        ("crypto", "crypto_inventory"),
     ):
         for item in _safe_list_of_dicts(cmap, section_key):
             file_path = item.get("file")
@@ -244,7 +247,7 @@ def _emit_site_annotations(
                 head += f" (line {line})"
             detail = [head]
             for k in ("allocator", "free_fn", "name", "grade", "role",
-                      "fn", "lock_var"):
+                      "fn", "lock_var", "api"):
                 if item.get(k):
                     detail.append(f"  {k}: {item[k]}")
             g["lines"].append("\n".join(detail))

--- a/packages/code_understanding/context_map_sites.py
+++ b/packages/code_understanding/context_map_sites.py
@@ -124,6 +124,24 @@ def build_shared_state(si: "SourceIntelResult") -> List[Dict[str, Any]]:
     return out
 
 
+def build_crypto_inventory(si: "SourceIntelResult") -> List[Dict[str, Any]]:
+    """Cryptographic primitive call + RNG-source sites.
+
+    Site `kind` is the call kind directly (`primitive_call` or
+    `rng_source`); the originating library (`api`: openssl/kernel/
+    libsodium/libc) and the concrete function (`fn`) ride alongside so
+    consumers can filter without re-parsing the kind string.
+    """
+    out: List[Dict[str, Any]] = []
+    for cc in getattr(si, "crypto_calls", ()) or ():
+        out.append(_site(
+            getattr(cc, "kind", "crypto"), cc,
+            api=getattr(cc, "api", None),
+            fn=getattr(cc, "fn", None),
+        ))
+    return out
+
+
 def enrich_context_map_with_sites(
     cmap: Dict[str, Any], si: "SourceIntelResult",
     *, repo_root: Optional[Union[str, Path]] = None,
@@ -147,7 +165,10 @@ def enrich_context_map_with_sites(
     merge-vs-replace decision — resolve it then, against that layer's design
     (the intended flow is mechanical-sites-first, LLM-enriches-on-top).
     """
-    counts = {"ownership_model": 0, "privilege_model": 0, "shared_state": 0}
+    counts = {
+        "ownership_model": 0, "privilege_model": 0,
+        "shared_state": 0, "crypto_inventory": 0,
+    }
     if not isinstance(cmap, dict):
         return counts
     root = Path(repo_root) if repo_root is not None else None
@@ -155,6 +176,7 @@ def enrich_context_map_with_sites(
         ("ownership_model", build_ownership_model),
         ("privilege_model", build_privilege_model),
         ("shared_state", build_shared_state),
+        ("crypto_inventory", build_crypto_inventory),
     ):
         try:
             sites = builder(si)

--- a/packages/code_understanding/tests/test_context_map_sites.py
+++ b/packages/code_understanding/tests/test_context_map_sites.py
@@ -38,6 +38,7 @@ class _SI:
     _FIELDS = (
         "allocations", "checked_allocations", "paired_frees",
         "double_frees", "capabilities", "lsm_hooks", "lock_sites",
+        "crypto_calls",
     )
 
     def __init__(self, **kw):
@@ -131,10 +132,49 @@ def test_shared_state_section_omitted_when_empty():
     assert "shared_state" not in cmap
 
 
+def test_crypto_inventory_sites_aggregated_with_api_and_fn():
+    # Coverage: both kinds × across-API mix carries api + fn alongside.
+    si = _SI(crypto_calls=[
+        _Ev(location=("c.c", 11), enclosing_function="encrypt_record",
+            kind="primitive_call", api="openssl", fn="EVP_EncryptInit_ex"),
+        _Ev(location=("c.c", 14), enclosing_function="encrypt_record",
+            kind="primitive_call", api="openssl", fn="EVP_EncryptUpdate"),
+        _Ev(location=("c.c", 22), enclosing_function="seed_state",
+            kind="rng_source", api="openssl", fn="RAND_bytes"),
+        _Ev(location=("c.c", 33), enclosing_function="legacy_hash",
+            kind="primitive_call", api="libsodium",
+            fn="crypto_generichash"),
+        _Ev(location=("c.c", 40), enclosing_function="legacy_hash",
+            kind="rng_source", api="libc", fn="rand"),
+    ])
+    cmap: dict = {}
+    counts = enrich_context_map_with_sites(cmap, si)
+    assert counts["crypto_inventory"] == 5
+    inv = cmap["crypto_inventory"]
+    # kind is the call kind directly (primitive_call / rng_source); api +
+    # fn ride alongside so a consumer can filter without re-parsing.
+    assert {e["kind"] for e in inv} == {"primitive_call", "rng_source"}
+    assert {e["api"] for e in inv} == {"openssl", "libsodium", "libc"}
+    evp_init = next(e for e in inv if e["fn"] == "EVP_EncryptInit_ex")
+    assert evp_init == {
+        "kind": "primitive_call", "file": "c.c", "line": 11,
+        "function": "encrypt_record", "api": "openssl",
+        "fn": "EVP_EncryptInit_ex",
+    }
+
+
+def test_crypto_inventory_section_omitted_when_empty():
+    cmap: dict = {}
+    counts = enrich_context_map_with_sites(cmap, _SI())
+    assert counts["crypto_inventory"] == 0
+    assert "crypto_inventory" not in cmap
+
+
 def test_empty_result_writes_no_keys():
     cmap = {"entry_points": []}
     counts = enrich_context_map_with_sites(cmap, _SI())
-    assert counts == {"ownership_model": 0, "privilege_model": 0, "shared_state": 0}
+    assert counts == {"ownership_model": 0, "privilege_model": 0,
+                      "shared_state": 0, "crypto_inventory": 0}
     assert "ownership_model" not in cmap and "privilege_model" not in cmap
 
 
@@ -159,7 +199,8 @@ def test_best_effort_on_malformed_evidence():
 
 def test_non_dict_cmap_is_noop():
     assert enrich_context_map_with_sites(None, _SI()) == {
-        "ownership_model": 0, "privilege_model": 0, "shared_state": 0,
+        "ownership_model": 0, "privilege_model": 0,
+        "shared_state": 0, "crypto_inventory": 0,
     }
 
 
@@ -195,7 +236,8 @@ def test_degrades_gracefully_without_spatch(monkeypatch):
 
     cmap = {"entry_points": []}
     counts = enrich_context_map_with_sites(cmap, si)
-    assert counts == {"ownership_model": 0, "privilege_model": 0, "shared_state": 0}
+    assert counts == {"ownership_model": 0, "privilege_model": 0,
+                      "shared_state": 0, "crypto_inventory": 0}
     assert "ownership_model" not in cmap and "privilege_model" not in cmap
 
 
@@ -304,6 +346,53 @@ def test_synth_aggregates_all_three_categories_with_shared_state(tmp_path):
     assert "fn: mutex_lock" in body and "lock_var: &m" in body
     # all three categories appear in the metadata header
     assert "site_categories=ownership,privilege,shared_state" in body
+
+
+def test_synth_aggregates_all_four_categories_with_crypto(tmp_path):
+    # Same regression class as the three-category test above, extended to
+    # verify crypto_inventory (Phase B crypto axis) joins the dispatch
+    # tuple cleanly. A function with ownership + privilege + lock + crypto
+    # sites must yield ONE annotation with every site, site_categories
+    # listing all four. Regression risk: if the synth dispatch tuple
+    # isn't extended, crypto sites silently drop and site_categories
+    # degrades to ownership,privilege,shared_state.
+    out = tmp_path / "run"
+    out.mkdir()
+    (out / "checklist.json").write_text(
+        json.dumps({"target_path": str(tmp_path / "repo")}), encoding="utf-8",
+    )
+    cmap = {
+        "ownership_model": [
+            {"kind": "alloc", "file": "k.c", "line": 5,
+             "function": "session", "allocator": "kmalloc"},
+        ],
+        "privilege_model": [
+            {"kind": "capability", "file": "k.c", "line": 7,
+             "function": "session", "name": "capable"},
+        ],
+        "shared_state": [
+            {"kind": "spin_acquire", "file": "k.c", "line": 11,
+             "function": "session", "fn": "spin_lock", "lock_var": "&sl"},
+        ],
+        "crypto_inventory": [
+            {"kind": "primitive_call", "file": "k.c", "line": 18,
+             "function": "session", "api": "openssl",
+             "fn": "EVP_EncryptInit_ex"},
+            {"kind": "rng_source", "file": "k.c", "line": 19,
+             "function": "session", "api": "openssl", "fn": "RAND_bytes"},
+        ],
+    }
+    (out / "context-map.json").write_text(json.dumps(cmap), encoding="utf-8")
+
+    counts = synthesise_from_understand_output(out)
+    assert counts.emitted == 1  # one annotation per (file, function)
+    body = (out / "annotations" / "k.c.md").read_text(encoding="utf-8")
+    assert body.count("site:") == 5  # 1+1+1+2 sites survive
+    # crypto-specific extras (api + fn) land in the body
+    assert "api: openssl" in body
+    assert "fn: EVP_EncryptInit_ex" in body and "fn: RAND_bytes" in body
+    # all four categories appear in the metadata header
+    assert "site_categories=crypto,ownership,privilege,shared_state" in body
 
 
 # --- producer shim --------------------------------------------------------

--- a/packages/source_intel/analyze.py
+++ b/packages/source_intel/analyze.py
@@ -290,6 +290,23 @@ class LockSiteEvidence:
 
 
 @dataclass(frozen=True)
+class CryptoCallEvidence:
+    """A single cryptographic primitive call or RNG-source call site.
+
+    Enumeration only — does NOT imply algorithm weakness, key reuse, or
+    misuse. Populated from
+    engine/coccinelle/source_intel/crypto/crypto_calls.cocci output.
+    Feeds the Phase B `crypto_inventory` /understand --map section.
+    """
+
+    kind: str                                     # "primitive_call" | "rng_source"
+    api: str                                      # "openssl" | "kernel" | "libsodium" | "libc"
+    fn: str                                       # concrete function name (e.g. "EVP_EncryptInit_ex")
+    location: Tuple[str, int]
+    enclosing_function: Optional[str] = None
+
+
+@dataclass(frozen=True)
 class WarnEvidence:
     """A single observation of a non-aborting runtime-warning call
     (WARN_ON / pr_warn / KASAN_REPORT etc.).
@@ -568,6 +585,13 @@ class SourceIntelResult:
     #: detection is lock_imbalance.cocci's job.
     lock_sites: Tuple[LockSiteEvidence, ...] = ()
 
+    #: Phase B (crypto axis): cryptographic primitive call + RNG-source
+    #: sites enumerated by crypto_calls.cocci. Informational; feeds the
+    #: crypto_inventory /understand --map section + per-function
+    #: annotations. No verdict policy attached — broken-RNG-in-crypto
+    #: reasoning is a separate finding-style rule.
+    crypto_calls: Tuple[CryptoCallEvidence, ...] = ()
+
     #: Axis 6 consumer: build-hardening flags observed in the target's
     #: build configuration. Populated from core.build.build_flags when
     #: signal exists; otherwise default BuildFlagsContext() (all None,
@@ -834,6 +858,7 @@ def analyze(
     double_free_observations: List[DoubleFreeEvidence] = []
     paired_free_observations: List[PairedFreeEvidence] = []
     lock_site_observations: List[LockSiteEvidence] = []
+    crypto_call_observations: List[CryptoCallEvidence] = []
 
     # spatch invocation per axis. ``no_includes=True`` matches the
     # existing PR-3 scan + PR-4 prereqs untrusted-target posture;
@@ -892,6 +917,9 @@ def analyze(
                 lock_site_observations.extend(
                     _parse_match_to_lock_site(match)
                 )
+                crypto_call_observations.extend(
+                    _parse_match_to_crypto_call(match)
+                )
 
     # Project-specific alias discovery: walk target headers, classify
     # `#define MACRO __attribute__((...))` patterns by family, count
@@ -938,6 +966,7 @@ def analyze(
         double_frees=tuple(double_free_observations),
         paired_frees=tuple(paired_free_observations),
         lock_sites=tuple(lock_site_observations),
+        crypto_calls=tuple(crypto_call_observations),
         build_flags=extract_flags(target),
     )
 
@@ -1469,6 +1498,41 @@ def _parse_match_to_lock_site(match: Any) -> List[LockSiteEvidence]:
         kind=kind,
         fn=fn,
         lock_var=lock_var,
+        location=(file_path, line_no),
+        enclosing_function=enclosing_fn,
+    )]
+
+
+_CRYPTO_CALL_KINDS = frozenset({"primitive_call", "rng_source"})
+_CRYPTO_CALL_APIS = frozenset({"openssl", "kernel", "libsodium", "libc"})
+
+
+def _parse_match_to_crypto_call(match: Any) -> List[CryptoCallEvidence]:
+    """Convert a cocci SpatchMatch from crypto_calls.cocci into a
+    CryptoCallEvidence record. Message: ``crypto:<kind>:<api>:<fn>``.
+    Function names from this rule set don't contain ``:`` so a 4-way
+    split is structural."""
+    msg = (getattr(match, "message", "") or "").strip()
+    if not msg.startswith("crypto:"):
+        return []
+    parts = msg.split(":", 3)
+    if len(parts) < 4:
+        return []
+    _prefix, kind, api, fn = parts
+    if kind not in _CRYPTO_CALL_KINDS or api not in _CRYPTO_CALL_APIS:
+        return []
+    fn = fn.strip()
+    if not fn:
+        return []
+    file_path = getattr(match, "file", "")
+    line_no = int(getattr(match, "line", 0))
+    enclosing_fn = (
+        _enclosing_function(file_path, line_no) if file_path else None
+    )
+    return [CryptoCallEvidence(
+        kind=kind,
+        api=api,
+        fn=fn,
         location=(file_path, line_no),
         enclosing_function=enclosing_fn,
     )]

--- a/packages/source_intel/tests/test_crypto_calls.py
+++ b/packages/source_intel/tests/test_crypto_calls.py
@@ -1,0 +1,219 @@
+"""Tests for the crypto axis — crypto_calls.cocci + CryptoCallEvidence.
+
+Two layers:
+  * Unit: the message parser (`_parse_match_to_crypto_call`) — deterministic,
+    no spatch. Pins the COCCIRESULT shape, the kind/api enums, the structural
+    4-segment split, and rejection of malformed payloads.
+  * Real-spatch E2E: gated on spatch availability. Smoke fixture with every
+    covered API + kind family fires; out-of-axis APIs (memcpy / strcmp /
+    open) do NOT fire.
+"""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+import pytest
+
+from packages.source_intel.analyze import (
+    CryptoCallEvidence,
+    SourceIntelResult,
+    _parse_match_to_crypto_call,
+    analyze,
+)
+
+
+class _Match:
+    """Shape-compatible stand-in for coccinelle.runner.SpatchMatch."""
+
+    def __init__(self, message: str, file: str = "x.c", line: int = 1) -> None:
+        self.message = message
+        self.file = file
+        self.line = line
+
+
+# --- parser unit tests ----------------------------------------------------
+
+
+def test_parser_accepts_canonical_message():
+    out = _parse_match_to_crypto_call(_Match(
+        "crypto:primitive_call:openssl:EVP_EncryptInit_ex",
+        file="c.c", line=42,
+    ))
+    assert out == [CryptoCallEvidence(
+        kind="primitive_call", api="openssl", fn="EVP_EncryptInit_ex",
+        location=("c.c", 42), enclosing_function=None,
+    )]
+
+
+def test_parser_recognises_every_api():
+    apis = ("openssl", "kernel", "libsodium", "libc")
+    for api in apis:
+        out = _parse_match_to_crypto_call(_Match(
+            f"crypto:primitive_call:{api}:some_fn",
+        ))
+        assert out and out[0].api == api, f"api={api} rejected"
+
+
+def test_parser_recognises_both_kinds():
+    for kind in ("primitive_call", "rng_source"):
+        out = _parse_match_to_crypto_call(_Match(
+            f"crypto:{kind}:openssl:some_fn",
+        ))
+        assert out and out[0].kind == kind, f"kind={kind} rejected"
+
+
+def test_parser_rejects_unknown_kind():
+    assert _parse_match_to_crypto_call(_Match(
+        "crypto:key_decl:openssl:some_var",
+    )) == []
+
+
+def test_parser_rejects_unknown_api():
+    # MbedTLS is deferred — until/unless the cocci adds a `mbedtls` rule,
+    # the parser must reject it so a typo doesn't silently leak through.
+    assert _parse_match_to_crypto_call(_Match(
+        "crypto:primitive_call:mbedtls:mbedtls_aes_setkey_enc",
+    )) == []
+
+
+def test_parser_rejects_truncated_message():
+    assert _parse_match_to_crypto_call(_Match(
+        "crypto:primitive_call:openssl",
+    )) == []
+
+
+def test_parser_rejects_empty_fn():
+    assert _parse_match_to_crypto_call(_Match(
+        "crypto:primitive_call:openssl:",
+    )) == []
+
+
+def test_parser_ignores_other_rules():
+    # Other rules' COCCIRESULTs must not leak through the dispatch.
+    assert _parse_match_to_crypto_call(_Match("lock_site:acquire:spin:spin_lock:&sl")) == []
+    assert _parse_match_to_crypto_call(_Match("lsm:security_inode_permission")) == []
+    assert _parse_match_to_crypto_call(_Match("alloc_paired:kmalloc:kfree")) == []
+
+
+def test_crypto_calls_default_empty_on_bare_result():
+    r = SourceIntelResult()
+    assert r.crypto_calls == ()
+
+
+# --- real-spatch E2E (skipped in CI; runs locally) ------------------------
+
+
+_CRYPTO_FIXTURE = """\
+#include <stddef.h>
+#include <stdint.h>
+
+/* OpenSSL */
+int EVP_EncryptInit_ex(void *, void *, void *, const unsigned char *, const unsigned char *);
+int EVP_DigestUpdate(void *, const void *, size_t);
+void AES_encrypt(const unsigned char *, unsigned char *, const void *);
+int  SHA256_Update(void *, const void *, size_t);
+int  RAND_bytes(unsigned char *, int);
+
+/* Linux kernel crypto */
+void *crypto_alloc_skcipher(const char *, unsigned int, unsigned int);
+int   crypto_skcipher_encrypt(void *);
+void  get_random_bytes(void *, int);
+
+/* libsodium */
+int crypto_secretbox_easy(unsigned char *, const unsigned char *,
+                          unsigned long long, const unsigned char *,
+                          const unsigned char *);
+void randombytes_buf(void *, size_t);
+
+/* libc */
+int rand(void);
+
+/* OUT OF AXIS — must NOT fire */
+void *memcpy(void *, const void *, size_t);
+int   strcmp(const char *, const char *);
+
+int driver(void) {
+    unsigned char k[32], iv[16], buf[64];
+
+    EVP_EncryptInit_ex(0, 0, 0, k, iv);
+    EVP_DigestUpdate(0, buf, sizeof buf);
+    AES_encrypt(buf, buf, k);
+    SHA256_Update(0, buf, sizeof buf);
+    RAND_bytes(buf, sizeof buf);
+
+    crypto_alloc_skcipher("aes", 0, 0);
+    crypto_skcipher_encrypt(0);
+    get_random_bytes(buf, sizeof buf);
+
+    crypto_secretbox_easy(buf, buf, sizeof buf, iv, k);
+    randombytes_buf(buf, sizeof buf);
+
+    int r = rand();
+
+    memcpy(buf, k, sizeof buf);
+    strcmp("a", "b");
+
+    return r;
+}
+"""
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(
+    not shutil.which("spatch"), reason="spatch not installed",
+)
+def test_e2e_crypto_calls_covers_every_api_kind_combination(tmp_path: Path) -> None:
+    (tmp_path / "c.c").write_text(_CRYPTO_FIXTURE)
+    r = analyze(tmp_path)
+
+    triples = {(c.kind, c.api, c.fn) for c in r.crypto_calls}
+    expected = {
+        # OpenSSL primitive_call surface
+        ("primitive_call", "openssl", "EVP_EncryptInit_ex"),
+        ("primitive_call", "openssl", "EVP_DigestUpdate"),
+        ("primitive_call", "openssl", "AES_encrypt"),
+        ("primitive_call", "openssl", "SHA256_Update"),
+        # OpenSSL RNG
+        ("rng_source", "openssl", "RAND_bytes"),
+        # Kernel primitive_call + RNG
+        ("primitive_call", "kernel", "crypto_alloc_skcipher"),
+        ("primitive_call", "kernel", "crypto_skcipher_encrypt"),
+        ("rng_source", "kernel", "get_random_bytes"),
+        # libsodium primitive_call + RNG
+        ("primitive_call", "libsodium", "crypto_secretbox_easy"),
+        ("rng_source", "libsodium", "randombytes_buf"),
+        # libc RNG
+        ("rng_source", "libc", "rand"),
+    }
+    missing = expected - triples
+    assert not missing, f"families not captured: {sorted(missing)}"
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(
+    not shutil.which("spatch"), reason="spatch not installed",
+)
+def test_e2e_crypto_calls_skips_out_of_axis_apis(tmp_path: Path) -> None:
+    # memcpy / strcmp aren't crypto; they belong to other rules (or none).
+    # If they appear in crypto_calls, the cocci is too broad.
+    (tmp_path / "c.c").write_text(_CRYPTO_FIXTURE)
+    r = analyze(tmp_path)
+
+    fns = {c.fn for c in r.crypto_calls}
+    assert "memcpy" not in fns
+    assert "strcmp" not in fns
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(
+    not shutil.which("spatch"), reason="spatch not installed",
+)
+def test_e2e_crypto_calls_carry_enclosing_function(tmp_path: Path) -> None:
+    (tmp_path / "c.c").write_text(_CRYPTO_FIXTURE)
+    r = analyze(tmp_path)
+
+    # Every site comes from `driver` — no stray attributions.
+    fns = {c.enclosing_function for c in r.crypto_calls}
+    assert fns == {"driver"}, f"unexpected enclosing functions: {fns}"

--- a/packages/source_intel/tests/test_rule_integrity.py
+++ b/packages/source_intel/tests/test_rule_integrity.py
@@ -52,6 +52,9 @@ EXPECTED_RULES = {
     "concurrency": {
         "lock_sites.cocci",
     },
+    "crypto": {
+        "crypto_calls.cocci",
+    },
     "hazards": {
         "deprecated_functions.cocci",
         "signed_alloc.cocci",


### PR DESCRIPTION
Fourth and final Phase B mechanical section, completing the ownership/privilege/shared_state/crypto map-schema set.

- New cocci axis engine/coccinelle/source_intel/crypto/crypto_calls.cocci: enumeration-only. Two kinds (primitive_call, rng_source) across four APIs (openssl, kernel, libsodium, libc). Covers OpenSSL modern EVP + legacy AES_/SHA_/HMAC_/DES_/RC4_/MD5_/BF_; Linux kernel crypto API (crypto_alloc_*, crypto_skcipher_*, crypto_shash_*, crypto_ahash_*, crypto_aead_*, crypto_akcipher_*); libsodium (secretbox/box/sign/aead/ pwhash/generichash); RNG sources (RAND_bytes, randombytes_buf, getrandom, get_random_bytes, rand/random). MbedTLS, Windows BCrypt, Bouncy Castle, C++ wrappers deliberately out of scope — add as separate rules when target corpus shows demand.
- New CryptoCallEvidence + crypto_calls field on SourceIntelResult; parser shape mirrors _parse_match_to_lock_site. Soundness limit documented in the cocci header: identifier matching is name-only, so a non-crypto project defining its own SHA256_Update would fire. Short names (rand, random) have highest collision risk. Downstream LLM analysis disambiguates from surrounding context.
- build_crypto_inventory in context_map_sites projects evidence as a flat list of {kind, file, line, function, api, fn} dicts, matching the shipped section shape.
- annotation_synth extended to aggregate crypto sites alongside the three existing categories; one annotation per (file, function) carrying every site. Four-category aggregation regression test added (same class as the per-site-clobber #689 surfaced).
- map.md MAP-5d extended; rule-integrity test registers the new axis.

8 unit + 3 real-spatch E2E (skip-silent on CI without spatch). Full suite (707 → 719 pass) + ruff clean.