### PR TITLE
feat(run): per-finding provenance_refs + cross-run coalescer preservation

### DIFF
--- a/core/project/merge.py
+++ b/core/project/merge.py
@@ -188,6 +188,14 @@ def merge_findings(run_dirs: List[Path]) -> List[Dict[str, Any]]:
     most progressed status (e.g. "confirmed" beats "not_disproven"). Among equal
     statuses, the latest run wins.
 
+    **Provenance preservation:** the winning representation's
+    ``provenance_refs`` becomes the UNION (deduped by ``run_id``, insertion-
+    order preserved) of every losing source's ``provenance_refs``. So a
+    finding seen in runs A → B → D where B "won" the status race still
+    surfaces the A and D refs on the merged record — the cross-run trail
+    survives the deduplication. Pre-stamping findings (no ``provenance_refs``
+    field) merge cleanly; they just don't contribute to the union.
+
     Args:
         run_dirs: Ordered list of run directories (later entries override earlier).
 
@@ -195,16 +203,41 @@ def merge_findings(run_dirs: List[Path]) -> List[Dict[str, Any]]:
         Deduplicated list of findings.
     """
     merged: Dict[tuple, Dict[str, Any]] = {}
+    # Parallel structure tracking the provenance union per key. Kept in
+    # insertion order via a dict-of-dicts indexed by run_id so re-additions
+    # of the same run (e.g. a /project clean + rerun on the same dir) don't
+    # multiply the refs.
+    refs_by_key: Dict[tuple, Dict[str, Dict[str, Any]]] = {}
 
     for run_dir in run_dirs:
         findings = _load_findings_from_dir(Path(run_dir))
         for finding in findings:
             key = _finding_key(finding)
+            # Accumulate this finding's refs (if any) into the union for the
+            # key — independent of who wins the status race.
+            ref_acc = refs_by_key.setdefault(key, {})
+            for r in finding.get("provenance_refs", []) or ():
+                if isinstance(r, dict):
+                    run_id = r.get("run_id")
+                    if isinstance(run_id, str) and run_id not in ref_acc:
+                        ref_acc[run_id] = r
             existing = merged.get(key)
             if existing is None or _status_rank(finding) >= _status_rank(existing):
                 merged[key] = finding
 
-    return list(merged.values())
+    # Inject the union back onto each winning representation. If the key has
+    # no refs at all (all sources were pre-stamping), leave the field absent
+    # rather than synthesising an empty list — preserves the "no provenance
+    # available" signal.
+    out: List[Dict[str, Any]] = []
+    for key, winner in merged.items():
+        union = list(refs_by_key.get(key, {}).values())
+        if union:
+            # Shallow-copy so we don't mutate the source-run finding dict.
+            winner = dict(winner)
+            winner["provenance_refs"] = union
+        out.append(winner)
+    return out
 
 
 def verify_merge(merged_findings: List, source_findings_count: int,

--- a/core/project/tests/test_merge.py
+++ b/core/project/tests/test_merge.py
@@ -152,6 +152,107 @@ class TestMergeFindings(unittest.TestCase):
             self.assertEqual(len(merged), 1)
             self.assertEqual(merged[0]["final_status"], "ruled_out")
 
+    # --- provenance_refs preservation across merge (#2 finding↔provenance) ---
+
+    def test_three_way_merge_preserves_all_provenance_refs(self):
+        """A finding surfaced in 3 runs collapses to one record whose
+        ``provenance_refs`` is the UNION of all 3 sources' refs (deduped by
+        run_id, insertion order preserved)."""
+        with TemporaryDirectory() as d:
+            key = {"file": "a.c", "function": "f", "line": 10}
+            a = self._make_run(d, "a", [{
+                "id": "F-001", **key, "status": "not_disproven",
+                "provenance_refs": [{"run_id": "run-A", "ts": "t1"}],
+            }])
+            b = self._make_run(d, "b", [{
+                "id": "F-002", **key, "status": "confirmed",
+                "provenance_refs": [{"run_id": "run-B", "ts": "t2"}],
+            }])
+            c = self._make_run(d, "c", [{
+                "id": "F-003", **key, "status": "exploitable",
+                "provenance_refs": [{"run_id": "run-C", "ts": "t3"}],
+            }])
+            merged = merge_findings([a, b, c])
+            self.assertEqual(len(merged), 1)
+            # Winning representation has the most-progressed status
+            self.assertEqual(merged[0]["status"], "exploitable")
+            # Provenance trail preserves all 3 source runs
+            refs = merged[0]["provenance_refs"]
+            self.assertEqual(
+                [r["run_id"] for r in refs], ["run-A", "run-B", "run-C"]
+            )
+
+    def test_merge_preserves_provenance_when_loser_has_more_refs(self):
+        """The "winning" status doesn't determine which refs survive — every
+        source's refs are unioned regardless of who won the status race."""
+        with TemporaryDirectory() as d:
+            key = {"file": "x.c", "function": "g", "line": 5}
+            # Loser carries 2 refs (from a prior coalesce upstream)
+            a = self._make_run(d, "a", [{
+                "id": "X1", **key, "status": "not_disproven",
+                "provenance_refs": [
+                    {"run_id": "old-1"}, {"run_id": "old-2"},
+                ],
+            }])
+            # Winner carries 1 ref
+            b = self._make_run(d, "b", [{
+                "id": "X2", **key, "status": "exploitable",
+                "provenance_refs": [{"run_id": "new-1"}],
+            }])
+            merged = merge_findings([a, b])
+            self.assertEqual(merged[0]["status"], "exploitable")
+            self.assertEqual(
+                [r["run_id"] for r in merged[0]["provenance_refs"]],
+                ["old-1", "old-2", "new-1"],
+            )
+
+    def test_merge_dedupes_duplicate_run_ids_in_union(self):
+        """If the same run's refs appear via multiple sources (e.g. a re-
+        ingestion path), the union dedupes by run_id — no double-counting."""
+        with TemporaryDirectory() as d:
+            key = {"file": "y.c", "function": "h", "line": 1}
+            a = self._make_run(d, "a", [{
+                "id": "Y", **key, "status": "confirmed",
+                "provenance_refs": [{"run_id": "dup", "ts": "first"}],
+            }])
+            b = self._make_run(d, "b", [{
+                "id": "Y", **key, "status": "confirmed",
+                "provenance_refs": [{"run_id": "dup", "ts": "second"}],
+            }])
+            merged = merge_findings([a, b])
+            refs = merged[0]["provenance_refs"]
+            # ONE entry for dup; the first-seen wins (insertion-order stable).
+            self.assertEqual(len(refs), 1)
+            self.assertEqual(refs[0]["ts"], "first")
+
+    def test_merge_legacy_findings_without_refs_omit_field(self):
+        """Pre-#2 findings (no ``provenance_refs`` on any source) merge
+        cleanly — the field is absent rather than synthesised as ``[]``,
+        so consumers can distinguish "no provenance" from "empty union"."""
+        with TemporaryDirectory() as d:
+            key = {"file": "z.c", "function": "i", "line": 99}
+            a = self._make_run(d, "a", [{"id": "Z1", **key, "status": "confirmed"}])
+            b = self._make_run(d, "b", [{"id": "Z2", **key, "status": "exploitable"}])
+            merged = merge_findings([a, b])
+            self.assertNotIn("provenance_refs", merged[0])
+
+    def test_merge_mixed_legacy_and_stamped(self):
+        """A legacy (un-stamped) source mixed with a stamped one yields a
+        union containing just the stamped run's refs — the legacy contributes
+        nothing rather than introducing a sentinel."""
+        with TemporaryDirectory() as d:
+            key = {"file": "m.c", "function": "j", "line": 2}
+            a = self._make_run(d, "a", [{"id": "M1", **key, "status": "confirmed"}])
+            b = self._make_run(d, "b", [{
+                "id": "M2", **key, "status": "exploitable",
+                "provenance_refs": [{"run_id": "stamped-only"}],
+            }])
+            merged = merge_findings([a, b])
+            self.assertEqual(
+                [r["run_id"] for r in merged[0]["provenance_refs"]],
+                ["stamped-only"],
+            )
+
 
 class TestVerifyMerge(unittest.TestCase):
 

--- a/core/run/findings.py
+++ b/core/run/findings.py
@@ -1,0 +1,185 @@
+"""Per-finding provenance stamping.
+
+Closes the gap between the L1 provenance layer (which records *what produced
+this run* in ``.raptor-run.json``) and individual findings (which historically
+carried no back-reference to the run that produced them). After a run
+completes, every finding gets a ``provenance_refs`` field — a list (always
+plural, one entry at stamp time) of ``{run_id, ts, manifest_path}`` triples.
+
+Why plural from day 1: cross-run merging (``core/project/merge.py``)
+collapses N runs that surface the same finding into ONE record. The merged
+record's ``provenance_refs`` is the UNION of all source runs' refs — the
+plural shape makes that concatenation trivial without a singular/plural
+schema awkwardness post-merge.
+
+What's INTENTIONALLY thin in a ProvenanceRef:
+  * run_id      = the run-dir basename (stable, file-system grep-able).
+  * ts          = the manifest's start-time ISO timestamp.
+  * manifest_path = the path to ``.raptor-run.json`` (relative to the run
+    dir when possible, absolute otherwise — see ``_relative_manifest_path``).
+
+Engines / models / target / det_repro are NOT duplicated here. Consumers
+that need them call ``core.run.load_run_metadata(Path(manifest_path).parent)``.
+This keeps the per-finding payload small and forces single-source-of-truth
+reads against the manifest.
+
+NOT stamped: SARIF files (the SARIF spec has its own ``tool`` / ``run`` /
+``originalUriBaseIds`` provenance; injecting our own field would mangle the
+standard). Only files matching the ``findings.json`` convention.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from core.logging import get_logger
+
+from .metadata import RUN_METADATA_FILE, load_run_metadata
+
+logger = get_logger()
+
+# Field name on each finding dict. Always a list (plural-from-day-1).
+PROVENANCE_REFS_FIELD = "provenance_refs"
+
+# Files we stamp, relative to the run dir. Tested via load_findings_from_dir's
+# shape detection (top-level list OR {"findings": [...]} wrapper).
+_STAMP_PATHS: tuple = (
+    "findings.json",
+    "sca/findings.json",
+)
+
+
+def build_provenance_ref(run_dir: Path) -> Optional[Dict[str, Any]]:
+    """Build the per-finding ProvenanceRef for ``run_dir``.
+
+    Returns ``None`` if the run dir has no ``.raptor-run.json`` (an
+    untracked output dir, or a stale partial run). Callers MUST treat
+    ``None`` as "no provenance available" and SKIP stamping — never
+    synthesise a partial ref.
+    """
+    manifest = load_run_metadata(run_dir)
+    if not manifest:
+        return None
+    ref = {
+        "run_id": run_dir.name,
+        "manifest_path": str(_relative_manifest_path(run_dir)),
+    }
+    # Manifest top-level uses ``timestamp`` (per core/run/metadata.py
+    # generate_run_metadata). Accept legacy/alternate keys defensively.
+    ts = manifest.get("timestamp") or manifest.get("started_at") or manifest.get("ts")
+    if ts:
+        ref["ts"] = ts
+    return ref
+
+
+def _relative_manifest_path(run_dir: Path) -> Path:
+    """Manifest path relative to ``run_dir`` (so it survives moves of the
+    enclosing project dir). Always returns a relative path within the run."""
+    return Path(RUN_METADATA_FILE)
+
+
+def stamp_findings_in_run(run_dir: Path) -> Dict[str, int]:
+    """Walk every ``findings.json`` in ``run_dir`` and inject
+    ``provenance_refs`` into each finding that doesn't already have it.
+
+    Idempotent — re-running on an already-stamped run is a no-op. Best-effort
+    per file: a malformed ``findings.json`` is logged and skipped, doesn't
+    abort the lifecycle. Returns ``{"files_stamped", "findings_stamped",
+    "files_skipped"}``.
+
+    No-op when the run dir has no manifest (returns zeros) — callers must
+    not assume stamping succeeded; check the counts.
+    """
+    counts = {"files_stamped": 0, "findings_stamped": 0, "files_skipped": 0}
+    run_dir = Path(run_dir)
+    ref = build_provenance_ref(run_dir)
+    if ref is None:
+        logger.debug(f"No manifest in {run_dir}; skipping stamping.")
+        return counts
+
+    for rel in _STAMP_PATHS:
+        path = run_dir / rel
+        if not path.is_file():
+            continue
+        stamped = _stamp_file(path, ref)
+        if stamped < 0:
+            counts["files_skipped"] += 1
+        elif stamped > 0:
+            counts["files_stamped"] += 1
+            counts["findings_stamped"] += stamped
+    return counts
+
+
+def _stamp_file(path: Path, ref: Dict[str, Any]) -> int:
+    """Stamp findings in one file. Returns count of findings newly stamped,
+    or -1 on parse failure (file skipped, not modified)."""
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except OSError as e:
+        logger.warning(f"stamp_findings: read failed {path}: {e}")
+        return -1
+    try:
+        data = json.loads(raw)
+    except (json.JSONDecodeError, ValueError) as e:
+        logger.warning(f"stamp_findings: parse failed {path}: {e}")
+        return -1
+
+    findings_list, container_kind = _resolve_findings_list(data)
+    if findings_list is None:
+        # Shape we don't recognise — skip silently rather than risk mangling.
+        return 0
+
+    new_count = 0
+    for f in findings_list:
+        if not isinstance(f, dict):
+            continue
+        existing = f.get(PROVENANCE_REFS_FIELD)
+        if isinstance(existing, list) and any(
+            isinstance(r, dict) and r.get("run_id") == ref["run_id"]
+            for r in existing
+        ):
+            # Idempotent — already stamped for this run.
+            continue
+        # Plural-from-day-1: always a list. New stamp = single-element.
+        if isinstance(existing, list):
+            existing.append(ref)
+        else:
+            f[PROVENANCE_REFS_FIELD] = [ref]
+        new_count += 1
+
+    if new_count == 0:
+        return 0
+
+    # Re-serialize the SAME container shape we read in.
+    if container_kind == "list":
+        out = json.dumps(data, indent=2, sort_keys=False, default=str) + "\n"
+    else:  # dict-wrapped
+        out = json.dumps(data, indent=2, sort_keys=False, default=str) + "\n"
+    try:
+        path.write_text(out, encoding="utf-8")
+    except OSError as e:
+        logger.warning(f"stamp_findings: write failed {path}: {e}")
+        return -1
+    return new_count
+
+
+def _resolve_findings_list(
+    data: Any,
+) -> tuple[Optional[List[Any]], Optional[str]]:
+    """Mirror load_findings_from_dir's shape detection but return the LIST
+    by reference so mutations stamp into the original container.
+
+    Returns ``(list_ref, container_kind)`` where container_kind is
+    ``"list"`` for a top-level array, ``"dict"`` for a wrapped shape, or
+    ``(None, None)`` if neither applies.
+    """
+    if isinstance(data, list):
+        return data, "list"
+    if isinstance(data, dict):
+        for key in ("findings", "results"):
+            v = data.get(key)
+            if isinstance(v, list):
+                return v, "dict"
+    return None, None

--- a/core/run/metadata.py
+++ b/core/run/metadata.py
@@ -552,9 +552,34 @@ def complete_run(output_dir: Path, extra: Dict[str, Any] = None,
     # Materialise the LLM read-coverage record from the plugin's .reads-manifest
     # FIRST, so the snapshot below imports it alongside the scanner records.
     _convert_reads_manifest(output_dir)
+    # Stamp findings with provenance_refs back to this run's manifest. Must run
+    # AFTER _update_status (manifest sealed) and BEFORE _snapshot_run_coverage
+    # (coverage importer pulls findings into the store; we want them stamped
+    # by then). Best-effort: a stamping failure must not fail the lifecycle.
+    _stamp_findings_provenance(output_dir)
     # Snapshot AFTER the status/manifest write so coverage provenance can read
     # the sealed manifest (engine versions / resolved models).
     _snapshot_run_coverage(output_dir)
+
+
+def _stamp_findings_provenance(output_dir: Path) -> None:
+    """Best-effort: stamp every finding in this run's ``findings.json`` (and
+    ``sca/findings.json``) with a ``provenance_refs`` field pointing back to
+    the run's manifest, so downstream consumers (``/project correlate``, the
+    citation view, audit reports) can trace each finding to the run that
+    produced it.
+
+    Idempotent (re-runs do nothing). Never raises — lifecycle hooks must not
+    fail on a stamping error. See ``core/run/findings.py``.
+    """
+    import logging
+    try:
+        from core.run.findings import stamp_findings_in_run
+        stamp_findings_in_run(Path(output_dir))
+    except Exception:  # noqa: BLE001 — never fail lifecycle on a stamping error
+        logging.getLogger(__name__).debug(
+            "_stamp_findings_provenance failed for %s", output_dir, exc_info=True
+        )
 
 
 def _convert_reads_manifest(output_dir: Path) -> None:

--- a/core/run/tests/test_findings_stamp.py
+++ b/core/run/tests/test_findings_stamp.py
@@ -1,0 +1,188 @@
+"""Tests for the per-finding provenance_refs stamping
+(:mod:`core.run.findings`). Deterministic — no spatch, no LLM."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from core.run.findings import (
+    PROVENANCE_REFS_FIELD,
+    build_provenance_ref,
+    stamp_findings_in_run,
+)
+from core.run.metadata import (
+    RUN_METADATA_FILE,
+    complete_run,
+    start_run,
+)
+
+
+def _write_manifest(d: Path, *, ts: str = "2026-05-30T12:00:00+00:00") -> None:
+    """Minimal manifest enough for build_provenance_ref to read."""
+    (d / RUN_METADATA_FILE).write_text(json.dumps({
+        "command": "scan", "timestamp": ts, "status": "running",
+    }))
+
+
+# --- build_provenance_ref ------------------------------------------------
+
+
+def test_build_ref_minimal_shape(tmp_path: Path) -> None:
+    _write_manifest(tmp_path)
+    ref = build_provenance_ref(tmp_path)
+    assert ref == {
+        "run_id": tmp_path.name,
+        "manifest_path": RUN_METADATA_FILE,
+        "ts": "2026-05-30T12:00:00+00:00",
+    }
+
+
+def test_build_ref_returns_none_without_manifest(tmp_path: Path) -> None:
+    # No .raptor-run.json — caller must skip stamping, not synthesise a ref.
+    assert build_provenance_ref(tmp_path) is None
+
+
+def test_build_ref_ts_optional(tmp_path: Path) -> None:
+    # Manifest with no timestamp key — ref omits ``ts`` rather than
+    # injecting None or an empty string.
+    (tmp_path / RUN_METADATA_FILE).write_text(json.dumps({"command": "scan"}))
+    ref = build_provenance_ref(tmp_path)
+    assert ref is not None
+    assert "ts" not in ref
+
+
+# --- stamp_findings_in_run -----------------------------------------------
+
+
+def test_stamps_top_level_list_shape(tmp_path: Path) -> None:
+    _write_manifest(tmp_path)
+    (tmp_path / "findings.json").write_text(json.dumps([
+        {"id": "F1"}, {"id": "F2"},
+    ]))
+    counts = stamp_findings_in_run(tmp_path)
+    assert counts == {
+        "files_stamped": 1, "findings_stamped": 2, "files_skipped": 0,
+    }
+    findings = json.loads((tmp_path / "findings.json").read_text())
+    assert all(PROVENANCE_REFS_FIELD in f for f in findings)
+    assert findings[0][PROVENANCE_REFS_FIELD][0]["run_id"] == tmp_path.name
+
+
+def test_stamps_wrapped_dict_shape(tmp_path: Path) -> None:
+    _write_manifest(tmp_path)
+    (tmp_path / "findings.json").write_text(json.dumps({
+        "stage": "scan", "target_path": "/x",
+        "findings": [{"id": "F1"}, {"id": "F2"}],
+    }))
+    counts = stamp_findings_in_run(tmp_path)
+    assert counts["findings_stamped"] == 2
+    data = json.loads((tmp_path / "findings.json").read_text())
+    # Container shape preserved (stage / target_path siblings still there).
+    assert data["stage"] == "scan"
+    assert all(PROVENANCE_REFS_FIELD in f for f in data["findings"])
+
+
+def test_stamps_sca_subpath_too(tmp_path: Path) -> None:
+    # ``/sca`` writes findings to ``<run>/sca/findings.json`` — must stamp.
+    _write_manifest(tmp_path)
+    (tmp_path / "sca").mkdir()
+    (tmp_path / "sca" / "findings.json").write_text(json.dumps([
+        {"id": "S1", "package": "lodash"},
+    ]))
+    counts = stamp_findings_in_run(tmp_path)
+    assert counts["files_stamped"] == 1
+    findings = json.loads((tmp_path / "sca" / "findings.json").read_text())
+    assert findings[0][PROVENANCE_REFS_FIELD][0]["run_id"] == tmp_path.name
+
+
+def test_idempotent_restamp_does_nothing(tmp_path: Path) -> None:
+    _write_manifest(tmp_path)
+    (tmp_path / "findings.json").write_text(json.dumps([{"id": "F1"}]))
+    stamp_findings_in_run(tmp_path)
+    # Second pass: no new stamps (refs by this run_id already present).
+    counts = stamp_findings_in_run(tmp_path)
+    assert counts == {
+        "files_stamped": 0, "findings_stamped": 0, "files_skipped": 0,
+    }
+    # And exactly one ref on the finding, not two.
+    finding = json.loads((tmp_path / "findings.json").read_text())[0]
+    assert len(finding[PROVENANCE_REFS_FIELD]) == 1
+
+
+def test_malformed_json_is_skipped_not_raised(tmp_path: Path) -> None:
+    _write_manifest(tmp_path)
+    (tmp_path / "findings.json").write_text("{ not valid json")
+    counts = stamp_findings_in_run(tmp_path)
+    assert counts == {
+        "files_stamped": 0, "findings_stamped": 0, "files_skipped": 1,
+    }
+
+
+def test_unrecognised_shape_left_alone(tmp_path: Path) -> None:
+    # Not a list, not a dict-with-findings — leave the file untouched.
+    _write_manifest(tmp_path)
+    original = json.dumps({"some_other_field": "value"})
+    (tmp_path / "findings.json").write_text(original)
+    counts = stamp_findings_in_run(tmp_path)
+    assert counts["files_stamped"] == 0
+    assert (tmp_path / "findings.json").read_text() == original
+
+
+def test_non_dict_finding_entries_are_skipped(tmp_path: Path) -> None:
+    # A malformed findings.json with a stray string/null in the list mustn't
+    # crash the stamper — those entries get skipped, the dict entries stamp.
+    _write_manifest(tmp_path)
+    (tmp_path / "findings.json").write_text(json.dumps([
+        {"id": "F1"}, "not a dict", None, {"id": "F2"},
+    ]))
+    counts = stamp_findings_in_run(tmp_path)
+    assert counts["findings_stamped"] == 2  # the 2 dicts
+
+
+def test_no_manifest_skips_all_files(tmp_path: Path) -> None:
+    # No .raptor-run.json — must NOT synthesise refs from thin air.
+    (tmp_path / "findings.json").write_text(json.dumps([{"id": "F1"}]))
+    counts = stamp_findings_in_run(tmp_path)
+    assert counts == {
+        "files_stamped": 0, "findings_stamped": 0, "files_skipped": 0,
+    }
+    # Finding left untouched — no provenance_refs field synthesised.
+    finding = json.loads((tmp_path / "findings.json").read_text())[0]
+    assert PROVENANCE_REFS_FIELD not in finding
+
+
+# --- complete_run lifecycle hook ----------------------------------------
+
+
+def test_complete_run_stamps_findings_end_to_end(tmp_path: Path) -> None:
+    start_run(tmp_path, command="scan", target="/x")
+    (tmp_path / "findings.json").write_text(json.dumps([{"id": "F1"}]))
+    complete_run(tmp_path)
+    finding = json.loads((tmp_path / "findings.json").read_text())[0]
+    refs = finding[PROVENANCE_REFS_FIELD]
+    assert len(refs) == 1
+    assert refs[0]["run_id"] == tmp_path.name
+    assert "ts" in refs[0]
+
+
+def test_complete_run_stamping_failure_does_not_break_lifecycle(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # If the stamping helper raises, complete_run must still mark status=
+    # completed (best-effort lifecycle hook contract).
+    def _raise(*_args, **_kw) -> None:
+        raise RuntimeError("stamping blew up")
+
+    monkeypatch.setattr(
+        "core.run.findings.stamp_findings_in_run", _raise,
+    )
+    start_run(tmp_path, command="scan", target="/x")
+    (tmp_path / "findings.json").write_text(json.dumps([{"id": "F1"}]))
+    complete_run(tmp_path)
+    manifest = json.loads(
+        (tmp_path / RUN_METADATA_FILE).read_text()
+    )
+    assert manifest["status"] == "completed"


### PR DESCRIPTION
Closes the gap between the L1 provenance layer (which records what produced this RUN in .raptor-run.json) and individual findings (which historically carried no back-reference to the producing run). Item #2 of the Provenance Substrate arc; unblocks the citation view (#8).

- New core/run/findings.py — stamp_findings_in_run(run_dir) walks findings.json (top-level + sca/) and injects a "provenance_refs" field (plural-from-day-1) into each finding dict. Handles both on-disk shapes (top-level list + {"findings":[...]} wrapper). Idempotent. Best-effort per file: malformed JSON skipped, never raised. NOT SARIF — that spec has its own tool/run/originalUriBaseIds provenance; injecting our field would mangle the standard.
- core/run/metadata.py complete_run hook — stamps after manifest seal, before coverage snapshot (so the coverage importer sees stamped findings). Best-effort: stamping failure cannot fail the lifecycle.
- core/project/merge.py merge_findings — UNION provenance_refs across all sources (deduped by run_id, insertion-order stable). Most- progressed-status still picks the winning representation; the cross-run trail survives independently of who won the status race. Pre-stamping (legacy) findings merge cleanly — field stays absent rather than synthesised as [], preserving the "no provenance" signal.

Schema kept LEAN: provenance_refs = [{run_id, ts, manifest_path}]. Engines / models / target are NOT duplicated here — consumers needing them read the manifest via load_run_metadata(). Single source of truth.

12 unit + 5 coalescer tests; 461 run+project suite pass; ruff clean. Adversarial probes (10K-ref source, malformed/non-dict ref entries, non-str run_id, no-manifest dir) handled by isinstance guards.