### PR TITLE
feat(run): finding_public_view — publication-grade structural projector

### DIFF
--- a/core/run/findings.py
+++ b/core/run/findings.py
@@ -1,4 +1,19 @@
-"""Per-finding provenance stamping.
+"""Per-finding provenance stamping + publication-grade projection.
+
+Two responsibilities in one module:
+
+* ``stamp_findings_in_run`` (lifecycle hook) — adds a ``provenance_refs``
+  back-link from each finding to the run that produced it. Closes the gap
+  between the L1 provenance layer (``.raptor-run.json``) and individual
+  findings. See the per-feature notes below.
+* ``finding_public_view`` (pure projector) — substrate for the disclosure
+  tooling theme (``/cite``, ZKPoX 1.5+ attestation, hall-of-fame ingestion).
+  Captures only the IMMUTABLE structural facts a finding carries; excludes
+  every mutable interpretation (severity, status, ruling, reasoning) on the
+  principle that those are operator-claim territory made at publication
+  time, not stamped into a permanent record here.
+
+------- provenance_refs stamping --------------------------------------
 
 Closes the gap between the L1 provenance layer (which records *what produced
 this run* in ``.raptor-run.json``) and individual findings (which historically
@@ -31,6 +46,7 @@ standard). Only files matching the ``findings.json`` convention.
 from __future__ import annotations
 
 import json
+import unicodedata
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
@@ -183,3 +199,228 @@ def _resolve_findings_list(
             if isinstance(v, list):
                 return v, "dict"
     return None, None
+
+
+# ------- finding_public_view (publication-grade projector) -----------------
+#
+# Pure projection of immutable structural facts for publication-grade
+# consumers (/cite, ZKPoX 1.5+ attestation, hall-of-fame ingestion).
+# Captures only what cannot move post-discovery: file/line/cwe/vuln_type/
+# provenance refs. Mutable interpretations (severity, status, ruling,
+# reasoning) are deliberately excluded — they're operator-claim territory,
+# made at publication time, not stamped here. This keeps the projection
+# never-stale: if the underlying finding's status moves through validation,
+# the public view doesn't lie because the public view never claimed it.
+
+FINDING_PUBLIC_SCHEMA_VERSION = 1
+
+# Top-level allowlist. Strings get L1-strict character validation; the
+# ``file`` field additionally gets path-relativised. Lists/dicts that
+# happen to land here (cwe_ids = list of strings, references = list of
+# URLs) get per-element validation. provenance_refs passes through.
+_ALLOWED_FIELDS = (
+    "id", "finding_id",
+    "file", "function", "line", "column",
+    "vuln_type", "cwe_id", "cwe_ids",
+    "references",
+    "provenance_refs",
+)
+
+
+def finding_public_view(
+    finding: Dict[str, Any],
+    *,
+    target_path: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Project ``finding`` into the publication-grade public view.
+
+    Returns a dict containing only the immutable structural facts —
+    where the bug lives (file/function/line/column), what class it is
+    (vuln_type/cwe_id), and the back-link to the producing run
+    (provenance_refs). Mutable interpretations (severity, status,
+    ruling, reasoning, snippets) are dropped by design.
+
+    ``target_path`` anchors the ``file`` field's relativisation. When
+    omitted, the projector attempts to resolve it from the manifest
+    pointed to by ``finding['provenance_refs'][0]['manifest_path']``;
+    if that also fails, falls back to the basename. Absolute paths are
+    never emitted (they leak deployment topology).
+
+    Strings are L1-strict validated (reject control bytes / ANSI
+    escapes / unicode category C*). A field that fails validation is
+    DROPPED rather than emitted — the other fields survive, so a
+    single malformed value doesn't kill the projection.
+
+    Pure / deterministic / idempotent: ``finding_public_view(
+    finding_public_view(f, target_path=t), target_path=t)`` is equal
+    to ``finding_public_view(f, target_path=t)``.
+    """
+    out: Dict[str, Any] = {"schema": FINDING_PUBLIC_SCHEMA_VERSION}
+    if not isinstance(finding, dict):
+        return out
+
+    anchor = target_path if target_path else _resolve_target_path(finding)
+
+    for key in _ALLOWED_FIELDS:
+        if key not in finding:
+            continue
+        value = finding[key]
+        if key == "file":
+            cleaned = _publish_path(value, anchor)
+        elif key == "provenance_refs":
+            cleaned = _passthrough_provenance_refs(value)
+        elif isinstance(value, str):
+            cleaned = _publish_string(value)
+        elif isinstance(value, list):
+            cleaned = _publish_list(value)
+        elif isinstance(value, (int, float, bool)) or value is None:
+            cleaned = value
+        elif isinstance(value, dict):
+            # We deliberately don't recurse into arbitrary dicts —
+            # the allowlist is flat, so a dict here is unexpected and
+            # safest to drop rather than risk passing nested sensitive
+            # content through.
+            cleaned = _DROP
+        else:
+            cleaned = _DROP
+        if cleaned is _DROP:
+            continue
+        out[key] = cleaned
+    return out
+
+
+# Sentinel — distinguishes "drop this field" from "emit None"
+class _Drop:
+    pass
+
+
+_DROP = _Drop()
+
+
+def _publish_string(value: str) -> Any:
+    """L1-strict: reject control bytes (0x00-0x1f), ANSI escape (0x1b),
+    unicode category C* (control/format incl. RTL override).
+    Legitimate unicode (José, 李) is preserved."""
+    for ch in value:
+        cp = ord(ch)
+        if cp < 0x20 or cp == 0x7f:  # control bytes + DEL
+            return _DROP
+        cat = unicodedata.category(ch)
+        if cat.startswith("C"):  # Cc / Cf / Cs / Co / Cn
+            return _DROP
+    return value
+
+
+def _publish_list(items: List[Any]) -> Any:
+    """Per-element validation; if any element fails the field's
+    validation, drop the whole list. cwe_ids / references are the
+    realistic cases here — both are lists of strings."""
+    cleaned: List[Any] = []
+    for item in items:
+        if isinstance(item, str):
+            v = _publish_string(item)
+            if v is _DROP:
+                return _DROP
+            cleaned.append(v)
+        elif isinstance(item, (int, float, bool)) or item is None:
+            cleaned.append(item)
+        else:
+            return _DROP
+    return cleaned
+
+
+# provenance_refs is RAPTOR-generated; the stamping code in this module
+# only writes {run_id, ts, manifest_path}. The projector restricts the
+# passthrough to those keys so a hand-edited or hostile findings.json
+# can't smuggle extra nested content out through the public view.
+_PROVENANCE_REF_KEYS = ("run_id", "ts", "manifest_path")
+
+
+def _passthrough_provenance_refs(refs: Any) -> Any:
+    """Pass through provenance_refs as a list of dicts restricted to
+    the known-safe keys (run_id, ts, manifest_path). Strings get
+    L1-strict validation; entries that fail are dropped from the
+    output list rather than crashing the projection."""
+    if not isinstance(refs, list):
+        return _DROP
+    out = []
+    for r in refs:
+        if not isinstance(r, dict):
+            continue
+        clean: Dict[str, Any] = {}
+        for k in _PROVENANCE_REF_KEYS:
+            v = r.get(k)
+            if isinstance(v, str):
+                vv = _publish_string(v)
+                if vv is not _DROP:
+                    clean[k] = vv
+        if clean:
+            out.append(clean)
+    if not out:
+        return _DROP
+    return out
+
+
+def _publish_path(value: Any, anchor: Optional[str]) -> Any:
+    """Relativise an absolute path against ``anchor`` when possible;
+    fall back to basename when no anchor is known OR when the path
+    contains ``..`` traversal segments. Always L1-strict validates
+    the result.
+
+    Path-traversal defence: ``../../etc/passwd`` in a published view
+    could be misread as "the bug is in /etc/passwd" or hide the real
+    file the bug lives in. Any path with a ``..`` segment collapses
+    to its basename — preserves the filename (the publishable signal)
+    without enabling traversal-style misdirection.
+    """
+    if not isinstance(value, str) or not value:
+        return _DROP
+    p = Path(value)
+    if p.is_absolute():
+        if anchor:
+            try:
+                rel = p.relative_to(anchor)
+                value = str(rel)
+            except ValueError:
+                # Path isn't under the anchor — fall back to basename
+                # rather than emit the leaky absolute path.
+                value = p.name
+        else:
+            value = p.name
+    # Relative paths with `..` traversal segments collapse to basename
+    # (whether arrived-here-originally or via the relative_to path).
+    if ".." in Path(value).parts:
+        value = Path(value).name
+    return _publish_string(value)
+
+
+def _resolve_target_path(finding: Dict[str, Any]) -> Optional[str]:
+    """Pull target_path from the manifest pointed to by the first
+    provenance_ref. Best-effort: failure returns None and the caller
+    falls back to basename."""
+    refs = finding.get(PROVENANCE_REFS_FIELD)
+    if not isinstance(refs, list) or not refs:
+        return None
+    first = refs[0]
+    if not isinstance(first, dict):
+        return None
+    manifest_path = first.get("manifest_path")
+    if not isinstance(manifest_path, str) or not manifest_path:
+        return None
+    # manifest_path is typically run-dir-relative (".raptor-run.json").
+    # Resolution needs the run dir; we don't have it here without the
+    # caller telling us. So this path only resolves when manifest_path
+    # is absolute (which it's NOT in the v1 #2 stamping convention).
+    # In practice: callers passing relative manifest_paths must supply
+    # target_path explicitly. Documented in the function docstring.
+    p = Path(manifest_path)
+    if not p.is_absolute():
+        return None
+    try:
+        manifest = json.loads(p.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+    if not isinstance(manifest, dict):
+        return None
+    tp = manifest.get("target_path") or manifest.get("target")
+    return tp if isinstance(tp, str) and tp else None

--- a/core/run/tests/test_finding_public_view.py
+++ b/core/run/tests/test_finding_public_view.py
@@ -1,0 +1,330 @@
+"""Tests for finding_public_view — the publication-grade structural projector.
+
+Pure-function tests; no spatch, no LLM, no lifecycle. The projector is
+substrate for /cite, ZKPoX Tier 1.5+ attestation, and hall-of-fame
+ingestion (none of which exist yet) — the contract is locked here so
+those future consumers get a stable shape.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from core.run.findings import (
+    FINDING_PUBLIC_SCHEMA_VERSION,
+    PROVENANCE_REFS_FIELD,
+    finding_public_view,
+)
+
+
+# --- allowlist enforcement -----------------------------------------------
+
+
+def test_schema_version_always_present() -> None:
+    out = finding_public_view({})
+    assert out == {"schema": FINDING_PUBLIC_SCHEMA_VERSION}
+
+
+def test_allowlist_keeps_known_structural_fields() -> None:
+    # Every allowed field round-trips.
+    finding = {
+        "id": "F-001",
+        "finding_id": "F-001",
+        "file": "src/auth.py",
+        "function": "login_user",
+        "line": 142,
+        "column": 8,
+        "vuln_type": "sql_injection",
+        "cwe_id": "CWE-89",
+        "cwe_ids": ["CWE-89", "CWE-20"],
+        "references": ["https://cwe.mitre.org/89.html"],
+        "provenance_refs": [{"run_id": "r1", "ts": "2026-05-30T12:00:00Z"}],
+    }
+    out = finding_public_view(finding)
+    # Schema added; everything else preserved.
+    assert out["schema"] == FINDING_PUBLIC_SCHEMA_VERSION
+    for key, value in finding.items():
+        assert out[key] == value, f"{key}: {out[key]!r} != {value!r}"
+
+
+def test_unknown_fields_dropped() -> None:
+    # Arbitrary field not on allowlist → not in output.
+    out = finding_public_view({
+        "id": "F", "secret_data": "leak me", "internal_cache_key": "x:y:z",
+    })
+    assert "secret_data" not in out
+    assert "internal_cache_key" not in out
+    assert out.get("id") == "F"
+
+
+def test_mutable_fields_dropped_even_when_present() -> None:
+    # The whole point of the slim allowlist: status/severity/ruling/
+    # reasoning are excluded because they're operator-claim territory.
+    finding = {
+        "id": "F",
+        "severity": "High",
+        "cvss_vector": "CVSS:3.1/AV:N/...",
+        "cvss_score": 9.8,
+        "status": "exploitable",
+        "final_status": "exploitable",
+        "title": "subject to operator refinement",
+        "ruling": {"status": "exploitable", "reasoning": "LLM prose"},
+        "reasoning": "long LLM-emitted prose that quotes source",
+        "snippet": "char buf[8]; strcpy(buf, user);",
+    }
+    out = finding_public_view(finding)
+    for dropped in (
+        "severity", "cvss_vector", "cvss_score",
+        "status", "final_status", "title",
+        "ruling", "reasoning", "snippet",
+    ):
+        assert dropped not in out, f"{dropped} leaked: {out}"
+
+
+def test_non_dict_input_returns_envelope_only() -> None:
+    # Defensive — caller passed something other than a dict.
+    assert finding_public_view(None) == {"schema": FINDING_PUBLIC_SCHEMA_VERSION}
+    assert finding_public_view([]) == {"schema": FINDING_PUBLIC_SCHEMA_VERSION}
+    assert finding_public_view("string") == {"schema": FINDING_PUBLIC_SCHEMA_VERSION}
+
+
+def test_missing_optional_fields_omitted_not_nulled() -> None:
+    # A field that's absent on input is absent on output (no None
+    # placeholders). Distinguishes "not present" from "explicitly null".
+    out = finding_public_view({"id": "F"})
+    assert out == {"schema": FINDING_PUBLIC_SCHEMA_VERSION, "id": "F"}
+
+
+# --- path relativization -------------------------------------------------
+
+
+def test_file_relativized_against_target_path_arg() -> None:
+    out = finding_public_view(
+        {"file": "/abs/repo/src/a.c"}, target_path="/abs/repo",
+    )
+    assert out["file"] == "src/a.c"
+
+
+def test_file_relativized_via_provenance_refs_when_no_arg(
+    tmp_path: Path,
+) -> None:
+    # Manifest carrying target_path that the projector reads via the
+    # absolute manifest_path on provenance_refs[0].
+    target = tmp_path / "repo"
+    target.mkdir()
+    src = target / "src" / "a.c"
+    src.parent.mkdir()
+    src.write_text("// fixture")
+    manifest = tmp_path / ".raptor-run.json"
+    manifest.write_text(json.dumps({"target_path": str(target)}))
+    out = finding_public_view({
+        "file": str(src),
+        PROVENANCE_REFS_FIELD: [
+            {"run_id": "r1", "manifest_path": str(manifest)},
+        ],
+    })
+    assert out["file"] == "src/a.c"
+
+
+def test_file_falls_back_to_basename_when_no_anchor() -> None:
+    # Absolute path + no target_path arg + no resolvable manifest →
+    # basename only (never leak absolute deployment paths).
+    out = finding_public_view({"file": "/abs/repo/src/a.c"})
+    assert out["file"] == "a.c"
+
+
+def test_file_outside_target_falls_back_to_basename() -> None:
+    # Path doesn't sit under target_path — fall back to basename
+    # rather than emit a leaky ``../`` traversal.
+    out = finding_public_view(
+        {"file": "/other/place/a.c"}, target_path="/abs/repo",
+    )
+    assert out["file"] == "a.c"
+
+
+def test_file_relative_path_passes_through() -> None:
+    # Already-relative path is publication-safe as-is.
+    out = finding_public_view(
+        {"file": "src/auth.py"}, target_path="/abs/repo",
+    )
+    assert out["file"] == "src/auth.py"
+
+
+# --- L1-strict character validation --------------------------------------
+
+
+def test_control_byte_drops_field_keeps_others() -> None:
+    out = finding_public_view({
+        "id": "F",
+        "function": "login\x00user",         # NUL byte → drop
+    })
+    assert "function" not in out
+    assert out["id"] == "F"
+
+
+def test_ansi_escape_drops_field() -> None:
+    # Terminal-injection vector: ANSI escape in a published view that
+    # a CI log or markdown rendering could interpret.
+    out = finding_public_view({
+        "id": "F",
+        "vuln_type": "sql_injection\x1b[31m red text",
+    })
+    assert "vuln_type" not in out
+
+
+def test_rtl_override_drops_field() -> None:
+    # Homograph / spoofing vector — U+202E reverses display direction.
+    out = finding_public_view({
+        "id": "F",
+        "function": "safe_‮gnp.exe",
+    })
+    assert "function" not in out
+
+
+def test_legitimate_unicode_preserved() -> None:
+    # Non-Latin identifiers must survive — RAPTOR scans codebases with
+    # all sorts of source language conventions.
+    out = finding_public_view({
+        "id": "F",
+        "function": "Joséfile",
+        "file": "src/李.c",
+    })
+    assert out["function"] == "Joséfile"
+    assert out["file"] == "src/李.c"
+
+
+def test_list_element_failing_validation_drops_whole_list() -> None:
+    # A poisoned references list (e.g. an injected ANSI in one URL)
+    # drops the whole field — partial publishing is risky.
+    out = finding_public_view({
+        "id": "F",
+        "references": ["https://good.example/x", "bad\x1b[Aoops"],
+    })
+    assert "references" not in out
+    assert out["id"] == "F"
+
+
+# --- provenance_refs passthrough -----------------------------------------
+
+
+def test_provenance_refs_structure_preserved() -> None:
+    refs = [
+        {"run_id": "scan-20260530", "ts": "2026-05-30T12:00:00+00:00",
+         "manifest_path": ".raptor-run.json"},
+        {"run_id": "scan-20260601", "ts": "2026-06-01T08:00:00+00:00",
+         "manifest_path": ".raptor-run.json"},
+    ]
+    out = finding_public_view({"provenance_refs": refs})
+    assert out["provenance_refs"] == refs
+
+
+def test_provenance_refs_non_dict_entries_filtered() -> None:
+    out = finding_public_view({
+        "provenance_refs": [
+            {"run_id": "good"}, "string-not-dict", None, 42,
+        ],
+    })
+    # Only the dict survives.
+    assert out["provenance_refs"] == [{"run_id": "good"}]
+
+
+def test_provenance_refs_non_list_drops_field() -> None:
+    out = finding_public_view({"id": "F", "provenance_refs": "not a list"})
+    assert "provenance_refs" not in out
+    assert out["id"] == "F"
+
+
+def test_provenance_refs_empty_list_drops_field() -> None:
+    out = finding_public_view({"id": "F", "provenance_refs": []})
+    assert "provenance_refs" not in out
+
+
+def test_provenance_refs_locked_to_known_keys() -> None:
+    # Hand-edited or hostile findings.json can't smuggle extra nested
+    # content out via the provenance_refs passthrough. Only the known
+    # keys (run_id, ts, manifest_path) survive — anything else drops.
+    out = finding_public_view({
+        "provenance_refs": [{
+            "run_id": "r1",
+            "ts": "2026-05-30T...",
+            "manifest_path": ".raptor-run.json",
+            "exfil": "sensitive customer data",
+            "nested": {"deep": {"junk": "should not leak"}},
+        }],
+    })
+    assert out["provenance_refs"] == [{
+        "run_id": "r1",
+        "ts": "2026-05-30T...",
+        "manifest_path": ".raptor-run.json",
+    }]
+
+
+# --- path-traversal defence ---------------------------------------------
+
+
+def test_relative_path_with_double_dot_collapses_to_basename() -> None:
+    # Could be misread as "bug is in /etc/passwd" in a published view.
+    out = finding_public_view({"file": "../../etc/passwd"})
+    assert out["file"] == "passwd"
+
+
+def test_absolute_traversal_through_target_collapses_to_basename() -> None:
+    # Absolute path that escapes the target via .. — collapse to basename
+    # rather than relativise into a confusing path.
+    out = finding_public_view(
+        {"file": "/abs/repo/../../etc/passwd"}, target_path="/abs/repo",
+    )
+    assert out["file"] == "passwd"
+
+
+# --- idempotence ---------------------------------------------------------
+
+
+def test_idempotent_round_trip() -> None:
+    finding = {
+        "id": "F-001",
+        "file": "src/auth.py",
+        "function": "login_user",
+        "line": 142,
+        "vuln_type": "sql_injection",
+        "cwe_id": "CWE-89",
+        "cwe_ids": ["CWE-89"],
+        "references": ["https://cwe.mitre.org/89.html"],
+        "provenance_refs": [{"run_id": "r1", "ts": "2026-05-30T..."}],
+        # mutable noise that should drop on first pass
+        "severity": "High", "status": "exploitable",
+    }
+    once = finding_public_view(finding)
+    twice = finding_public_view(once)
+    assert once == twice
+
+
+# --- type-coercion edge cases --------------------------------------------
+
+
+def test_numeric_and_bool_fields_pass_through() -> None:
+    # line / column are typically int; the projector accepts numeric
+    # primitives without trying to stringify-then-validate.
+    out = finding_public_view({"line": 142, "column": 8})
+    assert out["line"] == 142
+    assert out["column"] == 8
+
+
+def test_unexpected_nested_dict_in_allowlist_field_dropped() -> None:
+    # cwe_id arriving as a dict (caller-error / schema drift) is
+    # dropped rather than passed through — safer than risking nested
+    # sensitive content leaking via an allowlist field.
+    out = finding_public_view({
+        "id": "F",
+        "cwe_id": {"weird": "shape"},
+    })
+    assert "cwe_id" not in out
+    assert out["id"] == "F"
+
+
+def test_file_non_string_drops_field() -> None:
+    # file = list or dict or None → drop, don't crash.
+    for bad in ([], {}, None, 42):
+        out = finding_public_view({"file": bad})
+        assert "file" not in out, f"file={bad!r} leaked"


### PR DESCRIPTION
Project a finding into a publication-safe view containing only immutable structural facts: id/finding_id, file (relativized), function, line, column, vuln_type, cwe_id/cwe_ids, references, provenance_refs. Mutable interpretations (severity, status, ruling, reasoning, snippets) are excluded.

- L1-strict character validation per string field (reject control bytes / ANSI escapes / unicode category C*); a failing field is dropped, others survive.
- File path relativization: against the target_path argument, or resolved from the manifest pointed to by provenance_refs[0]; basename fallback when no anchor is known. `..` traversal segments collapse to basename.
- provenance_refs passthrough is restricted to the known keys (run_id, ts, manifest_path) so hand-edited findings can't smuggle extra nested content through.

Pure function — no lifecycle hook, no on-disk artefacts. 27 unit tests; ruff clean.