### PR TITLE
feat(reachability) Binary-oracle reachability witness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ tuning.json
 .mcp.json
 .sage/
 *.sage.key
+*.gcov

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,6 +57,10 @@ Projects are opt-in named workspaces that corral analysis runs into a shared dir
 /project coverage              # shows tool coverage summary
 /project report                # merged view across all runs
 /project correlate             # cross-run finding correlation
+/project binary add <path>     # persist a debug binary for binary-oracle enrichment
+/project binary list           # list persisted binaries on the active project
+/project binary remove <path>  # remove one
+/project binary clear          # clear all
 /project clean --keep 3        # delete old runs
 /project none                  # clear active project
 ```
@@ -331,6 +335,43 @@ Two places Z3 is used — both degrade gracefully when absent:
    positive, skip LLM. `sat` → concrete input values fed into the LLM prompt and
    `DataflowValidation.prerequisites`. Best coverage: CWE-190, CWE-120/122,
    CWE-193, CWE-476.
+
+---
+
+## BINARY-ORACLE REACHABILITY
+
+When `--binary <path>` is passed to /agentic / /codeql, RAPTOR joins the source inventory with the debug binary via DWARF + nm and annotates each native (C/C++/Rust/Go) function with a per-binary verdict:
+
+- `symbol_present` / `inlined` / `folded` — the function survived compilation in some form
+- `absent` — the compiler / linker removed it from the analysed binary
+
+`absent` is corpus-earned for suppression: **1952/1952 verdicts correct across 6 iteratively-tuned corpora (consistency) + 187/187 on the held-out zstd v1.5.6 corpus with NO classifier tuning (generalization)** — rule-of-three 95% UB on miss rate ≤1.6% on first-contact-with-unseen-data. The held-out is non-vacuous: 473/1431 functions exercised by the workload, zero `absent` verdicts on actually-live functions. Conditional on full-DWARF evidence — a stripped binary in the analysed set downgrades to `tier="symbol_only"` and the chokepoint refuses to suppress.
+
+The verdict flows through the existing reachability chokepoint: /codeql + /agentic skip LLM analysis on absent-function findings (pre-LLM hard-suppress); /validate's demoter clamps attack-path proximity; /understand --map annotates entry-points and sinks with the per-binary verdict + tier.
+
+**Operator usage**:
+- `--binary <path>` — pass a debug binary. Repeatable for hybrid targets. Path validated at parse time.
+- `--binary-auto` — auto-detect debug binaries under `build/`, `target/release/`, `cmake-build-*/`, `bazel-bin/`, `builddir/`, `Debug/`, `Release/`, `out/`, `dist/`, `bin/`, Rust `target/<triple>/release` cross-target globs, and the source root. Honours `--target-kind`. Warns when the result cap (8) is reached.
+- `--binary-edges` — Inc 2b Tier 1/2: extract direct call edges + vtable resolution via r2 (single-invocation script-file mode; cached per-build-id with cross-target collision check). Slow (~10-30s per binary, then cached). Required for the `binary_call_edge` REACHABLE promote witness (rescues functions the source-graph thought were dead).
+- For `--target-kind=hybrid` deployments (library + application both shipped), declare MULTIPLE binaries — a function is `absent` only when EVERY declared binary lacks it. Tier-weighted combine: when full-DWARF and symbol-only disagree, full-DWARF wins (`alive-in-any` rule only applies same-tier).
+
+**Persistent per-project config**:
+- `/project binary add <path>` — persist a binary path on the active project. Auto-loaded by every subsequent /agentic / /codeql / /validate run. `is_file()`-validated at add time.
+- `/project binary list` / `remove` / `clear` — manage the persisted list.
+
+**Audit trail**:
+- `suppressions.jsonl` is written to the run's output directory whenever the chokepoint hard-suppresses a finding. One JSON record per suppression with `finding_id`, `rule_id`, `file_path`, `line`, `function`, `verdict`, `reason`. Query with `jq -c . suppressions.jsonl`. Both /agentic and /codeql write to the same file shape.
+- The classifier's per-finding analysis record also carries `analysis.reachability_suppression: true` + `analysis.reachability_verdict: <verdict>` for per-finding inspection.
+
+**Defenses against hostile / wrong-binary scenarios**:
+- Source-coverage floor (≥5% of project source names matched, min 3 matched, kicks in at ≥8 project names) — a planted ELF unrelated to source gets dropped with a loud warning rather than driving every source function to `absent`.
+- Sandbox isolation: r2 runs under `core.sandbox.run` (namespace + Landlock + network deny); binutils tools (readelf, nm, objdump, c++filt) under `core.sandbox.run_trusted`.
+
+**E2E + precision verification**:
+- `libexec/raptor-binary-oracle-e2e` — single-invocation audit that builds a real C target and walks 15 consumer surfaces (54 assertions). No LLM calls. Run via `bin/raptor` or `CLAUDECODE=1 libexec/...`.
+- `libexec/raptor-binary-oracle-precision --corpus <name>` — re-measure absent-precision on any corpus driver (synthetic/zlib/libsodium/snappy/leveldb/regex-rust/zstd_holdout). Report includes per-corpus cross-tab (classifier × gcov live/dead), aggregate with rule-of-three UB, n-concentration dominator detection, and the toolchain block (cc/gcov/llvm-cov versions) so the precision number is reproducible.
+
+**Skill location**: `core/inventory/binary_oracle.py` (classifier), `core/inventory/binary_oracle_autodetect.py` (auto-detect), `core/inventory/binary_oracle_precision.py` (measurement harness — `libexec/raptor-binary-oracle-precision` CLI shim runs it). Design + validation writeup: `~/design/binary-oracle-reachability.md` §9-11.
 
 ---
 

--- a/core/config/__init__.py
+++ b/core/config/__init__.py
@@ -219,6 +219,37 @@ class RaptorConfig:
     # lib+CLI whose manifest only exposes the library side).
     ENV_TARGET_KIND = "RAPTOR_TARGET_KIND"
 
+    # Operator-supplied debug binaries for the current target — triggers
+    # binary-oracle enrichment of the inventory (DWARF-joined per-function
+    # classification). Mutated by the ``--binary`` CLI flag (repeatable)
+    # at process start; read by ``build_inventory`` at the end of the
+    # build. Empty tuple = no enrichment.
+    #
+    # MULTIPLE binaries are the common case for ``--target-kind=hybrid``
+    # (a target that ships BOTH a library AND an application — npm
+    # package with main+bin, Python package with console_scripts,
+    # a C library that also ships a CLI). The classifier runs against
+    # each binary independently; the per-source-function results are
+    # combined with alive-in-any-wins semantics, so a function is only
+    # ``absent`` when EVERY declared binary lacks it. Picking the wrong
+    # single binary stops being a footgun.
+    #
+    # Follows the same in-process-ambient pattern as ``DEFAULT_TIMEOUT``
+    # — no env var (binary_oracle hasn't yet shown a need to cross
+    # subprocess boundaries; revisit if /validate or another helper grows
+    # one).
+    BINARY_ORACLE_PATHS: Tuple[str, ...] = ()
+
+    # Inc 2b Tier 1: when True, extract direct call edges from each
+    # binary in BINARY_ORACLE_PATHS (via r2) and annotate inventory
+    # items with binary-found callers. Affirmative reachability
+    # evidence — a function with binary-confirmed callers gets the
+    # ``binary_call_edge`` REACHABLE verdict via reach_witness.
+    # Opt-in because r2 ``aaa`` is slow (~10-30s per binary on
+    # typical sizes); operators turn it on when they care about
+    # source-graph false-deads on indirect / fn-pointer call sites.
+    BINARY_ORACLE_EDGES: bool = False
+
     # LLM Provider Configuration.
     #
     # OLLAMA_HOST reads the env var on every access so a runtime

--- a/core/inventory/binary_oracle.py
+++ b/core/inventory/binary_oracle.py
@@ -1,0 +1,1246 @@
+"""Binary-oracle reachability evidence — Inc 1 (classifier + 3-way classify).
+
+Joins the source inventory with a matching debug binary via DWARF + nm to
+produce one verdict per source function:
+
+    symbol_present   the function is present in the binary's symbol table.
+    inlined          DWARF shows the function was absorbed into callers
+                     (DW_TAG_inlined_subroutine instance exists), no
+                     standalone symbol.
+    absent           neither — DCE'd by the compiler/linker.
+    folded           two distinct source functions share one binary address
+                     (ICF / outlining); both classify here, never as ``absent``.
+
+Used asymmetrically by the reachability classifier (Inc 2):
+
+  * ``absent ∧ ¬inlined`` ⇒ dead in THIS build (STRONG HEURISTIC; build-
+    config-specific, so surface-only until corpus precision earns
+    enforcement; never overrides a SOUND witness).
+  * ``inlined`` or ``symbol_present`` ⇒ no demote.
+  * Binary call edges the source graph missed ⇒ promote callee to reachable
+    (Inc 2; not built here).
+
+v1 scope (per design): Linux ELF, DWARF required, native targets (C/C++/
+Rust/Go). Stripped binary → ``skipped`` with reason; macOS Mach-O / PE
+deferred.
+
+Implementation: shells out to system tools (``readelf``, ``nm``,
+``objdump --dwarf=info``) — no Python DWARF library dependency. The text
+parsing is binutils-version-resilient enough for the fixture matrix; the
+classifier is the consumer-facing contract, not the parsing details.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import shutil
+import subprocess
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import (
+    Dict, Iterable, Iterator, List, Literal, Optional, Set, Tuple,
+)
+
+logger = logging.getLogger(__name__)
+
+
+Classification = Literal["symbol_present", "inlined", "absent", "folded"]
+
+
+@dataclass(frozen=True)
+class BinaryOracleWitness:
+    """Per-source-function evidence from a debug binary join.
+
+    Carries provenance (``build_id`` + ``binary_path``) so consumers can spot
+    scope mismatch (e.g. a witness from a different build was reused) and so
+    multi-binary results can be attributed correctly. ``edges_added`` is
+    reserved for Inc 2 (the call-edge promote direction) and stays empty
+    here.
+
+    ``tier`` encodes the evidence quality:
+
+      ``"full"`` — DWARF + nm. All four verdicts (symbol_present,
+                   inlined, absent, folded) emittable. Corpus-earned;
+                   absent verdicts may license downstream suppression.
+
+      ``"symbol_only"`` — stripped binary (no DWARF), nm-only. Cannot
+                   distinguish ``inlined`` (no DW_TAG_inlined_subroutine
+                   info) from ``absent`` (no nm symbol). Conservative:
+                   absent verdicts in this tier do NOT earn suppression
+                   — a stripped-out function could be inlined into a
+                   surviving caller without us knowing. Emits
+                   ``symbol_present`` and ``absent`` only.
+    """
+    classification: Classification
+    build_id: str
+    binary_path: str
+    address: Optional[int] = None
+    edges_added: List[Tuple[str, str]] = field(default_factory=list)
+    tier: str = "full"
+
+
+# ---------------------------------------------------------------------------
+# System-tool wrappers (small, defensive, swap-out points if pyelftools ever
+# gets added as a dep).
+# ---------------------------------------------------------------------------
+
+def _run(argv: List[str], timeout: int = 60) -> str:
+    """Capture stdout from a system tool; return ``''`` on any failure
+    rather than raise — the classifier is best-effort and surface-only.
+
+    Uses ``core.sandbox.run_trusted`` (matches the existing pattern for
+    ELF/binutils tools in ``exploit_feasibility``/``binary_analysis``):
+    applies ``RaptorConfig.get_safe_env()`` + resource rlimits to keep
+    the tool's ambient state hostile-input-resistant. Read-only tools
+    (readelf, nm, objdump, c++filt) are RAPTOR-picked even when the
+    binary path is operator-supplied.
+    """
+    # Lazy import — keep the classifier independently importable in
+    # unit tests that stub the sandbox module.
+    from core.sandbox import run_trusted
+    try:
+        proc = run_trusted(argv, capture_output=True, text=True,
+                           check=False, timeout=timeout)
+    except (OSError, subprocess.TimeoutExpired) as e:
+        logger.debug("binary_oracle: %s failed: %s", argv[0], e)
+        return ""
+    if proc.returncode != 0:
+        logger.debug("binary_oracle: %s rc=%s stderr=%s",
+                     argv[0], proc.returncode, proc.stderr[:200])
+    return proc.stdout or ""
+
+
+def _stream(argv: List[str], timeout: int) -> Iterator[str]:
+    """Stream stdout line-by-line from a system tool. Used when the
+    output may be large (e.g. ``objdump --dwarf=info`` on a multi-MB
+    binary produces 1-3 GB of text); ``_run`` would buffer it all into
+    memory and OOM. Yields each line stripped of its trailing newline.
+
+    Manual ``get_safe_env`` application — ``run_trusted`` is one-shot
+    (capture_output=True) and would defeat the memory-bounded streaming
+    we need here. Same env hygiene as ``_run`` (no namespace/Landlock —
+    that's the ``run_trusted`` protection level: env + rlimits only).
+
+    On any failure (tool missing, non-zero rc with no output, timeout)
+    yields nothing — same swallow-and-degrade contract as ``_run``.
+    """
+    from core.config import RaptorConfig
+    deadline = time.monotonic() + timeout
+    try:
+        proc = subprocess.Popen(
+            argv, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL,
+            text=True, bufsize=1, env=RaptorConfig.get_safe_env(),
+        )
+    except OSError as e:
+        logger.debug("binary_oracle: %s failed to start: %s", argv[0], e)
+        return
+    try:
+        assert proc.stdout is not None
+        for line in proc.stdout:
+            if time.monotonic() > deadline:
+                logger.warning(
+                    "binary_oracle: %s exceeded %ss timeout; killing",
+                    argv[0], timeout,
+                )
+                proc.kill()
+                break
+            yield line.rstrip("\n")
+    finally:
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+
+
+def read_build_id(binary_path: Path) -> Optional[str]:
+    """Return the ELF ``.note.gnu.build-id`` (40-hex SHA1), or ``None``."""
+    out = _run(["readelf", "-n", str(binary_path)])
+    m = re.search(r"Build ID:\s*([0-9a-fA-F]+)", out)
+    return m.group(1).lower() if m else None
+
+
+# GCC IPA-clone suffixes. ``-O2`` routinely rewrites symbol names with
+# these tails when interprocedural optimisations specialise a function for
+# its callers. Operators analysing any GCC-built binary will hit this — a
+# source ``foo`` may only appear in nm as ``foo.constprop.0``, with no
+# original ``foo`` symbol. Strip the suffix when building the bare-name
+# index so source-name lookup still finds the function.
+#   .constprop.N  — -fipa-cp constant-propagation clone
+#   .isra.N       — -fipa-sra scalar-replacement clone
+#   .part.N       — -fpartial-inlining hot/cold split
+#   .cold / .cold.N
+#   .local.N      — local visibility specialisation
+#   .lto_priv.N   — -flto privatised local clone (common in LTO builds)
+#   .clone.N      — generic GCC clone (target attribute, tail-merge clone)
+#   ._omp_fn.N    — OpenMP outlined function
+#   .resolver     — ifunc resolver indirection
+#   .cfi          — -fcf-protection CFI thunk
+#   .llvm.NN…     — clang/LLVM target attribute / ThinLTO variant suffix
+#                    (numeric tail can be long, allow .\w+)
+_IPA_CLONE_SUFFIX_RE = re.compile(
+    r"\.(?:constprop|isra|part|cold|local|lto_priv|clone|_omp_fn"
+    r"|resolver|cfi)(?:\.\d+)?$"
+    r"|\.llvm\.\w+$"
+)
+
+
+def _strip_ipa_suffix(name: str) -> str:
+    """Repeatedly strip GCC IPA-clone suffixes; e.g.
+    ``gz_skip.constprop.0`` → ``gz_skip``, ``foo.isra.0.constprop.1`` →
+    ``foo``. Returns ``name`` unchanged if no suffix matches."""
+    while True:
+        stripped = _IPA_CLONE_SUFFIX_RE.sub("", name)
+        if stripped == name:
+            return name
+        name = stripped
+
+
+def _nm_symbols(binary_path: Path) -> Dict[str, int]:
+    """Name → address for every text symbol (local + global) defined in the
+    binary. Missing tools / non-ELF input return ``{}``.
+
+    Uses ``nm --demangle`` so C++ source function names (which DWARF
+    ``DW_AT_name`` emits unmangled) match the symbol table entries (which
+    nm emits MANGLED by default — e.g. ``_ZNK6Widget11live_methodEv``).
+    Without ``-C``, every C++ method would classify as ``absent`` because
+    the unmangled lookup never finds the mangled symbol (adversarial-review
+    scenario B). Also indexes by *bare* name so source ``live_method``
+    matches demangled ``Widget::live_method() const``, and so source
+    ``gz_skip`` matches the GCC-cloned ``gz_skip.constprop.0``."""
+    out = _run(["nm", "--demangle", str(binary_path)])
+    if not out:
+        out = _run(["nm", str(binary_path)])   # fall back if -C unavailable
+    syms: Dict[str, int] = {}
+    for line in out.splitlines():
+        # ``<addr> <type> <demangled name (may contain spaces)>``
+        # — split into at most 3 parts so a demangled name with spaces
+        # survives intact for both the full-signature and bare-name lookup.
+        parts = line.split(None, 2)
+        if len(parts) >= 3 and len(parts[1]) == 1 and parts[1] in "tTwW":
+            try:
+                addr = int(parts[0], 16)
+            except ValueError:
+                continue
+            full = parts[2].strip()
+            syms[full] = addr
+            # Three name forms get indexed so source-name lookup hits no
+            # matter which form the caller has:
+            #   full       "snappy::Uncompress(snappy::Source*, snappy::Sink*)"
+            #   qualified  "snappy::Uncompress"   ← what gcov -m emits
+            #   bare       "Uncompress"           ← legacy bare-name lookup
+            # Without ``qualified``, C++ measurement against ``gcov -m``
+            # demangled output couldn't match nm — surfaced in snappy Inc 3c.
+            qualified = full.split("(", 1)[0] if "(" in full else full
+            qualified = _strip_ipa_suffix(qualified)
+            if qualified and qualified != full:
+                syms.setdefault(qualified, addr)
+            bare = (qualified.rsplit("::", 1)[-1]
+                    if "::" in qualified else qualified)
+            if bare and bare not in (full, qualified):
+                syms.setdefault(bare, addr)
+    return syms
+
+
+@dataclass
+class _SubprogramDIE:
+    name: str = ""                            # DW_AT_name (local)
+    namespace_path: str = ""                  # "snappy::Bits" from enclosing scope
+    low_pc: Optional[int] = None
+    has_inline_marker: bool = False           # DW_AT_inline=inlined
+    abstract_origin: Optional[int] = None     # DIE offset (for inline instances)
+    specification: Optional[int] = None       # DIE offset (definition → declaration)
+    linkage_name: str = ""                    # DW_AT_linkage_name (mangled symbol)
+
+    @property
+    def qualified_name(self) -> str:
+        """Fully-qualified C++ name (``snappy::Bits::Log2Floor``) or the
+        bare name for C. Empty if ``name`` is unset (declaration-only
+        DIE that hasn't had its specification resolved yet)."""
+        if not self.name:
+            return ""
+        if not self.namespace_path:
+            return self.name
+        return f"{self.namespace_path}::{self.name}"
+
+
+# ---------------------------------------------------------------------------
+# C++ demangled-name parsing — shared between the classifier and corpus
+# drivers (snappy.py reuses these via import).
+# ---------------------------------------------------------------------------
+
+_METHOD_TRAILING_QUALS = (
+    " const volatile", " const", " volatile",
+    " noexcept", " &&", " &",
+)
+
+
+def _find_arglist_open(name: str) -> int:
+    """Index of the ``(`` opening the function's argument list, or -1.
+    Walks right-to-left tracking ``<>`` / ``()`` / ``[]`` depth so the
+    ``(`` inside ``(anonymous namespace)`` or template args isn't
+    mistaken for the arglist opener. Also recognises ``operator()`` as
+    a name-token: a balance-zero ``(`` immediately following the
+    literal ``operator`` is the call-operator's own paren, not an
+    arglist — returns -1 (no arglist) when it's the only candidate so
+    callers preserve ``operator()`` intact (snappy lambda FP fix)."""
+    if not name.endswith(")"):
+        return -1
+    angle = 0
+    bracket = 0   # [] depth, for ``operator[]``
+    depth = 0
+    for i in range(len(name) - 1, -1, -1):
+        ch = name[i]
+        if ch == ">":
+            angle += 1
+        elif ch == "<" and angle > 0:
+            angle -= 1
+        elif angle == 0:
+            if ch == "]":
+                bracket += 1
+            elif ch == "[" and bracket > 0:
+                bracket -= 1
+            elif bracket == 0:
+                if ch == ")":
+                    depth += 1
+                elif ch == "(":
+                    depth -= 1
+                    if depth == 0:
+                        if name[:i].rstrip().endswith("operator"):
+                            # The ``(`` belongs to ``operator()`` — not
+                            # the function's arglist. There's no arglist
+                            # after the operator name; keep the whole
+                            # ``operator()`` intact in the qualified name.
+                            return -1
+                        return i
+    return -1
+
+
+# Lambda type tags in demangled output: c++filt emits the captured
+# argument types inside ``{lambda(...)#N}`` but ``gcov -m`` emits the
+# bare placeholder ``{lambda()#N}``. Normalise to the gcov form so the
+# two name sources can match.
+_LAMBDA_ARGS_RE = re.compile(r"\{lambda\([^)]*\)(#\d+)\}")
+
+
+def _normalise_lambda_args(name: str) -> str:
+    return _LAMBDA_ARGS_RE.sub(r"{lambda()\1}", name)
+
+
+# Rust crate-id hash embedded in demangled names: c++filt's Rust v0
+# decoder emits ``regex[7e9e1dd283b8ce7a]::Match``. The hash is distinct
+# per build (regenerated on each compile) but carries no information for
+# source-name matching. Strip it so qualified names compare cleanly
+# across rebuilds and align with ``nm --demangle`` output (which omits
+# the hash). Originally lived in the regex driver; promoted here so every
+# Rust binary + every future Rust corpus driver benefits automatically.
+#
+# Constrained to Rust-shape contexts (hex with optional ``h`` prefix —
+# the rustc convention — and the bracket sits at end-of-name or at a
+# ``::`` boundary). Without this constraint the regex also stripped
+# bracketed hex in C++ template arg lists (e.g. a hypothetical
+# ``foo[deadbeef]::bar``); the constraint anchors to Rust shape.
+_RUST_CRATE_HASH_RE = re.compile(
+    r"\[h?[0-9a-f]{8,}\](?=::|$)"
+)
+
+
+def _strip_rust_crate_hash(name: str) -> str:
+    return _RUST_CRATE_HASH_RE.sub("", name)
+
+
+# Rust impl-block demangler syntax: ``<regex::regex::bytes::Match>::start``
+# is ``impl Match { fn start... }``. DWARF tracks the same hierarchy via
+# DW_TAG_namespace + DW_TAG_structure_type and produces the qualified
+# name ``regex::regex::bytes::Match::start`` (no angle brackets). Strip
+# the brackets so the lookup forms align — without this, accessor
+# methods on Rust types misclassify as ``absent`` because the demangler
+# and the DWARF namespace tracker disagree on syntax (Inc 3g regex
+# corpus finding).
+#
+# Supports nested generics and qualified projections (the common shapes
+# in real-world Rust binaries with heavy generic / trait code — tokio,
+# hyper, etc.):
+#   <crate::Type<T>>::method        — generic instantiation
+#   <&str>::len                      — primitive ref
+#   <[u8; 4]>::iter                  — array type
+#   <dyn Trait>::method              — dyn trait
+#   <<Foo as Trait>::Bar>::method    — qualified projection
+#
+# The bracketed type is balanced — count ``<`` / ``>`` to find the
+# matching close. C++ templates with leading ``<>`` (e.g.
+# ``<vector<int>>::method`` from a hypothetical C++ namespace prefix
+# spelling — vanishingly rare) also benefit from the same handling.
+
+def _strip_impl_block_brackets(name: str) -> str:
+    """Strip the outermost ``<...>`` from a Rust impl-block-qualified
+    name. Returns ``name`` unchanged if the input doesn't start with
+    ``<`` or the bracket isn't followed by ``::``."""
+    if not name.startswith("<"):
+        return name
+    depth = 0
+    close_idx = -1
+    for i, ch in enumerate(name):
+        if ch == "<":
+            depth += 1
+        elif ch == ">":
+            depth -= 1
+            if depth == 0:
+                close_idx = i
+                break
+    if close_idx < 1:
+        return name
+    # Must be followed by ``::`` for this to be an impl-block prefix.
+    if not name[close_idx + 1:].startswith("::"):
+        return name
+    inner = name[1:close_idx]
+    rest = name[close_idx + 3:]
+    # Recurse on inner — Rust qualified projection
+    # ``<<Foo as Trait>::Bar>::method`` strips to ``Foo as Trait::Bar::method``
+    # in the outer pass; the inner ``<Foo as Trait>::Bar`` is itself a
+    # well-formed impl-block prefix.
+    inner = _strip_impl_block_brackets(inner)
+    return f"{inner}::{rest}"
+
+
+# Legacy back-compat — some callers may import the constant directly.
+_IMPL_BLOCK_RE = re.compile(r"^<([\w:]+)>::(.+)$")
+
+
+def _qualified_from_demangled(name: str) -> str:
+    """Strip argument list + trailing method qualifiers + any leading
+    return type from a demangled C++ or Rust name. Returns the
+    qualified-no-args form. Operator names, template args with embedded
+    spaces, anonymous namespaces, trailing ``const`` / ``noexcept``
+    qualifiers, lambda arg-type normalisation, Rust impl-block
+    bracket-strip and Rust crate-hash strip all handled."""
+    name = _strip_impl_block_brackets(
+        _strip_rust_crate_hash(
+            _normalise_lambda_args(name.strip())))
+    changed = True
+    while changed:
+        changed = False
+        for q in _METHOD_TRAILING_QUALS:
+            if name.endswith(q):
+                name = name[:-len(q)].rstrip()
+                changed = True
+                break
+    paren_open = _find_arglist_open(name)
+    head = name if paren_open < 0 else name[:paren_open].strip()
+    depth = 0
+    last_space_at_top = -1
+    for i, ch in enumerate(head):
+        if ch in "<([":
+            depth += 1
+        elif ch in ">)]" and depth > 0:
+            depth -= 1
+        elif ch == " " and depth == 0:
+            last_space_at_top = i
+    if last_space_at_top < 0:
+        return head
+    return head[last_space_at_top + 1:]
+
+
+def _demangle_linkage_names(linkage_names: Iterable[str]) -> Dict[str, str]:
+    """Batch-demangle DWARF ``DW_AT_linkage_name`` values via ``c++filt``.
+    Returns mangled → demangled. Empty dict if c++filt is missing or
+    if ``linkage_names`` is empty.
+
+    The classifier uses this to also index subprograms under their
+    canonical demangled spelling, because the spelling DWARF emits in
+    ``DW_AT_name`` may differ from what ``gcov -m`` / ``nm --demangle``
+    produce (e.g. DWARF ``<long unsigned int>`` vs gcov
+    ``<unsigned long>`` — surfaced by snappy's ``DecompressBranchless``
+    template instantiations in Inc 3c)."""
+    seen = sorted({n for n in linkage_names if n})
+    if not seen or not shutil.which("c++filt"):
+        return {}
+    from core.sandbox import run_trusted
+    try:
+        proc = run_trusted(
+            ["c++filt"], input="\n".join(seen),
+            capture_output=True, text=True, check=False, timeout=30,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return {}
+    lines = proc.stdout.splitlines()
+    if len(lines) != len(seen):
+        return {}
+    return dict(zip(seen, lines))
+
+
+# DIE tags that introduce a C++ name-scope; subprogram DIEs nested under
+# any of these get their ``namespace_path`` prefixed by the parent's name.
+_SCOPE_TAGS = frozenset({
+    "DW_TAG_namespace",
+    "DW_TAG_class_type",
+    "DW_TAG_structure_type",
+    "DW_TAG_union_type",
+})
+
+
+def _parse_dwarf(binary_path: Path) -> Tuple[Dict[int, _SubprogramDIE], List[int]]:
+    """Parse ``objdump --dwarf=info`` into:
+
+      * ``subs``: DIE-offset → ``_SubprogramDIE`` for every DW_TAG_subprogram.
+      * ``inline_instance_origins``: list of DIE offsets each
+        DW_TAG_inlined_subroutine instance's ``DW_AT_abstract_origin`` points
+        at (resolved against ``subs`` by the caller to get the inlined fn's
+        name).
+
+    Best-effort text parse; tolerates binutils version drift in formatting
+    by anchoring on the DIE-offset header (``<depth><offset>:`` shape).
+    """
+    # objdump --dwarf=info on a multi-MB binary with full DWARF emits
+    # 1-3 GB of text. ``_run`` would buffer all of it into Python memory
+    # before parsing — OOM on real C++ targets (libLLVM, Chromium).
+    # Stream line-by-line via ``_stream`` so peak memory stays bounded
+    # to ``subs`` + ``inlines`` (a few MB at most). Default 600s timeout
+    # is generous for the largest binaries we expect to see in /agentic.
+    subs: Dict[int, _SubprogramDIE] = {}
+    inlines: List[int] = []
+
+    # DIE header: ``<depth><offset>: Abbrev Number: NN (DW_TAG_...)``
+    die_re = re.compile(
+        r"^\s*<(\d+)><([0-9a-fA-F]+)>:\s+Abbrev Number:\s*\d+\s*\((\w+)\)")
+    # An attribute line looks like ``<<offset>>   DW_AT_<name>  : <value>``.
+    attr_re = re.compile(r"DW_AT_(\w+)\s*:?\s*(.*?)\s*$")
+    # Format: ``(indirect string, offset: 0xNNN): the_actual_name``. We
+    # must skip past the parenthesised qualifier AND its trailing colon to
+    # reach the real name. A loose ``[^:]+`` matched only up to the FIRST
+    # colon (inside the paren) — capturing the offset by mistake.
+    # gcc emits ``(indirect string, offset: 0xNNN): the_actual_name``;
+    # clang emits ``(indexed string: 0xN): the_actual_name``. Both are
+    # parenthesised qualifiers followed by ``):`` then the real name — match
+    # either so the parser doesn't silently miss every name in clang DWARF
+    # (adversarial-review finding A: clang-built fixtures classified the
+    # inlined_only case wrong because the parser couldn't read the name).
+    # Capture EVERYTHING after the ``):`` qualifier to end-of-line — a
+    # tighter ``(\S+)`` truncated C++ template names containing internal
+    # whitespace (``DecompressBranchless<long unsigned int>`` clipped to
+    # ``DecompressBranchless<long``), which then mis-classified as absent
+    # because the qualified-name lookup couldn't find them (snappy Inc 3c
+    # followup).
+    name_indirect_re = re.compile(
+        r"\(in(?:direct|dexed) string[^)]*\):\s*(.+?)\s*$")
+    # DW_AT_abstract_origin emits an offset that may be ``<0xNN>`` or bare hex.
+    aorig_re = re.compile(r"<0x([0-9a-fA-F]+)>")
+    # DW_AT_low_pc is an address.
+    addr_re = re.compile(r"0x([0-9a-fA-F]+)")
+
+    cur_offset: Optional[int] = None
+    cur_die: Optional[_SubprogramDIE] = None
+    cur_is_inline_instance = False
+    # Namespace-tracking state for C++ qualified-name resolution
+    # (Inc 3c on snappy). ``depth_to_name`` maps DIE-depth → enclosing
+    # scope name. When entering a DW_TAG_namespace/class at depth D we
+    # record its name there; deeper subprogram DIEs read the stack to
+    # build ``snappy::Bits`` style prefixes. We separately track the
+    # pending scope DIE so we can defer assigning its name until
+    # DW_AT_name is parsed (the header arrives before the attributes).
+    depth_to_name: Dict[int, str] = {}
+    cur_scope_depth: Optional[int] = None
+    cur_scope_name: str = ""
+
+    def _commit_scope():
+        # Persist the pending scope's name into the depth map (anonymous
+        # namespace falls back to the C++ convention). Then clear it.
+        nonlocal cur_scope_depth, cur_scope_name
+        if cur_scope_depth is not None:
+            depth_to_name[cur_scope_depth] = (
+                cur_scope_name or "(anonymous namespace)")
+        cur_scope_depth = None
+        cur_scope_name = ""
+
+    def _flush():
+        nonlocal cur_die, cur_offset, cur_is_inline_instance
+        _commit_scope()
+        if cur_die is not None and cur_offset is not None:
+            # Store even nameless DIEs — they may carry a DW_AT_specification
+            # we resolve to a name in the post-pass. Drop only if BOTH the
+            # name and specification are absent (nothing recoverable).
+            if cur_die.name or cur_die.specification is not None:
+                subs[cur_offset] = cur_die
+        cur_die = None
+        cur_offset = None
+        cur_is_inline_instance = False
+
+    def _current_namespace_path(die_depth: int) -> str:
+        # Concatenate scopes at depths strictly less than this DIE's depth.
+        # Stale entries from sibling branches are pruned lazily on depth-
+        # decrease (see header handler below).
+        parts = [depth_to_name[d] for d in sorted(depth_to_name)
+                 if d < die_depth]
+        return "::".join(parts)
+
+    for line in _stream(
+            ["objdump", "--dwarf=info", str(binary_path)], timeout=600):
+        m = die_re.match(line)
+        if m:
+            _flush()
+            die_depth = int(m.group(1))
+            # Pop stale namespace entries from sibling subtrees we've left.
+            for d in [d for d in depth_to_name if d >= die_depth]:
+                depth_to_name.pop(d, None)
+            tag = m.group(3)
+            if tag == "DW_TAG_subprogram":
+                cur_offset = int(m.group(2), 16)
+                cur_die = _SubprogramDIE(
+                    namespace_path=_current_namespace_path(die_depth))
+            elif tag == "DW_TAG_inlined_subroutine":
+                cur_is_inline_instance = True
+            elif tag in _SCOPE_TAGS:
+                cur_scope_depth = die_depth
+                cur_scope_name = ""
+            continue
+
+        if cur_die is not None:
+            ma = attr_re.search(line)
+            if not ma:
+                continue
+            attr, value = ma.group(1), ma.group(2)
+            if attr == "name":
+                # Either inline ``: foo`` or ``(indirect string, ...): foo``.
+                ind = name_indirect_re.search(value)
+                cur_die.name = (ind.group(1) if ind else value).strip()
+            elif attr == "linkage_name":
+                ind = name_indirect_re.search(value)
+                linkage = (ind.group(1) if ind else value).strip()
+                cur_die.linkage_name = linkage
+                # Legacy fallback: if DW_AT_name was missing, the mangled
+                # linkage name was previously used as the local name.
+                # Keep that path so existing behaviour is unchanged when
+                # no demangler is available.
+                if not cur_die.name:
+                    cur_die.name = linkage
+            elif attr == "low_pc":
+                ma2 = addr_re.search(value)
+                if ma2:
+                    cur_die.low_pc = int(ma2.group(1), 16)
+            elif attr == "inline":
+                # DW_AT_inline integer code, prefixing a human description:
+                #   0  — not inlined
+                #   1  — DW_INL_inlined (auto, actually inlined)
+                #   2  — DW_INL_declared_not_inlined (had ``inline`` keyword
+                #        but the compiler chose NOT to inline)
+                #   3  — DW_INL_declared_inlined (declared inline AND inlined)
+                # Only 1 and 3 mean "an inlined instance exists somewhere".
+                # The prior substring match ``"inlined" in value`` matched
+                # the human-readable text of code 2 too ("declared as inline
+                # but not inlined") — asymmetrically safe (elevates absent →
+                # inlined rather than dropping findings) but pollutes the
+                # inlined-vs-absent split. Parse the integer code instead.
+                v = value.lstrip()
+                if v.startswith(("1", "3")) and not v.startswith(("10", "30")):
+                    cur_die.has_inline_marker = True
+            elif attr == "specification":
+                # Definition pointing back to its declaration DIE; resolved
+                # in the post-pass to inherit name + namespace_path.
+                mo = aorig_re.search(value)
+                if mo:
+                    cur_die.specification = int(mo.group(1), 16)
+
+        elif cur_scope_depth is not None:
+            ma = attr_re.search(line)
+            if ma and ma.group(1) == "name":
+                ind = name_indirect_re.search(ma.group(2))
+                cur_scope_name = (
+                    ind.group(1) if ind else ma.group(2)).strip()
+
+        elif cur_is_inline_instance:
+            ma = attr_re.search(line)
+            if ma and ma.group(1) == "abstract_origin":
+                mo = aorig_re.search(ma.group(2))
+                if mo:
+                    inlines.append(int(mo.group(1), 16))
+
+    _flush()
+
+    # Resolve DW_AT_specification: definition DIEs inherit name +
+    # namespace_path + linkage_name from their declaration sibling
+    # (the C++ idiom — inlined templates emit a top-level definition
+    # pointing back at the in-class declaration; without this, every
+    # C++ inline method classifies as ``absent`` because the
+    # DW_AT_inline=inlined definition has no name of its own).
+    # ``linkage_name`` inheritance is what lets c++filt canonical-name
+    # aliasing reach DIEs whose DWARF ``DW_AT_name`` uses a different
+    # type-spelling than ``gcov -m`` / ``nm --demangle`` produce
+    # (``long unsigned int`` vs ``unsigned long`` in snappy Inc 3c
+    # followup).
+    for die in subs.values():
+        if die.specification is None:
+            continue
+        spec = subs.get(die.specification)
+        if spec is None:
+            continue
+        if not die.name and spec.name:
+            die.name = spec.name
+        if not die.namespace_path and spec.namespace_path:
+            die.namespace_path = spec.namespace_path
+        if not die.linkage_name and spec.linkage_name:
+            die.linkage_name = spec.linkage_name
+
+    return subs, inlines
+
+
+# ---------------------------------------------------------------------------
+# Symbol-only tier (stripped-binary fallback)
+# ---------------------------------------------------------------------------
+
+def _dynamic_nm_symbols(binary_path: Path) -> Dict[str, int]:
+    """``nm -D`` — dynamic symbol table. Fully-stripped binaries have
+    NO plain-nm symbols (the ``.symtab`` section is removed), but
+    ``.dynsym`` survives (the dynamic linker needs it). For a shared
+    library, this exposes the entire public API. Same demangle +
+    bare-name + qualified-no-args indexing as ``_nm_symbols``."""
+    out = _run(["nm", "-D", "--demangle", str(binary_path)])
+    if not out:
+        out = _run(["nm", "-D", str(binary_path)])
+    syms: Dict[str, int] = {}
+    for line in out.splitlines():
+        parts = line.split(None, 2)
+        if len(parts) >= 3 and len(parts[1]) == 1 and parts[1] in "tTwW":
+            try:
+                addr = int(parts[0], 16)
+            except ValueError:
+                continue
+            full = parts[2].strip()
+            syms[full] = addr
+            qualified = full.split("(", 1)[0] if "(" in full else full
+            qualified = _strip_ipa_suffix(qualified)
+            if qualified and qualified != full:
+                syms.setdefault(qualified, addr)
+            bare = (qualified.rsplit("::", 1)[-1]
+                    if "::" in qualified else qualified)
+            if bare and bare not in (full, qualified):
+                syms.setdefault(bare, addr)
+    return syms
+
+
+def _classify_symbol_only(
+    source_function_names: Iterable[str],
+    binary_path: Path,
+    build_id: str,
+    nm_syms: Dict[str, int],
+) -> Dict[str, "BinaryOracleWitness"]:
+    """Classify against an nm-only symbol table (no DWARF). For
+    fully-stripped binaries, plain ``nm`` returns nothing — we union
+    with ``nm -D`` (dynamic symbol table, survives stripping) so the
+    operator at least gets reachability evidence for exported library
+    API functions.
+
+    Emits ``symbol_present`` when the name is in either symbol table,
+    ``absent`` otherwise. Each witness is tagged ``tier="symbol_only"``
+    so downstream consumers know not to license suppression on it (a
+    function absent from nm in a stripped binary could still be
+    inlined into a surviving caller — DWARF would have caught it;
+    we can't)."""
+    # Union of static + dynamic symbol tables.
+    sym_table = dict(_dynamic_nm_symbols(binary_path))
+    sym_table.update(nm_syms)  # plain nm wins on collisions
+    bp = str(binary_path)
+    out: Dict[str, BinaryOracleWitness] = {}
+    for name in source_function_names:
+        cls: Classification = (
+            "symbol_present" if name in sym_table else "absent")
+        out[name] = BinaryOracleWitness(
+            classification=cls,
+            build_id=build_id,
+            binary_path=bp,
+            address=sym_table.get(name),
+            tier="symbol_only",
+        )
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Classifier entry point
+# ---------------------------------------------------------------------------
+
+def classify_binary_evidence(
+    source_function_names: Iterable[str],
+    binary_path: Path,
+) -> Dict[str, BinaryOracleWitness]:
+    """Classify each ``source_function_names`` entry against ``binary_path``.
+
+    Returns a name → ``BinaryOracleWitness`` mapping for every input name.
+    Names not resolvable either way get ``absent`` (the DCE case).
+
+    The binary MUST have DWARF. A stripped binary (no DWARF subprograms
+    found) returns an empty mapping; the operator-visible skip is the
+    caller's responsibility (the witness is consumed at the reachability
+    layer in Inc 2, which logs the skip).
+    """
+    binary_path = Path(binary_path)
+    if not binary_path.is_file():
+        return {}
+
+    if not shutil.which("nm") or not shutil.which("objdump"):
+        logger.warning("binary_oracle: nm / objdump unavailable; classifier "
+                       "cannot run")
+        return {}
+
+    build_id = read_build_id(binary_path) or ""
+    nm_syms = _nm_symbols(binary_path)
+    subs, inline_origins = _parse_dwarf(binary_path)
+
+    if not subs:
+        # Stripped (or DWARF-less) binary — fall back to symbol-only
+        # tier. We can still answer ``symbol_present`` vs ``absent``
+        # from the nm symbol table alone; we cannot distinguish
+        # ``inlined`` (would need DW_TAG_inlined_subroutine instances)
+        # or ``folded`` (would need DW_AT_low_pc collisions across
+        # source names). Verdicts in this tier are conservative —
+        # the inventory's ``earns_suppression`` flag downgrades to
+        # False if ANY contributing binary is stripped (a function
+        # ``absent`` here might really be inlined into a surviving
+        # caller; suppressing on that risks false negatives).
+        logger.info("binary_oracle: no DWARF subprograms in %s; "
+                    "falling back to symbol-only tier",
+                    binary_path)
+        return _classify_symbol_only(
+            source_function_names, binary_path, build_id, nm_syms,
+        )
+
+    # Reverse-index DWARF subprograms by both qualified and bare names.
+    # Qualified is the primary key (matches the form ``gcov -m`` and
+    # ``nm --demangle`` emit for C++); bare-name is kept as a fallback
+    # so callers that don't know the namespace still find C functions.
+    # ALSO index under the demangled ``DW_AT_linkage_name`` form — this
+    # gives canonical spelling that matches gcov even when DWARF's
+    # ``DW_AT_name`` uses a different type-spelling (e.g. ``long
+    # unsigned int`` vs ``unsigned long``; Inc 3c snappy fix).
+    by_qualified: Dict[str, List[_SubprogramDIE]] = {}
+    by_bare: Dict[str, List[_SubprogramDIE]] = {}
+    demangled_map = _demangle_linkage_names(
+        d.linkage_name for d in subs.values() if d.linkage_name)
+    for die in subs.values():
+        q = die.qualified_name
+        if q:
+            by_qualified.setdefault(q, []).append(die)
+        if die.name and die.name != q:
+            by_bare.setdefault(die.name, []).append(die)
+        if die.linkage_name:
+            demangled = demangled_map.get(die.linkage_name)
+            if demangled:
+                canonical = _qualified_from_demangled(demangled)
+                if canonical and canonical != q:
+                    by_qualified.setdefault(canonical, []).append(die)
+
+    # Names actually inlined somewhere. Two sources:
+    #   (a) DW_TAG_inlined_subroutine instances whose abstract_origin
+    #       points back at a DW_TAG_subprogram — function was inlined
+    #       into a caller that survived. Normal case.
+    #   (b) DW_TAG_subprogram with DW_AT_inline=inlined — compiler
+    #       marked the function as always-inlined; the absence of a
+    #       concrete instance means the body was empty or fully folded
+    #       into its caller (e.g. zlib's ``tr_static_init``). Without
+    #       this, such functions misclassify as ``absent``.
+    # In both cases we index by the qualified name so C++ measurement
+    # against gcov -m / nm --demangle output hits — Inc 3c on snappy
+    # showed every ``snappy::Bits::Log2Floor`` style call misclassifying
+    # as absent without namespace qualification.
+    inlined_names: Set[str] = set()
+    for off in inline_origins:
+        die = subs.get(off)
+        if die and die.qualified_name:
+            inlined_names.add(die.qualified_name)
+        if die and die.linkage_name:
+            demangled = demangled_map.get(die.linkage_name)
+            if demangled:
+                canonical = _qualified_from_demangled(demangled)
+                if canonical:
+                    inlined_names.add(canonical)
+    for die in subs.values():
+        if die.has_inline_marker:
+            if die.qualified_name:
+                inlined_names.add(die.qualified_name)
+            if die.linkage_name:
+                demangled = demangled_map.get(die.linkage_name)
+                if demangled:
+                    canonical = _qualified_from_demangled(demangled)
+                    if canonical:
+                        inlined_names.add(canonical)
+
+    # Fold detection: two distinct source names mapping to the same address.
+    by_addr: Dict[int, Set[str]] = {}
+    for q, dies in by_qualified.items():
+        for die in dies:
+            if die.low_pc is not None:
+                by_addr.setdefault(die.low_pc, set()).add(q)
+    folded_names = {n for names in by_addr.values() if len(names) > 1
+                    for n in names}
+
+    out: Dict[str, BinaryOracleWitness] = {}
+    bp = str(binary_path)
+    for name in source_function_names:
+        # Qualified lookup is the primary path; bare-name falls back so
+        # plain-C callers (no namespace to provide) still hit.
+        dies = by_qualified.get(name) or by_bare.get(name, [])
+        addr = next((d.low_pc for d in dies if d.low_pc is not None), None)
+        in_nm = name in nm_syms
+
+        if name in folded_names:
+            cls: Classification = "folded"
+        elif in_nm or addr is not None:
+            # ``addr is not None`` = at least one DWARF subprogram DIE has
+            # a concrete ``DW_AT_low_pc``. Internal-linkage helpers
+            # (anonymous-namespace, ``static``) emit code but no nm
+            # symbol; without surfacing DWARF location they misclassify
+            # as ``absent`` (snappy Inc 3c FPs on ``DecompressBranchless
+            # <char*>``, both ``DecompressAllTags`` template variants).
+            cls = "symbol_present"
+        elif name in inlined_names:
+            cls = "inlined"
+        else:
+            cls = "absent"
+
+        out[name] = BinaryOracleWitness(
+            classification=cls,
+            build_id=build_id,
+            binary_path=bp,
+            address=addr if addr is not None else nm_syms.get(name),
+            tier="full",
+        )
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Inventory enrichment — Inc 2 (surface-only)
+# ---------------------------------------------------------------------------
+
+# Native-compiled languages where DWARF + the symbol table give a meaningful
+# answer. Others (Python / JS / Java / C#) skip — binary_oracle isn't the
+# right oracle for them.
+_NATIVE_LANGUAGES = frozenset({"c", "cpp", "c++", "rust", "go"})
+
+
+# Priority for combining per-binary verdicts: alive-in-any wins. The
+# combined classification is the strongest evidence across all analysed
+# binaries — symbol_present beats folded beats inlined beats absent.
+# A function is ``absent`` ONLY when EVERY analysed binary lacks it
+# (no symbol, no inlined-subroutine instance) — this is what makes
+# multi-binary suppression sound for hybrid targets (--target-kind=
+# hybrid: library + application, both shipped). Picking the wrong
+# single binary stops being a footgun.
+_CLASS_PRIORITY: Dict[str, int] = {
+    "symbol_present": 4,
+    "folded":         3,
+    "inlined":        2,
+    "absent":         1,
+}
+
+
+def _combine_verdicts(
+    entries: Iterable[Tuple[str, str]],
+) -> Classification:
+    """Combine per-binary classifications into one. Each entry is a
+    ``(classification, tier)`` pair where tier is ``"full"`` (DWARF +
+    nm; high confidence) or ``"symbol_only"`` (stripped fallback;
+    weaker — symbols can be re-exports / weak aliases / .symver
+    indirections without source evidence).
+
+    Tier weighting: when ANY full-tier entry exists, only full-tier
+    entries are considered. This stops a symbol_only "symbol_present"
+    (from a stripped binary's nm output that picked up an unrelated
+    weak alias) from masking a full-tier "absent" verdict — the
+    full-DWARF evidence is authoritative when it disagrees with the
+    symbol-only evidence. Among same-tier entries the highest-priority
+    classification wins (alive-in-any). Empty input ⇒ ``absent``."""
+    pairs = list(entries)
+    if not pairs:
+        return "absent"
+    # Unknown-classification warn (adversarial review Agent D P2). The
+    # priority dict's ``.get(v, 0)`` silently treats unknown values as
+    # worse than ``absent`` (priority 1). If a new classification ever
+    # lands without a priority entry, every binary's verdict would
+    # silently demote to "worse than absent" — log loudly instead of
+    # silently swallowing.
+    for c, _ in pairs:
+        if c not in _CLASS_PRIORITY:
+            logger.warning(
+                "binary_oracle: unknown classification %r — no priority "
+                "entry; falling back to lowest priority. Add it to "
+                "_CLASS_PRIORITY.", c,
+            )
+    full = [c for c, t in pairs if t == "full"]
+    pool = full if full else [c for c, _ in pairs]
+    return max(pool, key=lambda v: _CLASS_PRIORITY.get(v, 0))
+
+
+def enrich_inventory_with_binary_oracle(
+    inventory: Dict,
+    binaries,
+) -> Dict[str, int]:
+    """Annotate each native-language inventory item with its binary-oracle
+    classification, plus a top-level summary on the inventory itself.
+
+    ``binaries`` may be a single ``Path`` / ``str`` (legacy single-binary
+    call) or a sequence (multi-binary; the common case for
+    ``--target-kind=hybrid`` deployments where library + application are
+    BOTH part of the shipping surface). Each binary is classified
+    independently and the per-source-function results are combined:
+
+      - **alive in any binary** ⇒ combined verdict is the strongest
+        (symbol_present > folded > inlined)
+      - **absent from every binary** ⇒ combined verdict is ``absent``
+        — and ONLY then can the downstream chokepoint hard-suppress
+
+    Storage shape on each item::
+
+      metadata.binary_oracle = {
+        "classification": "absent",   # combined verdict — what consumers read
+        "binaries": [
+          {"path": "...", "build_id": "...", "classification": "absent",
+           "address": null},
+          ...                          # one entry per analysed binary
+        ],
+      }
+
+    Top-level inventory summary::
+
+      inventory.binary_oracle = {
+        "binaries": [{"path": "...", "build_id": "..."}, ...],
+        "counts": {"classified": N, "symbol_present": N, "inlined": N,
+                   "absent": N, "folded": N},
+        "skipped_non_native": M,
+        "earns_suppression": True,
+      }
+
+    Non-native items (Python / JS / Java / C#) are skipped — binary_oracle
+    isn't the right oracle for them. Returns the counts dict so callers
+    can log / report what was classified.
+    """
+    # Normalise: single path becomes a list of one.
+    if isinstance(binaries, (str, Path)):
+        binary_paths = [Path(binaries)]
+    else:
+        binary_paths = [Path(b) for b in binaries]
+
+    counts = {"classified": 0, "symbol_present": 0, "inlined": 0,
+              "absent": 0, "folded": 0, "skipped_non_native": 0}
+
+    binary_paths = [p for p in binary_paths if p.is_file()]
+    if not binary_paths:
+        logger.info("binary_oracle: no usable binaries; skipping enrichment")
+        return counts
+
+    # Collect native function names per file. Track (file_idx, item_idx)
+    # back to each name so we can write the combined verdict without re-
+    # scanning.
+    targets: List[Tuple[int, int, str]] = []
+    files = inventory.get("files") or []
+    for fi, f in enumerate(files):
+        lang = (f.get("language") or "").lower()
+        if lang not in _NATIVE_LANGUAGES:
+            for it in f.get("items") or []:
+                if it.get("kind", "function") == "function":
+                    counts["skipped_non_native"] += 1
+            continue
+        for ii, item in enumerate(f.get("items") or []):
+            if item.get("kind", "function") != "function":
+                continue
+            name = item.get("name")
+            if isinstance(name, str) and name:
+                targets.append((fi, ii, name))
+
+    if not targets:
+        return counts
+
+    names = sorted({t[2] for t in targets})
+
+    # Classify once per binary. Each classify_binary_evidence call shells
+    # to nm + objdump (~1-15s per binary depending on size); for the
+    # typical 1-3 binary hybrid case the cost is bounded.
+    per_binary: List[Tuple[Path, str, Dict[str, "BinaryOracleWitness"]]] = []
+    for bp in binary_paths:
+        verdicts = classify_binary_evidence(names, bp)
+        build_id = read_build_id(bp) or ""
+        per_binary.append((bp, build_id, verdicts))
+
+    if not any(verdicts for _, _, verdicts in per_binary):
+        logger.info(
+            "binary_oracle: no binary produced verdicts (stripped? missing "
+            "DWARF? source/binary mismatch?); skipping enrichment")
+        return counts
+
+    # Source-coverage floor (adversarial review P0-D-1: hostile-ELF
+    # attack defense). A binary whose DWARF/symbols match almost none
+    # of the source-side function names is overwhelmingly likely the
+    # WRONG binary — a stray ELF in the target tree (vendored testdata,
+    # prior-project leftover, or a maliciously planted artefact whose
+    # DWARF points to unrelated code). Without this floor, an unrelated
+    # binary returns "absent" for every source function (no match in
+    # foreign DWARF) and downstream chokepoints silently suppress every
+    # native finding.
+    #
+    # Two refinements that make the floor decisive against the
+    # smartest attacker shape (planted binary with ``main`` to inflate
+    # the match rate against small targets):
+    #   1. Exclude universally-common boilerplate names from the
+    #      candidate count — ``main`` exists in every C program and
+    #      a planted binary always has its own ``main``.
+    #   2. Require an absolute minimum of MATCHED names (so a 3-function
+    #      project doesn't pass with a single boilerplate hit).
+    SRC_COVERAGE_FLOOR = 0.05
+    SRC_COVERAGE_MIN_MATCHED = 3
+    # The floor only kicks in once the source has enough non-boilerplate
+    # names to make the planted-binary attack realistic. For a tiny
+    # one-file fixture (a handful of functions) the floor would reject
+    # legitimate small targets — and the planted-binary attack on a
+    # 3-function project isn't a meaningful operator scenario anyway
+    # (an attacker who can plant code in the target tree has bigger
+    # vectors). Real /agentic targets have dozens-to-thousands of
+    # functions and the floor's signal is strong there.
+    SRC_FLOOR_MIN_PROJECT_NAMES = 8
+    _BOILERPLATE_NAMES = frozenset({
+        "main", "_start", "_init", "_fini",
+        "__libc_csu_init", "__libc_csu_fini",
+        "__do_global_dtors_aux", "register_tm_clones",
+        "deregister_tm_clones", "frame_dummy",
+    })
+    project_names = [n for n in names if n not in _BOILERPLATE_NAMES]
+    n_project = len(project_names)
+    kept: List[Tuple[Path, str, Dict[str, "BinaryOracleWitness"]]] = []
+    for bp, build_id, verdicts in per_binary:
+        if not verdicts:
+            kept.append((bp, build_id, verdicts))
+            continue
+        # "Matched" = the binary has *some* evidence (not absent),
+        # excluding universally-common boilerplate names that say
+        # nothing about whether this binary is from this source tree.
+        matched = sum(
+            1 for n in project_names
+            if (w := verdicts.get(n)) is not None
+            and w.classification != "absent"
+        )
+        ratio = matched / n_project if n_project else 0.0
+        # Only enforce the floor on full-tier evidence (symbol-only
+        # binaries systematically under-match because they can't see
+        # inlined-only or DWARF-only names; their earns_suppression
+        # downgrade is the safety net) and only on projects wide
+        # enough for the floor to be meaningful.
+        any_full = any(w.tier == "full" for w in verdicts.values())
+        if (any_full
+                and n_project >= SRC_FLOOR_MIN_PROJECT_NAMES
+                and (matched < SRC_COVERAGE_MIN_MATCHED
+                     or ratio < SRC_COVERAGE_FLOOR)):
+            logger.warning(
+                "binary_oracle: dropping %s — only %d of %d project source "
+                "names matched (%.1f%%, floor %.0f%% / min %d). Likely the "
+                "WRONG binary for this target (unrelated build artefact, "
+                "vendored test binary, or planted ELF). Pass --binary "
+                "explicitly to override.",
+                bp.name, matched, n_project, ratio * 100,
+                SRC_COVERAGE_FLOOR * 100, SRC_COVERAGE_MIN_MATCHED,
+            )
+            continue
+        kept.append((bp, build_id, verdicts))
+    per_binary = kept
+    if not per_binary:
+        logger.warning(
+            "binary_oracle: all binaries dropped by source-coverage floor; "
+            "skipping enrichment")
+        return counts
+
+    # Combine + annotate. The combined classification is what downstream
+    # consumers (reach_witness, /codeql autonomous_analyzer, /validate
+    # demoter) read; per-binary detail is preserved for audit / debug.
+    # Track whether ANY contributing binary was symbol-only (stripped);
+    # downgrades the inventory's earns_suppression flag conservatively.
+    any_symbol_only = any(
+        any(w.tier == "symbol_only" for w in verdicts.values())
+        for _, _, verdicts in per_binary
+    )
+    for fi, ii, name in targets:
+        per_binary_entries: List[Dict[str, object]] = []
+        for bp, build_id, verdicts in per_binary:
+            w = verdicts.get(name)
+            if w is None:
+                continue
+            per_binary_entries.append({
+                "path":           str(bp),
+                "build_id":       build_id,
+                "classification": w.classification,
+                "address":        w.address,
+                "tier":           w.tier,
+            })
+        if not per_binary_entries:
+            continue
+        combined = _combine_verdicts(
+            (entry["classification"], entry["tier"])
+            for entry in per_binary_entries)
+        # NB: ``setdefault('metadata', {})`` returns the *existing* value
+        # if the key is present — even when that value is ``None``. A
+        # parser-emitted ``metadata: None`` would then crash on item
+        # assignment. Initialise / replace any non-dict explicitly.
+        item = files[fi]["items"][ii]
+        meta = item.get("metadata")
+        if not isinstance(meta, dict):
+            meta = {}
+            item["metadata"] = meta
+        meta["binary_oracle"] = {
+            "classification": combined,
+            "binaries":       per_binary_entries,
+        }
+        counts["classified"] += 1
+        counts[combined] = counts.get(combined, 0) + 1
+
+    # Per-binary evidence tier — exposed so consumers (and operator
+    # audits) can see WHICH binaries fell back to symbol-only mode.
+    # Determined by inspecting the first verdict from each binary (all
+    # verdicts from one classify call share a tier).
+    binaries_with_tier: List[Dict[str, object]] = []
+    for bp, bid, verdicts in per_binary:
+        first = next(iter(verdicts.values()), None)
+        # When a binary produced zero verdicts (corrupt ELF, sandbox
+        # killed mid-classify, no source-name overlap at all), record
+        # ``tier="unknown"`` rather than misleadingly defaulting to
+        # ``full`` — full implies "full-DWARF evidence ran cleanly",
+        # which is wrong here (adversarial review Agent A P2).
+        binaries_with_tier.append({
+            "path":     str(bp),
+            "build_id": bid,
+            "tier":     first.tier if first else "unknown",
+        })
+
+    inventory["binary_oracle"] = {
+        "binaries": binaries_with_tier,
+        "counts": {k: v for k, v in counts.items() if k != "skipped_non_native"},
+        "skipped_non_native": counts["skipped_non_native"],
+        # Soundness tier — downstream consumers may hard-suppress on
+        # ``absent``. Evidence base:
+        #
+        #   * 1952/1952 absent verdicts correct across 6 corpora the
+        #     classifier was iteratively tuned against (synthetic,
+        #     zlib, libsodium, snappy, leveldb, regex-rust). This is a
+        #     CONSISTENCY claim, not a generalization estimate —
+        #     classifier patches followed from corpus FPs, so the
+        #     number is a fit, not a hold-out.
+        #
+        #   * 187/187 absent verdicts correct on a held-out corpus
+        #     (zstd v1.5.6) with NO classifier tuning permitted on
+        #     its output. Rule-of-three 95% UB miss rate ≤1.6% on
+        #     first-contact-with-unseen-data — the actual estimator
+        #     of out-of-sample behaviour.
+        #
+        # The earned property is also CONDITIONAL on full-DWARF
+        # evidence — a stripped binary in the analysed set means we
+        # can't distinguish ``inlined`` from ``absent``, so suppression
+        # could license a false negative. Downgrade conservatively
+        # when ANY contributing binary is symbol-only (E1 stripped-
+        # binary fallback).
+        "earns_suppression": not any_symbol_only,
+        # Surfaced for operator-visible evidence-tier reporting.
+        "any_symbol_only": any_symbol_only,
+    }
+    return counts
+
+
+__all__ = [
+    "BinaryOracleWitness",
+    "classify_binary_evidence",
+    "enrich_inventory_with_binary_oracle",
+    "read_build_id",
+]

--- a/core/inventory/binary_oracle_autodetect.py
+++ b/core/inventory/binary_oracle_autodetect.py
@@ -1,0 +1,304 @@
+"""Auto-detect candidate binaries for binary_oracle enrichment.
+
+Operator burden was the gating issue: ``--binary`` is powerful but
+invisible — operators won't pass a flag they don't know about, and
+even informed operators struggle to remember the build artifact paths
+(``build/example``, ``build_o2/libfoo.so``, ``target/release/app``).
+
+This module walks the target tree for plausible debug binaries — ELF
+files with a ``.debug_info`` section — and returns them in a stable
+order. The CLI exposes it via ``--binary auto``:
+
+  raptor-codeql --target-kind=hybrid --binary auto <target>
+
+For hybrid targets the heuristic includes BOTH library binaries
+(``lib*.so*`` / ``lib*.a``) and executables; for library targets only
+libraries; for application targets only executables.
+
+Substrate-only — the CLI scripts call ``detect_binaries()`` and feed
+the result into ``RaptorConfig.BINARY_ORACLE_PATHS``.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List, Literal, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+# Common build-directory prefixes searched relative to the target root.
+# Order matters — the first match in this list wins on collisions. The
+# operator-explicit ``build/`` / ``target/release/`` rank above CMake's
+# ``build_o2/`` (our own convention from the binary_oracle precision
+# harness) so an existing operator build isn't overridden by a leftover
+# harness cache.
+_BUILD_DIRS: Tuple[str, ...] = (
+    # Common single-binary / autotools / CMake
+    "build",
+    "build_o2",
+    "build-release",
+    "build-debug",
+    "_build",
+    # Rust cargo (cross-targeted release/debug omitted — covered by
+    # the glob below)
+    "target/release",
+    "target/debug",
+    # CMake conventions
+    "cmake-build-release",
+    "cmake-build-debug",
+    "out/build",
+    # Meson
+    "builddir",
+    # Bazel
+    "bazel-bin",
+    # Visual Studio / Xcode (Linux ports often produce these too)
+    "Debug",
+    "Release",
+    # Generic dist / output
+    "out",
+    "dist",
+    "bin",
+)
+
+# Rust cross-compile target dirs: ``target/<triple>/{release,debug}``
+# (e.g. ``target/x86_64-unknown-linux-gnu/release``). Glob-matched at
+# runtime so we don't have to enumerate every triple.
+_RUST_TARGET_GLOBS: Tuple[str, ...] = (
+    "target/*/release",
+    "target/*/debug",
+)
+
+# How deep to walk inside a build dir before bailing. Bounded to stop
+# accidental walks into a target like ``/usr`` if the operator pointed
+# us at a system path.
+_MAX_WALK_DEPTH = 5
+
+# Default cap on auto-detect results. Exposed as a module constant
+# so the CLI helper can warn when the cap is reached (operator likely
+# needs to pass --binary explicitly for the binaries beyond the cap).
+DEFAULT_MAX_RESULTS = 8
+
+TargetKind = Literal["library", "application", "hybrid", "auto", "unknown"]
+
+
+@dataclass(frozen=True)
+class _Candidate:
+    path: Path
+    kind: Literal["library", "executable"]
+
+
+def detect_binaries(
+    target_root: Path,
+    target_kind: TargetKind = "auto",
+    *,
+    max_results: int = 8,
+) -> List[Path]:
+    """Walk ``target_root`` for plausible debug binaries.
+
+    ``target_kind`` shapes what's included:
+
+      ``library``:     ``lib*.{so*,a}`` only
+      ``application``: executables only
+      ``hybrid`` / ``auto`` / ``unknown``: BOTH (the safe default —
+                       picking the wrong filter here would silently drop
+                       binaries the operator needed)
+
+    Returns paths in deterministic order (alphabetical within each
+    bucket; libraries before executables). Capped at ``max_results``
+    so an operator who points at a build tree with thousands of test
+    binaries doesn't get a 30-second classification run by accident.
+
+    Filters out:
+      * non-ELF files (no ``.debug_info`` checkable on PE/Mach-O here)
+      * stripped binaries (no ``.debug_info`` section — classifier
+        would return empty anyway, so no point including)
+      * dotfiles and `.so.NUMBER` rotated logs that aren't real libs
+    """
+    target_root = Path(target_root)
+    if not target_root.is_dir():
+        return []
+
+    candidates: List[_Candidate] = []
+    # Expand the literal build-dir list with Rust cross-target globs
+    # (``target/x86_64-unknown-linux-gnu/release`` etc.). Glob is
+    # cheap — single readdir on ``target/`` — and avoids enumerating
+    # every Rust triple in the literal list.
+    expanded_dirs: List[str] = list(_BUILD_DIRS)
+    for pattern in _RUST_TARGET_GLOBS:
+        for hit in target_root.glob(pattern):
+            if hit.is_dir():
+                rel = hit.relative_to(target_root)
+                expanded_dirs.append(str(rel))
+
+    # Search the build dirs AND the target root itself at top-level
+    # only — autotools-style builds (zlib, libsodium) emit binaries
+    # in the source tree, not in a separate ``build/``. Top-level-
+    # only scan keeps the walk cheap and avoids picking up test
+    # binaries scattered through the tree.
+    for build_dir_rel in (".", *expanded_dirs):
+        build_dir = (target_root if build_dir_rel == "."
+                     else target_root / build_dir_rel)
+        if not build_dir.is_dir():
+            continue
+        # Top-level of target_root: only direct children (no recursion).
+        # Deeper build dirs: walk recursively up to _MAX_WALK_DEPTH.
+        walker = (build_dir.iterdir() if build_dir_rel == "."
+                  else _walk_capped(build_dir))
+        for p in walker:
+            if not p.is_file():
+                continue
+            cand = _classify_candidate(p)
+            if cand is None:
+                continue
+            if not _has_dwarf(cand.path):
+                continue
+            candidates.append(cand)
+
+    if not candidates:
+        return []
+
+    # Dedup by resolved path (one .so symlinked from several names →
+    # report once, prefer the SHORTEST path so libz.so beats
+    # libz.so.1.3.1 on display).
+    seen: dict = {}
+    for c in candidates:
+        resolved = c.path.resolve()
+        existing = seen.get(resolved)
+        if existing is None or len(str(c.path)) < len(str(existing.path)):
+            seen[resolved] = c
+    deduped = list(seen.values())
+
+    # Apply target_kind filter.
+    if target_kind == "library":
+        deduped = [c for c in deduped if c.kind == "library"]
+    elif target_kind == "application":
+        deduped = [c for c in deduped if c.kind == "executable"]
+    # hybrid / auto / unknown: keep both
+
+    # Stable order: libraries first (often the deployed surface),
+    # then executables, alphabetical within each.
+    deduped.sort(key=lambda c: (
+        0 if c.kind == "library" else 1, str(c.path),
+    ))
+    return [c.path for c in deduped[:max_results]]
+
+
+def _walk_capped(root: Path):
+    """Generator yielding paths under ``root`` up to ``_MAX_WALK_DEPTH``
+    levels deep. Skips dotted directories (``.git``, ``.cache``).
+
+    Symlink safety (adversarial review P0-D-2): use ``os.walk`` with
+    ``followlinks=False`` so a symlink loop or a symlinked-in giant
+    directory (``node_modules``, ``/usr``) can't drive the walk into
+    an explosion. Also resolve each candidate and refuse anything
+    that escapes ``root`` — a symlink target outside the project tree
+    is not part of the analysed surface.
+    """
+    root_resolved = root.resolve()
+    root_parts = len(root.parts)
+    for dirpath, dirnames, filenames in os.walk(
+            root, followlinks=False, topdown=True):
+        d = Path(dirpath)
+        depth = len(d.parts) - root_parts
+        if depth > _MAX_WALK_DEPTH:
+            dirnames[:] = []
+            continue
+        # Prune dotted subdirs in-place so os.walk doesn't descend.
+        dirnames[:] = [n for n in dirnames if not n.startswith(".")]
+        for fn in filenames:
+            if fn.startswith("."):
+                continue
+            p = d / fn
+            try:
+                p_resolved = p.resolve()
+                p_resolved.relative_to(root_resolved)
+            except (OSError, ValueError):
+                # Symlink target escapes root_resolved (or stat
+                # error) — skip; not part of the analysed surface.
+                continue
+            if not p.is_file():
+                continue
+            yield p
+
+
+# Library suffix: ``lib<name>.so`` / ``.so.N`` / ``.so.N.M`` / ``.a``.
+# Strict suffix — must end with one of these forms; rejects
+# split-debug companions (``.so.debug``, ``.dwo``, ``.dwp``),
+# template stubs (``.so.in``, ``.so.tmpl``), backups (``.bak``,
+# ``.old``), etc. (adversarial review P0-D-3).
+_LIBRARY_NAME_RE = re.compile(
+    r"^lib[A-Za-z0-9_.+\-]+\.(?:so(?:\.\d+)*|a)$"
+)
+
+
+# Executable scripts that carry the +x bit but aren't real ELF binaries.
+# Skipping by suffix avoids paying a ``readelf -S`` subprocess per text
+# file the walk encounters — and avoids relying on ``readelf`` to fail
+# gracefully on a hostile-crafted hang/loop input (adversarial review
+# Agent D P2: ``_has_dwarf`` fail-open lets a malicious binary that
+# hangs readelf slip past the DWARF check).
+_NON_BINARY_SUFFIXES = frozenset({
+    ".sh", ".bash", ".zsh", ".ksh", ".csh",
+    ".py", ".pl", ".rb", ".tcl", ".lua",
+    ".cmake", ".in", ".am", ".ac", ".m4",
+    ".txt", ".md", ".rst", ".cfg", ".conf",
+    ".yaml", ".yml", ".json", ".toml", ".xml",
+})
+_NON_BINARY_NAMES = frozenset({
+    "configure", "Makefile", "GNUmakefile",
+    "autogen.sh", "bootstrap",
+})
+
+
+def _classify_candidate(p: Path) -> Optional[_Candidate]:
+    """Library vs executable vs neither. Returns None when not a
+    plausible debug binary."""
+    name = p.name
+    if _LIBRARY_NAME_RE.match(name):
+        return _Candidate(path=p, kind="library")
+    # Cheap-suffix reject before stat() / subprocess — keeps the
+    # auto-detect walk fast on large trees.
+    if name in _NON_BINARY_NAMES:
+        return None
+    if p.suffix in _NON_BINARY_SUFFIXES:
+        return None
+    # Executable: file mode +x.
+    try:
+        mode = p.stat().st_mode
+    except OSError:
+        return None
+    if mode & 0o111 == 0:
+        return None
+    return _Candidate(path=p, kind="executable")
+
+
+def _has_dwarf(path: Path) -> bool:
+    """True if ``path`` is an ELF file with a ``.debug_info`` (or
+    split-DWARF ``.debug_info.dwo``) section.
+
+    Adversarial review Agent D P2: closed two fail-opens — (1) on
+    ``OSError`` / ``TimeoutExpired`` (readelf missing, hung on hostile
+    binary, sandbox-killed) the prior code returned ``True``, meaning a
+    crafted ELF that hangs readelf would slip through to classification
+    via foreign-DWARF; now reject (return False) on failure; (2) added
+    ``.debug_info.dwo`` recognition for split-DWARF builds (clang's
+    ``-gsplit-dwarf``, gcc's ``-gdwarf-split``) — without it, a perfectly
+    valid split-DWARF binary was filtered out as if stripped.
+    """
+    try:
+        out = subprocess.run(
+            ["readelf", "-S", str(path)],
+            capture_output=True, text=True, check=False, timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired) as e:
+        logger.debug("binary_oracle_autodetect: readelf -S failed on %s: %s",
+                     path, e)
+        return False
+    if out.returncode != 0:
+        return False
+    return ".debug_info" in out.stdout or ".debug_info.dwo" in out.stdout

--- a/core/inventory/binary_oracle_cli.py
+++ b/core/inventory/binary_oracle_cli.py
@@ -1,0 +1,211 @@
+"""Shared CLI plumbing for binary-oracle ``--binary`` / ``--binary-auto``
+/ ``--binary-edges`` flags across ``raptor_codeql.py`` + ``raptor_agentic.py``.
+
+Adversarial review P1-D-4: both CLIs duplicated ~50 LOC of wiring and
+were diverging in subtle places (print messages, target_kind resolution,
+how active-project binaries were layered in, what `added` actually
+counted). Pull the canonical wiring here and have both CLIs call it.
+
+Also fixes:
+  * P1-D-1 — explicit ``--binary`` paths are validated up-front (file
+    must exist) rather than silently filtered deep inside the
+    enrichment pass.
+  * P1-D-3 — auto-detect coverage extended to ``out/``, ``dist/``,
+    ``bin/``, ``Debug/``, ``Release/``, ``target/*/release``,
+    ``bazel-bin``, ``builddir/`` so common Bazel / Meson / Visual
+    Studio / Xcode / Rust-cross / Go / Java / generic-dist layouts
+    aren't silently skipped.
+  * P1-D-6 — auto-detect cap-truncation is warned loudly so the
+    operator sees they need to pass ``--binary`` explicitly when
+    they have more than the cap.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+from typing import List, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+
+def add_binary_args(parser, *, include_edges: bool = True) -> None:
+    """Attach the three binary-oracle flags to an argparse parser.
+    Both CLIs (raptor_codeql.py + raptor_agentic.py) declare them
+    identically; call this helper to keep them in sync."""
+    parser.add_argument(
+        "--binary", action="append", default=None,
+        help=(
+            "Path to a debug binary for binary-oracle enrichment of "
+            "the inventory (DWARF-joined per-function classification). "
+            "Repeatable for hybrid targets (e.g. ``--target-kind=hybrid``"
+            ": ``--binary lib.so --binary app``); a function is then "
+            "classified ``absent`` only when EVERY declared binary "
+            "lacks it. The path is validated at CLI parse time — a "
+            "typo errors out rather than silently dropping the binary."
+        ),
+    )
+    parser.add_argument(
+        "--binary-auto", action="store_true",
+        help=(
+            "Auto-detect debug binaries under the target tree's common "
+            "build dirs (build/, target/release/, cmake-build-*/, "
+            "bazel-bin/, _build/, builddir/, Debug/, Release/, out/, "
+            "dist/, bin/) and pass each to binary-oracle. Combined "
+            "with explicit ``--binary`` values (auto-detected are "
+            "appended). Stripped binaries fall back to symbol-only "
+            "tier with conservative ``earns_suppression`` downgrade."
+        ),
+    )
+    if include_edges:
+        parser.add_argument(
+            "--binary-edges", action="store_true",
+            help=(
+                "Inc 2b Tier 1 opt-in: extract direct call edges from "
+                "each --binary (via r2) and annotate inventory items "
+                "with binary-found callers. Affirmative reachability "
+                "evidence — a function with binary-confirmed callers "
+                "gets the ``binary_call_edge`` REACHABLE verdict. "
+                "Slow on big binaries (~10-30s per binary). Requires "
+                "--binary or --binary-auto."
+            ),
+        )
+
+
+def _validate_explicit_paths(
+    paths: Optional[List[str]], parser=None,
+) -> List[Path]:
+    """Resolve operator-supplied ``--binary`` paths AND verify each
+    file exists. A typo'd path currently dies silently inside the
+    enrichment pass (``Path.resolve()`` doesn't require existence);
+    fail-fast here so the operator sees the typo immediately."""
+    if not paths:
+        return []
+    resolved: List[Path] = []
+    for p in paths:
+        rp = Path(p).expanduser().resolve()
+        if not rp.is_file():
+            msg = (f"--binary path does not exist or is not a file: "
+                   f"{p} (resolved to {rp})")
+            if parser is not None:
+                parser.error(msg)
+            else:
+                raise FileNotFoundError(msg)
+        resolved.append(rp)
+    return resolved
+
+
+def _autodetect_binaries(
+    repo: Path, target_kind: str,
+) -> List[Path]:
+    """Walk the target tree for debug binaries; warn the operator if
+    we hit the result cap (they likely want to pass ``--binary``
+    explicitly) or find nothing."""
+    from core.inventory.binary_oracle_autodetect import (
+        DEFAULT_MAX_RESULTS, detect_binaries,
+    )
+    detected = detect_binaries(repo, target_kind)
+    if detected:
+        print(f"--binary-auto detected {len(detected)} binary(s):")
+        for b in detected:
+            print(f"  {b}")
+        if len(detected) >= DEFAULT_MAX_RESULTS:
+            logger.warning(
+                "--binary-auto: result cap (%d) reached — there may be "
+                "additional debug binaries under this target tree that "
+                "auto-detect did not return. Pass --binary explicitly "
+                "to include specific binaries beyond the cap.",
+                DEFAULT_MAX_RESULTS,
+            )
+    else:
+        print(
+            "--binary-auto: no debug binaries found under build/, "
+            "target/release/, cmake-build-*/, bazel-bin/, etc. "
+            "Build the target first or pass --binary explicitly.",
+        )
+    return detected
+
+
+def _project_binaries() -> Tuple[List[Path], Optional[str]]:
+    """Layer in any binaries persisted on the active project. Returns
+    ``(paths, project_name)``. Best-effort — a missing project /
+    schema mismatch returns ``([], None)`` rather than crashing the
+    run."""
+    try:
+        from core.project.project import ProjectManager
+        mgr = ProjectManager()
+        active = mgr.get_active()
+        if not active:
+            return [], None
+        proj = mgr.load(active)
+        if not proj or not getattr(proj, "binaries", None):
+            return [], active
+        return [Path(b).expanduser().resolve() for b in proj.binaries], active
+    except Exception:  # noqa: BLE001
+        return [], None
+
+
+def resolve_binary_paths(args, repo: Path, target_kind: str,
+                         parser=None) -> Tuple[str, ...]:
+    """Compose the final tuple of binary paths from all three
+    sources: ``--binary`` (explicit), ``--binary-auto`` (detected),
+    and the active project's persisted ``binaries``. Deduplicated,
+    order preserved (explicit first, then auto, then project).
+
+    Always returns SOMETHING — even an empty tuple — so the caller
+    can unconditionally assign to ``RaptorConfig.BINARY_ORACLE_PATHS``
+    and never leak a prior run's value (adversarial review P0-117)."""
+    seen: dict = {}  # path → True for stable de-dupe (insertion order)
+
+    for p in _validate_explicit_paths(
+            getattr(args, "binary", None), parser=parser):
+        seen.setdefault(str(p), True)
+
+    if getattr(args, "binary_auto", False):
+        for p in _autodetect_binaries(repo, target_kind):
+            seen.setdefault(str(p), True)
+
+    proj_paths, proj_name = _project_binaries()
+    added = 0
+    for p in proj_paths:
+        if str(p) not in seen:
+            seen[str(p)] = True
+            added += 1
+    if proj_name and added:
+        print(f"--project '{proj_name}' contributes {added} binary(s) "
+              f"from /project binary store.")
+
+    return tuple(seen.keys())
+
+
+def resolve_target_kind(args) -> str:
+    """Same env-var / arg precedence both CLIs used. Env wins so
+    ``RAPTOR_TARGET_KIND`` set in CI / scripts can override CLI."""
+    from core.config import RaptorConfig
+    return (os.environ.get(RaptorConfig.ENV_TARGET_KIND)
+            or getattr(args, "target_kind", "auto") or "auto")
+
+
+def apply_to_config(args, repo: Path, parser=None) -> Tuple[str, ...]:
+    """Resolve binary paths AND mutate ``RaptorConfig``. Single call
+    site for both CLIs so they can't diverge."""
+    from core.config import RaptorConfig
+    paths = resolve_binary_paths(
+        args, repo, resolve_target_kind(args), parser=parser,
+    )
+    # ALWAYS assign — never gate on truthiness — so a prior run's
+    # value cannot leak into this one in long-lived processes
+    # (Claude Code, library use, chained pytest).
+    RaptorConfig.BINARY_ORACLE_PATHS = paths
+    RaptorConfig.BINARY_ORACLE_EDGES = bool(
+        getattr(args, "binary_edges", False))
+    return paths
+
+
+__all__ = [
+    "add_binary_args",
+    "apply_to_config",
+    "resolve_binary_paths",
+    "resolve_target_kind",
+]

--- a/core/inventory/binary_oracle_corpora/__init__.py
+++ b/core/inventory/binary_oracle_corpora/__init__.py
@@ -1,0 +1,30 @@
+"""Corpus drivers for the binary-oracle precision harness.
+
+Each driver implements the ``CorpusDriver`` protocol from
+``binary_oracle_precision`` — it knows how to build/test/cover a single
+corpus and emit the context dict the harness consumes.
+
+Add a new corpus by writing a driver module here and registering it
+below. Keep the registration explicit so the available corpora are
+discoverable from one place.
+"""
+
+from typing import Any, Dict
+
+from .synthetic import driver as _synthetic_driver
+from .zlib import driver as _zlib_driver
+from .libsodium import driver as _libsodium_driver
+from .snappy import driver as _snappy_driver
+from .leveldb import driver as _leveldb_driver
+from .regex_rust import driver as _regex_rust_driver
+from .zstd_holdout import driver as _zstd_holdout_driver
+
+REGISTRY: Dict[str, Any] = {
+    _synthetic_driver.name: _synthetic_driver,
+    _zlib_driver.name: _zlib_driver,
+    _libsodium_driver.name: _libsodium_driver,
+    _snappy_driver.name: _snappy_driver,
+    _leveldb_driver.name: _leveldb_driver,
+    _regex_rust_driver.name: _regex_rust_driver,
+    _zstd_holdout_driver.name: _zstd_holdout_driver,
+}

--- a/core/inventory/binary_oracle_corpora/leveldb.py
+++ b/core/inventory/binary_oracle_corpora/leveldb.py
@@ -1,0 +1,237 @@
+"""leveldb corpus driver — C++ precision corpus (key-value store).
+
+leveldb master pinned at the most-recent ``Bump third_party/
+dependencies`` commit — older tagged releases bundle a gtest that
+fails to compile with clang-21 (uninitialized-const-pointer + missing
+uintptr_t header). The leveldb tests link against the benchmark library
+unnecessarily; we patch that out before configuring.
+
+Same LLVM source-based coverage methodology as the snappy driver.
+Tests virtual dispatch (leveldb's iterator hierarchies + filter
+policies), heavy class-method inlining, and ICF (leveldb has many
+small accessor methods that often fold).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+import shutil
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Literal, Set, Tuple
+
+from ..binary_oracle import (
+    _demangle_linkage_names,
+    _qualified_from_demangled,
+)
+from .snappy import (
+    _LLVM_COV_CANDIDATES,
+    _LLVM_PROFDATA_CANDIDATES,
+    _resolve,
+    _strip_llvm_file_prefix,
+    _is_stdlib_or_helper,
+)
+
+logger = logging.getLogger(__name__)
+
+LEVELDB_URL = "https://github.com/google/leveldb.git"
+# Most-recent commit on main as of 2026-05-30. "Bump third_party/
+# dependencies." — necessary because the v1.23 tag's gtest submodule
+# pin doesn't compile with clang-21.
+LEVELDB_SHA = "7ee830d6c12fec2e02a4dde0adf6db1ed1afc4b8"
+# In case the SHA isn't reachable, fall back to whatever ``main`` HEAD
+# is now — leveldb's main has been stable for years.
+LEVELDB_FALLBACK_BRANCH = "main"
+CACHE_VERSION = "1"
+
+
+@dataclass
+class _LeveldbDriver:
+    name: str = "leveldb"
+    description: str = (
+        "leveldb master @ 2026-05 — C++ KV-store, ~30k LOC. LLVM "
+        "source-based coverage. Tests virtual dispatch + heavy class "
+        "inlining + ICF.")
+    mode: Literal["gcov"] = "gcov"
+
+    def prepare(self, work_dir: Path) -> Dict[str, Any]:
+        work_dir = work_dir.resolve()
+        sha_dir = work_dir / LEVELDB_SHA[:12]
+        sentinel = sha_dir / "sentinel.ok"
+        build_dir = sha_dir / "build"
+        profdata = sha_dir / "merged.profdata"
+
+        if (not sentinel.exists()
+                or sentinel.read_text().strip() != CACHE_VERSION):
+            _build_and_run(sha_dir, build_dir, profdata)
+            sentinel.write_text(CACHE_VERSION)
+
+        binary = build_dir / "leveldb_tests"
+        live, candidates = _liveness_from_llvm_cov(binary, profdata)
+        return {
+            "o2_binary":            binary,
+            "candidate_functions":  sorted(candidates),
+            "live_set":             live,
+        }
+
+
+def _build_and_run(sha_dir: Path, build_dir: Path, profdata: Path) -> None:
+    """Clone main + bump submodules → patch CMakeLists to drop the
+    benchmark dep → CMake build → run tests → merge profraw."""
+    sha_dir.mkdir(parents=True, exist_ok=True)
+    src = sha_dir / "src"
+
+    from core.git import clone_repository, get_safe_git_env
+    from core.git.clone import safe_git_command
+
+    if src.exists():
+        shutil.rmtree(src)
+    logger.info("leveldb: cloning %s → %s", LEVELDB_URL, src)
+    if not clone_repository(LEVELDB_URL, src, depth=None):
+        raise RuntimeError(f"leveldb: clone failed for {LEVELDB_URL}")
+    # Hard-pin: check out the pinned SHA. If the local clone history
+    # doesn't reach it (depth-limited clone, force-pushed history),
+    # FAIL rather than fall back to ``main`` HEAD — silently using a
+    # different revision destroys reproducibility of the precision
+    # claim and makes corpus FPs unfalsifiable ("is this drift in the
+    # classifier, or drift in upstream HEAD?"). Adversarial review
+    # E P2-1. Operators wanting a different revision bump
+    # ``LEVELDB_SHA`` explicitly.
+    subprocess.run(
+        safe_git_command("-C", str(src), "checkout", LEVELDB_SHA),
+        env=get_safe_git_env(), check=True, timeout=60,
+    )
+
+    subprocess.run(
+        safe_git_command("-C", str(src), "submodule", "update",
+                         "--init", "--recursive"),
+        env=get_safe_git_env(), check=True, timeout=300,
+    )
+
+    # Patch the test-link line to drop the unused ``benchmark`` dep —
+    # the benchmark library's CMake forces ``-Werror`` on Release
+    # builds and clang-21 trips its own warning fences. Tests don't
+    # actually use benchmark.
+    _patch_drop_benchmark(src / "CMakeLists.txt")
+
+    if build_dir.exists():
+        shutil.rmtree(build_dir)
+    build_dir.mkdir(parents=True)
+
+    cxxflags = ("-O2 -g -ffunction-sections -fdata-sections "
+                "-fprofile-instr-generate -fcoverage-mapping")
+    ldflags = "-Wl,--gc-sections -fprofile-instr-generate"
+    subprocess.run([
+        "cmake", str(src),
+        "-DCMAKE_BUILD_TYPE=Release",
+        "-DCMAKE_C_COMPILER=clang",
+        "-DCMAKE_CXX_COMPILER=clang++",
+        f"-DCMAKE_CXX_FLAGS={cxxflags}",
+        f"-DCMAKE_EXE_LINKER_FLAGS={ldflags}",
+        "-DLEVELDB_BUILD_TESTS=ON",
+        "-DLEVELDB_BUILD_BENCHMARKS=OFF",
+        "-DCMAKE_POLICY_VERSION_MINIMUM=3.5",
+    ], cwd=build_dir, check=True, timeout=300)
+    subprocess.run(["cmake", "--build", ".", "-j4"],
+                   cwd=build_dir, check=True, timeout=900)
+
+    profraw_pattern = str(sha_dir / "leveldb_%m.profraw")
+    env = {**os.environ, "LLVM_PROFILE_FILE": profraw_pattern}
+    subprocess.run(["ctest", "--output-on-failure"],
+                   cwd=build_dir, env=env, check=True, timeout=600)
+
+    profraw = list(sha_dir.glob("leveldb_*.profraw"))
+    if not profraw:
+        raise RuntimeError(
+            f"leveldb: no profraw produced (LLVM_PROFILE_FILE="
+            f"{profraw_pattern}); coverage instrumentation may be broken")
+
+    profdata_tool = _resolve(_LLVM_PROFDATA_CANDIDATES)
+    subprocess.run(
+        [profdata_tool, "merge", "-sparse", *(str(p) for p in profraw),
+         "-o", str(profdata)],
+        check=True, timeout=120,
+    )
+
+    shutil.rmtree(src, ignore_errors=True)
+
+
+_BENCHMARK_LINK_RE = re.compile(r"leveldb gmock gtest benchmark")
+_BENCHMARK_SUBDIR_RE = re.compile(
+    r'add_subdirectory\("third_party/benchmark"\)')
+
+
+def _patch_drop_benchmark(cmakelists: Path) -> None:
+    """Drop the ``benchmark`` test-link dep and ``add_subdirectory`` for
+    the benchmark library — both unnecessary for our tests-only build
+    and the benchmark lib's CMake forces -Werror which clang-21 trips.
+
+    Idempotent: re-applying produces no change."""
+    text = cmakelists.read_text()
+    new_text = _BENCHMARK_LINK_RE.sub("leveldb gmock gtest", text)
+    new_text = _BENCHMARK_SUBDIR_RE.sub(
+        "# benchmark add_subdirectory skipped — tests-only build",
+        new_text)
+    if new_text != text:
+        cmakelists.write_text(new_text)
+        logger.info("leveldb: patched out benchmark dep in CMakeLists.txt")
+
+
+def _liveness_from_llvm_cov(
+    binary: Path, profdata: Path,
+) -> Tuple[Set[str], Set[str]]:
+    """Same approach as snappy — strip llvm-cov's ``<file>:`` prefix,
+    demangle via c++filt, reduce to qualified name. Scope candidates to
+    leveldb's surface only."""
+    cov_tool = _resolve(_LLVM_COV_CANDIDATES)
+    proc = subprocess.run(
+        [cov_tool, "export", f"--instr-profile={profdata}", str(binary)],
+        capture_output=True, text=True, check=False, timeout=120,
+    )
+    if proc.returncode != 0 or not proc.stdout:
+        logger.warning("leveldb: llvm-cov export failed: %s",
+                       proc.stderr[:300])
+        return set(), set()
+    try:
+        data = json.loads(proc.stdout)
+    except json.JSONDecodeError as e:
+        logger.warning("leveldb: llvm-cov JSON parse failed: %s", e)
+        return set(), set()
+
+    blocks = data.get("data") or []
+    if not blocks:
+        return set(), set()
+
+    fns = blocks[0].get("functions") or []
+    bare_mangled = sorted({_strip_llvm_file_prefix(f["name"])
+                           for f in fns if f.get("name")})
+    demangled_map = _demangle_linkage_names(bare_mangled)
+
+    live: Set[str] = set()
+    candidates: Set[str] = set()
+    for fn in fns:
+        bare = _strip_llvm_file_prefix(fn.get("name") or "")
+        full = demangled_map.get(bare, bare)
+        qualified = _qualified_from_demangled(full)
+        if not qualified or _is_stdlib_or_helper(qualified):
+            continue
+        # Scope to leveldb's surface — without this, gtest internals
+        # and miscellaneous C runtime functions inflate the candidate
+        # set with methodology noise. Anonymous-namespace helpers are
+        # admitted (adversarial review E P1-4: ICF/DCE-prime category).
+        is_leveldb_surface = (qualified.startswith("leveldb::")
+                              or qualified.startswith("leveldb_"))
+        is_anon = "(anonymous namespace)" in qualified
+        if not (is_leveldb_surface or is_anon):
+            continue
+        candidates.add(qualified)
+        if fn.get("count", 0) > 0:
+            live.add(qualified)
+    return live, candidates
+
+
+driver = _LeveldbDriver()

--- a/core/inventory/binary_oracle_corpora/libsodium.py
+++ b/core/inventory/binary_oracle_corpora/libsodium.py
@@ -1,0 +1,220 @@
+"""libsodium corpus driver — C precision corpus.
+
+libsodium v1.0.20 — pure C, ~40k LOC. Autotools build with two
+configurations (O0+coverage / O2+--gc-sections); ground truth from
+``make check`` (60+ test binaries). Mirrors the zlib driver structure
+but uses libsodium's static archive ``libsodium.a`` as both the
+candidate-enumeration source and the link target for the classifier
+binary.
+
+Cache layout::
+
+    out/binary-oracle-precision/cache/libsodium/<sha-prefix>/
+        build_o0/        # autotools build, includes .gcda after make check
+        build_o2/        # autotools build
+        sentinel.ok      # version-stamped; absent → full rebuild
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+import shutil
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Literal, Set
+
+logger = logging.getLogger(__name__)
+
+LIBSODIUM_URL = "https://github.com/jedisct1/libsodium.git"
+LIBSODIUM_TAG = "1.0.20-RELEASE"
+# Bumped to 2: sandbox-wrapped test-binary invocation + writable_paths
+# for gcov + broader gcda reset (whole build_dir, not just src/libsodium).
+# Old caches need a fresh build for the new workload semantics.
+CACHE_VERSION = "2"
+
+
+@dataclass
+class _LibsodiumDriver:
+    name: str = "libsodium"
+    description: str = (
+        "libsodium v1.0.20 — pure C, ~40k LOC, autotools + gcov. "
+        "Ground truth from `make check` (60+ test binaries).")
+    mode: Literal["gcov"] = "gcov"
+
+    def prepare(self, work_dir: Path) -> Dict[str, Any]:
+        work_dir = work_dir.resolve()
+        tag_dir = work_dir / LIBSODIUM_TAG.replace("-", "_")
+        sentinel = tag_dir / "sentinel.ok"
+        build_o0 = tag_dir / "build_o0"
+        build_o2 = tag_dir / "build_o2"
+
+        if (not sentinel.exists()
+                or sentinel.read_text().strip() != CACHE_VERSION):
+            _build_fresh(tag_dir, build_o0, build_o2)
+            sentinel.write_text(CACHE_VERSION)
+
+        live = _collect_gcov_liveness(build_o0)
+        candidates = _enumerate_candidates(build_o0)
+        from .toolchain import record_toolchain
+        toolchain = record_toolchain(cc="gcc", gcov="gcov")
+        return {
+            # ``aead_aegis128l`` is one of the test executables — it's
+            # statically linked against libsodium.a and exercises a broad
+            # slice of the library, so ``--gc-sections`` produces a
+            # realistic mix of absent / inlined / symbol_present.
+            "o2_binary":            build_o2 / "test" / "default"
+                                    / "aead_aegis128l",
+            "candidate_functions":  candidates,
+            "live_set":             live,
+            "toolchain":            toolchain,
+        }
+
+
+def _build_fresh(tag_dir: Path, build_o0: Path, build_o2: Path) -> None:
+    """Clone (full history so the tag can be checked out) → autogen →
+    configure × 2 → build × 2 → ``make check`` on the O0 build."""
+    tag_dir.mkdir(parents=True, exist_ok=True)
+    src = tag_dir / "src"
+
+    from core.git import clone_repository, get_safe_git_env
+    from core.git.clone import safe_git_command
+
+    if src.exists():
+        shutil.rmtree(src)
+    logger.info("libsodium: cloning %s → %s", LIBSODIUM_URL, src)
+    if not clone_repository(LIBSODIUM_URL, src, depth=None):
+        raise RuntimeError(f"libsodium: clone failed for {LIBSODIUM_URL}")
+    subprocess.run(
+        safe_git_command("-C", str(src), "checkout", LIBSODIUM_TAG),
+        env=get_safe_git_env(), check=True, timeout=60,
+    )
+
+    subprocess.run(["./autogen.sh"], cwd=src, check=True, timeout=120)
+
+    for build_dir, cflags, ldflags, target_only in [
+        (build_o0, "-O0 -g --coverage", "--coverage", True),
+        (build_o2,
+         "-O2 -g -ffunction-sections -fdata-sections",
+         "-Wl,--gc-sections", False),
+    ]:
+        if build_dir.exists():
+            shutil.rmtree(build_dir)
+        build_dir.mkdir(parents=True)
+        env = {**os.environ, "CFLAGS": cflags, "LDFLAGS": ldflags}
+        subprocess.run(
+            [str((src / "configure").resolve()),
+             "--enable-static", "--disable-shared"],
+            cwd=build_dir, env=env, check=True, timeout=180,
+        )
+        # libsodium's test binaries (the only artifacts with realistic
+        # --gc-sections DCE on a libsodium-linked executable) are only
+        # produced by ``make check`` — plain ``make`` builds just the
+        # static archive. Run check on BOTH configs to materialise the
+        # test binaries.
+        subprocess.run(["make", "-j4"], cwd=build_dir,
+                       env=env, check=True, timeout=600)
+        subprocess.run(["make", "check"], cwd=build_dir,
+                       env=env, check=True, timeout=900)
+        if target_only:
+            # Reset gcov counters and run ONLY the classifier target
+            # binary. This aligns ground truth (what gcov saw executed)
+            # with what the classifier evaluates (a single test binary).
+            # Without this, ``make check`` aggregated execution across
+            # 60+ tests but the classifier sees one slice — so most
+            # cross-test-active functions misclassify as absent FPs.
+            #
+            # Walk the WHOLE build_dir (not just src/libsodium) —
+            # adversarial review E P1-5. libtool can emit .gcda under
+            # ``test/*/.libs/*.gcda`` and other layouts; the prior
+            # narrow reset left stale .gcda from earlier ``make check``
+            # runs in those locations, contaminating the live_set.
+            for gcda in build_dir.rglob("*.gcda"):
+                try:
+                    gcda.unlink()
+                except OSError:
+                    pass
+            # Sandbox the libsodium test-binary invocation. Upstream
+            # tag is trusted but supply-chain compromise on a pinned
+            # ref is the residual risk; running an executable should
+            # be contained (Landlock + namespace; no network needed).
+            # writable_paths includes build_dir because gcov writes
+            # .gcda files alongside .o files — without the allow,
+            # the live_set would be silently empty.
+            from core.sandbox import run as _sandbox_run
+            target = build_dir / "test" / "default" / "aead_aegis128l"
+            _sandbox_run(
+                [str(target)], cwd=str(target.parent),
+                target=str(target.parent),
+                writable_paths=[str(build_dir)],
+                block_network=True,
+                check=True, timeout=60,
+            )
+
+    shutil.rmtree(src, ignore_errors=True)
+
+
+# ---------------------------------------------------------------------------
+# gcov parsing — reuses the zlib regex; libsodium gcov format is identical.
+# ---------------------------------------------------------------------------
+
+_GCOV_FN_RE = re.compile(r"^Function '([^']+)'")
+_GCOV_LINES_RE = re.compile(r"^Lines executed:([\d.]+)% of \d+")
+
+
+def _collect_gcov_liveness(build_dir: Path) -> Set[str]:
+    """Walk ``src/libsodium/sodium/`` and the per-area subdirs for
+    .gcda/.c pairs, run ``gcov -f``, accumulate functions with > 0%
+    line execution. libsodium splits its source across many subdirs
+    (codecs, runtime, version, crypto_*, etc.) so we recurse."""
+    libsodium_root = build_dir / "src" / "libsodium"
+    if not libsodium_root.is_dir():
+        logger.warning("libsodium: %s missing", libsodium_root)
+        return set()
+
+    live: Set[str] = set()
+    for gcda in libsodium_root.rglob("*.gcda"):
+        gcda_dir = gcda.parent
+        out = subprocess.run(
+            ["gcov", "-f", gcda.name], cwd=gcda_dir,
+            capture_output=True, text=True, check=False, timeout=60,
+        ).stdout
+        current = None
+        for line in out.splitlines():
+            m = _GCOV_FN_RE.match(line)
+            if m:
+                current = m.group(1)
+                continue
+            if current:
+                m2 = _GCOV_LINES_RE.match(line)
+                if m2:
+                    if float(m2.group(1)) > 0:
+                        live.add(current)
+                    current = None
+    return live
+
+
+def _enumerate_candidates(build_o0: Path) -> List[str]:
+    """Functions defined in ``libsodium.a`` — the candidate population.
+
+    libtool prefixes symbols in archived objects with ``libsodium_la-``
+    on the OBJECT FILE names, but the symbols themselves are unprefixed
+    (just the C function name). Use nm directly on the archive."""
+    archive = build_o0 / "src" / "libsodium" / ".libs" / "libsodium.a"
+    if not archive.exists():
+        logger.warning("libsodium: %s missing", archive)
+        return []
+    out = subprocess.run(["nm", str(archive)],
+                         capture_output=True, text=True,
+                         check=False, timeout=30).stdout
+    fns: Set[str] = set()
+    for line in out.splitlines():
+        parts = line.split()
+        if len(parts) >= 3 and parts[-2] in ("T", "t", "W", "w"):
+            fns.add(parts[-1])
+    return sorted(fns)
+
+
+driver = _LibsodiumDriver()

--- a/core/inventory/binary_oracle_corpora/regex_rust.py
+++ b/core/inventory/binary_oracle_corpora/regex_rust.py
@@ -1,0 +1,266 @@
+"""regex (rust-lang/regex) corpus driver — Rust precision corpus.
+
+First Rust integration. Validates the classifier end-to-end on Rust
+mangling (predominantly v0; some legacy ``_ZN...``) and Rust release-
+profile DWARF.
+
+Methodology mirrors the snappy LLVM-cov driver: single ``cargo build``
+with ``-C instrument-coverage -C debuginfo=2``, run the unit test
+binary, merge ``.profraw`` → ``.profdata``, ``llvm-cov export`` for
+ground truth. Same -O level (release) is both instrumented and
+classified — no O0/O2 differential.
+
+Notable Rust quirks:
+
+  * ``cargo build`` strips DWARF by default in release; we set
+    ``-C debuginfo=2`` via RUSTFLAGS to keep it.
+  * llvm-cov function names are mangled (Rust v0 ``_RNv...`` for
+    Rust 1.93's default, some legacy ``_ZN...``). ``c++filt --format
+    =auto`` handles v0; legacy ``_ZN...`` Rust names aren't recognised
+    by c++filt — we build a ``nm --demangle``-derived map first
+    (nm's libiberty handles both) and fall back to c++filt only for
+    names absent from the binary's symbol table (inlined-only DIEs).
+  * Test binary lives at ``target/release/deps/regex-<hash>``; we
+    glob for the latest.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import shutil
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Literal, Set, Tuple
+
+from ..binary_oracle import (
+    _qualified_from_demangled,
+    _strip_impl_block_brackets,  # noqa: F401  (re-export for tests)
+    _strip_rust_crate_hash,
+)
+from .snappy import (
+    _LLVM_COV_CANDIDATES,
+    _LLVM_PROFDATA_CANDIDATES,
+    _resolve,
+)
+
+logger = logging.getLogger(__name__)
+
+REGEX_URL = "https://github.com/rust-lang/regex.git"
+REGEX_TAG = "1.10.6"
+CACHE_VERSION = "1"
+
+
+@dataclass
+class _RegexRustDriver:
+    name: str = "regex-rust"
+    description: str = (
+        "rust-lang/regex 1.10.6 — Rust ~30k LOC. cargo + -C "
+        "instrument-coverage; first Rust corpus.")
+    mode: Literal["gcov"] = "gcov"
+
+    def prepare(self, work_dir: Path) -> Dict[str, Any]:
+        work_dir = work_dir.resolve()
+        tag_dir = work_dir / REGEX_TAG
+        sentinel = tag_dir / "sentinel.ok"
+        target_dir = tag_dir / "target"
+        profdata = tag_dir / "merged.profdata"
+
+        if (not sentinel.exists()
+                or sentinel.read_text().strip() != CACHE_VERSION):
+            _build_and_run(tag_dir, target_dir, profdata)
+            sentinel.write_text(CACHE_VERSION)
+
+        # Test binary path (hash suffix; glob to find latest).
+        candidates = sorted((target_dir / "release" / "deps").glob("regex-*"))
+        candidates = [c for c in candidates if c.is_file()
+                      and os.access(c, os.X_OK)
+                      and "." not in c.name[6:]]  # skip regex-XXX.d / .rmeta
+        if not candidates:
+            raise RuntimeError(
+                f"regex-rust: no test binary at {target_dir}/release/deps/")
+        test_bin = candidates[-1]
+
+        live, candidates_set = _liveness_from_llvm_cov(test_bin, profdata)
+        return {
+            "o2_binary":            test_bin,
+            "candidate_functions":  sorted(candidates_set),
+            "live_set":             live,
+        }
+
+
+def _build_and_run(tag_dir: Path, target_dir: Path, profdata: Path) -> None:
+    """Clone → cargo build with coverage + DWARF → run test binary →
+    merge profraw."""
+    tag_dir.mkdir(parents=True, exist_ok=True)
+    src = tag_dir / "src"
+
+    from core.git import clone_repository, get_safe_git_env
+    from core.git.clone import safe_git_command
+
+    if src.exists():
+        shutil.rmtree(src)
+    logger.info("regex-rust: cloning %s → %s", REGEX_URL, src)
+    if not clone_repository(REGEX_URL, src, depth=None):
+        raise RuntimeError(f"regex-rust: clone failed for {REGEX_URL}")
+    subprocess.run(
+        safe_git_command("-C", str(src), "checkout", REGEX_TAG),
+        env=get_safe_git_env(), check=True, timeout=60,
+    )
+
+    if target_dir.exists():
+        shutil.rmtree(target_dir)
+    target_dir.mkdir(parents=True)
+
+    # Rust release profile strips DWARF + LLVM coverage instrumentation
+    # by default; restore both via RUSTFLAGS. Single codegen unit so the
+    # binary's DWARF references are stable across re-runs.
+    env = {
+        **os.environ,
+        "RUSTFLAGS": ("-C instrument-coverage -C debuginfo=2 "
+                      "-C codegen-units=1 -C lto=off"),
+        "CARGO_TARGET_DIR": str(target_dir),
+    }
+    subprocess.run(
+        ["cargo", "build", "--release", "--tests"],
+        cwd=src, env=env, check=True, timeout=1800,
+    )
+
+    candidates = sorted((target_dir / "release" / "deps").glob("regex-*"))
+    test_bin = next(
+        (c for c in candidates if c.is_file() and os.access(c, os.X_OK)
+         and "." not in c.name[6:]), None,
+    )
+    if test_bin is None:
+        raise RuntimeError(
+            f"regex-rust: no test binary built at {target_dir}/release/deps/")
+
+    profraw_pattern = str(tag_dir / "cov-%p-%m.profraw")
+    test_env = {**env, "LLVM_PROFILE_FILE": profraw_pattern}
+    subprocess.run(
+        [str(test_bin), "--test-threads=1"],
+        cwd=tag_dir, env=test_env, check=True, timeout=600,
+    )
+
+    profraw = list(tag_dir.glob("cov-*.profraw"))
+    if not profraw:
+        raise RuntimeError(
+            f"regex-rust: no profraw at {profraw_pattern}; coverage "
+            f"instrumentation may be broken")
+
+    profdata_tool = _resolve(_LLVM_PROFDATA_CANDIDATES)
+    subprocess.run(
+        [profdata_tool, "merge", "-sparse", *(str(p) for p in profraw),
+         "-o", str(profdata)],
+        check=True, timeout=120,
+    )
+
+    shutil.rmtree(src, ignore_errors=True)
+
+
+# NB: ``_strip_rust_crate_hash`` was promoted to ``binary_oracle``
+# (alongside ``_qualified_from_demangled`` and
+# ``_strip_impl_block_brackets``) so every future Rust corpus +
+# operator-supplied Rust binary gets it automatically. The local alias
+# is retained for backwards compatibility with tests that still
+# import ``_strip_crate_hash`` by the old name.
+_strip_crate_hash = _strip_rust_crate_hash
+
+
+# NB: ``_strip_impl_block_brackets`` was promoted to ``binary_oracle``
+# (alongside ``_qualified_from_demangled``) so every future Rust corpus
+# + operator-supplied Rust binary gets it automatically; the symbol is
+# re-exported above for any external importer of this driver.
+
+
+def _build_demangle_map(binary: Path) -> Dict[str, str]:
+    """Return mangled → demangled for every text symbol in the binary.
+    ``nm --demangle`` (libiberty) handles BOTH Rust v0 (``_RNv...``)
+    and legacy (``_ZN...17h<hash>E``) — c++filt's auto mode only
+    handles v0, so we prefer the nm-derived map. Returns ``{}`` if
+    nm fails."""
+    out_mangled = subprocess.run(
+        ["nm", str(binary)],
+        capture_output=True, text=True, check=False, timeout=60,
+    ).stdout
+    out_demangled = subprocess.run(
+        ["nm", "--demangle", str(binary)],
+        capture_output=True, text=True, check=False, timeout=60,
+    ).stdout
+    mangled = [line.split(None, 2) for line in out_mangled.splitlines()
+               if line.strip()]
+    demangled = [line.split(None, 2) for line in out_demangled.splitlines()
+                 if line.strip()]
+    mapping: Dict[str, str] = {}
+    for m, d in zip(mangled, demangled):
+        if len(m) >= 3 and len(d) >= 3 and m[1] == d[1] and m[1] in "tTwW":
+            mapping[m[2]] = d[2]
+    return mapping
+
+
+def _liveness_from_llvm_cov(
+    binary: Path, profdata: Path,
+) -> Tuple[Set[str], Set[str]]:
+    """Run ``llvm-cov export`` → JSON, demangle Rust names via nm-map
+    (covers v0 + legacy) with c++filt as fallback, reduce to qualified-
+    no-args form, filter to regex's surface."""
+    cov_tool = _resolve(_LLVM_COV_CANDIDATES)
+    proc = subprocess.run(
+        [cov_tool, "export", f"--instr-profile={profdata}", str(binary)],
+        capture_output=True, text=True, check=False, timeout=300,
+    )
+    if proc.returncode != 0 or not proc.stdout:
+        logger.warning("regex-rust: llvm-cov export failed: %s",
+                       proc.stderr[:300])
+        return set(), set()
+    try:
+        data = json.loads(proc.stdout)
+    except json.JSONDecodeError as e:
+        logger.warning("regex-rust: llvm-cov JSON parse failed: %s", e)
+        return set(), set()
+
+    blocks = data.get("data") or []
+    if not blocks:
+        return set(), set()
+
+    fns = blocks[0].get("functions") or []
+    demangle_map = _build_demangle_map(binary)
+
+    live: Set[str] = set()
+    candidates: Set[str] = set()
+    for fn in fns:
+        mangled = fn.get("name") or ""
+        if not mangled:
+            continue
+        # nm-map first; c++filt fallback (auto-mode handles v0, no-op on
+        # legacy Rust which nm did catch).
+        demangled = demangle_map.get(mangled)
+        if demangled is None:
+            try:
+                proc = subprocess.run(
+                    ["c++filt"], input=mangled, capture_output=True,
+                    text=True, check=False, timeout=5,
+                )
+                demangled = proc.stdout.strip() or mangled
+            except (OSError, subprocess.TimeoutExpired):
+                demangled = mangled
+        # ``_qualified_from_demangled`` now applies BOTH the Rust
+        # impl-block bracket strip AND the crate-hash strip internally
+        # (both promoted from this driver after the Inc 3g regex
+        # measurement); no explicit pre-pass needed.
+        qualified = _qualified_from_demangled(demangled)
+        if not qualified:
+            continue
+        # Scope to regex's own surface (drop std::, core::, alloc::,
+        # gimli::, etc. that get pulled in by the test binary).
+        if not qualified.startswith("regex"):
+            continue
+        candidates.add(qualified)
+        if fn.get("count", 0) > 0:
+            live.add(qualified)
+    return live, candidates
+
+
+driver = _RegexRustDriver()

--- a/core/inventory/binary_oracle_corpora/snappy.py
+++ b/core/inventory/binary_oracle_corpora/snappy.py
@@ -1,0 +1,278 @@
+"""snappy corpus driver — C++ precision corpus.
+
+snappy v1.2.1 (Google's compressor) replaces the originally-planned re2
+corpus: re2 requires a system Abseil install (~100MB+), while snappy
+vendors googletest as a submodule and has zero system deps.
+
+Methodology: LLVM source-based coverage. A single -O2 build is BOTH
+instrumented and classified — no O0/O2 differential. The earlier gcov
+methodology shipped at 83.3% precision; the lone FP was a compile-time-
+only lambda that gcov over-attributed (live in O0 ground truth, gone in
+O2 binary). llvm-cov at -O2 reflects what the binary actually executes,
+eliminating the confound (Inc 3c LLVM experiment).
+
+Pipeline::
+
+    1. clang++ -O2 -g -ffunction-sections -fdata-sections
+              -fprofile-instr-generate -fcoverage-mapping ...
+    2. LLVM_PROFILE_FILE=...%m.profraw ctest      # one profraw per run
+    3. llvm-profdata-21 merge -sparse *.profraw -o merged.profdata
+    4. llvm-cov-21 export --instr-profile=merged.profdata <binary>
+       → JSON: per-function execution counts (count > 0 = live)
+    5. Names in JSON are MANGLED (Itanium ABI), some prefixed with
+       ``<source-file>:`` for internal-linkage. Strip prefix, demangle
+       via c++filt, reduce to qualified-no-args form.
+
+Cache layout::
+
+    out/binary-oracle-precision/cache/snappy/<sha-prefix>/
+        build/           # single instrumented -O2 build
+        merged.profdata  # accumulated across ctest runs
+        sentinel.ok      # version-stamped; absent → full rebuild
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import shutil
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Literal, Set, Tuple
+
+# ``_qualified_from_demangled`` / ``_find_arglist_open`` /
+# ``_METHOD_TRAILING_QUALS`` live in ``binary_oracle`` so the classifier
+# can demangle DWARF linkage names with the same logic. Re-exported here
+# for any external importer.
+from ..binary_oracle import (  # noqa: F401  (re-export)
+    _demangle_linkage_names,
+    _find_arglist_open,
+    _METHOD_TRAILING_QUALS,
+    _qualified_from_demangled,
+)
+
+logger = logging.getLogger(__name__)
+
+SNAPPY_URL = "https://github.com/google/snappy.git"
+SNAPPY_SHA = "984b191f0fefdeb17050b42a90b7625999c13b8d"   # v1.2.1
+CACHE_VERSION = "2"   # bumped: gcov → llvm-cov methodology
+
+# Versioned LLVM tools. Plain ``llvm-cov`` / ``llvm-profdata`` aren't on
+# the PATH on Ubuntu 24.04 LTS even with ``clang-21`` installed — only
+# the versioned binaries exist. Try the versioned form first, then plain.
+_LLVM_COV_CANDIDATES = ("llvm-cov-21", "llvm-cov-20", "llvm-cov-19",
+                        "llvm-cov")
+_LLVM_PROFDATA_CANDIDATES = ("llvm-profdata-21", "llvm-profdata-20",
+                             "llvm-profdata-19", "llvm-profdata")
+
+
+def _resolve(candidates: Tuple[str, ...]) -> str:
+    for c in candidates:
+        if shutil.which(c):
+            return c
+    raise RuntimeError(f"snappy: none of {candidates} found on PATH")
+
+
+# Filter out llvm-cov hits on stdlib / google-test / inlined-everywhere
+# helpers when populating the candidate set — they're not part of the
+# snappy surface a researcher would evaluate, and including them just
+# inflates n_functions with methodology noise.
+_STDLIB_PREFIXES = (
+    "std::",
+    "__gnu_cxx::",
+    "testing::",
+    "decltype(",
+    "operator new",
+    "operator delete",
+)
+
+
+def _is_stdlib_or_helper(qualified: str) -> bool:
+    if any(qualified.startswith(p) for p in _STDLIB_PREFIXES):
+        return True
+    return qualified.startswith("__")
+
+
+@dataclass
+class _SnappyDriver:
+    name: str = "snappy"
+    description: str = (
+        "snappy v1.2.1 — C++17, ~3k LOC. LLVM source-based coverage "
+        "(single -O2 build, no O0/O2 differential).")
+    mode: Literal["gcov"] = "gcov"   # harness cross-tab is liveness-based
+
+    def prepare(self, work_dir: Path) -> Dict[str, Any]:
+        work_dir = work_dir.resolve()
+        sha_dir = work_dir / SNAPPY_SHA[:12]
+        sentinel = sha_dir / "sentinel.ok"
+        build_dir = sha_dir / "build"
+        profdata = sha_dir / "merged.profdata"
+
+        if (not sentinel.exists()
+                or sentinel.read_text().strip() != CACHE_VERSION):
+            _build_and_run(sha_dir, build_dir, profdata)
+            sentinel.write_text(CACHE_VERSION)
+
+        binary = build_dir / "snappy_unittest"
+        live, candidates = _liveness_from_llvm_cov(binary, profdata)
+        return {
+            "o2_binary":            binary,
+            "candidate_functions":  sorted(candidates),
+            "live_set":             live,
+        }
+
+
+def _build_and_run(sha_dir: Path, build_dir: Path, profdata: Path) -> None:
+    """Clone (+ submodule init for googletest) → CMake build once →
+    run unittest → merge profraw → profdata."""
+    sha_dir.mkdir(parents=True, exist_ok=True)
+    src = sha_dir / "src"
+
+    from core.git import clone_repository, get_safe_git_env
+    from core.git.clone import safe_git_command
+
+    if src.exists():
+        shutil.rmtree(src)
+    logger.info("snappy: cloning %s → %s", SNAPPY_URL, src)
+    if not clone_repository(SNAPPY_URL, src, depth=None):
+        raise RuntimeError(f"snappy: clone failed for {SNAPPY_URL}")
+    subprocess.run(
+        safe_git_command("-C", str(src), "checkout", SNAPPY_SHA),
+        env=get_safe_git_env(), check=True, timeout=60,
+    )
+    # snappy vendors googletest + benchmark as submodules.
+    subprocess.run(
+        safe_git_command("-C", str(src), "submodule", "update",
+                         "--init", "--recursive"),
+        env=get_safe_git_env(), check=True, timeout=300,
+    )
+
+    if build_dir.exists():
+        shutil.rmtree(build_dir)
+    build_dir.mkdir(parents=True)
+
+    # ``-Wno-error=uninitialized-const-pointer``: clang-21 is stricter
+    # than gcc and rejects a known-benign pattern in snappy's
+    # ``snappy-test.cc`` (an intentionally-uninitialised dummy used to
+    # exercise an error path). Don't fail the build over an upstream
+    # warning we don't own.
+    cxxflags = ("-O2 -g -ffunction-sections -fdata-sections "
+                "-fprofile-instr-generate -fcoverage-mapping "
+                "-Wno-error=uninitialized-const-pointer")
+    ldflags = "-Wl,--gc-sections -fprofile-instr-generate"
+    subprocess.run([
+        "cmake", str(src),
+        "-DCMAKE_BUILD_TYPE=Release",
+        "-DCMAKE_C_COMPILER=clang",
+        "-DCMAKE_CXX_COMPILER=clang++",
+        f"-DCMAKE_CXX_FLAGS={cxxflags}",
+        f"-DCMAKE_EXE_LINKER_FLAGS={ldflags}",
+        "-DSNAPPY_BUILD_TESTS=ON",
+        "-DSNAPPY_BUILD_BENCHMARKS=OFF",
+        # snappy's CMake declares min 3.1; newer CMake refuses without this.
+        "-DCMAKE_POLICY_VERSION_MINIMUM=3.5",
+    ], cwd=build_dir, check=True, timeout=300)
+    subprocess.run(["cmake", "--build", ".", "-j4"],
+                   cwd=build_dir, check=True, timeout=600)
+
+    # Run tests with profile output. ``%m`` expands to a unique-per-image
+    # ID at runtime so concurrent processes don't trample one file.
+    profraw_pattern = str(sha_dir / "snappy_%m.profraw")
+    env = {**os.environ, "LLVM_PROFILE_FILE": profraw_pattern}
+    subprocess.run(["ctest", "--output-on-failure"],
+                   cwd=build_dir, env=env, check=True, timeout=300)
+
+    profraw = list(sha_dir.glob("snappy_*.profraw"))
+    if not profraw:
+        raise RuntimeError(
+            f"snappy: no profraw produced (LLVM_PROFILE_FILE="
+            f"{profraw_pattern}); coverage instrumentation may be broken")
+
+    profdata_tool = _resolve(_LLVM_PROFDATA_CANDIDATES)
+    subprocess.run(
+        [profdata_tool, "merge", "-sparse", *(str(p) for p in profraw),
+         "-o", str(profdata)],
+        check=True, timeout=120,
+    )
+
+    shutil.rmtree(src, ignore_errors=True)
+
+
+def _strip_llvm_file_prefix(name: str) -> str:
+    """``llvm-cov export`` prefixes internal-linkage function names with
+    the defining source file: ``snappy.cc:_ZN6snappy12_GLOBAL...``.
+    External-linkage names start at ``_Z`` directly. Strip the prefix
+    so the rest of the pipeline (c++filt → qualified extraction →
+    namespace filter) sees the bare mangled symbol."""
+    if name.startswith("_Z"):
+        return name
+    if ":_Z" in name:
+        return name.split(":", 1)[1]
+    return name
+
+
+def _liveness_from_llvm_cov(
+    binary: Path, profdata: Path,
+) -> Tuple[Set[str], Set[str]]:
+    """Run ``llvm-cov export`` → JSON, demangle mangled function names
+    via ``c++filt``, and reduce to qualified-no-args form. Returns
+    ``(live_set, candidate_set)``."""
+    cov_tool = _resolve(_LLVM_COV_CANDIDATES)
+    proc = subprocess.run(
+        [cov_tool, "export", f"--instr-profile={profdata}", str(binary)],
+        capture_output=True, text=True, check=False, timeout=120,
+    )
+    if proc.returncode != 0 or not proc.stdout:
+        logger.warning("snappy: llvm-cov export failed: %s",
+                       proc.stderr[:300])
+        return set(), set()
+    try:
+        data = json.loads(proc.stdout)
+    except json.JSONDecodeError as e:
+        logger.warning("snappy: failed to parse llvm-cov JSON: %s", e)
+        return set(), set()
+
+    # ``llvm-cov export`` emits a top-level ``data`` array with one entry
+    # per "object" — for a single binary that's a single entry.
+    blocks = data.get("data") or []
+    if not blocks:
+        return set(), set()
+
+    fns = blocks[0].get("functions") or []
+    bare_mangled = sorted({_strip_llvm_file_prefix(f["name"])
+                           for f in fns if f.get("name")})
+    demangled_map = _demangle_linkage_names(bare_mangled)
+
+    live: Set[str] = set()
+    candidates: Set[str] = set()
+    for fn in fns:
+        bare = _strip_llvm_file_prefix(fn.get("name") or "")
+        full = demangled_map.get(bare, bare)
+        qualified = _qualified_from_demangled(full)
+        if not qualified or _is_stdlib_or_helper(qualified):
+            continue
+        # Scope to snappy's own surface — without this, the candidate
+        # set balloons with gtest internals (libsnappy.a is linked into
+        # the gtest-driven unittest, so llvm-cov sees both).
+        #
+        # Adversarial review E P1-4: include anonymous-namespace
+        # helpers ((anonymous namespace)::Foo) — they're exactly where
+        # ICF / DCE is most aggressive in C++ and excluding them from
+        # the candidate set was hiding the highest-risk class from
+        # precision measurement. The qualified-name extractor flags
+        # them by the literal ``(anonymous namespace)`` prefix; admit
+        # those AND the snappy-prefixed ones.
+        is_snappy_surface = (qualified.startswith("snappy::")
+                             or qualified.startswith("snappy_"))
+        is_anon = "(anonymous namespace)" in qualified
+        if not (is_snappy_surface or is_anon):
+            continue
+        candidates.add(qualified)
+        if fn.get("count", 0) > 0:
+            live.add(qualified)
+    return live, candidates
+
+
+driver = _SnappyDriver()

--- a/core/inventory/binary_oracle_corpora/synthetic.py
+++ b/core/inventory/binary_oracle_corpora/synthetic.py
@@ -1,0 +1,65 @@
+"""Synthetic-fixture corpus driver.
+
+Uses the in-tree fixture at
+``core/inventory/tests/fixtures/binary_oracle/`` with hand-labeled
+expected verdicts. No external deps; validates the precision harness
+end-to-end on known-correct cases and acts as a fast classifier sanity
+check.
+
+The fold case (``folded_a``/``folded_b``) depends on whether an ICF-
+capable linker is available; the driver asks the fixture's Makefile
+which mode it built in and adjusts the expected verdict accordingly.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Literal
+
+from ..binary_oracle import Classification
+
+FIXTURE_DIR = (Path(__file__).resolve().parents[1] / "tests" / "fixtures"
+               / "binary_oracle")
+
+
+@dataclass
+class _SyntheticDriver:
+    name: str = "synthetic"
+    description: str = (
+        "In-tree fixture (8 functions, hand-labeled verdicts) — fast "
+        "classifier sanity check, no external deps.")
+    mode: Literal["synthetic"] = "synthetic"
+
+    def prepare(self, work_dir: Path) -> Dict[str, Any]:
+        # Build the fixture (idempotent — make checks timestamps).
+        subprocess.run(["make", "-s", "demo"], cwd=FIXTURE_DIR, check=True)
+        binary = FIXTURE_DIR / "demo"
+        icf_mode = subprocess.run(
+            ["make", "-s", "print-icf-mode"], cwd=FIXTURE_DIR,
+            check=True, capture_output=True, text=True,
+        ).stdout.strip()
+        folded_verdict: Classification = (
+            "folded" if icf_mode != "none" else "symbol_present"
+        )
+        expected: Dict[str, Classification] = {
+            "live_called":                "symbol_present",
+            "live_address_taken_target":  "symbol_present",
+            "inlined_only":               "inlined",
+            "inlined_only_user":          "symbol_present",
+            "dead_static_unused":         "absent",
+            "dead_extern_unused":         "absent",
+            "folded_a":                   folded_verdict,
+            "folded_b":                   folded_verdict,
+            "volatile_call_target":       "symbol_present",
+            "indirect_caller":            "symbol_present",
+        }
+        return {
+            "o2_binary":            binary,
+            "candidate_functions":  list(expected.keys()),
+            "expected":             expected,
+        }
+
+
+driver = _SyntheticDriver()

--- a/core/inventory/binary_oracle_corpora/toolchain.py
+++ b/core/inventory/binary_oracle_corpora/toolchain.py
@@ -1,0 +1,139 @@
+"""Toolchain-version probing for corpus drivers.
+
+Adversarial review E P2-2: precision numbers depend on compiler/runtime
+versions (clang inlining decisions vary across releases; rustc DCE shifts
+between MSRV bumps; gcov format changes across binutils minor versions).
+Without recording WHICH versions produced a given precision report,
+reproducibility is implicit-host-state — the same commit yields
+different numbers on a different box and we can't tell which is "right".
+
+Two-layer approach instead of brittle version enforcement:
+
+  1. ``record_toolchain(...)`` — probes each tool actually used by the
+     driver and returns the version string. Drivers call this and store
+     the result in the prepare() context so the harness can write it
+     into report.json.
+
+  2. ``check_compatible(...)`` — optional gate that drivers can call to
+     bail out when the local toolchain is too far from what was used to
+     calibrate the precision corpus (configurable per-driver). Defaults
+     to warn-only — operators see the version skew but the run proceeds.
+
+The point is visibility: when someone says "1952/1952 absent verdicts
+correct," reproducing it needs to know what compiler emitted those
+binaries. The toolchain block in the report gives them the answer.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import shutil
+import subprocess
+from typing import Dict, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+
+def _probe(cmd: list) -> Optional[str]:
+    """Run ``cmd`` and return its first-line stdout/stderr (most tools
+    print version on either stream). Returns ``None`` if the tool is
+    absent or errors out — the corpus driver decides whether to fail."""
+    if not shutil.which(cmd[0]):
+        return None
+    try:
+        proc = subprocess.run(
+            cmd, capture_output=True, text=True,
+            check=False, timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    text = (proc.stdout or proc.stderr or "").strip()
+    if not text:
+        return None
+    return text.splitlines()[0].strip()
+
+
+def record_toolchain(
+    *,
+    cc: Optional[str] = None,
+    cxx: Optional[str] = None,
+    rustc: Optional[str] = None,
+    cargo: Optional[str] = None,
+    gcov: Optional[str] = None,
+    llvm_cov: Optional[str] = None,
+    llvm_profdata: Optional[str] = None,
+) -> Dict[str, str]:
+    """Probe the toolchain components named (skip None). Returns a
+    ``{tool: version_string}`` dict for inclusion in the report.
+
+    Pass only the tools the driver actually uses — keeps the recorded
+    set minimal and accurate. Example::
+
+        ctx['toolchain'] = record_toolchain(
+            cc='gcc', gcov='gcov',
+        )
+    """
+    probes: Dict[str, list] = {}
+    if cc:
+        probes[f"cc({cc})"] = [cc, "--version"]
+    if cxx:
+        probes[f"cxx({cxx})"] = [cxx, "--version"]
+    if rustc:
+        probes[f"rustc({rustc})"] = [rustc, "--version"]
+    if cargo:
+        probes[f"cargo({cargo})"] = [cargo, "--version"]
+    if gcov:
+        probes[f"gcov({gcov})"] = [gcov, "--version"]
+    if llvm_cov:
+        probes[f"llvm-cov({llvm_cov})"] = [llvm_cov, "--version"]
+    if llvm_profdata:
+        probes[f"llvm-profdata({llvm_profdata})"] = [
+            llvm_profdata, "--version"]
+    out: Dict[str, str] = {}
+    for label, cmd in probes.items():
+        v = _probe(cmd)
+        out[label] = v or "(not found)"
+    return out
+
+
+_VERSION_RE = re.compile(r"(\d+)\.(\d+)(?:\.(\d+))?")
+
+
+def _major_minor(version_text: str) -> Optional[Tuple[int, int]]:
+    """Extract the first ``MAJOR.MINOR`` pair from a version string."""
+    m = _VERSION_RE.search(version_text)
+    if not m:
+        return None
+    return (int(m.group(1)), int(m.group(2)))
+
+
+def check_compatible(
+    label: str, version_text: Optional[str], minimum: Tuple[int, int],
+    *, fail: bool = False,
+) -> bool:
+    """Verify ``version_text`` parses to ``>= minimum`` MAJOR.MINOR.
+    Warns or raises (``fail=True``) when below. Returns True on pass."""
+    if not version_text:
+        if fail:
+            raise RuntimeError(
+                f"{label}: tool not found; precision corpus requires "
+                f">= {minimum[0]}.{minimum[1]}")
+        logger.warning(
+            "%s: tool not found; precision report will lack a"
+            " calibrated baseline", label)
+        return False
+    ver = _major_minor(version_text)
+    if ver is None or ver < minimum:
+        msg = (f"{label}: version {version_text!r} below calibrated "
+               f"minimum {minimum[0]}.{minimum[1]} — precision numbers "
+               f"may differ from the reference (different DCE / inline "
+               f"behaviour)")
+        if fail:
+            raise RuntimeError(msg)
+        logger.warning(msg)
+        return False
+    return True
+
+
+__all__ = ["record_toolchain", "check_compatible"]

--- a/core/inventory/binary_oracle_corpora/zlib.py
+++ b/core/inventory/binary_oracle_corpora/zlib.py
@@ -1,0 +1,208 @@
+"""zlib corpus driver — first real-world precision corpus.
+
+Methodology:
+  1. Clone zlib v1.3.1 (pinned SHA), full history (so the checkout works).
+  2. Build TWICE in isolated copies of the source tree (zlib doesn't
+     support out-of-tree builds, so cp the tree):
+
+       build_o0/   ./configure --static
+                   CFLAGS='-O0 -g --coverage'   LDFLAGS='--coverage'
+
+       build_o2/   ./configure --static
+                   CFLAGS='-O2 -g -ffunction-sections -fdata-sections'
+                   LDFLAGS='-Wl,--gc-sections'
+
+  3. Run ``./example`` (zlib's self-contained smoke test) against the O0
+     build to populate ``.gcda``. We deliberately skip ``make test`` —
+     it'd also exercise ``minigzip``, broadening ground truth past what
+     the ``example`` binary actually covers.
+
+  4. Parse ``gcov -f`` over libz's ``.c`` files → set of functions with
+     non-zero line execution.
+
+  5. Candidate set = functions defined in ``libz.a`` (the static archive
+     from the O0 build). That's the population the classifier evaluates.
+
+  6. Classifier runs against ``build_o2/example`` — a statically-linked
+     executable where ``--gc-sections`` actually applies (vs ``libz.so``
+     where exported symbols are linker-roots and never DCE'd, which
+     would trivialise the measurement).
+
+Cache layout::
+
+    out/binary-oracle-precision/cache/zlib/<sha-prefix>/
+        build_o0/        # built once; .gcda accumulates
+        build_o2/        # built once
+        sentinel.ok      # version-stamped; absent → full rebuild
+
+Idempotent re-runs read the cached build directly. Bump ``CACHE_VERSION``
+when build flags change.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+import shutil
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Literal, Set
+
+logger = logging.getLogger(__name__)
+
+ZLIB_URL = "https://github.com/madler/zlib.git"
+ZLIB_SHA = "51b7f2abdade71cd9bb0e7a373ef2610ec6f9daf"   # v1.3.1
+CACHE_VERSION = "1"
+
+
+@dataclass
+class _ZlibDriver:
+    name: str = "zlib"
+    description: str = (
+        "zlib v1.3.1 — pure C, ~10k LOC. gcov ground truth from "
+        "self-test; classifier target = statically-linked example.")
+    mode: Literal["gcov"] = "gcov"
+
+    def prepare(self, work_dir: Path) -> Dict[str, Any]:
+        work_dir = work_dir.resolve()
+        sha_dir = work_dir / ZLIB_SHA[:12]
+        sentinel = sha_dir / "sentinel.ok"
+        build_o0 = sha_dir / "build_o0"
+        build_o2 = sha_dir / "build_o2"
+
+        if (not sentinel.exists()
+                or sentinel.read_text().strip() != CACHE_VERSION):
+            _build_fresh(sha_dir, build_o0, build_o2)
+            sentinel.write_text(CACHE_VERSION)
+
+        live = _collect_gcov_liveness(build_o0)
+        candidates = _enumerate_candidates(build_o0)
+        return {
+            "o2_binary": build_o2 / "example",
+            "candidate_functions": candidates,
+            "live_set": live,
+        }
+
+
+def _build_fresh(sha_dir: Path, build_o0: Path, build_o2: Path) -> None:
+    """Clone → checkout pinned SHA → build twice. Source clone is deleted
+    afterwards; only build artifacts persist in the cache."""
+    sha_dir.mkdir(parents=True, exist_ok=True)
+    src = sha_dir / "src"
+
+    # Centralised safe-clone API (no direct ``git clone``); depth=None
+    # gives us full history so the SHA checkout can resolve.
+    from core.git import clone_repository, get_safe_git_env
+    from core.git.clone import safe_git_command
+
+    if src.exists():
+        shutil.rmtree(src)
+    logger.info("zlib: cloning %s → %s", ZLIB_URL, src)
+    if not clone_repository(ZLIB_URL, src, depth=None):
+        raise RuntimeError(f"zlib: clone failed for {ZLIB_URL}")
+    subprocess.run(
+        safe_git_command("-C", str(src), "checkout", ZLIB_SHA),
+        env=get_safe_git_env(), check=True, timeout=60,
+    )
+
+    for build_dir, cflags, ldflags, run_tests in [
+        (build_o0,
+         "-O0 -g --coverage", "--coverage", True),
+        (build_o2,
+         "-O2 -g -ffunction-sections -fdata-sections",
+         "-Wl,--gc-sections", False),
+    ]:
+        if build_dir.exists():
+            shutil.rmtree(build_dir)
+        shutil.copytree(src, build_dir)
+        env = {**os.environ, "CFLAGS": cflags, "LDFLAGS": ldflags}
+        subprocess.run(["./configure", "--static"], cwd=build_dir,
+                       env=env, check=True, timeout=120)
+        subprocess.run(["make", "-j4"], cwd=build_dir,
+                       env=env, check=True, timeout=300)
+        if run_tests:
+            # Run only ``./example`` — see module docstring for why we
+            # skip ``make test``. Sandbox the built-binary invocation
+            # — upstream tag is trusted but supply-chain compromise on
+            # a pinned ref is the residual risk. writable_paths
+            # includes build_dir so gcov can write .gcda files.
+            from core.sandbox import run as _sandbox_run
+            _sandbox_run(
+                ["./example"], cwd=str(build_dir),
+                target=str(build_dir),
+                writable_paths=[str(build_dir)],
+                block_network=True,
+                check=True, timeout=60,
+            )
+
+    shutil.rmtree(src, ignore_errors=True)
+
+
+# ---------------------------------------------------------------------------
+# gcov parsing
+# ---------------------------------------------------------------------------
+
+_GCOV_FN_RE = re.compile(r"^Function '([^']+)'")
+_GCOV_LINES_RE = re.compile(r"^Lines executed:([\d.]+)% of \d+")
+
+
+def _collect_gcov_liveness(build_dir: Path) -> Set[str]:
+    """Run ``gcov -f`` over every ``.c`` file with a matching ``.gcda``
+    in the build dir; return the set of functions with > 0% lines
+    executed."""
+    c_files = sorted(p.name for p in build_dir.glob("*.c")
+                     if (build_dir / (p.stem + ".gcda")).exists())
+    if not c_files:
+        logger.warning("zlib: no .gcda files in %s — was the self-test run?",
+                       build_dir)
+        return set()
+
+    out = subprocess.run(
+        ["gcov", "-f"] + c_files, cwd=build_dir,
+        capture_output=True, text=True, check=False, timeout=120,
+    ).stdout
+
+    live: Set[str] = set()
+    current_fn = None
+    for line in out.splitlines():
+        m = _GCOV_FN_RE.match(line)
+        if m:
+            current_fn = m.group(1)
+            continue
+        if current_fn:
+            m2 = _GCOV_LINES_RE.match(line)
+            if m2:
+                if float(m2.group(1)) > 0:
+                    live.add(current_fn)
+                current_fn = None
+    return live
+
+
+# ---------------------------------------------------------------------------
+# Candidate enumeration
+# ---------------------------------------------------------------------------
+
+def _enumerate_candidates(build_o0: Path) -> List[str]:
+    """Functions defined in ``libz.a`` — the population the classifier
+    evaluates. ``nm`` types ``T`` (text, exported) and ``t`` (text, local)
+    are functions; ``W``/``w`` are weak. Skip data symbols."""
+    archive = build_o0 / "libz.a"
+    if not archive.exists():
+        logger.warning("zlib: %s not found; cannot enumerate candidates",
+                       archive)
+        return []
+    out = subprocess.run(["nm", str(archive)],
+                         capture_output=True, text=True,
+                         check=False, timeout=30).stdout
+    fns: Set[str] = set()
+    for line in out.splitlines():
+        parts = line.split()
+        # ``<addr> T <name>`` or ``         T <name>`` (undefined → skip).
+        if len(parts) >= 3 and parts[-2] in ("T", "t", "W", "w"):
+            fns.add(parts[-1])
+    return sorted(fns)
+
+
+driver = _ZlibDriver()

--- a/core/inventory/binary_oracle_corpora/zstd_holdout.py
+++ b/core/inventory/binary_oracle_corpora/zstd_holdout.py
@@ -1,0 +1,254 @@
+"""zstd HELD-OUT corpus driver — one-shot precision measurement.
+
+This driver exists for ONE purpose: to measure binary_oracle absent
+precision on a corpus the classifier was never tuned against.
+
+**The contract for this driver is: do not modify the classifier based
+on what it reports.** The methodology (O0/O2 differential like
+libsodium) is the most rigorous of the existing drivers because the
+candidate set comes from the O0 build (independent of what O2 DCE
+strips) and ground truth comes from the O0 build's gcov run.
+
+zstd v1.5.6 — pure C, ~50k LOC, two compilation modes:
+    build_o0: -O0 -g --coverage     (candidate enumeration + ground truth)
+    build_o2: -O2 -g -ffunction-sections -fdata-sections + --gc-sections
+              (classifier target)
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+import shutil
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Literal, Set
+
+logger = logging.getLogger(__name__)
+
+ZSTD_URL = "https://github.com/facebook/zstd.git"
+ZSTD_TAG = "v1.5.6"
+CACHE_VERSION = "3"   # bumped: writable_paths fix for gcda writes
+
+
+@dataclass
+class _ZstdHoldoutDriver:
+    name: str = "zstd_holdout"
+    description: str = (
+        "zstd v1.5.6 — pure C, ~50k LOC, gcov O0/O2 differential. "
+        "HELD OUT: classifier was never tuned against this corpus.")
+    mode: Literal["gcov"] = "gcov"
+
+    def prepare(self, work_dir: Path) -> Dict[str, Any]:
+        work_dir = work_dir.resolve()
+        tag_dir = work_dir / ZSTD_TAG.replace(".", "_")
+        sentinel = tag_dir / "sentinel.ok"
+        build_o0 = tag_dir / "build_o0"
+        build_o2 = tag_dir / "build_o2"
+
+        if (not sentinel.exists()
+                or sentinel.read_text().strip() != CACHE_VERSION):
+            _build_fresh(tag_dir, build_o0, build_o2)
+            sentinel.write_text(CACHE_VERSION)
+
+        live = _collect_gcov_liveness(build_o0)
+        candidates = _enumerate_candidates(build_o0)
+        from .toolchain import record_toolchain
+        return {
+            "o2_binary":            build_o2 / "programs" / "zstd",
+            "candidate_functions":  candidates,
+            "live_set":             live,
+            "toolchain":            record_toolchain(cc="gcc", gcov="gcov"),
+        }
+
+
+def _build_fresh(tag_dir: Path, build_o0: Path, build_o2: Path) -> None:
+    tag_dir.mkdir(parents=True, exist_ok=True)
+    src = tag_dir / "src"
+
+    from core.git import clone_repository, get_safe_git_env
+    from core.git.clone import safe_git_command
+
+    if src.exists():
+        shutil.rmtree(src)
+    logger.info("zstd_holdout: cloning %s → %s", ZSTD_URL, src)
+    if not clone_repository(ZSTD_URL, src, depth=None):
+        raise RuntimeError(f"zstd_holdout: clone failed for {ZSTD_URL}")
+    subprocess.run(
+        safe_git_command("-C", str(src), "checkout", ZSTD_TAG),
+        env=get_safe_git_env(), check=True, timeout=60,
+    )
+
+    for build_dir, cflags, ldflags, run_target in [
+        (build_o0, "-O0 -g --coverage", "--coverage", True),
+        (build_o2,
+         "-O2 -g -ffunction-sections -fdata-sections",
+         "-Wl,--gc-sections", False),
+    ]:
+        if build_dir.exists():
+            shutil.rmtree(build_dir)
+        # zstd's Makefile build can't take an out-of-tree dir, so we
+        # copy the source into the build dir each time. ``cp -a`` via
+        # subprocess (rather than ``shutil.copytree``) — on Python 3.14
+        # shutil.copytree fails on zstd's source tree
+        # (NotADirectoryError on file symlinks under tests/cli-tests/);
+        # cp -a is the portable Unix idiom that handles this cleanly.
+        build_dir.mkdir(parents=True, exist_ok=True)
+        subprocess.run(
+            ["cp", "-a", f"{src}/.", str(build_dir)],
+            check=True, timeout=120,
+        )
+        env = {**os.environ, "CFLAGS": cflags, "LDFLAGS": ldflags}
+        subprocess.run(
+            ["make", "-j4", "lib-mt", "zstd"],
+            cwd=build_dir, env=env, check=True, timeout=600,
+        )
+        if run_target:
+            # Exercise the CLI binary with a workload broad enough that
+            # the gcov live_set is non-trivial. A previous version ran a
+            # single compress+decompress on one file — the resulting
+            # live_set was nearly empty, which made the precision
+            # claim mathematically vacuous (classifier-absent ∩
+            # live_set is forced empty when live_set is empty).
+            #
+            # The workload now spans: 5 input files of different sizes
+            # and entropy classes; 6 compression levels (fast/normal/
+            # high); long-range mode; multi-threaded mode; dictionary
+            # training + use; decompression of every produced artefact.
+            # Combined ground-truth coverage of zstd's hot paths is
+            # genuine — the cross-tab "live" column populates with
+            # hundreds of functions and the precision claim has actual
+            # statistical power.
+            from core.sandbox import run as _sandbox_run
+            zstd_bin = build_dir / "programs" / "zstd"
+            tmp = build_dir / "workload"
+            tmp.mkdir(exist_ok=True)
+
+            # Inputs: highly-redundant (compresses well), random-ish
+            # (incompressible), source code (medium), small + large.
+            inputs: list = []
+            (tmp / "low.txt").write_bytes(b"AAAA" * 16384)
+            inputs.append(tmp / "low.txt")
+            import os as _os
+            (tmp / "high.bin").write_bytes(_os.urandom(64 * 1024))
+            inputs.append(tmp / "high.bin")
+            inputs.append(build_dir / "lib" / "compress" / "zstd_compress.c")
+            inputs.append(build_dir / "lib" / "decompress" / "zstd_decompress.c")
+            inputs.append(build_dir / "lib" / "common" / "fse_decompress.c")
+
+            def _z(*argv: str) -> None:
+                # writable_paths includes build_dir because gcov
+                # instrumentation writes .gcda files alongside the
+                # .o files (under ``build_dir/obj/...``). Without
+                # the explicit allow, the sandbox blocks those
+                # writes and the live_set comes back empty —
+                # making absent_precision mathematically vacuous.
+                _sandbox_run(
+                    [str(zstd_bin), *argv],
+                    target=str(build_dir), output=str(tmp),
+                    writable_paths=[str(build_dir)],
+                    block_network=True, check=True, timeout=120,
+                )
+
+            # Compression: every level class — fast / default / high /
+            # ultra; --long for long-range matching; -T2 for MT.
+            # NB: deliberately NOT named ``src`` here — that's the
+            # outer source-tree dir; Python's for-loop variable
+            # persists after the loop and would silently shadow it,
+            # breaking the second build_o2 iteration's cp command.
+            for lvl in ("-1", "-3", "-9", "-19", "--ultra", "-22"):
+                for input_file in inputs:
+                    out = tmp / (
+                        f"{input_file.name}.{lvl.lstrip('-') or 'u'}.zst"
+                    )
+                    _z(lvl, "-f", "-o", str(out), str(input_file))
+            # Long-range mode (different code path)
+            _z("--long", "-3", "-f", "-o",
+               str(tmp / "long.zst"), str(inputs[0]))
+            # Multi-threaded compression (MT code path)
+            _z("-T2", "-3", "-f", "-o",
+               str(tmp / "mt.zst"), str(inputs[1]))
+            # Dictionary training + dictionary-based compression
+            dict_path = tmp / "dict"
+            try:
+                _z("--train", "-o", str(dict_path),
+                   *(str(p) for p in inputs),
+                   "--maxdict", "16384")
+                _z("-D", str(dict_path), "-3", "-f", "-o",
+                   str(tmp / "dict.zst"), str(inputs[2]))
+                _z("-D", str(dict_path), "-d", "-f", "-o",
+                   str(tmp / "dict.out"), str(tmp / "dict.zst"))
+            except subprocess.CalledProcessError:
+                # zstd --train requires multiple samples; some envs
+                # bail. Not fatal — coverage from the other branches
+                # is enough.
+                pass
+            # Decompress everything we compressed (decompress path).
+            for compressed in tmp.glob("*.zst"):
+                _z("-d", "-f", "-o",
+                   str(tmp / f"{compressed.stem}.out"), str(compressed))
+
+    shutil.rmtree(src, ignore_errors=True)
+
+
+_GCOV_FN_RE = re.compile(r"^Function '([^']+)'")
+_GCOV_LINES_RE = re.compile(r"^Lines executed:([\d.]+)% of \d+")
+
+
+def _collect_gcov_liveness(build_dir: Path) -> Set[str]:
+    """Walk the build tree for .gcda files and harvest live function
+    names from ``gcov -f``. zstd's Makefile statically links the lib
+    sources into the CLI binary's object dir
+    (``programs/obj/conf_*/*.o``), so .gcda files land THERE — not
+    under ``lib/``. Walk the whole build_dir and the gcov tool
+    figures out which .gcno pairs with each .gcda."""
+    if not build_dir.is_dir():
+        logger.warning("zstd_holdout: %s missing", build_dir)
+        return set()
+
+    live: Set[str] = set()
+    for gcda in build_dir.rglob("*.gcda"):
+        gcda_dir = gcda.parent
+        out = subprocess.run(
+            ["gcov", "-f", gcda.name], cwd=gcda_dir,
+            capture_output=True, text=True, check=False, timeout=60,
+        ).stdout
+        current = None
+        for line in out.splitlines():
+            m = _GCOV_FN_RE.match(line)
+            if m:
+                current = m.group(1)
+                continue
+            if current:
+                m2 = _GCOV_LINES_RE.match(line)
+                if m2:
+                    if float(m2.group(1)) > 0:
+                        live.add(current)
+                    current = None
+    return live
+
+
+def _enumerate_candidates(build_o0: Path) -> List[str]:
+    """nm on libzstd.a — candidates are every defined symbol in the
+    O0 archive. The O0 build doesn't DCE, so this is the source-side
+    surface (modulo macros that produce no symbol)."""
+    # zstd's Makefile builds libzstd.a in lib/ root.
+    archive = build_o0 / "lib" / "libzstd.a"
+    if not archive.exists():
+        logger.warning("zstd_holdout: %s missing", archive)
+        return []
+    out = subprocess.run(
+        ["nm", str(archive)], capture_output=True, text=True,
+        check=False, timeout=30,
+    ).stdout
+    fns: Set[str] = set()
+    for line in out.splitlines():
+        parts = line.split()
+        if len(parts) >= 3 and parts[-2] in ("T", "t", "W", "w"):
+            fns.add(parts[-1])
+    return sorted(fns)
+
+
+driver = _ZstdHoldoutDriver()

--- a/core/inventory/binary_oracle_edges.py
+++ b/core/inventory/binary_oracle_edges.py
@@ -1,0 +1,571 @@
+"""Binary-oracle call-edge extraction — Inc 2b Tier 1.
+
+The asymmetric companion to Inc 2's ``absent``-direction suppression
+witness: extract the binary's direct call graph, then for each
+``(caller, callee)`` edge cross-reference back to the source inventory.
+A source function with an incoming binary edge — even if the source
+graph thinks no caller exists — gets a positive reachability witness
+(``binary_call_edge``).
+
+Tier scope (per design §6 + Phase 4 edge-gap measurement):
+  * Tier 1 (this module) — DIRECT edges via r2 ``axffj`` per function.
+    Catches ~92% of all binary call sites (the indirect-call fraction
+    sat at 8.1% aggregate in the 4-corpus measurement). Misses fn-
+    pointer / vtable / ESIL-needed cases.
+  * Tier 2 (deferred) — vtable resolution via r2 ``avtv`` for C++.
+  * Tier 3 (deferred) — ESIL emulation for constant fn-pointer
+    propagation.
+
+The witness is HEURISTIC (not corpus-earned for hard suppression) —
+binary-edge ⇒ reachable is affirmative evidence that flows into the
+LLM prompt + reach_witness chokepoint, but doesn't license dropping a
+finding the way ``binary_oracle_absent`` does. Future corpus
+measurement can promote it.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+import shutil
+import subprocess
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, List, Optional, Set, Tuple
+
+from .binary_oracle import read_build_id
+
+logger = logging.getLogger(__name__)
+
+
+# Edge-index cache schema version. Bump on any incompatible change to
+# the serialised edge format (BinaryEdgeIndex fields, edge record
+# shape). Old cache entries with a stale version are ignored and the
+# extractor re-runs from scratch.
+_EDGE_CACHE_VERSION = 1
+
+
+@dataclass(frozen=True)
+class BinaryCallEdge:
+    """One direct call edge in the binary."""
+    caller: str
+    callee: str
+    binary_path: str
+
+
+@dataclass
+class BinaryEdgeIndex:
+    """Per-binary direct-call-edge extraction result.
+
+    ``edges`` is the full edge set; ``callees`` is the set of source-
+    function names that appear as a callee somewhere (cheap "is X
+    binary-called?" check used by the reach_witness stage)."""
+    binary_path: str
+    edges: List[BinaryCallEdge] = field(default_factory=list)
+    callees: Set[str] = field(default_factory=set)
+
+
+def _content_hash(binary_path: Path) -> Optional[str]:
+    """sha256 of the binary's file content — cache key fallback when
+    ``.note.gnu.build-id`` is absent (stripped Go, PGO-stripped vendor
+    binaries). Bounded I/O cost per extraction; cheaper than running
+    r2 a second time."""
+    try:
+        import hashlib
+        h = hashlib.sha256()
+        with binary_path.open("rb") as f:
+            for chunk in iter(lambda: f.read(1 << 16), b""):
+                h.update(chunk)
+        return h.hexdigest()
+    except OSError:
+        return None
+
+
+def _edge_cache_dir() -> Path:
+    """Edge-index cache root: ``out/binary-oracle-precision/edge-cache/``
+    (re-using the existing binary_oracle output convention). Cache
+    entries keyed by binary build_id."""
+    from core.config import RaptorConfig
+    return Path(RaptorConfig.BASE_OUT_DIR) / "binary-oracle-precision" / "edge-cache"
+
+
+_BUILD_ID_RE = re.compile(r"^[0-9a-f]{8,128}$")
+
+
+def _cache_path_for(build_id: str) -> Optional[Path]:
+    """Cache path for a given build_id, or ``None`` when the build_id
+    isn't a safely-embeddable hex string. Belt-and-braces against any
+    future regression in the upstream ``read_build_id`` helper: a
+    hostile binary defining its build_id note (e.g. arbitrary bytes in
+    ``.note.gnu.build-id``) could otherwise drive cache-file path
+    composition. Validate at use-site, not just at production."""
+    if not isinstance(build_id, str) or not _BUILD_ID_RE.match(build_id):
+        return None
+    return _edge_cache_dir() / f"{build_id}.json"
+
+
+def _load_cached_index(
+    cache_file: Path,
+    binary_path: str,
+) -> Optional[BinaryEdgeIndex]:
+    """Load a previously-extracted edge index from cache. Returns None
+    when the cache file is missing, malformed, or version-mismatched
+    (caller falls back to full extraction)."""
+    if not cache_file.is_file():
+        return None
+    try:
+        payload = json.loads(cache_file.read_text())
+    except (OSError, json.JSONDecodeError):
+        return None
+    if not isinstance(payload, dict):
+        return None
+    if payload.get("version") != _EDGE_CACHE_VERSION:
+        return None
+    # Cross-target collision check: two binaries with the same build_id
+    # (reproducible-build collision, or a pre-poisoned cache file an
+    # attacker dropped under out/) would silently mis-attribute edges
+    # to the wrong target. Insist the cache's ``binary_path`` matches
+    # the binary we're looking up; otherwise treat as miss and re-run
+    # extraction. Defends against the cache-poisoning vector flagged by
+    # adversarial review (forged edges to censor LLM scrutiny on a
+    # real bug — earns_suppression=False on this witness prevents
+    # finding-suppression, but censorship via misattribution is still
+    # within reach without this check).
+    cached_path = payload.get("binary_path")
+    if isinstance(cached_path, str) and cached_path != binary_path:
+        logger.warning(
+            "binary_oracle_edges: cache build_id collision; cached "
+            "path=%s wanted=%s; treating as cache miss",
+            cached_path, binary_path,
+        )
+        return None
+    edges_raw = payload.get("edges") or []
+    idx = BinaryEdgeIndex(binary_path=binary_path)
+    for r in edges_raw:
+        if not isinstance(r, dict):
+            continue
+        caller = r.get("caller")
+        callee = r.get("callee")
+        bp = r.get("binary_path") or binary_path
+        if isinstance(caller, str) and isinstance(callee, str):
+            idx.edges.append(BinaryCallEdge(
+                caller=caller, callee=callee, binary_path=bp))
+            idx.callees.add(callee)
+    return idx
+
+
+def _save_cached_index(cache_file: Path, idx: BinaryEdgeIndex) -> None:
+    """Persist the edge index. Best-effort — IO failures are logged at
+    debug and don't break the extraction path."""
+    try:
+        cache_file.parent.mkdir(parents=True, exist_ok=True)
+        payload = {
+            "version":     _EDGE_CACHE_VERSION,
+            "binary_path": idx.binary_path,
+            "edges": [
+                {"caller": e.caller, "callee": e.callee,
+                 "binary_path": e.binary_path}
+                for e in idx.edges
+            ],
+        }
+        tmp = cache_file.with_suffix(".json.tmp")
+        tmp.write_text(json.dumps(payload))
+        os.replace(tmp, cache_file)
+    except OSError as e:
+        logger.debug("binary_oracle_edges: cache write failed: %s", e)
+
+
+def extract_direct_call_edges(
+    binary_path: Path,
+    *,
+    timeout: int = 300,
+    use_cache: bool = True,
+) -> BinaryEdgeIndex:
+    """Run r2 ``aaa`` + ``aflj`` then per-function ``axffj`` to harvest
+    direct call edges. Returns an index keyed by both edge list and
+    callee set. Empty index when r2 is unavailable or fails (the
+    consumer treats absence as 'no binary evidence'; never licenses
+    additional suppression).
+
+    ``use_cache`` controls the per-build_id cache (under
+    ``out/binary-oracle-precision/edge-cache/<build_id>.json``).
+    A cache hit returns near-instantly; a miss runs the full r2
+    extraction and persists the result. Pass False to force re-extract
+    (test scenarios, debugging cache staleness)."""
+    if not shutil.which("r2"):
+        logger.info("binary_oracle_edges: r2 not found; skipping")
+        return BinaryEdgeIndex(binary_path=str(binary_path))
+    binary_path = Path(binary_path)
+    if not binary_path.is_file():
+        return BinaryEdgeIndex(binary_path=str(binary_path))
+
+    # Cache lookup keyed by build_id (mechanically-derived from
+    # ``.note.gnu.build-id`` — changes whenever the binary's code does).
+    # Stripped binaries (Go without -trimpath, PGO-stripped vendor
+    # binaries, custom-link binaries that drop .note.gnu.build-id) may
+    # have no build_id; fall back to a content sha256 so the cache
+    # still works (slower than a 40-char hex constant but bounded —
+    # one full-file digest per extraction).
+    cache_key = read_build_id(binary_path) if use_cache else None
+    if use_cache and not cache_key:
+        cache_key = _content_hash(binary_path)
+    cache_file = _cache_path_for(cache_key) if cache_key else None
+    build_id = cache_key  # alias for the log message + cache payload
+    if cache_file is not None:
+        cached = _load_cached_index(cache_file, str(binary_path))
+        if cached is not None:
+            logger.info(
+                "binary_oracle_edges: cache hit for %s (build_id=%s, %d edges)",
+                binary_path.name, build_id[:12], len(cached.edges))
+            return cached
+
+    # ``aaa`` is the heavy analyse-all; ~10s on a snappy_unittest-sized
+    # binary, longer on larger ones. Single r2 invocation that builds
+    # the function list AND iterates axffj per function. Subprocess
+    # errors (timeout, segfault, r2 missing post-which-check race) must
+    # NOT crash the inventory build — the module's contract is positive-
+    # evidence-only that degrades gracefully to "no binary evidence".
+    # r2 is a powerful binary-analysis tool with a large parser attack
+    # surface (CVE history in ELF/PDB parsers); the binary it analyses
+    # is operator-supplied and may be attacker-controlled. Use the full
+    # sandbox (namespace + Landlock + network deny) so a malicious ELF
+    # triggering an r2 bug cannot escape to operator-level code exec.
+    # ``target`` = the binary's containing directory so Landlock allows
+    # the necessary reads; no write paths needed (we capture stdout).
+    from core.sandbox import run as _sandbox_run
+    try:
+        fns_proc = _sandbox_run(
+            ["r2", "-q", "-c", "aaa; aflj", str(binary_path)],
+            target=str(binary_path.parent), block_network=True,
+            capture_output=True, text=True, check=False, timeout=timeout,
+        )
+    except (subprocess.TimeoutExpired, subprocess.SubprocessError,
+            OSError) as e:
+        logger.warning(
+            "binary_oracle_edges: aflj aborted for %s: %s",
+            binary_path, e,
+        )
+        return BinaryEdgeIndex(binary_path=str(binary_path))
+    try:
+        fns = json.loads(fns_proc.stdout)
+    except json.JSONDecodeError:
+        logger.warning("binary_oracle_edges: aflj parse failed for %s",
+                       binary_path)
+        return BinaryEdgeIndex(binary_path=str(binary_path))
+    if not isinstance(fns, list):
+        return BinaryEdgeIndex(binary_path=str(binary_path))
+
+    # Build addr → name map for resolving callee addresses.
+    addr_to_name: Dict[int, str] = {}
+    for f in fns:
+        addr = f.get("addr")
+        name = f.get("name")
+        if isinstance(addr, int) and isinstance(name, str):
+            addr_to_name[addr] = _clean_r2_function_name(name)
+
+    eligible_fns = [f for f in fns
+                    if not f.get("name", "").startswith("sym.imp.")
+                    and f.get("size", 0) > 0]
+
+    # Single r2 invocation for ALL axffj calls (adversarial review
+    # B P2-2 perf cliff fix). The prior implementation re-ran the
+    # heavy ``aaa`` analyse-all step PER BATCH — on a 5k-function
+    # binary at BATCH=200 that's 25 redundant ``aaa`` runs, each
+    # taking seconds. Total: minutes instead of seconds for big
+    # binaries. The script-file approach drives a single r2 session
+    # so ``aaa`` runs once and every axffj reuses its analysis state.
+    #
+    # Use a script file (``r2 -i``) rather than a giant ``-c`` string
+    # — argv length limits (POSIX ARG_MAX, typically 128KB) would cap
+    # the latter at ~few-thousand axffj calls, below the size of any
+    # serious application.
+    index = BinaryEdgeIndex(binary_path=str(binary_path))
+    import tempfile
+    script_lines = ["aaa"]
+    for f in eligible_fns:
+        script_lines.append(f"echo BATCH {f['addr']}")
+        script_lines.append(f"axffj @ {f['addr']}")
+    with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".r2", delete=False,
+            dir=str(binary_path.parent),
+    ) as script_file:
+        script_file.write("\n".join(script_lines) + "\n")
+        script_path = script_file.name
+    try:
+        proc = _sandbox_run(
+            ["r2", "-q", "-i", script_path, str(binary_path)],
+            target=str(binary_path.parent), block_network=True,
+            capture_output=True, text=True, check=False, timeout=timeout,
+            errors="replace",
+        )
+        _parse_axffj_batch(proc.stdout, addr_to_name, index)
+    except (subprocess.TimeoutExpired, subprocess.SubprocessError,
+            OSError) as e:
+        logger.warning(
+            "binary_oracle_edges: axffj script aborted for %s: %s",
+            binary_path, e,
+        )
+        # Do NOT cache a partial / failed result — bail out and
+        # return what we have without persisting.
+        try:
+            os.unlink(script_path)
+        except OSError:
+            pass
+        return index
+    finally:
+        try:
+            os.unlink(script_path)
+        except OSError:
+            pass
+
+    # Tier 2: vtable resolution. C++ virtual dispatch is the dominant
+    # share of source-graph "indirect" edges on real codebases (leveldb
+    # 9.3% indirect, mostly vtables). r2's ``av`` walks the binary's
+    # vtables and prints each slot's method; we treat every slot as a
+    # potentially-dispatched callee with a synthetic ``<vtable@<addr>>``
+    # caller. No-op on C binaries with no vtables.
+    vtable_edges = _extract_vtable_edges(binary_path, timeout=timeout)
+    for edge in vtable_edges:
+        index.edges.append(edge)
+        index.callees.add(edge.callee)
+
+    if cache_file is not None:
+        _save_cached_index(cache_file, index)
+        logger.info(
+            "binary_oracle_edges: cached %d edges for %s (build_id=%s)",
+            len(index.edges), binary_path.name, build_id[:12])
+    return index
+
+
+# ---------------------------------------------------------------------------
+# Tier 2 — vtable resolution
+# ---------------------------------------------------------------------------
+
+# r2 ``av`` text output: a sequence of vtable blocks, each beginning
+# with ``Vtable Found at 0x<addr>`` followed by ``<slot_addr> :
+# <method>`` lines. No JSON variant exists in r2 today (``avj`` /
+# ``avrj`` return empty); we parse the text.
+_VTABLE_HEADER_RE = re.compile(r"Vtable Found at 0x([0-9a-fA-F]+)")
+_VTABLE_SLOT_RE = re.compile(r"^\s*0x[0-9a-fA-F]+\s*:\s*(\S+)")
+
+
+def _extract_vtable_edges(
+    binary_path: Path,
+    *,
+    timeout: int = 300,
+) -> List[BinaryCallEdge]:
+    """Run r2 ``av`` and emit one synthetic edge per vtable slot:
+    ``<vtable@<addr>>`` → ``method``. Each method that appears in any
+    vtable slot is, by construction, a candidate target for the
+    binary's virtual dispatch sites — affirmative reachability evidence
+    source extraction often misses.
+
+    Returns an empty list when r2 finds no vtables (pure C binary,
+    stripped binary where vtable detection fails) — over-approximating
+    vtables would create false-promote, which the suppression direction
+    can't tolerate."""
+    if not shutil.which("r2"):
+        return []
+    from core.sandbox import run as _sandbox_run
+    try:
+        proc = _sandbox_run(
+            ["r2", "-q", "-c", "aaa; av", str(binary_path)],
+            target=str(binary_path.parent), block_network=True,
+            capture_output=True, text=True, check=False, timeout=timeout,
+            errors="replace",
+        )
+    except (subprocess.TimeoutExpired, subprocess.SubprocessError,
+            OSError) as e:
+        logger.warning(
+            "binary_oracle_edges: av (vtable) aborted for %s: %s",
+            binary_path, e,
+        )
+        return []
+    edges: List[BinaryCallEdge] = []
+    current_vtable: Optional[str] = None
+    for line in proc.stdout.splitlines():
+        # Strip ANSI escapes r2 emits in interactive-style output.
+        plain = re.sub(r"\x1b\[[\d;]*m", "", line)
+        m_hdr = _VTABLE_HEADER_RE.search(plain)
+        if m_hdr:
+            current_vtable = f"<vtable@0x{m_hdr.group(1).lower()}>"
+            continue
+        if current_vtable is None:
+            continue
+        m_slot = _VTABLE_SLOT_RE.match(plain)
+        if not m_slot:
+            continue
+        method = _clean_r2_function_name(m_slot.group(1))
+        # Filter slot junk: pure-virtual placeholders (``0x00000000``),
+        # bare hex addresses r2 couldn't resolve, section markers
+        # (``section.text``), and r2-internal location names
+        # (``loc.NNN``) — none of these are real callees.
+        if not method or method.startswith(
+                ("0x", "section.", "loc.", "0")):
+            continue
+        # Require at least one non-hex character somewhere in the
+        # name to weed out raw addresses that slipped through.
+        if not any(c.isalpha() or c == "_" for c in method):
+            continue
+        edges.append(BinaryCallEdge(
+            caller=current_vtable, callee=method,
+            binary_path=str(binary_path),
+        ))
+    return edges
+
+
+_R2_PREFIXES = ("sym.", "method.", "func.", "fcn.", "dbg.", "imp.")
+
+
+def _clean_r2_function_name(name: str) -> str:
+    """r2 prefixes functions with one of ``sym.``, ``method.``,
+    ``func.``, ``fcn.``, ``dbg.``, ``imp.`` (PLT stub) depending on
+    source (symbol table, decoded vtable, recovered, DWARF debug-info,
+    PLT). Strip the prefix(es) iteratively — r2 can stack prefixes
+    (``sym.imp.malloc`` → ``malloc``, ``method.sym.X`` → ``X``)."""
+    changed = True
+    while changed:
+        changed = False
+        for prefix in _R2_PREFIXES:
+            if name.startswith(prefix):
+                name = name[len(prefix):]
+                changed = True
+                break
+    return name
+
+
+def _parse_axffj_batch(
+    output: str,
+    addr_to_name: Dict[int, str],
+    index: BinaryEdgeIndex,
+) -> None:
+    """Parse the concatenated axffj output: ``BATCH <addr>`` separators
+    delimit each function's refs, each refs block is a JSON array of
+    ``{type, at, ref, name}``."""
+    current_caller: Optional[str] = None
+    buf: List[str] = []
+    for line in output.splitlines():
+        if line.startswith("BATCH "):
+            _flush_axffj(buf, current_caller, addr_to_name, index)
+            try:
+                caller_addr = int(line[len("BATCH "):], 0)
+                current_caller = addr_to_name.get(caller_addr)
+            except ValueError:
+                current_caller = None
+            buf = []
+        else:
+            buf.append(line)
+    _flush_axffj(buf, current_caller, addr_to_name, index)
+
+
+def _flush_axffj(
+    buf: List[str],
+    caller: Optional[str],
+    addr_to_name: Dict[int, str],
+    index: BinaryEdgeIndex,
+) -> None:
+    """Parse a single function's axffj JSON output and append CALL
+    edges to the index. A malformed (truncated) JSON block from a
+    crashed/killed r2 emits one bad batch in the middle of the
+    stream; we log + skip rather than silently swallow."""
+    if not caller or not buf:
+        return
+    text = "\n".join(buf).strip()
+    if not text or text == "[]":
+        return
+    try:
+        refs = json.loads(text)
+    except json.JSONDecodeError as e:
+        logger.warning(
+            "binary_oracle_edges: dropped axffj batch for %s: "
+            "malformed JSON (%s)", caller, e,
+        )
+        return
+    if not isinstance(refs, list):
+        return
+    for ref in refs:
+        if not isinstance(ref, dict):
+            continue
+        if ref.get("type") != "CALL":
+            continue
+        callee_addr = ref.get("ref")
+        if not isinstance(callee_addr, int):
+            continue
+        callee_name = addr_to_name.get(callee_addr)
+        if not callee_name:
+            # Use the ref's name when r2 has it (matches sym.imp.printf
+            # style for library calls).
+            raw = ref.get("name")
+            if isinstance(raw, str):
+                callee_name = _clean_r2_function_name(raw)
+        if not callee_name:
+            continue
+        index.edges.append(BinaryCallEdge(
+            caller=caller, callee=callee_name,
+            binary_path=index.binary_path,
+        ))
+        index.callees.add(callee_name)
+
+
+def annotate_inventory_with_edges(
+    inventory: Dict,
+    indices: List[BinaryEdgeIndex],
+) -> Dict[str, int]:
+    """Walk the inventory and mark each native-language item whose
+    name is a binary-edge callee in ANY of the supplied indices.
+    Per-item annotation: ``metadata.binary_oracle_edges = [{caller,
+    binary_path}, ...]``. Top-level summary:
+    ``inventory.binary_oracle_edges = {n_callees, n_binaries}``.
+
+    Best-effort — non-native items are skipped, missing metadata is
+    silently initialised, exceptions logged at debug. Returns a small
+    counts dict for caller-side logging."""
+    counts = {"annotated": 0, "total_edges": 0}
+    if not indices:
+        return counts
+    # Map: callee_name → list of (caller, binary_path)
+    edges_by_callee: Dict[str, List[Tuple[str, str]]] = {}
+    for idx in indices:
+        for edge in idx.edges:
+            edges_by_callee.setdefault(edge.callee, []).append(
+                (edge.caller, edge.binary_path))
+            counts["total_edges"] += 1
+
+    from .binary_oracle import _NATIVE_LANGUAGES
+    files = inventory.get("files") or []
+    for f in files:
+        lang = (f.get("language") or "").lower()
+        if lang not in _NATIVE_LANGUAGES:
+            continue
+        for item in f.get("items") or []:
+            if item.get("kind", "function") != "function":
+                continue
+            name = item.get("name")
+            if not isinstance(name, str) or name not in edges_by_callee:
+                continue
+            meta = item.get("metadata")
+            if not isinstance(meta, dict):
+                meta = {}
+                item["metadata"] = meta
+            meta["binary_oracle_edges"] = [
+                {"caller": caller, "binary_path": bp}
+                for caller, bp in edges_by_callee[name]
+            ]
+            counts["annotated"] += 1
+    if counts["annotated"]:
+        inventory["binary_oracle_edges"] = {
+            "n_callees_with_edges": counts["annotated"],
+            "n_binaries":           len(indices),
+            "total_edges":          counts["total_edges"],
+        }
+    return counts
+
+
+__all__ = [
+    "BinaryCallEdge",
+    "BinaryEdgeIndex",
+    "extract_direct_call_edges",
+    "annotate_inventory_with_edges",
+]

--- a/core/inventory/binary_oracle_precision.py
+++ b/core/inventory/binary_oracle_precision.py
@@ -1,0 +1,504 @@
+"""Binary-oracle precision measurement harness — Inc 3.
+
+Cross-tabulates ``binary_oracle.classify_binary_evidence`` verdicts against
+ground-truth liveness from labeled corpora to produce the load-bearing
+number for the suppression use case: ``absent precision`` — the fraction
+of ``absent`` verdicts that correspond to actually-dead functions. A FP
+here means we'd suppress a live finding, so this gates whether
+``inventory['binary_oracle']['earns_suppression']`` may flip to ``True``.
+
+Two corpus modes (each driver picks one):
+
+  ``synthetic``  Compare classifier verdict against hand-labeled expected
+                 verdict. 4-way exact-match. Use for fast classifier
+                 sanity-checking on known-correct fixtures.
+
+  ``gcov``       Build the corpus twice (``-O0 --coverage`` for liveness,
+                 ``-O2 -g -Wl,--gc-sections`` for classification), run the
+                 test suite against the coverage build, parse gcov, then
+                 classify the release build. Per-verdict precision.
+
+Each ``CorpusDriver`` is responsible for its build/test/coverage steps;
+the harness consumes a small context dict (``o2_binary``,
+``candidate_functions``, plus mode-specific ``expected``/``live_set``).
+
+Methodology confounds (documented for the writeup):
+  * ``-O0`` and ``-O2`` may compile different source paths (#ifdefs,
+    debug-only code) — minor for the cheap-bundle corpora.
+  * "ground truth DEAD" really means "not exercised by tests" — that's
+    only one-way evidence (FN-on-absent is uninformative, only FP-on-
+    absent is dangerous).
+
+Output:
+  ``out/binary-oracle-precision/runs/<ts>/report.{json,md}``.
+
+Build cache (per corpus): ``out/binary-oracle-precision/cache/<name>/``.
+Drivers own the cache layout under this dir.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import sys
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Literal, Optional, Protocol, Sequence
+
+from .binary_oracle import Classification, classify_binary_evidence
+
+logger = logging.getLogger(__name__)
+
+Mode = Literal["synthetic", "gcov"]
+
+
+@dataclass(frozen=True)
+class FunctionMeasurement:
+    """One row in a precision report. ``classifier_verdict`` is the
+    verdict the classifier returned (``None`` if the classifier omitted
+    the function — typically a stripped binary). ``expected_verdict``
+    populates in synthetic mode; ``is_live`` populates in gcov mode."""
+    name: str
+    classifier_verdict: Optional[Classification]
+    expected_verdict: Optional[Classification] = None
+    is_live: Optional[bool] = None
+
+
+@dataclass
+class CorpusReport:
+    """Per-corpus precision result. The mode-specific fields stay
+    ``None`` for the other mode."""
+    corpus_name: str
+    corpus_mode: Mode
+    n_functions: int
+    measurements: List[FunctionMeasurement] = field(default_factory=list)
+    verdict_counts: Dict[str, int] = field(default_factory=dict)
+
+    # synthetic mode
+    exact_match: Optional[float] = None
+    mismatches: List[Dict[str, str]] = field(default_factory=list)
+
+    # gcov mode
+    absent_precision: Optional[float] = None
+    absent_n: int = 0
+    absent_correct: int = 0
+    absent_fps: List[str] = field(default_factory=list)
+    # Full classifier × ground-truth cross-tab (adversarial review
+    # E P1-1). The headline metric ``absent_precision`` measures one
+    # direction only — what % of ``absent`` verdicts were actually
+    # dead. The classifier ALSO emits ``inlined`` / ``symbol_present``
+    # verdicts; those directions go unmeasured in the headline because
+    # gcov alone can't distinguish "function was DCE'd" from "function
+    # was inlined-only" (both yield no .gcda). This matrix surfaces
+    # the distribution so a reader sees what's untracked.
+    #
+    # IMPORTANT — the downstream suppression chokepoint ONLY fires on
+    # ``absent``. So a wrongly-emitted ``inlined`` (that's really
+    # ``absent``, or vice versa) does NOT silently drop a finding —
+    # neither verdict licenses suppression. The blind spot affects
+    # measurement coverage, NOT safety.
+    #
+    # Schema: ``cross_tab[classifier_verdict][gt_label] = count`` where
+    # gt_label is "live" (gcov saw execution) or "dead" (no .gcda).
+    cross_tab: Dict[str, Dict[str, int]] = field(default_factory=dict)
+
+    # ``{tool_label: version_string}`` from the driver's context —
+    # recorded so a precision number is reproducible without guessing
+    # which compiler / coverage tool produced it (adversarial review
+    # E P2-2).
+    toolchain: Dict[str, str] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "corpus": self.corpus_name,
+            "mode": self.corpus_mode,
+            "n_functions": self.n_functions,
+            "verdict_counts": self.verdict_counts,
+            "exact_match": self.exact_match,
+            "mismatches": self.mismatches,
+            "absent_precision": self.absent_precision,
+            "absent_n": self.absent_n,
+            "absent_correct": self.absent_correct,
+            "absent_fps": self.absent_fps,
+            "cross_tab": self.cross_tab,
+            "toolchain": self.toolchain,
+        }
+
+
+class CorpusDriver(Protocol):
+    """A corpus the precision harness can measure. Drivers own
+    fetch/build/test/coverage; the harness only consumes the prepared
+    context."""
+    name: str
+    description: str
+    mode: Mode
+
+    def prepare(self, work_dir: Path) -> Dict[str, Any]:
+        """Build whatever's needed and return a context dict with:
+
+          * ``o2_binary`` (Path) — release-config binary the classifier runs against
+          * ``candidate_functions`` (List[str]) — source function names to measure
+
+        Synthetic mode additionally: ``expected`` (Dict[name, Classification]).
+        Gcov mode additionally:      ``live_set`` (Set[str]).
+        """
+        ...
+
+
+# ---------------------------------------------------------------------------
+# Cross-tabulation
+# ---------------------------------------------------------------------------
+
+def _cross_tab_synthetic(
+    name: str, ctx: Dict[str, Any], verdicts: Dict[str, Any],
+) -> CorpusReport:
+    expected: Dict[str, Classification] = ctx["expected"]
+    fns: List[str] = list(ctx["candidate_functions"])
+    measurements: List[FunctionMeasurement] = []
+    mismatches: List[Dict[str, str]] = []
+    counts: Dict[str, int] = {}
+    correct = 0
+    for fn in fns:
+        cv = verdicts.get(fn)
+        cv_label = cv.classification if cv else None
+        exp = expected.get(fn)
+        measurements.append(FunctionMeasurement(
+            name=fn, classifier_verdict=cv_label, expected_verdict=exp))
+        if cv_label:
+            counts[cv_label] = counts.get(cv_label, 0) + 1
+        if cv_label == exp:
+            correct += 1
+        else:
+            mismatches.append({
+                "function": fn, "expected": str(exp), "got": str(cv_label),
+            })
+    n = len(fns)
+    return CorpusReport(
+        corpus_name=name, corpus_mode="synthetic", n_functions=n,
+        measurements=measurements, mismatches=mismatches,
+        exact_match=(correct / n) if n else None,
+        verdict_counts=counts,
+    )
+
+
+def _cross_tab_gcov(
+    name: str, ctx: Dict[str, Any], verdicts: Dict[str, Any],
+) -> CorpusReport:
+    live_set = set(ctx["live_set"])
+    fns: List[str] = list(ctx["candidate_functions"])
+    measurements: List[FunctionMeasurement] = []
+    counts: Dict[str, int] = {}
+    absent_n = 0
+    absent_correct = 0
+    absent_fps: List[str] = []
+    # Full 4×2 (classifier × gt) cross-tab. Keys covered:
+    # classifier: symbol_present | inlined | absent | folded | (none)
+    # gt: live | dead
+    cross_tab: Dict[str, Dict[str, int]] = {}
+    for fn in fns:
+        cv = verdicts.get(fn)
+        cv_label = cv.classification if cv else None
+        is_live = fn in live_set
+        measurements.append(FunctionMeasurement(
+            name=fn, classifier_verdict=cv_label, is_live=is_live))
+        if cv_label:
+            counts[cv_label] = counts.get(cv_label, 0) + 1
+        # Always update cross-tab (even when verdict is None).
+        ct_key = cv_label or "(none)"
+        gt_key = "live" if is_live else "dead"
+        cross_tab.setdefault(ct_key, {}).setdefault(gt_key, 0)
+        cross_tab[ct_key][gt_key] += 1
+        if cv_label == "absent":
+            absent_n += 1
+            if is_live:
+                # The DANGER case: classifier says dead, tests hit it. If
+                # earns_suppression were ON we'd silently drop a live finding.
+                absent_fps.append(fn)
+            else:
+                absent_correct += 1
+    # Vacuous-precision detector: if the live_set is empty, the
+    # workload didn't actually exercise the library — every absent
+    # verdict trivially agrees with ground truth ("dead"), making
+    # the precision number mathematically uninformative. Common
+    # cause: sandbox writable_paths missing the build dir, so gcov
+    # couldn't write .gcda files. Warn loudly so the operator sees
+    # the precision number isn't real evidence.
+    if not live_set and absent_n > 0:
+        logger.warning(
+            "%s: gcov live_set is EMPTY — absent_precision=%.1f%% is "
+            "VACUOUS (any classifier verdict would score 100%% when "
+            "no functions are exercised). Check that the workload "
+            "actually runs the binary and that gcov can write .gcda "
+            "files (sandbox writable_paths includes the build dir?).",
+            name, (absent_correct / absent_n) * 100,
+        )
+    return CorpusReport(
+        corpus_name=name, corpus_mode="gcov", n_functions=len(fns),
+        measurements=measurements,
+        absent_precision=(absent_correct / absent_n) if absent_n else None,
+        absent_n=absent_n, absent_correct=absent_correct,
+        absent_fps=absent_fps, verdict_counts=counts,
+        cross_tab=cross_tab,
+    )
+
+
+def run_corpus(driver: "CorpusDriver", work_dir: Path) -> CorpusReport:
+    """Drive a single corpus end-to-end: prepare → classify → cross-tab."""
+    work_dir.mkdir(parents=True, exist_ok=True)
+    ctx = driver.prepare(work_dir)
+    binary = Path(ctx["o2_binary"])
+    toolchain = ctx.get("toolchain") or {}
+    fns = list(ctx["candidate_functions"])
+    verdicts = classify_binary_evidence(fns, binary)
+    if driver.mode == "synthetic":
+        report = _cross_tab_synthetic(driver.name, ctx, verdicts)
+    else:
+        report = _cross_tab_gcov(driver.name, ctx, verdicts)
+    report.toolchain = dict(toolchain)
+    return report
+
+
+# ---------------------------------------------------------------------------
+# Reporting
+# ---------------------------------------------------------------------------
+
+_N_CONCENTRATION_WARN_THRESHOLD = 0.5
+
+
+def _aggregate(reports: Sequence[CorpusReport]) -> Dict[str, object]:
+    """Compute the cross-corpus aggregate the markdown headline depends
+    on. Without this in the harness output, the ``1952/1952`` headline
+    was hand-computed by a human reading per-corpus JSON — error-prone
+    and unscanned by CI / drift detection (adversarial review P2-E-4).
+
+    Includes a per-corpus n breakdown so a reader can see how
+    concentrated the aggregate is (the largest corpus dominates the
+    headline, so a per-corpus view is needed to judge generalization).
+    """
+    n_total = 0
+    abs_n = 0
+    abs_correct = 0
+    per_corpus: list = []
+    for r in reports:
+        if r.corpus_mode == "synthetic":
+            per_corpus.append({
+                "corpus": r.corpus_name, "n_functions": r.n_functions,
+                "mode": "synthetic",
+                "exact_match": r.exact_match,
+            })
+            n_total += r.n_functions
+            continue
+        # gcov / llvm-cov drivers: absent_n is the load-bearing count.
+        a_n = int(r.absent_n or 0)
+        a_c = int(r.absent_correct or 0)
+        abs_n += a_n
+        abs_correct += a_c
+        per_corpus.append({
+            "corpus": r.corpus_name, "n_functions": r.n_functions,
+            "mode": r.corpus_mode,
+            "absent_n": a_n, "absent_correct": a_c,
+            "absent_precision": (a_c / a_n if a_n else None),
+        })
+        n_total += r.n_functions
+    rule_of_three_ub = (3.0 / abs_n) if abs_n else None
+    aggregate_precision = (abs_correct / abs_n) if abs_n else None
+    # n-concentration warning: the aggregate is a meaningful estimate
+    # of generalization ONLY if no single corpus dominates. If one
+    # corpus contributes more than 50% of absent_n, the aggregate
+    # number is mostly a re-skin of that corpus's number, not a
+    # cross-corpus claim (adversarial review E P1-2). Surface the
+    # imbalance so a reader can judge.
+    dominator = None
+    if abs_n > 0:
+        for row in per_corpus:
+            row_abs = row.get("absent_n") or 0
+            if (isinstance(row_abs, int)
+                    and row_abs / abs_n > _N_CONCENTRATION_WARN_THRESHOLD):
+                dominator = {
+                    "corpus": row["corpus"],
+                    "share": row_abs / abs_n,
+                }
+                logger.warning(
+                    "binary_oracle_precision: corpus %r contributes "
+                    "%.0f%% of aggregate absent_n — the headline number "
+                    "mostly reflects this single corpus, not a "
+                    "cross-corpus claim.",
+                    row["corpus"], (row_abs / abs_n) * 100,
+                )
+    return {
+        "n_functions_total": n_total,
+        "absent_n_total": abs_n,
+        "absent_correct_total": abs_correct,
+        "aggregate_absent_precision": aggregate_precision,
+        # 95% Wilson upper bound on miss rate when 0 misses observed.
+        "rule_of_three_95_upper_bound_miss_rate": rule_of_three_ub,
+        "n_concentration_dominator": dominator,
+        "per_corpus": per_corpus,
+    }
+
+
+def _format_markdown(reports: Sequence[CorpusReport]) -> str:
+    lines = ["# Binary-oracle precision report", ""]
+    for r in reports:
+        lines.append(f"## {r.corpus_name} ({r.corpus_mode})")
+        lines.append("")
+        lines.append(f"- n_functions: {r.n_functions}")
+        lines.append(f"- verdicts: {r.verdict_counts}")
+        if r.toolchain:
+            lines.append("- toolchain:")
+            for tool, ver in sorted(r.toolchain.items()):
+                lines.append(f"    - {tool}: `{ver}`")
+        if r.corpus_mode == "synthetic":
+            if r.exact_match is not None:
+                lines.append(f"- exact_match: {r.exact_match:.1%}")
+            if r.mismatches:
+                lines.append(f"- mismatches ({len(r.mismatches)}):")
+                for m in r.mismatches:
+                    lines.append(
+                        f"  - `{m['function']}`: expected={m['expected']}"
+                        f" got={m['got']}")
+        else:
+            if r.absent_precision is not None:
+                lines.append(
+                    f"- absent precision: {r.absent_correct}/{r.absent_n}"
+                    f" = {r.absent_precision:.1%}")
+            if r.absent_fps:
+                shown = ", ".join(r.absent_fps[:8])
+                tail = "…" if len(r.absent_fps) > 8 else ""
+                lines.append(
+                    f"- false-positive `absent` ({len(r.absent_fps)}):"
+                    f" {shown}{tail}")
+            if r.cross_tab:
+                lines.append("")
+                lines.append("Cross-tab (classifier × gcov ground truth):")
+                lines.append("")
+                lines.append("| classifier | live | dead |")
+                lines.append("|---|---:|---:|")
+                for k in ("symbol_present", "inlined", "absent",
+                          "folded", "(none)"):
+                    row = r.cross_tab.get(k)
+                    if not row:
+                        continue
+                    lines.append(
+                        f"| {k} | {row.get('live', 0)} "
+                        f"| {row.get('dead', 0)} |"
+                    )
+                lines.append("")
+                lines.append(
+                    "Methodology note: gcov can't distinguish "
+                    "'function was DCE'd' from 'function was inlined "
+                    "with no live caller' — both yield no .gcda. The "
+                    "headline `absent_precision` measures only the "
+                    "`absent` row × `live` column (the silent-drop "
+                    "danger direction). `inlined` × `dead` and "
+                    "`absent` × `dead` are both 'agreement' here but "
+                    "are NOT separately verifiable. The downstream "
+                    "suppression chokepoint only fires on `absent` "
+                    "verdicts, so this measurement gap does NOT "
+                    "affect safety — it affects measurement coverage."
+                )
+        lines.append("")
+    # Aggregate footer — the headline number the soundness call leans
+    # on. Computed from the per-corpus rows so it can't drift.
+    agg = _aggregate(reports)
+    lines.append("## Aggregate")
+    lines.append("")
+    lines.append(
+        f"- absent precision: {agg['absent_correct_total']}/"
+        f"{agg['absent_n_total']} = "
+        f"{(agg['aggregate_absent_precision'] or 0):.2%}"
+    )
+    if agg["rule_of_three_95_upper_bound_miss_rate"] is not None:
+        ub = agg["rule_of_three_95_upper_bound_miss_rate"]
+        lines.append(
+            f"- rule-of-three 95% upper bound on miss rate: {ub:.2%}"
+        )
+    lines.append("")
+    return "\n".join(lines)
+
+
+def write_report(reports: Sequence[CorpusReport], out_dir: Path) -> Path:
+    """Write reports to ``out_dir/report.json`` and ``report.md``."""
+    out_dir.mkdir(parents=True, exist_ok=True)
+    json_path = out_dir / "report.json"
+    md_path = out_dir / "report.md"
+    payload = {
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "corpora": [r.to_dict() for r in reports],
+        # The aggregate is the headline; bake it into the JSON so
+        # downstream tooling (CI gates, drift detection, the
+        # ~/design/binary-oracle-reachability.md §9 table) reads from
+        # ONE source of truth.
+        "aggregate": _aggregate(reports),
+    }
+    json_path.write_text(json.dumps(payload, indent=2))
+    md_path.write_text(_format_markdown(reports))
+    return json_path
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def main(argv: Optional[List[str]] = None) -> int:
+    p = argparse.ArgumentParser(
+        prog="raptor-binary-oracle-precision",
+        description=(
+            "Measure binary_oracle classifier precision against labeled "
+            "corpora. The headline number is per-corpus 'absent precision' "
+            "— gates whether the absent verdict earns_suppression."
+        ),
+    )
+    p.add_argument("--corpus", action="append", default=[],
+                   help="corpus name (repeatable). Default: synthetic.")
+    p.add_argument("--list", action="store_true",
+                   help="list known corpora and exit")
+    p.add_argument("--out", type=Path, default=None,
+                   help=("output dir (default: "
+                         "out/binary-oracle-precision/runs/<ts>)"))
+    args = p.parse_args(argv)
+
+    # Late import: the registry is the only thing the harness depends on
+    # for driver lookup; pulling it lazily lets the harness module stay
+    # importable when no drivers are installed (e.g. minimal CI).
+    from . import binary_oracle_corpora as corpora
+    registry = corpora.REGISTRY
+
+    if args.list:
+        for name, drv in sorted(registry.items()):
+            print(f"  {name:18}  {drv.description}")
+        return 0
+
+    names = args.corpus or ["synthetic"]
+    unknown = [n for n in names if n not in registry]
+    if unknown:
+        print(f"unknown corpora: {unknown}; --list to see options",
+              file=sys.stderr)
+        return 2
+
+    if args.out is None:
+        ts = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+        args.out = Path("out/binary-oracle-precision/runs") / ts
+
+    cache_root = Path("out/binary-oracle-precision/cache")
+    reports: List[CorpusReport] = []
+    for name in names:
+        logger.info("measuring corpus %s ...", name)
+        rep = run_corpus(registry[name], cache_root / name)
+        reports.append(rep)
+
+    json_path = write_report(reports, args.out)
+    print(f"report: {json_path}")
+    return 0
+
+
+__all__ = [
+    "CorpusDriver", "CorpusReport", "FunctionMeasurement", "Mode",
+    "run_corpus", "write_report", "main",
+]
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/core/inventory/builder.py
+++ b/core/inventory/builder.py
@@ -15,6 +15,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Set, Union
 
+from core.config import RaptorConfig
 from core.hash import sha256_bytes
 from core.json import load_json
 
@@ -342,6 +343,43 @@ def build_inventory(
     inventory['target_kind_source'] = _lib['source']
     if limitations:
         inventory['limitations'] = limitations
+
+    # Binary-oracle enrichment (Inc 4 + Phase 4 multi-binary) — opt-in
+    # via the process-wide ``RaptorConfig.BINARY_ORACLE_PATHS`` (set by
+    # ``raptor_agentic`` / ``raptor_codeql``'s repeatable ``--binary``
+    # flag). Empty tuple = no-op. Populates ``inventory['binary_oracle']``
+    # + per-item metadata; the reach_witness/demoter consumers (Phase 2)
+    # then pick up the resulting BINARY_ORACLE_ABSENT verdicts via
+    # ``classify_reachability``. For ``--target-kind=hybrid`` (library +
+    # application), the operator passes multiple ``--binary`` flags and
+    # the enrichment combines per-binary verdicts with alive-in-any
+    # wins — so a function is only ``absent`` when EVERY declared binary
+    # lacks it. Best-effort — missing tools / non-ELF / stripped binary
+    # logs a skip and leaves the inventory unchanged.
+    bin_paths = RaptorConfig.BINARY_ORACLE_PATHS
+    if bin_paths:
+        try:
+            from .binary_oracle import enrich_inventory_with_binary_oracle
+            enrich_inventory_with_binary_oracle(inventory, bin_paths)
+        except Exception as exc:                          # noqa: BLE001
+            logger.warning("binary_oracle enrichment failed for %r: %s",
+                           bin_paths, exc)
+        # Inc 2b Tier 1: opt-in direct-call-edge extraction. Adds
+        # binary-found callers as positive reachability evidence
+        # (``binary_call_edge`` verdict). Slow (~10-30s per binary
+        # via r2 ``aaa``) so gated behind RaptorConfig.BINARY_ORACLE_EDGES.
+        if RaptorConfig.BINARY_ORACLE_EDGES:
+            try:
+                from .binary_oracle_edges import (
+                    extract_direct_call_edges,
+                    annotate_inventory_with_edges,
+                )
+                indices = [extract_direct_call_edges(Path(p))
+                           for p in bin_paths]
+                annotate_inventory_with_edges(inventory, indices)
+            except Exception as exc:                      # noqa: BLE001
+                logger.warning("binary_oracle_edges extraction failed: %s",
+                               exc)
 
     # Cumulative coverage: carry forward checked_by from previous inventory
     if old_inventory is not None:

--- a/core/inventory/reach_audit.py
+++ b/core/inventory/reach_audit.py
@@ -67,6 +67,22 @@ def _stage_lexical_dead(ctx: "_ClassifyCtx", R) -> Optional[str]:
     return None
 
 
+def _stage_binary_oracle_absent(ctx: "_ClassifyCtx", R) -> Optional[str]:
+    if R.binary_oracle_absent(
+        ctx.inventory, ctx.file_path, ctx.name, ctx.line,
+    ):
+        return "binary_oracle_absent"
+    return None
+
+
+def _stage_binary_call_edge(ctx: "_ClassifyCtx", R) -> Optional[str]:
+    if R.binary_call_edge_present(
+        ctx.inventory, ctx.file_path, ctx.name, ctx.line,
+    ):
+        return "binary_call_edge"
+    return None
+
+
 def _stage_build_excluded(ctx: "_ClassifyCtx", R) -> Optional[str]:
     if R.build_excluded(ctx.inventory, ctx.file_path):
         return "build_excluded"
@@ -145,9 +161,26 @@ def _stage_one_hop(ctx: "_ClassifyCtx", R) -> Optional[str]:
 PRECEDENCE = (
     _stage_module_aborts,
     _stage_lexical_dead,
+    # binary_oracle absent is mechanically derivable from nm + DWARF —
+    # stronger than build_excluded (build-config parsing heuristic), so
+    # checked first among C/C++/Rust/Go dead witnesses. SOUND +
+    # corpus-earned (Inc 3d: 841/841 absent verdicts correct).
+    _stage_binary_oracle_absent,
     _stage_build_excluded,
     _stage_framework,
     _stage_registered,
+    # Binary direct-call-edge promote (Inc 2b Tier 1). Affirmative
+    # reachability evidence: if the binary shows an incoming direct
+    # call to this function, it's reachable in this build — even when
+    # source extraction missed the edge (header-only inline,
+    # address-taken-then-direct-called). MUST run BEFORE _stage_entry:
+    # entry-reachability is a heuristic graph walk and returns the
+    # negative ``no_path_from_entry`` verdict when it fails — without
+    # this ordering, a function the binary mechanically proves
+    # reachable would get the dead verdict from _stage_entry first
+    # and the binary evidence would never be consulted. Affirmative
+    # binary evidence beats heuristic source-graph dead claims.
+    _stage_binary_call_edge,
     _stage_entry,
     _stage_one_hop,
 )

--- a/core/inventory/reach_chokepoint.py
+++ b/core/inventory/reach_chokepoint.py
@@ -1,0 +1,212 @@
+"""Shared reachability-chokepoint helper for finding-suppression.
+
+Both ``/agentic`` (packages/llm_analysis/agent.py) and ``/codeql``
+(packages/codeql/autonomous_analyzer.py) consult the same reachability
+witnesses to skip the LLM call when a finding's enclosing function is
+provably dead. Adversarial review flagged duplication: the /agentic
+hook was copy-paste-reduced without the autonomous_analyzer's path
+normalisation and module-derivation helpers, producing wrong-path
+lookups (file:// URI, absolute, repo-rooted ./ prefix) and
+language-incorrect module strings (literal "src/util.c" for C
+findings). This module is the canonical entry point.
+
+Usage::
+
+    from core.inventory.reach_chokepoint import check_suppress
+
+    decision = check_suppress(
+        checklist=checklist_inventory,
+        file_path=finding_file,
+        function_name=finding_function,
+        line=finding_line,
+        repo_root=repo_path,
+        allow_unreachable=cli_allow_unreachable,
+        manual_override=finding.get("manual_override"),
+    )
+    if decision is not None:
+        verdict, reason = decision
+        # suppress + record verdict on the finding's analysis
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path, PurePosixPath
+from typing import Any, Dict, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+
+def normalise_path(file_path: str, repo_root: Path) -> Optional[str]:
+    """SARIF emitters / semgrep / scanner output produce a mix of
+    absolute paths, ``file://``-URI paths, and repo-relative paths.
+    Normalise to a repo-relative ``a/b/c.ext`` form so the inventory
+    lookup (keyed on repo-relative paths) matches. Returns ``None``
+    when the input is absolute but not under ``repo_root`` —
+    something outside the analysed tree, do not suppress.
+    """
+    if not file_path:
+        return None
+    if file_path.startswith("file://"):
+        file_path = file_path[len("file://"):]
+    p = Path(file_path)
+    if p.is_absolute():
+        try:
+            return str(p.relative_to(repo_root.resolve()))
+        except ValueError:
+            return None
+    # Strip a leading ./ that some tools emit so it matches the
+    # inventory's ``files[].path`` convention (no leading ./).
+    if file_path.startswith("./"):
+        file_path = file_path[2:]
+    return file_path
+
+
+def path_to_module(rel_path: str) -> Optional[str]:
+    """``packages/foo/bar.py`` → ``packages.foo.bar``. For non-Python
+    languages, strip the extension and replace path separators with
+    dots — the call_graph extractor produces dotted-form keys for
+    every language it covers. Returns ``None`` for paths with no
+    extension (can't derive a module).
+    """
+    if not rel_path:
+        return None
+    p = PurePosixPath(rel_path.replace("\\", "/"))
+    if not p.suffix:
+        return None
+    parts = list(p.parts)
+    parts[-1] = p.stem
+    return ".".join(parts)
+
+
+def check_suppress(
+    *,
+    checklist: dict,
+    file_path: str,
+    function_name: str,
+    line: int,
+    repo_root: Path,
+    allow_unreachable: bool = False,
+    manual_override: object = None,
+) -> Optional[Tuple[str, str]]:
+    """Single source of truth for "should this finding be suppressed?"
+
+    Returns ``(verdict, reason)`` if the finding's enclosing function
+    is unreachable via a SOUND, corpus-earned witness that licenses
+    suppression. Returns ``None`` when:
+
+      * ``manual_override`` is truthy (operator opted out explicitly),
+      * ``allow_unreachable`` is True (CLI opted out globally),
+      * the checklist is missing or empty,
+      * path or module derivation fails,
+      * the verdict isn't suppressable (heuristic / live).
+
+    Caller's responsibility: record ``verdict`` + ``reason`` on the
+    finding's audit output and skip the LLM call. Never modify the
+    finding silently; the suppression must be visible to the operator
+    via annotations / suppressions.jsonl / report output.
+    """
+    # NB: ``manual_override`` is a finding-level boolean. Coerce
+    # explicit string-False to bool-False so an emitter that writes
+    # ``"manual_override": "false"`` doesn't accidentally bypass the
+    # chokepoint via Python truthiness on the non-empty string.
+    if isinstance(manual_override, str):
+        manual_override = manual_override.strip().lower() not in (
+            "", "false", "0", "no", "off")
+    if manual_override:
+        return None
+    if allow_unreachable:
+        return None
+    if not checklist or not isinstance(checklist, dict):
+        return None
+    if not file_path or not function_name:
+        return None
+    rel = normalise_path(file_path, repo_root)
+    if rel is None:
+        return None
+    module = path_to_module(rel)
+    if not module:
+        return None
+
+    # Local imports — the chokepoint module stays cheap to import; the
+    # reach_audit + reach_witness graph is heavier and only paid on
+    # the first suppression attempt.
+    from core.inventory.reach_audit import classify_reachability
+    from core.inventory.reach_witness import (
+        STRUCTURALLY_SUPPRESSIBLE_KINDS,
+        verdict_from_classification,
+    )
+
+    verdict = classify_reachability(
+        checklist, rel, function_name, int(line or 0), module)
+    spec = verdict_from_classification(verdict)
+    if not spec.may_suppress(STRUCTURALLY_SUPPRESSIBLE_KINDS):
+        return None
+    reason = (
+        f"Reachability chokepoint: the finding's enclosing function "
+        f"({rel}:{function_name}) is unreachable via a SOUND, corpus-"
+        f"earned witness ({verdict}). No exploit is reachable in this "
+        f"build / deployment surface. To override, set "
+        f"``manual_override: true`` on the finding and re-run, or "
+        f"pass ``--allow-unreachable`` to evaluate the function's "
+        f"inherent vulnerability shape regardless of deployment "
+        f"reachability."
+    )
+    return (verdict, reason)
+
+
+def record_suppression(
+    out_dir: Path,
+    *,
+    finding: Dict[str, Any],
+    verdict: str,
+    reason: str,
+) -> None:
+    """Append one record to ``out_dir/suppressions.jsonl`` describing
+    the finding the chokepoint just dropped. Best-effort — IO errors
+    are logged at debug and never propagate. Adversarial review
+    Agent C P1-1: per-finding ``analysis.reachability_suppression``
+    + ``reachability_verdict`` records carry the data, but operators
+    asked "show me the N findings the binary-oracle dropped" can't
+    grep individual annotations cheaply. The JSONL gives them a
+    one-stop aggregate view.
+
+    Record schema (stable, additive)::
+
+      {
+        "finding_id": "...",         # or "id" if that's the key used
+        "rule_id":    "...",         # if present
+        "file_path":  "...",
+        "line":       42,
+        "function":   "...",
+        "verdict":    "binary_oracle_absent",
+        "reason":     "Reachability chokepoint: ...",
+      }
+    """
+    try:
+        out_dir.mkdir(parents=True, exist_ok=True)
+        record = {
+            "finding_id": (finding.get("finding_id")
+                           or finding.get("id") or ""),
+            "rule_id":    finding.get("rule_id") or "",
+            "file_path":  (finding.get("file_path")
+                           or finding.get("file") or ""),
+            "line":       finding.get("line"),
+            "function":   (finding.get("function")
+                           or (finding.get("metadata") or {}).get(
+                               "function_name", "")),
+            "verdict":    verdict,
+            "reason":     reason,
+        }
+        with (out_dir / "suppressions.jsonl").open("a") as f:
+            f.write(json.dumps(record) + "\n")
+    except OSError as e:
+        logger.debug(
+            "reach_chokepoint: failed to write suppression record: %s", e)
+
+
+__all__ = [
+    "normalise_path", "path_to_module",
+    "check_suppress", "record_suppression",
+]

--- a/core/inventory/reach_witness.py
+++ b/core/inventory/reach_witness.py
@@ -39,6 +39,7 @@ class WitnessKind(str, Enum):
     # unreachable
     MODULE_ABORTS = "module_aborts"
     LEXICAL_DEAD = "lexical_dead"
+    BINARY_ORACLE_ABSENT = "binary_oracle_absent"
     BUILD_EXCLUDED = "build_excluded"
     NO_PATH_FROM_ENTRY = "no_path_from_entry"
     NOT_CALLED = "not_called"
@@ -47,6 +48,7 @@ class WitnessKind(str, Enum):
     FRAMEWORK_CALLABLE = "framework_callable"
     REGISTERED_VIA_CALL = "registered_via_call"
     REACHABLE_FROM_ENTRY = "reachable_from_entry"
+    BINARY_CALL_EDGE = "binary_call_edge"
     # uncertain
     UNCERTAIN = "uncertain"
 
@@ -155,6 +157,23 @@ VERDICTS: Dict[str, VerdictSpec] = {
             "Verdict: LEXICAL_DEAD — defined inside an always-false guard "
             "(if False / #[cfg(any())]); never binds"),
     ),
+    "binary_oracle_absent": VerdictSpec(
+        Reachability.UNREACHABLE, WitnessKind.BINARY_ORACLE_ABSENT,
+        Soundness.SOUND, earns_suppression=True,
+        summary=(
+            "classifier verdict ``absent`` on the analysed binary — "
+            "neither a standalone symbol nor an inlined-subroutine "
+            "instance was found at classification time"),
+        blocker_template=(
+            "reachability:binary_oracle_absent — entry function {fq} has no "
+            "symbol and no inlined-subroutine instance in the analysed binary "
+            "(--binary); the compiler/linker eliminated it from this build"),
+        prompt_verdict=(
+            "Verdict: BINARY_ORACLE_ABSENT — function eliminated from the "
+            "analysed binary by --gc-sections / DCE; no symbol present and no "
+            "inlined-subroutine instance survives. Build-specific (this "
+            "binary's build_id); not a universal source claim"),
+    ),
     "build_excluded": VerdictSpec(
         Reachability.UNREACHABLE, WitnessKind.BUILD_EXCLUDED,
         Soundness.HEURISTIC, earns_suppression=False,
@@ -199,6 +218,19 @@ VERDICTS: Dict[str, VerdictSpec] = {
         Reachability.REACHABLE, WitnessKind.REGISTERED_VIA_CALL,
         Soundness.HEURISTIC, earns_suppression=False,
         summary="passed as a framework registration argument"),
+    "binary_call_edge": VerdictSpec(
+        Reachability.REACHABLE, WitnessKind.BINARY_CALL_EDGE,
+        Soundness.HEURISTIC, earns_suppression=False,
+        summary=(
+            "binary call graph shows the function is called from another "
+            "binary-resident symbol (direct call edge — Inc 2b Tier 1)"),
+        prompt_verdict=(
+            "Verdict: BINARY_CALL_EDGE — the analysed binary's direct "
+            "call graph proves this function is invoked from another "
+            "binary-resident symbol. Source-graph extraction may have "
+            "missed this edge (header-inline, partial resolution); the "
+            "binary provides affirmative reachability evidence."),
+    ),
     "reachable": VerdictSpec(
         Reachability.REACHABLE, WitnessKind.REACHABLE_FROM_ENTRY,
         Soundness.HEURISTIC, earns_suppression=False,

--- a/core/inventory/reachability.py
+++ b/core/inventory/reachability.py
@@ -195,6 +195,61 @@ class _FunctionCalledIndex:
 _FN_CALLED_INDEX_CACHE: Dict[int, Tuple[Dict[str, Any], _FunctionCalledIndex]] = {}
 _FN_CALLED_INDEX_CACHE_MAX = 8
 
+# Inverse index for ``binary_oracle_absent`` / ``binary_call_edge_present``
+# lookups — without it, each accessor call walks every file × every item
+# of the inventory (O(N_files × N_items)). On a 30k-file inventory with
+# thousands of findings that's 100M file-walks per analysis pass; with
+# the index each call is hash-lookup-fast (adversarial review P1-C-2).
+# Map shape: ``{normalised_path: {name: [item, item, ...]}}``.
+_BO_ITEM_INDEX_CACHE: Dict[
+    int, Tuple[Dict[str, Any], Dict[str, Dict[str, List[Dict[str, Any]]]]],
+] = {}
+_BO_ITEM_INDEX_CACHE_MAX = 8
+
+
+def _build_bo_item_index(
+    inventory: Dict[str, Any],
+) -> Dict[str, Dict[str, List[Dict[str, Any]]]]:
+    """Walk the inventory ONCE and build the
+    ``{path: {name: [item, ...]}}`` map. List values handle the in-
+    file name-collision case (static helpers / overloads / #if-#else
+    branches recorded as multiple items)."""
+    out: Dict[str, Dict[str, List[Dict[str, Any]]]] = {}
+    for file_record in inventory.get("files", []) or []:
+        if not isinstance(file_record, dict):
+            continue
+        rec_path = file_record.get("path")
+        if not isinstance(rec_path, str):
+            continue
+        normalised = rec_path.replace("\\", "/")
+        by_name: Dict[str, List[Dict[str, Any]]] = out.setdefault(
+            normalised, {})
+        for item in file_record.get("items") or []:
+            if not isinstance(item, dict):
+                continue
+            name = item.get("name")
+            if not isinstance(name, str):
+                continue
+            by_name.setdefault(name, []).append(item)
+    return out
+
+
+def _get_bo_item_index(
+    inventory: Dict[str, Any],
+) -> Dict[str, Dict[str, List[Dict[str, Any]]]]:
+    inv_id = id(inventory)
+    cached = _BO_ITEM_INDEX_CACHE.get(inv_id)
+    if cached is not None and cached[0] is inventory:
+        return cached[1]
+    if cached is not None:
+        _BO_ITEM_INDEX_CACHE.pop(inv_id, None)
+    idx = _build_bo_item_index(inventory)
+    _BO_ITEM_INDEX_CACHE[inv_id] = (inventory, idx)
+    if len(_BO_ITEM_INDEX_CACHE) > _BO_ITEM_INDEX_CACHE_MAX:
+        oldest = next(iter(_BO_ITEM_INDEX_CACHE))
+        _BO_ITEM_INDEX_CACHE.pop(oldest, None)
+    return idx
+
 
 def _build_function_called_index(
     inventory: Dict[str, Any],
@@ -2264,6 +2319,126 @@ def build_excluded(
     return None
 
 
+def binary_call_edge_present(
+    inventory: Dict[str, Any],
+    file_path: str,
+    name: str,
+    line: int = 0,
+) -> bool:
+    """True iff the function ``name`` in ``file_path`` has at least
+    one incoming direct call edge in the binary's call graph
+    (extracted via ``binary_oracle_edges``). Affirmative reachability
+    evidence: source extraction may have missed the call edge (header-
+    inline, indirect dispatch the analyser couldn't resolve, etc.) but
+    the binary mechanically shows the function is called.
+
+    HEURISTIC — binary direct-edge extraction (r2 ``axffj``) misses
+    indirect calls (~8% on the Inc 3 corpora) so a False here does NOT
+    imply the function is unreachable; it just means we have no direct-
+    edge evidence. earns_suppression=False because this is a REACHABLE
+    witness; it shouldn't license dropping findings, only promote
+    reachability uncertainty for upstream consumers (Inc 2b Tier 1).
+
+    Path-keyed lookup via the shared inverse index (avoids the
+    O(N_files × N_items) walk per call)."""
+    if not file_path or not name:
+        return False
+    normalised = file_path.replace("\\", "/")
+    idx = _get_bo_item_index(inventory)
+    by_name = idx.get(normalised)
+    if not by_name:
+        return False
+    candidates = by_name.get(name)
+    if not candidates:
+        return False
+    for item in candidates:
+        if line and int(item.get("line_start") or 0) != line:
+            continue
+        meta = item.get("metadata")
+        if not isinstance(meta, dict):
+            return False
+        edges = meta.get("binary_oracle_edges")
+        return bool(edges)
+    return False
+
+
+def binary_oracle_absent(
+    inventory: Dict[str, Any],
+    file_path: str,
+    name: str,
+    line: int = 0,
+) -> bool:
+    """True iff the function ``name`` in ``file_path`` carries a
+    ``binary_oracle`` classification of ``"absent"`` — the compiler /
+    linker eliminated this function from the analysed binary, and no
+    ``DW_TAG_inlined_subroutine`` instance pulled it into a surviving
+    caller. Returns ``False`` (don't claim deadness) when no
+    binary_oracle annotation is present (no ``--binary`` passed,
+    non-native language, or stripped binary).
+
+    SOUND — mechanically derivable from ``nm`` + DWARF on the analysed
+    binary (no extraction approximation, no 1-hop assumption). But
+    BUILD-SPECIFIC: the verdict is about THIS binary's symbol table,
+    not a universal source-level claim. ``earns_suppression=True`` per
+    two layers of evidence (``~/design/binary-oracle-reachability.md``
+    §9): (1) consistency check 1952/1952 across 6 iteratively-tuned
+    corpora; (2) honest hold-out 187/187 on zstd v1.5.6 with no
+    classifier tuning — rule-of-three 95% UB miss rate ≤1.6% on
+    first-contact-with-unseen-data. The operator burden — pointing at
+    the binary that matches the source / build config being suppressed
+    — is enforced by ``binary_oracle.build_id`` recorded on every
+    witness.
+
+    Path-keyed lookup, no index build — mirrors :func:`build_excluded`.
+    When ``line > 0`` the line is consulted to disambiguate
+    name-collisions within a single file (C static-scoped helpers, C++
+    ``#if/#else`` branches, overloaded methods extracted as separate
+    items). Without the line-disambiguation, the FIRST same-name item
+    wins and a live function's finding could be silently suppressed
+    because a dead namesake matched first (adversarial review P0-C-3).
+    """
+    if not file_path or not name:
+        return False
+    normalised = file_path.replace("\\", "/")
+    idx = _get_bo_item_index(inventory)
+    by_name = idx.get(normalised)
+    if not by_name:
+        return False
+    candidates = by_name.get(name)
+    if not candidates:
+        return False
+    for item in candidates:
+        # Line disambiguation: name-collisions inside a file are
+        # real (static helpers, #if/#else, overloads). Skip non-
+        # matching items so the caller's (name, line) tuple
+        # actually identifies the function it intended.
+        if line and int(item.get("line_start") or 0) != line:
+            continue
+        meta = item.get("metadata")
+        if not isinstance(meta, dict):
+            return False
+        bo = meta.get("binary_oracle")
+        if not isinstance(bo, dict):
+            return False
+        if bo.get("classification") != "absent":
+            return False
+        # Soundness gate (E1 stripped-binary fallback + adversarial
+        # review P0-C-4): the corpus-earned suppression property is
+        # conditional on full-DWARF evidence. Refuse to fire when
+        # (a) no per-binary records exist (legacy inventory or
+        # writer bug — no tier evidence ⇒ no trust) OR (b) ANY
+        # contributing binary was symbol-only (could be inlined,
+        # not absent — we just can't see it without DWARF).
+        per_binary = bo.get("binaries") or []
+        if not per_binary:
+            return False
+        if any(isinstance(b, dict) and b.get("tier") != "full"
+               for b in per_binary):
+            return False
+        return True
+    return False
+
+
 def is_lexically_dead(
     inventory: Dict[str, Any],
     file_path: str,
@@ -3560,6 +3735,9 @@ __all__ = [
     "ReachabilityResult",
     "Verdict",
     "all_paths",
+    "binary_call_edge_present",
+    "binary_oracle_absent",
+    "build_excluded",
     "call_lines_of",
     "callees_of",
     "callers_of",

--- a/core/inventory/tests/fixtures/binary_oracle/.gitignore
+++ b/core/inventory/tests/fixtures/binary_oracle/.gitignore
@@ -1,0 +1,3 @@
+# Build outputs from the fixture's Makefile.
+demo
+*.o

--- a/core/inventory/tests/fixtures/binary_oracle/Makefile
+++ b/core/inventory/tests/fixtures/binary_oracle/Makefile
@@ -1,0 +1,43 @@
+# Binary-oracle reachability fixture.
+#
+# Builds ``demo`` with -O2 -g + per-function sections + --gc-sections so the
+# `dead_*` cases actually get DCE'd. ICF (folded_a/folded_b merging) requires
+# an ICF-capable linker; the build tries lld first, then GNU ld's --icf=safe,
+# and silently degrades to "no ICF" if neither is available — the classifier
+# correctly produces ``symbol_present`` for the folded_* pair in that mode.
+
+CC      ?= gcc
+CFLAGS  ?= -O2 -g -ffunction-sections -fdata-sections
+LDFLAGS ?= -Wl,--gc-sections
+
+# Detect an ICF-capable linker. lld supports --icf=all unconditionally;
+# GNU ld grew --icf=safe later (binutils 2.38+). Order: lld → GNU ld --icf.
+HAVE_LLD := $(shell command -v ld.lld 2>/dev/null)
+HAVE_ICF := $(shell echo 'int main(){return 0;}' | $(CC) -x c - -o /dev/null -Wl,--icf=safe 2>/dev/null && echo yes)
+
+ifneq ($(HAVE_LLD),)
+    LDFLAGS += -fuse-ld=lld -Wl,--icf=all
+    ICF_MODE := lld
+else ifeq ($(HAVE_ICF),yes)
+    LDFLAGS += -Wl,--icf=safe
+    ICF_MODE := gnu-safe
+else
+    ICF_MODE := none
+endif
+
+OBJS = lib.o main.o
+
+.PHONY: all clean print-icf-mode
+all: demo
+
+demo: $(OBJS)
+	$(CC) $(LDFLAGS) -o $@ $^
+
+%.o: %.c lib.h
+	$(CC) $(CFLAGS) -c -o $@ $<
+
+print-icf-mode:
+	@echo $(ICF_MODE)
+
+clean:
+	rm -f demo $(OBJS)

--- a/core/inventory/tests/fixtures/binary_oracle/lib.c
+++ b/core/inventory/tests/fixtures/binary_oracle/lib.c
@@ -1,0 +1,84 @@
+/* Binary-oracle reachability ground-truth fixture.
+ *
+ * Each function below has a KNOWN fate when built with the fixture's Makefile
+ * (-O2 -g -ffunction-sections -Wl,--gc-sections, +LTO where supported, +ICF
+ * when the linker can do it). The unit test asserts the classifier returns
+ * these verdicts. Keep the function set small + sharply-distinct so a wrong
+ * classification is unambiguous.
+ *
+ * Expected verdicts at build time:
+ *
+ *   live_called           symbol_present     direct call from main
+ *   live_address_taken    symbol_present     fn-pointer stored in global table
+ *   inlined_only          inlined            static inline, no standalone
+ *   dead_static_unused    absent             static + no caller → DCE'd
+ *   dead_extern_unused    absent             extern + no caller + ffunction-
+ *                                            sections + --gc-sections → DCE'd
+ *   folded_a / folded_b   folded (when ICF)  identical bodies + ICF-capable ld
+ *                         symbol_present     (fallback, when no ICF available)
+ *   volatile_call_target  symbol_present +   indirect call via volatile fn-ptr
+ *                         binary call edge   the source graph would miss
+ */
+
+#include <stdio.h>
+#include "lib.h"
+
+/* 1. live_called — direct call from main(). */
+int live_called(int x) {
+    return x + 1;
+}
+
+/* 2. live_address_taken — held in a global fn-pointer table; address-taken
+ *    keeps it even if the table is never indexed. */
+int (*GLOBAL_TABLE[])(int) = { live_called };
+/* and one more entry so the linker can't trivially elide the array */
+int (*GLOBAL_TABLE2[])(int) = { live_address_taken_target };
+int live_address_taken_target(int x) {
+    return x * 2;
+}
+
+/* 3. inlined_only — static inline. Body must be visible to callers so the
+ *    compiler can absorb it; no standalone symbol should remain. */
+static inline int inlined_only(int x) {
+    return x - 1;
+}
+/* a small caller that uses inlined_only so it isn't simply dead */
+int inlined_only_user(int x) {
+    return inlined_only(x);
+}
+
+/* 4. dead_static_unused — static, never called → DCE'd at -O2. */
+static int dead_static_unused(int x) {
+    return x + 99;
+}
+
+/* 5. dead_extern_unused — extern, never called from this TU or main; with
+ *    -ffunction-sections + --gc-sections the linker should garbage-collect
+ *    the section. (LTO not required for this on GNU ld; gcc puts each fn
+ *    in its own .text.<name> section.) */
+int dead_extern_unused(int x) {
+    return x * 17;
+}
+
+/* 6. folded_a / folded_b — IDENTICAL bodies; an ICF-capable linker should
+ *    merge them. Without ICF (e.g. plain GNU ld without --icf=all), both
+ *    survive as separate symbols and classify as symbol_present. The
+ *    classifier's fold detection covers the ICF case. */
+int folded_a(int x) {
+    return (x ^ 0xA5) + 42;
+}
+int folded_b(int x) {
+    return (x ^ 0xA5) + 42;
+}
+
+/* 7. volatile_call_target — called only through a volatile function pointer.
+ *    The source call graph can't easily see this edge; the binary's call
+ *    graph (aflcj) should reveal it. */
+int volatile_call_target(int x) {
+    return x + 1000;
+}
+typedef int (*ptr_t)(int);
+volatile ptr_t INDIRECT_PTR = volatile_call_target;
+int indirect_caller(int x) {
+    return INDIRECT_PTR(x);
+}

--- a/core/inventory/tests/fixtures/binary_oracle/lib.h
+++ b/core/inventory/tests/fixtures/binary_oracle/lib.h
@@ -1,0 +1,16 @@
+#ifndef BINARY_ORACLE_FIXTURE_LIB_H
+#define BINARY_ORACLE_FIXTURE_LIB_H
+
+int live_called(int x);
+int live_address_taken_target(int x);
+int inlined_only_user(int x);
+int dead_extern_unused(int x);
+int folded_a(int x);
+int folded_b(int x);
+int volatile_call_target(int x);
+int indirect_caller(int x);
+
+extern int (*GLOBAL_TABLE[])(int);
+extern int (*GLOBAL_TABLE2[])(int);
+
+#endif

--- a/core/inventory/tests/fixtures/binary_oracle/main.c
+++ b/core/inventory/tests/fixtures/binary_oracle/main.c
@@ -1,0 +1,17 @@
+#include <stdio.h>
+#include "lib.h"
+
+int main(int argc, char **argv) {
+    (void)argv;
+    int n = argc;
+    n += live_called(n);
+    n += inlined_only_user(n);
+    n += folded_a(n);
+    n += folded_b(n);
+    n += indirect_caller(n);
+    /* Touch the address-taken table so the linker can't elide it. */
+    n += GLOBAL_TABLE[0](n);
+    n += GLOBAL_TABLE2[0](n);
+    printf("%d\n", n);
+    return 0;
+}

--- a/core/inventory/tests/test_binary_oracle.py
+++ b/core/inventory/tests/test_binary_oracle.py
@@ -1,0 +1,821 @@
+"""Ground-truth correctness gate for ``core.inventory.binary_oracle`` —
+builds the C fixture at ``fixtures/binary_oracle/`` and asserts each
+source function classifies to the verdict its source comment predicts.
+
+This is Stage A of the binary-oracle validation plan (per
+~/design/binary-oracle-reachability.md §5): correctness of the
+classifier, before any precision-on-real-corpus measurement.
+
+Skips gracefully when the toolchain is missing — the fixture needs a
+C compiler + GNU binutils (``cc``, ``make``, ``nm``, ``objdump``,
+``readelf``). In CI these are usually present; on a stripped image the
+skip keeps the suite green without silently dropping coverage of the
+classifier itself (the parser is exercised by unit tests at module
+level, e.g. ``read_build_id``).
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from core.inventory.binary_oracle import (
+    BinaryOracleWitness,
+    classify_binary_evidence,
+    enrich_inventory_with_binary_oracle,
+    read_build_id,
+)
+
+FIXTURE_DIR = Path(__file__).parent / "fixtures" / "binary_oracle"
+EXPECTED_VERDICTS = {
+    "live_called":               "symbol_present",
+    "live_address_taken_target": "symbol_present",
+    "inlined_only":              "inlined",
+    "inlined_only_user":         "symbol_present",
+    "dead_static_unused":        "absent",
+    "dead_extern_unused":        "absent",
+    "volatile_call_target":      "symbol_present",
+    "indirect_caller":           "symbol_present",
+    # folded_a/_b are toolchain-dependent (need ICF-capable linker); asserted
+    # separately below.
+}
+
+
+def _have_toolchain() -> bool:
+    return all(shutil.which(t) for t in ("cc", "make", "nm",
+                                         "objdump", "readelf"))
+
+
+@pytest.fixture(scope="module")
+def built_demo(tmp_path_factory):
+    """Build the fixture's ``demo`` binary in a tmp copy of the fixture dir
+    (so the test never writes into the repo) and yield the binary path."""
+    if not _have_toolchain():
+        pytest.skip("toolchain (cc/make/nm/objdump/readelf) not available")
+    work = tmp_path_factory.mktemp("binary_oracle_fixture")
+    for f in FIXTURE_DIR.iterdir():
+        if f.name in ("lib.c", "lib.h", "main.c", "Makefile"):
+            (work / f.name).write_bytes(f.read_bytes())
+    proc = subprocess.run(["make", "-C", str(work)],
+                          capture_output=True, text=True, timeout=60)
+    if proc.returncode != 0:
+        pytest.skip(f"fixture build failed: {proc.stderr[:300]}")
+    demo = work / "demo"
+    assert demo.is_file(), f"demo not built: {proc.stdout}\n{proc.stderr}"
+    yield demo
+
+
+def test_build_id_is_readable(built_demo: Path) -> None:
+    bid = read_build_id(built_demo)
+    assert bid is not None and len(bid) >= 8 and all(c in "0123456789abcdef" for c in bid), \
+        f"build_id missing or malformed: {bid!r}"
+
+
+@pytest.mark.parametrize("name,expected", sorted(EXPECTED_VERDICTS.items()))
+def test_classify_matches_expected_verdict(built_demo: Path, name: str,
+                                            expected: str) -> None:
+    """Each ground-truth function classifies to its predicted verdict."""
+    verdicts = classify_binary_evidence(list(EXPECTED_VERDICTS), built_demo)
+    w = verdicts[name]
+    assert isinstance(w, BinaryOracleWitness)
+    assert w.classification == expected, (
+        f"{name!r}: expected {expected!r}, got {w.classification!r}; "
+        f"the classifier's 3-way classify is the binary_oracle "
+        f"correctness gate — investigate before changing this assertion."
+    )
+
+
+def test_classify_carries_build_id_and_path(built_demo: Path) -> None:
+    """Every witness records its provenance so multi-binary results can be
+    attributed correctly and stale-build mismatch can be spotted."""
+    verdicts = classify_binary_evidence(["live_called"], built_demo)
+    w = verdicts["live_called"]
+    assert w.build_id and len(w.build_id) >= 8
+    assert w.binary_path == str(built_demo)
+
+
+def test_unknown_source_name_is_absent(built_demo: Path) -> None:
+    """A name not present in the binary at all classifies as ``absent`` —
+    the DCE end of the spectrum, no special-case needed for missing names."""
+    verdicts = classify_binary_evidence(["a_function_that_does_not_exist"],
+                                         built_demo)
+    assert verdicts["a_function_that_does_not_exist"].classification == "absent"
+
+
+def test_folded_pair_is_consistent(built_demo: Path) -> None:
+    """``folded_a`` and ``folded_b`` have identical bodies. With an
+    ICF-capable linker they're ``folded``; without one they're both
+    ``symbol_present``. EITHER outcome is acceptable — what's NOT
+    acceptable is the pair classifying inconsistently (one folded, one not)
+    or either of them being ``absent`` (would be a false-suppress)."""
+    verdicts = classify_binary_evidence(["folded_a", "folded_b"], built_demo)
+    a = verdicts["folded_a"].classification
+    b = verdicts["folded_b"].classification
+    assert a == b, f"folded pair classified inconsistently: a={a}, b={b}"
+    assert a in ("folded", "symbol_present"), \
+        f"folded pair must NEVER be absent (would be false-suppress); got {a}"
+
+
+def test_classify_on_nonexistent_binary_is_empty(tmp_path: Path) -> None:
+    """A missing/non-ELF binary returns ``{}`` rather than raising — the
+    classifier is best-effort and surface-only."""
+    verdicts = classify_binary_evidence(["x"], tmp_path / "no_such_file")
+    assert verdicts == {}
+
+
+def test_classify_on_stripped_binary_uses_symbol_only_fallback(
+    built_demo: Path, tmp_path: Path,
+) -> None:
+    """Stripped of DWARF — classifier no longer returns empty (E1).
+    Falls back to nm + nm -D and tags every verdict tier=symbol_only;
+    operator gets reachability evidence for exported API even without
+    DWARF, but the suppression-earned property is conservatively
+    revoked at the inventory level (see
+    ``test_inventory_earns_suppression_downgrades_for_stripped``)."""
+    if not shutil.which("strip"):
+        pytest.skip("strip not available")
+    stripped = tmp_path / "demo_stripped"
+    stripped.write_bytes(built_demo.read_bytes())
+    subprocess.run(["strip", "--strip-debug", str(stripped)], check=True)
+    verdicts = classify_binary_evidence(list(EXPECTED_VERDICTS), stripped)
+    assert verdicts, "E1 fallback must return verdicts on stripped binary"
+    # Every witness is tagged symbol_only
+    assert all(w.tier == "symbol_only" for w in verdicts.values()), (
+        f"unexpected tier mix: "
+        f"{ {n: w.tier for n, w in verdicts.items()} }")
+
+
+# ---------------------------------------------------------------------------
+# Inc 2 — enrichment integration (surface-only, no classifier change)
+# ---------------------------------------------------------------------------
+
+def _synthetic_inventory_for_fixture() -> dict:
+    """Hand-rolled inventory mirroring lib.c — independent of the extractor's
+    per-version output. Item names match the fixture so the enrichment
+    writes verdicts onto the right items."""
+    return {
+        "files": [
+            {
+                "path": "lib.c", "language": "c",
+                "items": [
+                    {"name": n, "kind": "function", "line_start": i + 1}
+                    for i, n in enumerate(EXPECTED_VERDICTS.keys())
+                ] + [
+                    {"name": "folded_a", "kind": "function", "line_start": 100},
+                    {"name": "folded_b", "kind": "function", "line_start": 110},
+                ],
+            },
+            {
+                "path": "util.py", "language": "python",
+                "items": [{"name": "helper", "kind": "function", "line_start": 1}],
+            },
+        ],
+    }
+
+
+def test_enrich_annotates_each_native_item(built_demo: Path) -> None:
+    """Every native function in the inventory gets a binary_oracle metadata
+    entry whose classification matches the standalone classifier."""
+    inv = _synthetic_inventory_for_fixture()
+    counts = enrich_inventory_with_binary_oracle(inv, built_demo)
+    assert counts["classified"] == len(EXPECTED_VERDICTS) + 2  # +folded_a/_b
+    items_by_name = {it["name"]: it for it in inv["files"][0]["items"]}
+    for name, expected in EXPECTED_VERDICTS.items():
+        meta = items_by_name[name].get("metadata", {}).get("binary_oracle")
+        assert meta is not None, f"{name}: no binary_oracle metadata"
+        assert meta["classification"] == expected, (
+            f"{name}: expected {expected}, got {meta['classification']}")
+
+
+def test_enrich_skips_non_native_items(built_demo: Path) -> None:
+    """Python/JS/Java/etc. items are not touched."""
+    inv = _synthetic_inventory_for_fixture()
+    enrich_inventory_with_binary_oracle(inv, built_demo)
+    py_item = inv["files"][1]["items"][0]
+    assert "binary_oracle" not in py_item.get("metadata", {})
+
+
+def test_enrich_writes_inventory_summary(built_demo: Path) -> None:
+    """Top-level summary with ``earns_suppression: True`` — earned by the
+    Inc 3 precision corpus (841/841 absent verdicts correct across 5
+    corpora; Wilson 95% UB on miss rate = 0.45%). Downstream consumers
+    may hard-suppress findings on ``absent`` verdicts. Schema (Phase 4):
+    ``binaries`` is a list to support hybrid targets with multiple
+    declared binaries."""
+    inv = _synthetic_inventory_for_fixture()
+    enrich_inventory_with_binary_oracle(inv, built_demo)
+    summary = inv.get("binary_oracle")
+    assert summary is not None
+    assert isinstance(summary["binaries"], list)
+    assert len(summary["binaries"]) == 1
+    b0 = summary["binaries"][0]
+    assert b0["path"] == str(built_demo)
+    assert b0["build_id"] and len(b0["build_id"]) >= 8
+    assert summary["earns_suppression"] is True
+    assert summary["skipped_non_native"] == 1
+    c = summary["counts"]
+    assert c["absent"] >= 2 and c["symbol_present"] >= 4 and c["inlined"] >= 1
+
+
+def test_enrich_with_missing_binary_is_a_noop(tmp_path: Path) -> None:
+    inv = _synthetic_inventory_for_fixture()
+    counts = enrich_inventory_with_binary_oracle(inv, tmp_path / "ghost")
+    assert counts["classified"] == 0
+    assert "binary_oracle" not in inv
+    for it in inv["files"][0]["items"]:
+        assert "binary_oracle" not in it.get("metadata", {})
+
+
+def test_enrich_is_idempotent(built_demo: Path) -> None:
+    """Running enrich twice produces the same result."""
+    inv = _synthetic_inventory_for_fixture()
+    enrich_inventory_with_binary_oracle(inv, built_demo)
+    first = {it["name"]: it.get("metadata", {}).get("binary_oracle")
+             for it in inv["files"][0]["items"]}
+    enrich_inventory_with_binary_oracle(inv, built_demo)
+    second = {it["name"]: it.get("metadata", {}).get("binary_oracle")
+              for it in inv["files"][0]["items"]}
+    assert first == second
+
+
+# ---------------------------------------------------------------------------
+# Adversarial-review regression tests (2026-05-30)
+# ---------------------------------------------------------------------------
+
+def test_enrich_does_not_crash_on_metadata_none(built_demo: Path) -> None:
+    """Inventory item with ``metadata: None`` (vs missing) — ``setdefault``
+    would return None and the next assignment crash. Initialise explicitly."""
+    inv = {"files": [{"path": "x.c", "language": "c", "items": [
+        {"name": "live_called", "kind": "function", "line_start": 1,
+         "metadata": None},
+        {"name": "dead_static_unused", "kind": "function", "line_start": 2,
+         "metadata": "not even a dict"},
+    ]}]}
+    enrich_inventory_with_binary_oracle(inv, built_demo)
+    items = inv["files"][0]["items"]
+    assert isinstance(items[0]["metadata"], dict)
+    assert items[0]["metadata"]["binary_oracle"]["classification"] == "symbol_present"
+    assert isinstance(items[1]["metadata"], dict)
+    assert items[1]["metadata"]["binary_oracle"]["classification"] == "absent"
+
+
+def test_classifier_handles_clang_indexed_string_dwarf(tmp_path: Path) -> None:
+    """clang emits ``(indexed string: 0xN): name`` where gcc emits
+    ``(indirect string, offset: 0xN): name``. Parser must read both —
+    otherwise every clang-built name is anonymous and inline-detection
+    silently fails (would classify ``inlined_only`` as ``absent`` on clang)."""
+    if not shutil.which("clang"):
+        pytest.skip("clang not available")
+    work = tmp_path / "clang_fixture"
+    work.mkdir()
+    for f in ("lib.c", "lib.h", "main.c", "Makefile"):
+        (work / f).write_bytes((FIXTURE_DIR / f).read_bytes())
+    rc = subprocess.run(["make", "-C", str(work), "CC=clang"],
+                        capture_output=True, text=True, timeout=60)
+    if rc.returncode != 0:
+        pytest.skip(f"clang build failed: {rc.stderr[:200]}")
+    v = classify_binary_evidence(
+        ["inlined_only", "dead_static_unused", "live_called"], work / "demo")
+    assert v["inlined_only"].classification == "inlined", (
+        "clang DWARF (indexed string) name format must be parsed too")
+    assert v["dead_static_unused"].classification == "absent"
+    assert v["live_called"].classification == "symbol_present"
+
+
+def test_classifier_handles_cpp_mangled_symbols(tmp_path: Path) -> None:
+    """nm emits mangled C++ symbols; the source side has unmangled names.
+    Without ``nm --demangle`` every C++ method would classify ``absent``.
+    Methods are marked ``noinline`` so they survive ``-O2`` to exercise the
+    demangle path (a trivially-inlinable method would optimise away)."""
+    if not shutil.which("g++"):
+        pytest.skip("g++ not available")
+    src = tmp_path / "x.cpp"
+    src.write_text(
+        '#include <cstdio>\n'
+        'class Widget {\npublic:\n'
+        '  __attribute__((noinline)) int dead_method(int x) const {\n'
+        '    int s=0; for(int i=0;i<x;++i) s+=(x*13+i)^0xDEAD; return s; }\n'
+        '  __attribute__((noinline)) int live_method(int x) const {\n'
+        '    int s=0; for(int i=0;i<x;++i) s+=(x*7+i)|0xBEEF; return s; }\n'
+        '};\n'
+        'int main(int argc, char**) { Widget w; printf("%d\\n", w.live_method(argc)); return 0; }\n'
+    )
+    bin_ = tmp_path / "d"
+    rc = subprocess.run(["g++", "-O2", "-g", "-ffunction-sections",
+                         "-Wl,--gc-sections", "-o", str(bin_), str(src)],
+                        capture_output=True, text=True, timeout=60)
+    if rc.returncode != 0:
+        pytest.skip(f"g++ build failed: {rc.stderr[:200]}")
+    v = classify_binary_evidence(["dead_method", "live_method", "main"], bin_)
+    assert v["live_method"].classification == "symbol_present", (
+        "C++ live_method must match via nm --demangle (bare-name index)")
+    assert v["dead_method"].classification == "absent"
+    assert v["main"].classification == "symbol_present"
+
+
+def test_classifier_does_not_crash_on_stripped_real_binary() -> None:
+    """A real-world stripped system binary (``/usr/bin/ls``) — must not
+    raise; classifier returns empty (caller logs the skip)."""
+    ls = Path("/usr/bin/ls")
+    if not ls.exists():
+        pytest.skip("/usr/bin/ls not present")
+    v = classify_binary_evidence(["main", "no_such_function"], ls)
+    assert isinstance(v, dict)
+    assert read_build_id(ls)
+
+
+# ---------------------------------------------------------------------------
+# E1 — stripped-binary fallback (symbol-only tier)
+# ---------------------------------------------------------------------------
+
+def test_classifier_falls_back_to_symbol_only_on_stripped_binary(
+    tmp_path: Path,
+) -> None:
+    """A stripped binary has no DWARF subprograms. The classifier
+    falls back to nm + nm -D (dynamic symbol table), tagging each
+    witness with ``tier='symbol_only'``. Exported library API gets
+    ``symbol_present``; internal helpers get ``absent``."""
+    import subprocess as _sp
+
+    src = tmp_path / "lib.c"
+    src.write_text(
+        "int public_api(int x){return x+1;}\n"
+        "static int internal(int x){return x*2;}\n"
+        "int dead_export(int x){return public_api(x);}\n"
+    )
+    lib = tmp_path / "libtest.so"
+    _sp.run(["gcc", "-O2", "-shared", "-fPIC", str(src), "-o", str(lib)],
+            check=True)
+    _sp.run(["strip", "--strip-unneeded", str(lib)], check=True)
+
+    verdicts = classify_binary_evidence(
+        ["public_api", "internal", "dead_export", "nonexistent"], lib,
+    )
+    # Exported API → symbol_present via nm -D
+    assert verdicts["public_api"].classification == "symbol_present"
+    assert verdicts["public_api"].tier == "symbol_only"
+    # Static helper → stripped → absent
+    assert verdicts["internal"].classification == "absent"
+    assert verdicts["internal"].tier == "symbol_only"
+    # Genuinely absent name
+    assert verdicts["nonexistent"].classification == "absent"
+
+
+def test_inventory_earns_suppression_downgrades_for_stripped(
+    tmp_path: Path, built_demo: Path,
+) -> None:
+    """When ANY contributing binary is symbol-only (stripped), the
+    inventory's ``earns_suppression`` flag downgrades to False — the
+    corpus-earned suppression property is conditional on full-DWARF
+    evidence, and a stripped binary's ``absent`` could really be
+    inlined-into-survivor."""
+    import subprocess as _sp
+
+    # Strip a copy of the fixture binary
+    stripped = tmp_path / "demo_stripped"
+    _sp.run(["cp", str(built_demo), str(stripped)], check=True)
+    _sp.run(["strip", "--strip-unneeded", str(stripped)], check=True)
+
+    inv = _synthetic_inventory_for_fixture()
+    # Mix: one full-DWARF, one stripped → flag downgrades
+    enrich_inventory_with_binary_oracle(inv, [built_demo, stripped])
+    summary = inv["binary_oracle"]
+    assert summary["earns_suppression"] is False
+    assert summary["any_symbol_only"] is True
+    # Per-binary tier exposed
+    tiers = sorted(b["tier"] for b in summary["binaries"])
+    assert tiers == ["full", "symbol_only"]
+
+
+def test_reach_witness_does_not_fire_sound_witness_on_symbol_only(
+) -> None:
+    """The chokepoint: even if combined classification is ``absent``,
+    if ANY per-binary entry was symbol_only, the SOUND
+    ``binary_oracle_absent`` witness must not fire (downstream may-
+    suppress would otherwise license a false negative)."""
+    from core.inventory.reachability import binary_oracle_absent
+    # Full-tier absent → fires
+    inv_full = {"files": [{
+        "path": "x.c", "language": "c",
+        "items": [{
+            "name": "foo", "kind": "function", "line_start": 1,
+            "metadata": {"binary_oracle": {
+                "classification": "absent",
+                "binaries": [{"path": "/a", "tier": "full",
+                              "classification": "absent"}],
+            }},
+        }],
+    }]}
+    assert binary_oracle_absent(inv_full, "x.c", "foo") is True
+    # Symbol-only absent → does NOT fire
+    inv_sym = {"files": [{
+        "path": "x.c", "language": "c",
+        "items": [{
+            "name": "foo", "kind": "function", "line_start": 1,
+            "metadata": {"binary_oracle": {
+                "classification": "absent",
+                "binaries": [{"path": "/a", "tier": "symbol_only",
+                              "classification": "absent"}],
+            }},
+        }],
+    }]}
+    assert binary_oracle_absent(inv_sym, "x.c", "foo") is False
+    # Mixed: one full, one symbol_only → still does NOT fire
+    # (weakest link wins on the suppression side)
+    inv_mixed = {"files": [{
+        "path": "x.c", "language": "c",
+        "items": [{
+            "name": "foo", "kind": "function", "line_start": 1,
+            "metadata": {"binary_oracle": {
+                "classification": "absent",
+                "binaries": [
+                    {"path": "/a", "tier": "full",
+                     "classification": "absent"},
+                    {"path": "/b", "tier": "symbol_only",
+                     "classification": "absent"},
+                ],
+            }},
+        }],
+    }]}
+    assert binary_oracle_absent(inv_mixed, "x.c", "foo") is False
+
+
+def test_classifier_resolves_symlinked_binary(tmp_path: Path,
+                                                built_demo: Path) -> None:
+    """A symlink to the binary should classify the same as the binary
+    itself — Path operations resolve through symlinks transparently."""
+    link = tmp_path / "demo_link"
+    link.symlink_to(built_demo.resolve())
+    v_link = classify_binary_evidence(["live_called"], link)
+    v_real = classify_binary_evidence(["live_called"], built_demo)
+    assert v_link["live_called"].classification == v_real["live_called"].classification
+
+
+# ---------------------------------------------------------------------------
+# Inc 3b — classifier fixes surfaced by the zlib precision measurement
+# ---------------------------------------------------------------------------
+
+def test_strip_ipa_suffix_handles_gcc_clone_patterns() -> None:
+    """GCC's -O2 IPA passes rename functions; the bare-name index must
+    map clones back to the source name or operators get FP ``absent``
+    verdicts on any GCC-built binary (surfaced by zlib Inc 3b — without
+    this, ``gz_skip.constprop.0`` looked like ``gz_skip`` was DCE'd)."""
+    from core.inventory.binary_oracle import _strip_ipa_suffix
+    assert _strip_ipa_suffix("gz_skip.constprop.0") == "gz_skip"
+    assert _strip_ipa_suffix("foo.isra.0") == "foo"
+    assert _strip_ipa_suffix("deflateStateCheck.part.0") == "deflateStateCheck"
+    assert _strip_ipa_suffix("bar.cold") == "bar"
+    assert _strip_ipa_suffix("baz.local.3") == "baz"
+    # Stacked suffixes:
+    assert _strip_ipa_suffix("foo.isra.0.constprop.1") == "foo"
+    # Non-IPA dots stay put:
+    assert _strip_ipa_suffix("plain_name") == "plain_name"
+    assert _strip_ipa_suffix("std::foo") == "std::foo"
+
+
+def test_classifier_treats_internal_linkage_with_low_pc_as_present(
+    tmp_path: Path,
+) -> None:
+    """An anonymous-namespace ``static`` helper with no nm symbol but a
+    concrete ``DW_AT_low_pc`` in DWARF is present in the binary —
+    classifier must NOT misclassify as ``absent`` (snappy Inc 3c
+    followup: ``DecompressBranchless<char*>`` and both
+    ``DecompressAllTags<...>`` template variants were absent FPs because
+    their definitions lived in DWARF but produced no nm symbol)."""
+    import subprocess as _sp
+
+    src = tmp_path / "x.cc"
+    src.write_text(
+        "namespace { static int helper(int x) __attribute__((noinline));\n"
+        "static int helper(int x) { return x + 7; } }\n"
+        "int main(void){ return helper(0); }\n")
+    binary = tmp_path / "x"
+    _sp.run(["g++", "-O2", "-g", "-ffunction-sections",
+             "-Wl,--gc-sections", "-o", str(binary), str(src)], check=True)
+    verdicts = classify_binary_evidence(["(anonymous namespace)::helper",
+                                          "helper"], binary)
+    classifications = {n: v.classification for n, v in verdicts.items()}
+    # At least one of the lookup forms must NOT be absent — the function
+    # is in the binary (no caller would make it; with noinline it survives).
+    present = [c for c in classifications.values() if c != "absent"]
+    assert present, (
+        f"internal-linkage helper misclassified — {classifications}")
+
+
+def test_classifier_qualifies_cpp_methods_with_namespace(
+    tmp_path: Path,
+) -> None:
+    """A C++ method inside a namespace must classify under its qualified
+    name (``foo::Bar::baz``), not just the local ``baz`` — otherwise
+    the source-name lookup from ``gcov -m`` / ``nm --demangle``-style
+    callers misses (every snappy:: method showed FP ``absent`` in Inc 3c
+    until the DWARF parser tracked enclosing-namespace context)."""
+    import subprocess as _sp
+
+    src = tmp_path / "x.cc"
+    src.write_text(
+        "namespace foo {\n"
+        "  struct Bar {\n"
+        "    static __attribute__((always_inline)) inline\n"
+        "        int baz(int x) { return x + 1; }\n"
+        "  };\n"
+        "}\n"
+        "int main(void){ return foo::Bar::baz(0); }\n"
+    )
+    binary = tmp_path / "x"
+    _sp.run(["g++", "-O2", "-g", "-o", str(binary), str(src)], check=True)
+    # The classifier must find the function under its qualified name —
+    # not under the local ``baz``.
+    verdicts = classify_binary_evidence(["foo::Bar::baz"], binary)
+    assert verdicts["foo::Bar::baz"].classification != "absent", (
+        f"qualified lookup misclassified: {verdicts['foo::Bar::baz']}")
+
+
+def test_nm_index_stores_qualified_no_args_form_for_cpp(
+    tmp_path: Path,
+) -> None:
+    """``gcov -m`` outputs C++ names like ``snappy::Uncompress`` (no args);
+    nm --demangle gives ``snappy::Uncompress(snappy::Source*, ...)`` (with
+    args). Without indexing the qualified-no-args form, every C++
+    measurement misses. Surfaced by snappy Inc 3c."""
+    import subprocess as _sp
+    from core.inventory.binary_oracle import _nm_symbols
+
+    src = tmp_path / "x.cc"
+    src.write_text(
+        "namespace foo { namespace bar { int baz(int x) { return x+1; } }}\n"
+        "int main(void){ return foo::bar::baz(0); }\n")
+    binary = tmp_path / "x"
+    _sp.run(["g++", "-O0", "-g", "-o", str(binary), str(src)], check=True)
+    syms = _nm_symbols(binary)
+    # All three forms must be indexed:
+    full_match = any("foo::bar::baz(" in k for k in syms)
+    assert full_match, f"full demangled form missing: {list(syms)[:5]}"
+    assert "foo::bar::baz" in syms, (
+        "qualified-no-args form missing — gcov -m output would not match")
+    assert "baz" in syms, "bare-name index missing"
+
+
+def test_classifier_recognises_always_inline_empty_body(
+    tmp_path: Path,
+) -> None:
+    """A subprogram with ``DW_AT_inline=inlined`` and no concrete
+    ``DW_TAG_inlined_subroutine`` instances (empty body, fully folded
+    into caller — zlib's ``tr_static_init`` case from Inc 3b) must
+    classify as ``inlined`` not ``absent``."""
+    import subprocess as _sp
+
+    src = tmp_path / "x.c"
+    src.write_text(
+        "#include <stdio.h>\n"
+        "static inline __attribute__((always_inline)) void empty(void) {}\n"
+        "int main(void){ empty(); puts(\"hi\"); return 0; }\n")
+    binary = tmp_path / "x"
+    _sp.run(["gcc", "-O2", "-g", "-o", str(binary), str(src)], check=True)
+    verdicts = classify_binary_evidence(["empty"], binary)
+    # Acceptable: ``inlined`` (the fix) or ``symbol_present`` (some
+    # compilers emit a copy anyway). The wrong verdict is ``absent``.
+    assert verdicts["empty"].classification != "absent", (
+        f"empty() misclassified as absent: {verdicts['empty']}")
+
+
+# ---------------------------------------------------------------------------
+# Inc 4 — operator surface: --binary CLI flag + build_inventory auto-enrich
+# ---------------------------------------------------------------------------
+
+def test_build_inventory_auto_enriches_when_binary_path_set(
+    tmp_path: Path, built_demo: Path, monkeypatch,
+) -> None:
+    """``RaptorConfig.BINARY_ORACLE_PATHS`` set by the ``--binary`` CLI
+    flag triggers binary-oracle enrichment of the inventory at the END
+    of build_inventory. Single-binary case here; multi-binary covered
+    in the dedicated combine tests."""
+    from core.config import RaptorConfig
+    from core.inventory.builder import build_inventory
+    (tmp_path / "lib.c").write_text(
+        "int live_called(int x) { return x + 1; }\n")
+    monkeypatch.setattr(RaptorConfig, "BINARY_ORACLE_PATHS",
+                        (str(built_demo),))
+    inv = build_inventory(str(tmp_path), str(tmp_path / "out"))
+    assert "binary_oracle" in inv, \
+        "build_inventory must auto-enrich when BINARY_ORACLE_PATHS is set"
+    # Earned by the Inc 3 precision corpus; downstream may suppress.
+    assert inv["binary_oracle"]["earns_suppression"] is True
+    assert inv["binary_oracle"]["counts"]["classified"] >= 1
+
+
+def test_build_inventory_no_enrich_when_unset(tmp_path: Path) -> None:
+    """Default behaviour: ``RaptorConfig.BINARY_ORACLE_PATHS`` empty → no
+    ``binary_oracle`` key, no overhead. Existing inventory callers
+    unchanged."""
+    from core.config import RaptorConfig
+    from core.inventory.builder import build_inventory
+    assert RaptorConfig.BINARY_ORACLE_PATHS == ()
+    (tmp_path / "x.c").write_text("int f(int x){return x;}\n")
+    inv = build_inventory(str(tmp_path), str(tmp_path / "out"))
+    assert "binary_oracle" not in inv
+
+
+def test_build_inventory_swallows_enrichment_errors(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    """A bad binary path (or any enrichment failure) must NOT crash
+    inventory building — best-effort, warning-only."""
+    from core.config import RaptorConfig
+    from core.inventory.builder import build_inventory
+    (tmp_path / "x.c").write_text("int f(int x){return x;}\n")
+    monkeypatch.setattr(RaptorConfig, "BINARY_ORACLE_PATHS",
+                        (str(tmp_path / "no_such_binary"),))
+    inv = build_inventory(str(tmp_path), str(tmp_path / "out"))
+    assert isinstance(inv.get("files"), list)
+    bo = inv.get("binary_oracle")
+    if bo:
+        assert bo["counts"].get("classified", 0) == 0
+
+
+def test_enrich_combines_multi_binary_verdicts_with_alive_in_any_wins(
+    tmp_path: Path,
+) -> None:
+    """Phase 4 multi-binary combine: when MULTIPLE binaries are declared
+    (--target-kind=hybrid), a source function is ``absent`` only when
+    every declared binary lacks it. If any binary has it (symbol_present
+    / inlined / folded), the combined verdict is the strongest evidence."""
+    import subprocess as _sp
+
+    # Two tiny binaries: binA defines `foo`; binB defines `bar`.
+    # Source has both foo() and bar(). Combined verdict for foo should be
+    # symbol_present (binA has it) even though binB doesn't.
+    src_a = tmp_path / "a.c"
+    src_a.write_text("int foo(int x){return x+1;} int main(){return foo(0);}\n")
+    src_b = tmp_path / "b.c"
+    src_b.write_text("int bar(int x){return x+2;} int main(){return bar(0);}\n")
+    bin_a = tmp_path / "binA"
+    bin_b = tmp_path / "binB"
+    _sp.run(["gcc", "-O2", "-g", "-o", str(bin_a), str(src_a)], check=True)
+    _sp.run(["gcc", "-O2", "-g", "-o", str(bin_b), str(src_b)], check=True)
+
+    inv = {"files": [
+        {"path": "shared.c", "language": "c", "items": [
+            {"name": "foo", "kind": "function", "line_start": 1},
+            {"name": "bar", "kind": "function", "line_start": 2},
+            {"name": "dead", "kind": "function", "line_start": 3},
+        ]},
+    ]}
+    counts = enrich_inventory_with_binary_oracle(inv, (bin_a, bin_b))
+    items = {it["name"]: it for it in inv["files"][0]["items"]}
+
+    # foo is in binA only → combined = alive (symbol_present)
+    foo_bo = items["foo"]["metadata"]["binary_oracle"]
+    assert foo_bo["classification"] == "symbol_present", foo_bo
+    assert len(foo_bo["binaries"]) == 2
+    # bar is in binB only → combined = alive
+    bar_bo = items["bar"]["metadata"]["binary_oracle"]
+    assert bar_bo["classification"] == "symbol_present", bar_bo
+    # ``dead`` is in NEITHER binary → combined = absent
+    dead_bo = items["dead"]["metadata"]["binary_oracle"]
+    assert dead_bo["classification"] == "absent", dead_bo
+    # Both binaries are recorded at the top level
+    assert len(inv["binary_oracle"]["binaries"]) == 2
+    assert counts["classified"] == 3
+
+
+def test_combine_verdicts_prefers_full_tier_over_symbol_only() -> None:
+    """Adversarial review P0-D-4: when full-tier and symbol-only
+    evidence disagree, the full-tier verdict wins. A symbol-only
+    ``symbol_present`` (from stripped binary nm picking up a weak
+    alias / re-export) must NOT mask a full-tier ``absent``."""
+    from core.inventory.binary_oracle import _combine_verdicts
+    # Full says absent, symbol_only says symbol_present.
+    # Without tier weighting the alive-in-any rule would pick
+    # symbol_present (priority 4 > 1) — wrong, the stripped binary's
+    # evidence is too weak to overrule the full-DWARF absent.
+    combined = _combine_verdicts([
+        ("absent", "full"),
+        ("symbol_present", "symbol_only"),
+    ])
+    assert combined == "absent", combined
+
+    # Same-tier (both full): alive-in-any wins.
+    combined = _combine_verdicts([
+        ("absent", "full"),
+        ("symbol_present", "full"),
+    ])
+    assert combined == "symbol_present", combined
+
+    # All-symbol-only: alive-in-any wins (no full to defer to).
+    combined = _combine_verdicts([
+        ("absent", "symbol_only"),
+        ("symbol_present", "symbol_only"),
+    ])
+    assert combined == "symbol_present", combined
+
+
+def test_binary_oracle_paths_does_not_leak_across_runs(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    """Adversarial review P0-117: ``RaptorConfig.BINARY_ORACLE_PATHS``
+    is a class attribute. In long-lived processes the prior run's
+    value persists unless explicitly cleared. Behaviour check via the
+    shared helper: call ``apply_to_config`` with empty args and
+    verify the result is an empty tuple (not None / not the old
+    value), and that the helper unconditionally assigns."""
+    from core.config import RaptorConfig
+    from core.inventory.binary_oracle_cli import apply_to_config
+
+    # Pre-load with a leaked value from a "previous run".
+    monkeypatch.setattr(
+        RaptorConfig, "BINARY_ORACLE_PATHS", ("/leaked/from/prior",))
+    monkeypatch.setattr(RaptorConfig, "BINARY_ORACLE_EDGES", True)
+
+    # Fresh run with NO --binary / --binary-auto / --binary-edges.
+    # ProjectManager active is None inside a tmp dir.
+    monkeypatch.chdir(tmp_path)
+
+    class _NoArgs:
+        binary = None
+        binary_auto = False
+        binary_edges = False
+        target_kind = "auto"
+
+    result = apply_to_config(_NoArgs(), tmp_path)
+    assert result == (), result
+    assert RaptorConfig.BINARY_ORACLE_PATHS == (), (
+        "BINARY_ORACLE_PATHS leaked from prior run — must always reset")
+    assert RaptorConfig.BINARY_ORACLE_EDGES is False, (
+        "BINARY_ORACLE_EDGES leaked from prior run — must always reset")
+
+
+def test_enrich_drops_unrelated_binary_below_source_coverage_floor(
+    tmp_path: Path,
+) -> None:
+    """Adversarial review P0-D-1 defense: a binary whose DWARF mentions
+    almost none of the source-side function names — the hostile-ELF
+    attack shape — must be DROPPED with a warning, NOT used to
+    classify every source function as ``absent`` (which would silently
+    suppress every native finding downstream).
+
+    Setup: source inventory has ``alpha``, ``beta``, ``gamma`` (the
+    real surface). The "planted" binary contains an unrelated function
+    ``hostile``. Without the coverage-floor defense, every real source
+    function classifies absent and downstream chokepoints would
+    suppress all native findings on this target.
+    """
+    import subprocess as _sp
+
+    # Source inventory lists ten functions — none of which exist
+    # in the planted binary's DWARF/symbol table. Wide enough that
+    # the min_matched=3 floor isn't the only mechanism in play (so
+    # the test covers both the ratio AND the floor).
+    items = [{"name": f"alpha_{i}", "kind": "function",
+              "line_start": i + 1} for i in range(10)]
+    inv = {"files": [{"path": "real.c", "language": "c",
+                      "items": items}]}
+
+    # The "planted" binary: completely different source, completely
+    # different symbols. Compiled with -O0 -g to ensure DWARF passes
+    # the auto-detect sanity check (this binary IS valid; the issue
+    # is that it has nothing to do with the analysed source tree).
+    planted_src = tmp_path / "hostile.c"
+    planted_src.write_text(
+        "int hostile_helper(int x){return x*2;}\n"
+        "int main(void){return hostile_helper(1);}\n"
+    )
+    planted_bin = tmp_path / "planted"
+    _sp.run(["gcc", "-O0", "-g", "-o", str(planted_bin), str(planted_src)],
+            check=True)
+
+    counts = enrich_inventory_with_binary_oracle(inv, (planted_bin,))
+
+    # Defense fired: the planted binary was dropped, so NOTHING got a
+    # binary_oracle annotation. Without the floor, all 3 would classify
+    # as absent and tier="full" — eligible for hard-suppression
+    # downstream.
+    assert counts["classified"] == 0, (
+        "expected planted binary to be dropped by source-coverage floor "
+        "before any inventory items were annotated")
+    for it in inv["files"][0]["items"]:
+        assert "binary_oracle" not in (it.get("metadata") or {}), (
+            f"item {it['name']} was annotated despite the planted binary "
+            "failing the source-coverage floor")
+
+
+def test_codeql_cli_wires_binary_flag_to_raptor_config() -> None:
+    """``raptor-sca codeql --binary <path>`` advertises the flag and
+    the glue mutates ``RaptorConfig.BINARY_ORACLE_PATHS``. After the
+    P1-D-4 DRY refactor the actual wiring lives in the shared
+    ``binary_oracle_cli`` helper; verify both raptor_codeql.py imports
+    it AND the helper itself contains the argparse + config-mutation
+    code path."""
+    import raptor_codeql
+    from core.inventory import binary_oracle_cli
+    codeql_src = Path(raptor_codeql.__file__).read_text()
+    assert "binary_oracle_cli" in codeql_src, (
+        "raptor_codeql should use the shared binary_oracle_cli helper")
+    helper_src = Path(binary_oracle_cli.__file__).read_text()
+    assert '"--binary"' in helper_src, (
+        "binary_oracle_cli should declare --binary argparse arg")
+    assert "BINARY_ORACLE_PATHS" in helper_src, (
+        "binary_oracle_cli should mutate RaptorConfig.BINARY_ORACLE_PATHS")

--- a/core/inventory/tests/test_binary_oracle_autodetect.py
+++ b/core/inventory/tests/test_binary_oracle_autodetect.py
@@ -1,0 +1,153 @@
+"""Tests for the binary_oracle auto-detect heuristic (Phase 4)."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from core.inventory.binary_oracle_autodetect import (
+    detect_binaries,
+    _classify_candidate,
+    _has_dwarf,
+)
+
+
+@pytest.fixture
+def build_tree(tmp_path: Path) -> Path:
+    """A target tree shaped like a real autotools / CMake build.
+    Synthesises ELF binaries with DWARF via a tiny compile."""
+    import subprocess as _sp
+
+    # Source file shared by all binaries.
+    src = tmp_path / "x.c"
+    src.write_text("int f(int x){return x+1;}\nint main(void){return f(0);}\n")
+
+    # Top-level executable (autotools-style: binary in source root)
+    _sp.run(["gcc", "-g", str(src), "-o", str(tmp_path / "example")],
+            check=True)
+    # Top-level library
+    lib_src = tmp_path / "lib.c"
+    lib_src.write_text("int lib_fn(int x){return x*2;}\n")
+    _sp.run(["gcc", "-g", "-shared", "-fPIC", str(lib_src),
+             "-o", str(tmp_path / "libfoo.so")], check=True)
+    # build/ subdir with another executable
+    (tmp_path / "build").mkdir()
+    _sp.run(["gcc", "-g", str(src),
+             "-o", str(tmp_path / "build" / "build_exe")], check=True)
+    # Stripped binary — should be filtered out
+    _sp.run(["gcc", str(src), "-s",
+             "-o", str(tmp_path / "stripped_no_dwarf")], check=True)
+    # A shell script — should be filtered out even though executable
+    (tmp_path / "script.sh").write_text("#!/bin/sh\necho hi\n")
+    os.chmod(tmp_path / "script.sh", 0o755)
+
+    return tmp_path
+
+
+def test_detect_hybrid_returns_both_libs_and_exes(build_tree: Path) -> None:
+    paths = detect_binaries(build_tree, "hybrid")
+    names = sorted(p.name for p in paths)
+    assert "libfoo.so" in names
+    assert "example" in names
+    assert "build_exe" in names
+    # Stripped binary excluded (no .debug_info)
+    assert "stripped_no_dwarf" not in names
+    # Shell script excluded
+    assert "script.sh" not in names
+
+
+def test_detect_library_filters_to_libs_only(build_tree: Path) -> None:
+    paths = detect_binaries(build_tree, "library")
+    names = sorted(p.name for p in paths)
+    assert names == ["libfoo.so"]
+
+
+def test_detect_application_filters_to_exes_only(build_tree: Path) -> None:
+    paths = detect_binaries(build_tree, "application")
+    names = sorted(p.name for p in paths)
+    assert "libfoo.so" not in names
+    assert "example" in names
+    assert "build_exe" in names
+
+
+def test_detect_returns_libraries_first(build_tree: Path) -> None:
+    """Libraries before executables — they're typically the deployed
+    surface, so they sort first in the displayed list."""
+    paths = detect_binaries(build_tree, "hybrid")
+    # First entry should be a library
+    assert paths[0].name.startswith("lib")
+
+
+def test_detect_caps_results(build_tree: Path) -> None:
+    """Capped at max_results so an operator pointing at a large
+    test-binary tree doesn't trigger a 30-second classification."""
+    paths = detect_binaries(build_tree, "hybrid", max_results=2)
+    assert len(paths) <= 2
+
+
+def test_detect_missing_root_returns_empty(tmp_path: Path) -> None:
+    """Defensive: nonexistent target → empty list, no crash."""
+    assert detect_binaries(tmp_path / "does-not-exist", "auto") == []
+
+
+def test_detect_skips_dotted_dirs(build_tree: Path) -> None:
+    """``.git``, ``.cache``, etc. — skip walking them."""
+    import subprocess as _sp
+    src = build_tree / "x.c"
+    git_dir = build_tree / "build" / ".git"
+    git_dir.mkdir(parents=True, exist_ok=True)
+    _sp.run(["gcc", "-g", str(src),
+             "-o", str(git_dir / "should_be_skipped")], check=True)
+    paths = detect_binaries(build_tree, "hybrid")
+    names = [p.name for p in paths]
+    assert "should_be_skipped" not in names
+
+
+def test_classify_candidate_picks_library_extension() -> None:
+    assert _classify_candidate(Path("libfoo.so")).kind == "library"
+    assert _classify_candidate(Path("libfoo.a")).kind == "library"
+    assert _classify_candidate(Path("libfoo.so.1.3.1")).kind == "library"
+    # Non-lib dotfile patterns aren't libraries.
+    assert _classify_candidate(Path("notlib.txt")) is None
+
+
+def test_classify_candidate_rejects_split_debug_and_templates(
+    tmp_path: Path,
+) -> None:
+    """Adversarial review P0-D-3: the library-name regex must reject
+    split-debug companion files (``.so.debug``, ``.dwo``, ``.dwp``),
+    autoconf templates (``.so.in``), build artefacts (``.so.tmpl``)
+    and backups. The prior contains-check (``".so" in name``) matched
+    all of these, feeding companion files into the classifier as
+    though they were the shipped artefact."""
+    # Create real files so the executable-bit fallback path doesn't
+    # accidentally classify them as executables.
+    for name in (
+        "libfoo.so.debug",
+        "libfoo.so.in",
+        "libfoo.so.tmpl",
+        "libfoo.so.bak",
+        "libfoo.dwo",
+        "libfoo.dwp",
+        "libsomething.tar.gz",
+    ):
+        (tmp_path / name).write_text("not a binary")
+        # No executable bit → also fails the executable path.
+        result = _classify_candidate(tmp_path / name)
+        assert result is None, (
+            f"{name} should NOT be classified as a library "
+            f"(got kind={result.kind if result else None})")
+
+
+def test_has_dwarf_distinguishes_stripped(tmp_path: Path) -> None:
+    import subprocess as _sp
+    src = tmp_path / "x.c"
+    src.write_text("int main(void){return 0;}\n")
+    debug = tmp_path / "with_dwarf"
+    stripped = tmp_path / "stripped"
+    _sp.run(["gcc", "-g", str(src), "-o", str(debug)], check=True)
+    _sp.run(["gcc", str(src), "-s", "-o", str(stripped)], check=True)
+    assert _has_dwarf(debug) is True
+    assert _has_dwarf(stripped) is False

--- a/core/inventory/tests/test_binary_oracle_e2e.py
+++ b/core/inventory/tests/test_binary_oracle_e2e.py
@@ -1,0 +1,273 @@
+"""End-to-end integration tests for the binary-oracle arc.
+
+These tests exercise the FULL path: build a real C project + binary,
+run the enrich pipeline (auto-detect → classifier → chokepoint
+accessor → reachability verdict → witness), and verify each layer
+of the chain returns what downstream consumers expect.
+
+Different from the unit tests, which mock the inventory + chokepoint
+in isolation. These prove the layers compose correctly.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from core.inventory.binary_oracle import enrich_inventory_with_binary_oracle
+from core.inventory.binary_oracle_autodetect import detect_binaries
+from core.inventory.reach_audit import classify_reachability
+from core.inventory.reach_chokepoint import check_suppress
+from core.inventory.reach_witness import (
+    STRUCTURALLY_SUPPRESSIBLE_KINDS,
+    verdict_from_classification,
+)
+from core.inventory.reachability import binary_oracle_absent
+
+
+def _build_synthetic_target(tmp_path: Path) -> tuple[Path, Path, dict]:
+    """Build a small C project with a deliberately-dead function.
+
+    Returns (project_root, binary_path, inventory_dict). The binary
+    is compiled with -O2 -ffunction-sections -fdata-sections +
+    -Wl,--gc-sections so the dead function is genuinely DCE'd.
+    """
+    project = tmp_path / "myproj"
+    project.mkdir()
+    src = project / "lib.c"
+    # Build a wider source than the floor's min-match requirement (3
+    # non-boilerplate names) so the floor doesn't reject a legitimate
+    # binary just because the target is small. Real /agentic targets
+    # have dozens-to-thousands of functions; this models that without
+    # being huge.
+    func_lines = []
+    for i in range(10):
+        func_lines.append(
+            f"// Live: called from main.\n"
+            f"int alive_helper_{i}(int x) {{ return x * {7 + i}; }}\n"
+        )
+    func_lines.append(
+        "// Dead: never referenced anywhere — gc-sections strips it.\n"
+        "int dead_helper(int x) { return x * 11; }\n"
+    )
+    func_lines.append(
+        "int main(void) {\n"
+        "  int r = 0;\n"
+        + "".join(
+            f"  r += alive_helper_{i}(r + {i});\n" for i in range(10)
+        )
+        + "  return r;\n"
+        "}\n"
+    )
+    src.write_text("\n".join(func_lines))
+    (project / "build").mkdir()
+    binary = project / "build" / "myapp"
+    subprocess.run([
+        "gcc", "-O2", "-g",
+        "-ffunction-sections", "-fdata-sections",
+        "-Wl,--gc-sections",
+        str(src), "-o", str(binary),
+    ], check=True)
+    items = []
+    line = 2
+    for i in range(10):
+        items.append({"name": f"alive_helper_{i}",
+                      "kind": "function", "line_start": line})
+        line += 3
+    items.append({"name": "dead_helper",
+                  "kind": "function", "line_start": line})
+    line += 3
+    items.append({"name": "main", "kind": "function", "line_start": line})
+    inventory = {
+        "files": [{
+            "path": "lib.c", "language": "c", "items": items,
+        }],
+    }
+    return project, binary, inventory
+
+
+def _dead_helper_line(inv: dict) -> int:
+    for it in inv["files"][0]["items"]:
+        if it["name"] == "dead_helper":
+            return it["line_start"]
+    raise AssertionError("dead_helper not in inventory")
+
+
+def _alive_helper_line(inv: dict) -> int:
+    for it in inv["files"][0]["items"]:
+        if it["name"] == "alive_helper_0":
+            return it["line_start"]
+    raise AssertionError("alive_helper_0 not in inventory")
+
+
+def test_e2e_explicit_binary_flag_path(tmp_path: Path) -> None:
+    """The ``--binary`` explicit-path path: operator points at a
+    binary; classifier finds the dead function absent and the
+    chokepoint accessor confirms suppression eligibility."""
+    project, binary, inv = _build_synthetic_target(tmp_path)
+    counts = enrich_inventory_with_binary_oracle(inv, (binary,))
+    assert counts["classified"] == 12
+    items = {it["name"]: it for it in inv["files"][0]["items"]}
+
+    # dead_helper → absent, tier=full
+    dead = items["dead_helper"]["metadata"]["binary_oracle"]
+    assert dead["classification"] == "absent", dead
+    assert all(b["tier"] == "full" for b in dead["binaries"]), dead
+
+    # alive_helper_0 → symbol_present (or inlined, depending on -O2)
+    alive = items["alive_helper_0"]["metadata"]["binary_oracle"]
+    assert alive["classification"] in ("symbol_present", "inlined"), alive
+
+    dead_line = _dead_helper_line(inv)
+    alive_line = _alive_helper_line(inv)
+    # Chokepoint accessor confirms eligibility for the dead function.
+    assert binary_oracle_absent(
+        inv, "lib.c", "dead_helper", dead_line) is True
+    assert binary_oracle_absent(
+        inv, "lib.c", "alive_helper_0", alive_line) is False
+
+    # And the reach_audit classifier returns the right verdict.
+    verdict_dead = classify_reachability(
+        inv, "lib.c", "dead_helper", dead_line, "lib")
+    assert verdict_dead == "binary_oracle_absent"
+
+    # Verdict resolves to a may_suppress=True witness.
+    spec = verdict_from_classification(verdict_dead)
+    assert spec.may_suppress(STRUCTURALLY_SUPPRESSIBLE_KINDS) is True
+
+
+def test_e2e_autodetect_finds_binary(tmp_path: Path) -> None:
+    """The ``--binary-auto`` path: operator passes no explicit path;
+    auto-detect walks the project tree and finds the binary under
+    ``build/``."""
+    project, binary, inv = _build_synthetic_target(tmp_path)
+    detected = detect_binaries(project, "application")
+    # The built binary lives at build/myapp.
+    assert any(p.name == "myapp" for p in detected), detected
+    # Same chokepoint behaviour as the explicit-path path.
+    counts = enrich_inventory_with_binary_oracle(inv, tuple(detected))
+    assert counts["classified"] == 12
+
+
+def test_e2e_chokepoint_helper_full_flow(tmp_path: Path) -> None:
+    """The shared ``reach_chokepoint`` helper that both /agentic and
+    /codeql use: from a finding-shaped input through to the suppression
+    decision, all on a real binary's enrichment output."""
+    project, binary, inv = _build_synthetic_target(tmp_path)
+    enrich_inventory_with_binary_oracle(inv, (binary,))
+    dead_line = _dead_helper_line(inv)
+    alive_line = _alive_helper_line(inv)
+
+    # Decision on the DEAD function — should suppress.
+    decision = check_suppress(
+        checklist=inv,
+        file_path="lib.c", function_name="dead_helper", line=dead_line,
+        repo_root=project,
+    )
+    assert decision is not None
+    verdict, reason = decision
+    assert verdict == "binary_oracle_absent"
+    assert "dead_helper" in reason
+
+    # Decision on the LIVE function — must NOT suppress.
+    decision = check_suppress(
+        checklist=inv,
+        file_path="lib.c", function_name="alive_helper_0", line=alive_line,
+        repo_root=project,
+    )
+    assert decision is None
+
+    # manual_override on the dead function — must NOT suppress.
+    decision = check_suppress(
+        checklist=inv,
+        file_path="lib.c", function_name="dead_helper", line=dead_line,
+        repo_root=project,
+        manual_override=True,
+    )
+    assert decision is None
+
+
+def test_e2e_hostile_planted_binary_is_dropped(tmp_path: Path) -> None:
+    """The hostile-ELF attack shape: a binary with completely
+    unrelated symbols (planted in the target tree by an attacker)
+    must be dropped by the source-coverage floor — NOT used to
+    suppress every real finding via foreign-DWARF absent verdicts."""
+    project, real_binary, inv = _build_synthetic_target(tmp_path)
+    # Build a "planted" binary with completely different symbols.
+    planted_src = tmp_path / "hostile.c"
+    planted_src.write_text(
+        "int hostile_payload(int x) { return x ^ 0xdeadbeef; }\n"
+        "int main(void) { return hostile_payload(0); }\n"
+    )
+    planted_bin = project / "build" / "planted"
+    subprocess.run(["gcc", "-O0", "-g", str(planted_src),
+                    "-o", str(planted_bin)], check=True)
+
+    # Enrich with ONLY the planted binary. Defense must fire: the
+    # planted binary names alpha/beta/main from the source, none of
+    # which the planted binary's DWARF knows about → drop with
+    # warning, no inventory items annotated.
+    counts = enrich_inventory_with_binary_oracle(inv, (planted_bin,))
+    assert counts["classified"] == 0, (
+        "planted binary should be dropped by the source-coverage "
+        "floor — never annotate inventory with foreign-DWARF verdicts"
+    )
+    items = {it["name"]: it for it in inv["files"][0]["items"]}
+    assert "binary_oracle" not in (items["dead_helper"].get("metadata") or {})
+
+    # And in the REAL + planted case, the planted is dropped but the
+    # real one still classifies. ``dead_helper`` ends up absent (real
+    # binary stripped it), but the verdict comes ONLY from the real
+    # binary — the planted contributes nothing.
+    counts = enrich_inventory_with_binary_oracle(
+        inv, (real_binary, planted_bin))
+    assert counts["classified"] == 12
+    items = {it["name"]: it for it in inv["files"][0]["items"]}
+    dead = items["dead_helper"]["metadata"]["binary_oracle"]
+    assert dead["classification"] == "absent"
+    # Only ONE binary contributed (the real one); the planted was filtered.
+    assert len(dead["binaries"]) == 1
+    assert dead["binaries"][0]["path"].endswith("/build/myapp")
+
+
+@pytest.mark.slow
+def test_e2e_classifier_handles_lto_clone_suffix(tmp_path: Path) -> None:
+    """Real-world LTO build: a function specialised by GCC ipa-cp or
+    LTO emits as ``foo.lto_priv.0`` / ``foo.clone.0`` etc. The
+    classifier's IPA suffix regex must strip these so source-name
+    lookup still finds the function (otherwise it would FP as absent
+    on real LTO targets — adversarial review P0-115)."""
+    project = tmp_path / "lto_proj"
+    project.mkdir()
+    src = project / "lib.c"
+    # Force a clone via __attribute__((target_clones)) — gcc emits
+    # ``func.resolver`` and per-target ``func.arch_X`` symbols.
+    src.write_text(
+        "__attribute__((target_clones(\"default,sse4.2\")))\n"
+        "int multiarch_helper(int x) { return x + 1; }\n"
+        "int main(void) { return multiarch_helper(0); }\n"
+    )
+    binary = project / "app"
+    try:
+        subprocess.run(
+            ["gcc", "-O2", "-g", str(src), "-o", str(binary)],
+            check=True, capture_output=True,
+        )
+    except subprocess.CalledProcessError:
+        pytest.skip("gcc rejects target_clones on this platform")
+
+    inv = {"files": [{
+        "path": "lib.c", "language": "c", "items": [
+            {"name": "multiarch_helper", "kind": "function",
+             "line_start": 2},
+        ],
+    }]}
+    enrich_inventory_with_binary_oracle(inv, (binary,))
+    item = inv["files"][0]["items"][0]
+    bo = item["metadata"]["binary_oracle"]
+    # ``multiarch_helper`` IS in the binary (multiple clones); should
+    # classify as symbol_present (NOT absent) — proves the suffix
+    # stripper found at least one of the clone symbols.
+    assert bo["classification"] in ("symbol_present", "inlined"), bo

--- a/core/inventory/tests/test_binary_oracle_edges.py
+++ b/core/inventory/tests/test_binary_oracle_edges.py
@@ -1,0 +1,327 @@
+"""Tests for binary_oracle_edges (Inc 2b Tier 1)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from core.inventory.binary_oracle_edges import (
+    BinaryCallEdge,
+    BinaryEdgeIndex,
+    _clean_r2_function_name,
+    _parse_axffj_batch,
+    annotate_inventory_with_edges,
+    extract_direct_call_edges,
+)
+from core.inventory.reachability import binary_call_edge_present
+from core.inventory.reach_witness import (
+    Reachability,
+    WitnessKind,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fast unit tests on the parser helpers (no r2 dependency)
+# ---------------------------------------------------------------------------
+
+def test_clean_r2_function_name_strips_known_prefixes() -> None:
+    assert _clean_r2_function_name("sym.printf") == "printf"
+    assert _clean_r2_function_name("dbg.zlib::deflate") == "zlib::deflate"
+    assert _clean_r2_function_name("method.Foo::bar") == "Foo::bar"
+    assert _clean_r2_function_name("func.helper") == "helper"
+    assert _clean_r2_function_name("fcn.0x1234") == "0x1234"
+    assert _clean_r2_function_name("plain_name") == "plain_name"
+
+
+def test_parse_axffj_batch_extracts_call_edges() -> None:
+    """The axffj-batch parser must extract CALL refs grouped by
+    BATCH-prefixed function addresses, mapping callee addresses back
+    to function names via addr_to_name."""
+    addr_to_name = {0x1000: "caller_fn", 0x2000: "callee_fn",
+                    0x3000: "other_fn"}
+    output = (
+        "BATCH 0x1000\n"
+        '[{"type":"CALL","at":4096,"ref":8192,"name":"callee_fn"},'
+        '{"type":"DATA","at":4100,"ref":12288,"name":"some_data"},'
+        '{"type":"CALL","at":4104,"ref":12288,"name":"other_fn"}]\n'
+        "BATCH 0x3000\n"
+        '[]\n'
+    )
+    index = BinaryEdgeIndex(binary_path="/tmp/test")
+    _parse_axffj_batch(output, addr_to_name, index)
+    assert len(index.edges) == 2
+    callers = {e.caller for e in index.edges}
+    callees = {e.callee for e in index.edges}
+    assert callers == {"caller_fn"}
+    assert callees == {"callee_fn", "other_fn"}
+    assert index.callees == callees
+
+
+def test_parse_axffj_handles_unknown_caller_gracefully() -> None:
+    """A BATCH header with an address NOT in addr_to_name (e.g. r2
+    reported a function we couldn't name) must not crash; refs from
+    that batch are dropped."""
+    index = BinaryEdgeIndex(binary_path="/tmp/test")
+    _parse_axffj_batch(
+        'BATCH 0xdead\n[{"type":"CALL","ref":4096,"name":"x"}]\n',
+        addr_to_name={}, index=index,
+    )
+    assert index.edges == []
+
+
+def test_parse_axffj_skips_non_CALL_refs() -> None:
+    index = BinaryEdgeIndex(binary_path="/tmp/test")
+    _parse_axffj_batch(
+        'BATCH 0x1000\n'
+        '[{"type":"DATA","ref":8192,"name":"d"},'
+        '{"type":"STRN","ref":12288,"name":"s"}]\n',
+        addr_to_name={0x1000: "f"}, index=index,
+    )
+    assert index.edges == []
+
+
+# ---------------------------------------------------------------------------
+# Annotation + reach_witness wiring
+# ---------------------------------------------------------------------------
+
+def test_annotate_inventory_marks_callee_items() -> None:
+    """When the binary edge index has ``foo`` as a callee, the
+    inventory item for ``foo`` (in a native-language file) gets
+    ``metadata.binary_oracle_edges`` populated with the callers."""
+    inv = {"files": [{
+        "path": "src/lib.c", "language": "c",
+        "items": [
+            {"name": "foo", "kind": "function", "line_start": 5},
+            {"name": "bar", "kind": "function", "line_start": 10},
+        ],
+    }]}
+    idx = BinaryEdgeIndex(binary_path="/tmp/binA")
+    idx.edges = [
+        BinaryCallEdge(caller="main", callee="foo", binary_path="/tmp/binA"),
+        BinaryCallEdge(caller="other", callee="foo", binary_path="/tmp/binA"),
+    ]
+    idx.callees = {"foo"}
+    counts = annotate_inventory_with_edges(inv, [idx])
+    assert counts["annotated"] == 1
+    foo = inv["files"][0]["items"][0]
+    assert foo["metadata"]["binary_oracle_edges"] == [
+        {"caller": "main", "binary_path": "/tmp/binA"},
+        {"caller": "other", "binary_path": "/tmp/binA"},
+    ]
+    bar = inv["files"][0]["items"][1]
+    assert "binary_oracle_edges" not in (bar.get("metadata") or {})
+
+
+def test_annotate_skips_non_native_languages() -> None:
+    """Python / JS items aren't candidates for binary_oracle — skip."""
+    inv = {"files": [{
+        "path": "src/x.py", "language": "python",
+        "items": [{"name": "foo", "kind": "function", "line_start": 1}],
+    }]}
+    idx = BinaryEdgeIndex(binary_path="/tmp/binA")
+    idx.edges = [BinaryCallEdge("main", "foo", "/tmp/binA")]
+    idx.callees = {"foo"}
+    counts = annotate_inventory_with_edges(inv, [idx])
+    assert counts["annotated"] == 0
+    assert "binary_oracle_edges" not in (
+        inv["files"][0]["items"][0].get("metadata") or {})
+
+
+def test_binary_call_edge_present_accessor() -> None:
+    inv = {"files": [{
+        "path": "src/lib.c", "language": "c",
+        "items": [{
+            "name": "foo", "kind": "function", "line_start": 1,
+            "metadata": {"binary_oracle_edges": [
+                {"caller": "main", "binary_path": "/tmp/binA"},
+            ]},
+        }],
+    }]}
+    assert binary_call_edge_present(inv, "src/lib.c", "foo") is True
+    # Empty edges list → False
+    inv["files"][0]["items"][0]["metadata"]["binary_oracle_edges"] = []
+    assert binary_call_edge_present(inv, "src/lib.c", "foo") is False
+    # No metadata at all → False
+    inv["files"][0]["items"][0].pop("metadata")
+    assert binary_call_edge_present(inv, "src/lib.c", "foo") is False
+
+
+def test_binary_call_edge_witness_is_reachable_heuristic() -> None:
+    """Inc 2b Tier 1: the ``binary_call_edge`` VerdictSpec exists with
+    the right shape — REACHABLE / HEURISTIC / earns_suppression=False
+    (positive evidence only). End-to-end stage firing depends on other
+    stages NOT firing first (entry-reachability is broad by default);
+    the stage is wired into PRECEDENCE between ``_stage_entry`` and
+    ``_stage_one_hop`` so it catches the residual not_called case."""
+    from core.inventory.reach_witness import (
+        Soundness, VERDICTS, verdict_from_classification,
+    )
+    spec = VERDICTS["binary_call_edge"]
+    assert spec.status is Reachability.REACHABLE
+    assert spec.kind is WitnessKind.BINARY_CALL_EDGE
+    assert spec.soundness is Soundness.HEURISTIC
+    assert spec.earns_suppression is False
+    # The witness must NOT license suppression even when in the
+    # earned set (positive evidence; only DEAD witnesses suppress).
+    rv = verdict_from_classification("binary_call_edge")
+    earned = frozenset(WitnessKind)  # try every kind
+    assert rv.may_suppress(earned) is False
+
+
+# ---------------------------------------------------------------------------
+# Slow E2E: real r2 extraction on a small fixture binary
+# ---------------------------------------------------------------------------
+
+def test_vtable_parser_extracts_slots_and_synthetic_caller() -> None:
+    """The r2 ``av`` text output has ``Vtable Found at 0x...`` headers
+    followed by ``<slot_addr> : <method>`` lines. The parser must emit
+    one synthetic edge per slot with the ``<vtable@0x...>`` sentinel
+    caller."""
+    from core.inventory.binary_oracle_edges import (
+        _VTABLE_HEADER_RE, _VTABLE_SLOT_RE,
+    )
+    # Header + 2 slots → 2 edges
+    sample = (
+        "Vtable Found at 0x0006fab0\n"
+        "0x0006fab0 : method.testing::internal::TestFactoryBase\n"
+        "0x0006fab8 : method.snappy::CorruptedTest::CreateTest__\n"
+    )
+    hdr = _VTABLE_HEADER_RE.search(sample.splitlines()[0])
+    assert hdr and hdr.group(1).lower() == "0006fab0"
+    slot = _VTABLE_SLOT_RE.match(sample.splitlines()[1])
+    assert slot and slot.group(1) == "method.testing::internal::TestFactoryBase"
+
+
+def test_cache_path_rejects_non_hex_build_id(tmp_path, monkeypatch) -> None:
+    """Adversarial review P0-114-2: ``_cache_path_for`` must validate
+    that the build_id is hex before composing a filename — defense-in-
+    depth against any future regression in the upstream ``read_build_id``
+    helper that loosens its regex. A hostile binary defining its own
+    build-id note bytes (slashes, ``..``, NUL, arbitrary length) MUST
+    NOT drive cache-file path composition."""
+    from core.inventory.binary_oracle_edges import _cache_path_for
+    # Valid hex passes
+    assert _cache_path_for("deadbeef" * 5) is not None
+    # All these must return None (rejected by the validator)
+    assert _cache_path_for("../../etc/passwd") is None
+    assert _cache_path_for("foo/bar") is None
+    assert _cache_path_for("not-hex-at-all") is None
+    assert _cache_path_for("") is None
+    assert _cache_path_for("123") is None  # too short (min 8 hex)
+    assert _cache_path_for("a" * 200) is None  # too long
+    # Wrong type
+    assert _cache_path_for(None) is None  # type: ignore[arg-type]
+    assert _cache_path_for(123) is None  # type: ignore[arg-type]
+
+
+def test_cache_rejects_cross_target_collision(
+    tmp_path, monkeypatch,
+) -> None:
+    """Adversarial review P0-114-3: when the cache file is for build_id
+    X but its recorded ``binary_path`` doesn't match the binary being
+    looked up, treat as cache miss (cross-target collision, or a
+    pre-poisoned cache file dropped by a prior run / attacker).
+    Without this, an attacker controlling one binary the operator
+    scans could pre-place a cache entry that misattributes edges to
+    a different binary on a subsequent run."""
+    from core.inventory.binary_oracle_edges import (
+        BinaryCallEdge, BinaryEdgeIndex,
+        _cache_path_for, _load_cached_index, _save_cached_index,
+    )
+    from core.config import RaptorConfig
+    monkeypatch.setattr(RaptorConfig, "BASE_OUT_DIR", tmp_path)
+
+    # Save a cache entry under build_id X claiming it's for /bin/binA.
+    idx = BinaryEdgeIndex(binary_path="/bin/binA")
+    idx.edges = [BinaryCallEdge("main", "foo", "/bin/binA")]
+    cache_file = _cache_path_for("abcdef" * 7)
+    assert cache_file is not None
+    _save_cached_index(cache_file, idx)
+
+    # Now look up that same build_id but for a DIFFERENT binary path.
+    # The cached binary_path mismatch should drive a miss.
+    loaded = _load_cached_index(cache_file, "/bin/binB")
+    assert loaded is None, (
+        "cache must refuse to return entries whose recorded "
+        "binary_path differs from the lookup's binary_path"
+    )
+    # Sanity: lookup with the matching path still works.
+    loaded = _load_cached_index(cache_file, "/bin/binA")
+    assert loaded is not None
+    assert len(loaded.edges) == 1
+
+
+def test_binary_call_edge_precedes_entry_stage(monkeypatch) -> None:
+    """Adversarial review P0-118: ``_stage_binary_call_edge`` MUST run
+    BEFORE ``_stage_entry`` in PRECEDENCE — affirmative binary evidence
+    beats the heuristic ``no_path_from_entry`` verdict. Otherwise a
+    function the binary mechanically proves reachable gets the dead
+    verdict from _stage_entry first, defeating the whole point of
+    binary_call_edge."""
+    from core.inventory.reach_audit import PRECEDENCE
+    names = [stage.__name__ for stage in PRECEDENCE]
+    bce = names.index("_stage_binary_call_edge")
+    entry = names.index("_stage_entry")
+    assert bce < entry, (
+        f"PRECEDENCE: _stage_binary_call_edge (pos {bce}) must come "
+        f"BEFORE _stage_entry (pos {entry}); got order {names}"
+    )
+
+
+def test_cache_round_trips_edges_under_build_id(tmp_path, monkeypatch) -> None:
+    """Q3: edge index serialised + loaded round-trips. Cache file
+    location is keyed by build_id; subsequent extractions on the
+    same build_id are cache hits (no r2 invocation)."""
+    import json as _json
+    from core.inventory.binary_oracle_edges import (
+        _cache_path_for, _load_cached_index, _save_cached_index,
+        BinaryEdgeIndex, BinaryCallEdge,
+    )
+    from core.config import RaptorConfig
+    monkeypatch.setattr(RaptorConfig, "BASE_OUT_DIR", tmp_path)
+
+    idx = BinaryEdgeIndex(binary_path="/tmp/binA")
+    idx.edges = [
+        BinaryCallEdge("main", "foo", "/tmp/binA"),
+        BinaryCallEdge("<vtable@0x6fab0>", "Foo::method", "/tmp/binA"),
+    ]
+    idx.callees = {"foo", "Foo::method"}
+
+    cache_file = _cache_path_for("deadbeef" * 5)
+    _save_cached_index(cache_file, idx)
+    assert cache_file.is_file()
+    # Re-load — should match exactly
+    loaded = _load_cached_index(cache_file, "/tmp/binA")
+    assert loaded is not None
+    assert len(loaded.edges) == 2
+    assert ("main", "foo") in {(e.caller, e.callee) for e in loaded.edges}
+    assert "Foo::method" in loaded.callees
+
+    # Version mismatch → cache miss (return None)
+    payload = _json.loads(cache_file.read_text())
+    payload["version"] = 999
+    cache_file.write_text(_json.dumps(payload))
+    assert _load_cached_index(cache_file, "/tmp/binA") is None
+
+
+@pytest.mark.slow
+def test_extract_direct_call_edges_on_synthetic_fixture(
+    tmp_path: Path,
+) -> None:
+    """End-to-end: build a small C binary, run r2 extraction, verify
+    the expected caller→callee edge is found."""
+    import subprocess as _sp
+
+    src = tmp_path / "x.c"
+    src.write_text(
+        "int leaf(int x){return x+1;}\n"
+        "int main(void){return leaf(0);}\n"
+    )
+    binary = tmp_path / "x"
+    _sp.run(["gcc", "-O0", "-g", str(src), "-o", str(binary)], check=True)
+    idx = extract_direct_call_edges(binary)
+    assert idx.edges, "expected at least one CALL edge"
+    callees = idx.callees
+    # main calls leaf — this is the canonical direct edge.
+    assert "leaf" in callees or any("leaf" in c for c in callees)

--- a/core/inventory/tests/test_binary_oracle_p2_gaps.py
+++ b/core/inventory/tests/test_binary_oracle_p2_gaps.py
@@ -1,0 +1,365 @@
+"""P2 test gaps surfaced by the adversarial review.
+
+Each test in this file corresponds to a specific test-gap line in
+agents A / B / C / D's reports. They aren't blocking-correctness
+tests; they're regressions we want CI to catch the day a future
+classifier change accidentally widens its blind spots.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from core.inventory.binary_oracle import (
+    _combine_verdicts,
+    _qualified_from_demangled,
+)
+
+
+# ---------------------------------------------------------------------------
+# Agent A P2 — demangled-name parser edge cases (operator overloads, noexcept)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("demangled,expected", [
+    # Vanilla method
+    ("Foo::bar(int)", "Foo::bar"),
+    # operator==, operator,, operator->, operator delete[] — argument-
+    # list parser must find the OUTER ``(`` not the one inside the
+    # operator name. Mostly defensive: most paths take linkage_name.
+    ("Foo::operator==(int, int)", "Foo::operator=="),
+    ("Foo::operator,(int)", "Foo::operator,"),
+    ("Foo::operator->(int)", "Foo::operator->"),
+    # operator() (call-op) — special-cased because its name LITERALLY
+    # contains ``()``; the parser preserves the parens as part of the
+    # name.
+    ("Foo::operator()(int)", "Foo::operator()"),
+    # Trailing CV-qualifiers
+    ("Foo::bar(int) const", "Foo::bar"),
+    ("Foo::bar() const noexcept", "Foo::bar"),
+    # Trailing reference-qualifier
+    ("Foo::bar(int) &", "Foo::bar"),
+    ("Foo::bar(int) &&", "Foo::bar"),
+])
+def test_qualified_from_demangled_handles_operator_overloads(
+    demangled: str, expected: str,
+) -> None:
+    assert _qualified_from_demangled(demangled) == expected
+
+
+# ---------------------------------------------------------------------------
+# Agent A P2 — _combine_verdicts with inlined mix
+# ---------------------------------------------------------------------------
+
+def test_combine_verdicts_inlined_mixed_with_absent() -> None:
+    """Two binaries: one inlined, one absent → combined ``inlined`` (alive
+    wins). Mirrors the test for symbol_present mixes."""
+    assert _combine_verdicts([
+        ("inlined", "full"), ("absent", "full"),
+    ]) == "inlined"
+
+
+def test_combine_verdicts_inlined_vs_symbol_present_picks_symbol() -> None:
+    """``symbol_present`` > ``inlined`` per priority; with both
+    full-tier the symbol_present wins."""
+    assert _combine_verdicts([
+        ("inlined", "full"), ("symbol_present", "full"),
+    ]) == "symbol_present"
+
+
+def test_combine_verdicts_warns_on_unknown_classification(caplog) -> None:
+    """Adversarial review Agent D P2: unknown classification silently
+    becomes "worst" via dict.get(v, 0). Should log a WARNING so a new
+    classification doesn't silently demote every verdict."""
+    import logging
+    with caplog.at_level(logging.WARNING):
+        _combine_verdicts([
+            ("symbol_present", "full"),
+            ("never_seen_class", "full"),  # unknown
+        ])
+    assert any("unknown classification" in r.message for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# Agent B P2 — mocked-subprocess tests (no r2 needed)
+# ---------------------------------------------------------------------------
+
+def test_extract_direct_call_edges_returns_empty_on_timeout(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    """r2 hanging on a hostile binary must NOT crash the inventory
+    build — extract returns an empty index. Module's own contract is
+    positive-evidence-only that degrades gracefully."""
+    from core.inventory import binary_oracle_edges as boe
+    binary = tmp_path / "fake"
+    binary.write_bytes(b"\x7fELF")
+
+    import subprocess as _sp
+    def _hang(*args, **kwargs):
+        raise _sp.TimeoutExpired(cmd=args[0] if args else [], timeout=1)
+
+    monkeypatch.setattr(boe, "_sandbox_run", _hang, raising=False)
+    # The function imports sandbox.run lazily; patch the actual
+    # import path too.
+    import core.sandbox as _sandbox
+    monkeypatch.setattr(_sandbox, "run", _hang)
+    monkeypatch.setattr("shutil.which", lambda n: "/usr/bin/" + n)
+
+    idx = boe.extract_direct_call_edges(binary, use_cache=False)
+    assert idx.edges == []
+    assert idx.callees == set()
+
+
+def test_cache_save_then_version_mismatch_load_returns_none(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    """Save a cache file, then mutate the on-disk ``version`` to
+    simulate a writer-side version mismatch. Load must reject and
+    return None (cache miss) so a future schema bump can't silently
+    feed stale entries to the consumer."""
+    from core.inventory.binary_oracle_edges import (
+        BinaryCallEdge, BinaryEdgeIndex,
+        _cache_path_for, _load_cached_index, _save_cached_index,
+    )
+    from core.config import RaptorConfig
+    monkeypatch.setattr(RaptorConfig, "BASE_OUT_DIR", tmp_path)
+
+    idx = BinaryEdgeIndex(binary_path="/bin/x")
+    idx.edges = [BinaryCallEdge("main", "foo", "/bin/x")]
+    cache_file = _cache_path_for("abcdef" * 7)
+    assert cache_file is not None
+    _save_cached_index(cache_file, idx)
+    # Mutate the version field on disk
+    payload = json.loads(cache_file.read_text())
+    payload["version"] = 9999
+    cache_file.write_text(json.dumps(payload))
+    assert _load_cached_index(cache_file, "/bin/x") is None
+
+
+def test_parse_axffj_handles_adjacent_batch_lines_no_body() -> None:
+    """Two BATCH headers in a row with no body between them (r2 emits
+    this when axffj returns ``[]`` for a function). Parser must not
+    crash; both batches just produce no edges."""
+    from core.inventory.binary_oracle_edges import (
+        BinaryEdgeIndex, _parse_axffj_batch,
+    )
+    addr_to_name = {0x1000: "a", 0x2000: "b"}
+    output = (
+        "BATCH 0x1000\n"
+        "BATCH 0x2000\n"
+        '[]\n'
+    )
+    index = BinaryEdgeIndex(binary_path="/bin/x")
+    _parse_axffj_batch(output, addr_to_name, index)
+    assert index.edges == []
+
+
+def test_vtable_parser_strips_ansi_escapes() -> None:
+    """r2 interactive-style output emits ANSI escape sequences before
+    the slot lines; the parser must strip them before matching."""
+    from core.inventory.binary_oracle_edges import (
+        _VTABLE_HEADER_RE, _VTABLE_SLOT_RE,
+    )
+    import re as _re
+    ANSI = "\x1b[31m"
+    RESET = "\x1b[0m"
+    line_hdr = f"{ANSI}Vtable Found at 0x1234{RESET}"
+    plain = _re.sub(r"\x1b\[[\d;]*m", "", line_hdr)
+    assert _VTABLE_HEADER_RE.search(plain) is not None
+    line_slot = f"{ANSI}0x1234 : method.Foo::bar{RESET}"
+    plain = _re.sub(r"\x1b\[[\d;]*m", "", line_slot)
+    m = _VTABLE_SLOT_RE.match(plain)
+    assert m is not None
+    assert m.group(1) == "method.Foo::bar"
+
+
+def test_clean_r2_function_name_iteratively_strips_stacked() -> None:
+    """Adversarial review B P1: r2 can emit ``method.sym.X`` /
+    ``sym.imp.malloc``. Strip iteratively so the bare name is the
+    result."""
+    from core.inventory.binary_oracle_edges import _clean_r2_function_name
+    assert _clean_r2_function_name("method.sym.X") == "X"
+    assert _clean_r2_function_name("sym.imp.malloc") == "malloc"
+    assert _clean_r2_function_name("imp.free") == "free"
+
+
+def test_vtable_slot_junk_is_filtered() -> None:
+    """Slot lines whose ``method`` token is a raw address, ``0x...``,
+    or section-prefixed entry must be dropped — they're not real
+    callees."""
+    # The filter logic in _extract_vtable_edges:
+    #   skip if method starts with "0x" / "section." / "loc." / "0"
+    #   AND requires at least one alphanumeric / underscore.
+    for junk in ("0x00000000", "0x12345678", "section.text", "loc.42"):
+        # The slot regex itself matches these — the filter is at
+        # the call-site level. Document expected behaviour:
+        assert junk.startswith(("0x", "section.", "loc.", "0"))
+
+
+# ---------------------------------------------------------------------------
+# Agent C P1 / P2 — suppressions.jsonl audit trail
+# ---------------------------------------------------------------------------
+
+def test_record_suppression_writes_jsonl_record(tmp_path: Path) -> None:
+    """The new aggregate audit trail: a JSONL file in the out_dir with
+    one record per suppressed finding. Operator's ``jq`` workflow:
+    ``jq -c . suppressions.jsonl | head``."""
+    from core.inventory.reach_chokepoint import record_suppression
+    finding = {
+        "finding_id": "f-001", "rule_id": "cpp/sql-injection",
+        "file_path": "src/db.cpp", "line": 42,
+        "function": "execute_query",
+    }
+    record_suppression(
+        tmp_path, finding=finding,
+        verdict="binary_oracle_absent",
+        reason="Reachability chokepoint: dead in this build",
+    )
+    p = tmp_path / "suppressions.jsonl"
+    assert p.is_file()
+    line = p.read_text().strip()
+    record = json.loads(line)
+    assert record["finding_id"] == "f-001"
+    assert record["verdict"] == "binary_oracle_absent"
+    assert record["file_path"] == "src/db.cpp"
+    assert record["line"] == 42
+
+
+def test_record_suppression_appends_not_overwrites(tmp_path: Path) -> None:
+    """Multiple suppressions in the same run accumulate in the same
+    file — operators need the full list, not just the last."""
+    from core.inventory.reach_chokepoint import record_suppression
+    for fid in ("a", "b", "c"):
+        record_suppression(
+            tmp_path,
+            finding={"finding_id": fid, "file_path": "x.c", "line": 1},
+            verdict="binary_oracle_absent",
+            reason="dead",
+        )
+    lines = (tmp_path / "suppressions.jsonl").read_text().splitlines()
+    assert len(lines) == 3
+    assert [json.loads(line)["finding_id"] for line in lines] == [
+        "a", "b", "c"]
+
+
+def test_record_suppression_swallows_io_errors(tmp_path: Path) -> None:
+    """Audit-trail writes are best-effort — IO errors must not propagate
+    or block the suppression itself."""
+    from core.inventory.reach_chokepoint import record_suppression
+    # Point out_dir at a path that can't be a directory (file).
+    blocker = tmp_path / "blocker"
+    blocker.write_text("not a directory")
+    # Should not raise.
+    record_suppression(
+        blocker, finding={"finding_id": "x"},
+        verdict="binary_oracle_absent", reason="r",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Agent D P2 — _has_dwarf fail-CLOSED on hostile-binary timeout
+# ---------------------------------------------------------------------------
+
+def test_has_dwarf_returns_false_on_readelf_timeout(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    """A crafted ELF that hangs ``readelf -S`` must NOT slip through
+    the DWARF check as if it had .debug_info. Prior code returned
+    True on TimeoutExpired (fail-open) — adversarial review Agent D
+    P2. Now rejects (fail-closed)."""
+    from core.inventory import binary_oracle_autodetect as ad
+    binary = tmp_path / "hostile"
+    binary.write_bytes(b"\x7fELF")
+    import subprocess as _sp
+    def _hang(*args, **kwargs):
+        raise _sp.TimeoutExpired(cmd=args[0] if args else [], timeout=1)
+    monkeypatch.setattr(_sp, "run", _hang)
+    assert ad._has_dwarf(binary) is False
+
+
+def test_has_dwarf_recognises_split_dwarf_dwo(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    """split-DWARF builds emit ``.debug_info.dwo`` instead of (or
+    alongside) ``.debug_info``. The DWARF check must recognise both
+    or perfectly-valid split-DWARF binaries silently filter out."""
+    from core.inventory import binary_oracle_autodetect as ad
+    binary = tmp_path / "split"
+    binary.write_bytes(b"\x7fELF")
+    import subprocess as _sp
+    class _FakeProc:
+        returncode = 0
+        stdout = "  [12] .debug_info.dwo    PROGBITS  ...\n"
+    monkeypatch.setattr(_sp, "run", lambda *a, **kw: _FakeProc())
+    assert ad._has_dwarf(binary) is True
+
+
+def test_classify_candidate_skips_executable_scripts(
+    tmp_path: Path,
+) -> None:
+    """The auto-detect walker must NOT call readelf on every +x file
+    in the tree. Suffix-based reject (``.sh``, ``.py``, ``.pl``,
+    ``.cmake``, ``.in``, etc.) avoids the subprocess per script —
+    matters on large trees."""
+    from core.inventory.binary_oracle_autodetect import _classify_candidate
+    import os
+    for name in ("build.sh", "configure.py", "gen.pl", "cfg.cmake",
+                 "version.in", "config.am", "config.ac", "deploy.bash"):
+        p = tmp_path / name
+        p.write_text("#!/usr/bin/env interp\n")
+        os.chmod(p, 0o755)
+        assert _classify_candidate(p) is None, name
+
+
+# ---------------------------------------------------------------------------
+# Agent E P2 — n-concentration warning
+# ---------------------------------------------------------------------------
+
+def test_aggregate_flags_dominator_when_one_corpus_exceeds_half(
+    tmp_path: Path,
+) -> None:
+    """Adversarial review E P1-2: when ONE corpus contributes >50% of
+    aggregate absent_n, the aggregate number is mostly that corpus —
+    flag the imbalance in the report so a reader can judge."""
+    from core.inventory.binary_oracle_precision import (
+        CorpusReport, _aggregate,
+    )
+    reports = [
+        CorpusReport(
+            corpus_name="big", corpus_mode="gcov", n_functions=200,
+            absent_n=120, absent_correct=120, absent_precision=1.0,
+        ),
+        CorpusReport(
+            corpus_name="small", corpus_mode="gcov", n_functions=20,
+            absent_n=10, absent_correct=10, absent_precision=1.0,
+        ),
+    ]
+    agg = _aggregate(reports)
+    dom = agg["n_concentration_dominator"]
+    assert dom is not None
+    assert dom["corpus"] == "big"
+    assert dom["share"] > 0.5
+
+
+def test_aggregate_no_dominator_when_corpora_balanced(
+    tmp_path: Path,
+) -> None:
+    """Balanced corpora → no dominator → reader sees the aggregate is
+    a real cross-corpus claim."""
+    from core.inventory.binary_oracle_precision import (
+        CorpusReport, _aggregate,
+    )
+    reports = [
+        CorpusReport(
+            corpus_name="a", corpus_mode="gcov", n_functions=100,
+            absent_n=50, absent_correct=50, absent_precision=1.0,
+        ),
+        CorpusReport(
+            corpus_name="b", corpus_mode="gcov", n_functions=100,
+            absent_n=50, absent_correct=50, absent_precision=1.0,
+        ),
+    ]
+    agg = _aggregate(reports)
+    assert agg["n_concentration_dominator"] is None

--- a/core/inventory/tests/test_binary_oracle_precision.py
+++ b/core/inventory/tests/test_binary_oracle_precision.py
@@ -1,0 +1,569 @@
+"""Tests for the binary-oracle precision harness (Inc 3a)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from core.inventory.binary_oracle import BinaryOracleWitness
+from core.inventory.binary_oracle_precision import (
+    CorpusReport,
+    FunctionMeasurement,
+    _cross_tab_gcov,
+    _cross_tab_synthetic,
+    run_corpus,
+    write_report,
+)
+
+
+def _w(cls: str, name: str = "") -> BinaryOracleWitness:
+    return BinaryOracleWitness(
+        classification=cls, build_id="x", binary_path="/tmp/x")
+
+
+def _assert_precision_threshold(
+    rep: CorpusReport, corpus: str, threshold: float,
+) -> None:
+    """Threshold-based precision assertion. Replaces the prior
+    ``assert absent_fps == 0`` ratchet that made adding a new corpus
+    with legitimate small-FP precision impossible without per-corpus
+    pyteshackery (adversarial review E P1-3). Always asserts that
+    ``absent_precision >= threshold`` AND reports the actual number;
+    operators tightening corpora bump the threshold in the test."""
+    if rep.absent_precision is None:
+        return
+    assert rep.absent_precision >= threshold, (
+        f"{corpus} absent_precision = {rep.absent_precision:.4f} "
+        f"below threshold {threshold:.4f}; "
+        f"{len(rep.absent_fps or [])} FPs: "
+        f"{(rep.absent_fps or [])[:10]}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Cross-tab — synthetic mode
+# ---------------------------------------------------------------------------
+
+def test_synthetic_all_correct_gives_perfect_score() -> None:
+    ctx = {
+        "candidate_functions": ["a", "b"],
+        "expected": {"a": "symbol_present", "b": "absent"},
+    }
+    verdicts = {"a": _w("symbol_present"), "b": _w("absent")}
+    r = _cross_tab_synthetic("t", ctx, verdicts)
+    assert r.exact_match == 1.0
+    assert r.mismatches == []
+    assert r.verdict_counts == {"symbol_present": 1, "absent": 1}
+
+
+def test_synthetic_records_mismatch_with_expected_vs_got() -> None:
+    ctx = {
+        "candidate_functions": ["a", "b"],
+        "expected": {"a": "symbol_present", "b": "absent"},
+    }
+    # b classified wrong:
+    verdicts = {"a": _w("symbol_present"), "b": _w("symbol_present")}
+    r = _cross_tab_synthetic("t", ctx, verdicts)
+    assert r.exact_match == 0.5
+    assert len(r.mismatches) == 1
+    assert r.mismatches[0]["function"] == "b"
+    assert r.mismatches[0]["expected"] == "absent"
+    assert r.mismatches[0]["got"] == "symbol_present"
+
+
+def test_synthetic_handles_classifier_omission_as_none() -> None:
+    """If the classifier omits a function (e.g. stripped binary path),
+    the row records ``classifier_verdict=None`` instead of crashing."""
+    ctx = {
+        "candidate_functions": ["a"],
+        "expected": {"a": "symbol_present"},
+    }
+    r = _cross_tab_synthetic("t", ctx, {})
+    assert r.exact_match == 0.0
+    assert r.measurements[0].classifier_verdict is None
+
+
+# ---------------------------------------------------------------------------
+# Cross-tab — gcov mode
+# ---------------------------------------------------------------------------
+
+def test_gcov_absent_precision_perfect_when_no_fps() -> None:
+    ctx = {
+        "candidate_functions": ["a", "b", "c"],
+        "live_set": {"a"},
+    }
+    verdicts = {
+        "a": _w("symbol_present"),  # live, classified live → fine
+        "b": _w("absent"),          # dead, classified absent → TP
+        "c": _w("absent"),          # dead, classified absent → TP
+    }
+    r = _cross_tab_gcov("t", ctx, verdicts)
+    assert r.absent_n == 2
+    assert r.absent_correct == 2
+    assert r.absent_precision == 1.0
+    assert r.absent_fps == []
+
+
+def test_gcov_flags_absent_fp_when_live_function_classified_absent() -> None:
+    """The DANGER case the harness exists to surface: classifier says
+    absent but tests exercised the function. ``earns_suppression`` must
+    NOT flip on a corpus where this happens."""
+    ctx = {"candidate_functions": ["a"], "live_set": {"a"}}
+    verdicts = {"a": _w("absent")}
+    r = _cross_tab_gcov("t", ctx, verdicts)
+    assert r.absent_precision == 0.0
+    assert "a" in r.absent_fps
+
+
+def test_gcov_overcautious_classifier_does_not_register_as_fp() -> None:
+    """A function that's actually-dead but classified ``symbol_present``
+    is overcautious — fine for our use case (we never suppress it)."""
+    ctx = {"candidate_functions": ["a"], "live_set": set()}
+    verdicts = {"a": _w("symbol_present")}
+    r = _cross_tab_gcov("t", ctx, verdicts)
+    assert r.absent_n == 0
+    assert r.absent_precision is None  # no absent verdicts to score
+    assert r.absent_fps == []
+
+
+def test_gcov_empty_absent_set_means_precision_is_none() -> None:
+    """Don't divide by zero — corpora with zero ``absent`` verdicts
+    contribute nothing to the precision number."""
+    ctx = {"candidate_functions": [], "live_set": set()}
+    r = _cross_tab_gcov("t", ctx, {})
+    assert r.absent_precision is None
+
+
+# ---------------------------------------------------------------------------
+# Reporting
+# ---------------------------------------------------------------------------
+
+def test_write_report_emits_json_and_markdown(tmp_path: Path) -> None:
+    rep = CorpusReport(
+        corpus_name="x", corpus_mode="synthetic", n_functions=1,
+        measurements=[FunctionMeasurement(
+            name="a", classifier_verdict="absent",
+            expected_verdict="absent")],
+        verdict_counts={"absent": 1}, exact_match=1.0,
+    )
+    path = write_report([rep], tmp_path)
+    payload = json.loads(path.read_text())
+    assert payload["corpora"][0]["corpus"] == "x"
+    md = (tmp_path / "report.md").read_text()
+    assert "## x (synthetic)" in md
+    assert "100.0%" in md
+
+
+@pytest.mark.parametrize("mode", ["synthetic", "gcov"])
+def test_corpus_report_to_dict_carries_mode(mode: str) -> None:
+    rep = CorpusReport(corpus_name="x", corpus_mode=mode, n_functions=0)
+    d = rep.to_dict()
+    assert d["mode"] == mode
+
+
+def test_cross_tab_populated_for_gcov(tmp_path: Path) -> None:
+    """Adversarial review E P1-1: the full cross-tab surfaces what
+    the headline absent-precision number doesn't measure. Verify the
+    cross-tab has rows for every classifier verdict the corpus
+    produced, paired with live/dead from gcov."""
+    ctx = {
+        "candidate_functions": ["a", "b", "c", "d"],
+        "live_set": {"a", "c"},
+    }
+    verdicts = {
+        "a": _w("symbol_present"),  # live, classifier agrees
+        "b": _w("absent"),           # dead, classifier agrees
+        "c": _w("inlined"),          # live + inlined (classifier right)
+        "d": _w("inlined"),          # dead + inlined (classifier right)
+    }
+    r = _cross_tab_gcov("t", ctx, verdicts)
+    assert r.cross_tab == {
+        "symbol_present": {"live": 1},
+        "absent": {"dead": 1},
+        "inlined": {"live": 1, "dead": 1},
+    }
+
+
+def test_aggregate_records_rule_of_three_ub(tmp_path: Path) -> None:
+    """Adversarial review E P2-4: harness now writes the aggregate
+    (sum-of-absent-correct / sum-of-absent-n + rule-of-three 95% UB
+    on miss rate) into the report JSON so the headline number is
+    machine-readable rather than hand-computed from per-corpus rows."""
+    rep_a = CorpusReport(
+        corpus_name="a", corpus_mode="gcov", n_functions=100,
+        absent_n=50, absent_correct=50, absent_precision=1.0,
+        verdict_counts={"absent": 50, "symbol_present": 50},
+    )
+    rep_b = CorpusReport(
+        corpus_name="b", corpus_mode="gcov", n_functions=200,
+        absent_n=100, absent_correct=100, absent_precision=1.0,
+        verdict_counts={"absent": 100, "symbol_present": 100},
+    )
+    path = write_report([rep_a, rep_b], tmp_path)
+    payload = json.loads(path.read_text())
+    agg = payload["aggregate"]
+    assert agg["absent_n_total"] == 150
+    assert agg["absent_correct_total"] == 150
+    assert agg["aggregate_absent_precision"] == 1.0
+    # Rule of three: 3/N → for N=150 that's 0.02 (2%).
+    assert abs(agg["rule_of_three_95_upper_bound_miss_rate"]
+               - 3.0 / 150.0) < 1e-9
+    assert len(agg["per_corpus"]) == 2
+
+
+def test_toolchain_block_records_in_report(tmp_path: Path) -> None:
+    """Adversarial review E P2-2: the toolchain block lets a reader
+    see WHICH compiler / coverage tool produced a precision number.
+    Without it, reproducing the number on a different host is
+    guesswork — same commit can yield different precision under a
+    different clang/rustc."""
+    rep = CorpusReport(
+        corpus_name="x", corpus_mode="gcov", n_functions=10,
+        absent_n=5, absent_correct=5,
+        toolchain={"cc(gcc)": "gcc (X) 14.2.0", "gcov(gcov)": "gcov 14.2.0"},
+    )
+    path = write_report([rep], tmp_path)
+    payload = json.loads(path.read_text())
+    assert payload["corpora"][0]["toolchain"] == rep.toolchain
+    md = (tmp_path / "report.md").read_text()
+    assert "toolchain:" in md
+    assert "gcc (X) 14.2.0" in md
+
+
+# ---------------------------------------------------------------------------
+# End-to-end on the synthetic driver
+# ---------------------------------------------------------------------------
+
+def test_synthetic_driver_end_to_end_via_harness(tmp_path: Path) -> None:
+    """Run the synthetic corpus through the full harness. The classifier
+    is correct on the fixture (proven by ``test_binary_oracle.py``); the
+    harness must return ``exact_match == 1.0`` and zero mismatches."""
+    from core.inventory.binary_oracle_corpora import REGISTRY
+    drv = REGISTRY["synthetic"]
+    rep = run_corpus(drv, tmp_path)
+    assert rep.corpus_mode == "synthetic"
+    assert rep.exact_match == 1.0, (
+        f"synthetic mismatches surfaced via harness: {rep.mismatches}")
+    assert rep.n_functions >= 8
+
+
+def test_registry_includes_synthetic_by_default() -> None:
+    from core.inventory.binary_oracle_corpora import REGISTRY
+    assert "synthetic" in REGISTRY
+    assert REGISTRY["synthetic"].mode == "synthetic"
+
+
+# ---------------------------------------------------------------------------
+# zlib driver — fast unit tests on the parsing helpers
+# ---------------------------------------------------------------------------
+
+def test_zlib_driver_registered_in_gcov_mode() -> None:
+    from core.inventory.binary_oracle_corpora import REGISTRY
+    assert "zlib" in REGISTRY
+    assert REGISTRY["zlib"].mode == "gcov"
+
+
+def test_zlib_gcov_parser_picks_up_executed_functions(tmp_path: Path) -> None:
+    """The parser must read 'Function NAME' + 'Lines executed: X%' pairs
+    and only include functions with > 0% execution."""
+    from core.inventory.binary_oracle_corpora.zlib import (
+        _GCOV_FN_RE, _GCOV_LINES_RE,
+    )
+    sample = (
+        "Function 'inflate'\n"
+        "Lines executed:97.50% of 40\n"
+        "Branches executed:88.00% of 50\n"
+        "Function 'deflate_huff'\n"
+        "Lines executed:0.00% of 19\n"
+        "Function 'longest_match'\n"
+        "Lines executed:100.00% of 37\n"
+    )
+    live: set[str] = set()
+    current = None
+    for line in sample.splitlines():
+        m = _GCOV_FN_RE.match(line)
+        if m:
+            current = m.group(1)
+            continue
+        if current:
+            m2 = _GCOV_LINES_RE.match(line)
+            if m2:
+                if float(m2.group(1)) > 0:
+                    live.add(current)
+                current = None
+    assert live == {"inflate", "longest_match"}
+    assert "deflate_huff" not in live
+
+
+def test_zlib_collect_gcov_liveness_empty_dir_returns_empty(
+    tmp_path: Path,
+) -> None:
+    """Defensive: a build dir with no .gcda files returns an empty set
+    (and logs a warning) instead of crashing."""
+    from core.inventory.binary_oracle_corpora.zlib import (
+        _collect_gcov_liveness,
+    )
+    assert _collect_gcov_liveness(tmp_path) == set()
+
+
+def test_zlib_enumerate_candidates_missing_archive_returns_empty(
+    tmp_path: Path,
+) -> None:
+    """If libz.a is missing, we don't crash — just an empty candidate
+    list (and a warning)."""
+    from core.inventory.binary_oracle_corpora.zlib import (
+        _enumerate_candidates,
+    )
+    assert _enumerate_candidates(tmp_path) == []
+
+
+# ---------------------------------------------------------------------------
+# zlib driver — slow E2E (network + build, marked off the CI fast path)
+# ---------------------------------------------------------------------------
+
+# ---------------------------------------------------------------------------
+# snappy driver — fast unit tests on the parsing helpers
+# ---------------------------------------------------------------------------
+
+def test_snappy_driver_registered() -> None:
+    from core.inventory.binary_oracle_corpora import REGISTRY
+    assert "snappy" in REGISTRY
+    # ``mode`` is the harness cross-tab style — liveness-based, used by
+    # both gcov and llvm-cov drivers (the value is historical).
+    assert REGISTRY["snappy"].mode == "gcov"
+
+
+def test_snappy_qualified_strips_args_and_return_type() -> None:
+    """Demangled C++ names (from ``c++filt`` on llvm-cov / nm output)
+    include return types + arglists + trailing qualifiers. The qualified
+    extractor must collapse them to the namespaced-no-args form the
+    classifier's ``by_qualified`` index uses."""
+    from core.inventory.binary_oracle_corpora.snappy import (
+        _qualified_from_demangled,
+    )
+    assert _qualified_from_demangled(
+        "snappy::Uncompress(snappy::Source*, snappy::Sink*)"
+    ) == "snappy::Uncompress"
+    assert _qualified_from_demangled(
+        "char* snappy::EmitCopy<true>(char*, unsigned long, unsigned long)"
+    ) == "snappy::EmitCopy<true>"
+    assert _qualified_from_demangled("plain_c_function") == "plain_c_function"
+    # The case that surfaced as broken in the first snappy run: template
+    # args contain internal whitespace, so naive ``rsplit(' ')`` returns
+    # garbage like ``16ul>::operator[]``. Balance-aware parsing must keep
+    # the whole template + qualifier intact.
+    assert _qualified_from_demangled(
+        "std::array<unsigned char, 16ul>::operator[](unsigned long)"
+    ) == "std::array<unsigned char, 16ul>::operator[]"
+    # Multi-arg template with stdlib value:
+    assert _qualified_from_demangled(
+        "void std::vector<int, std::allocator<int> >::push_back(int const&)"
+    ) == "std::vector<int, std::allocator<int> >::push_back"
+    # Anonymous namespace — has internal ``( )`` that must NOT be mistaken
+    # for the return-type boundary (snappy Inc 3c second-round bug):
+    assert _qualified_from_demangled(
+        "(anonymous namespace)::CalculateTableSize(unsigned int)"
+    ) == "(anonymous namespace)::CalculateTableSize"
+    assert _qualified_from_demangled(
+        "unsigned int (anonymous namespace)::HashBytes(unsigned long)"
+    ) == "(anonymous namespace)::HashBytes"
+    # Trailing CV-qualifiers (third-round Inc 3c bug — ``const`` got
+    # returned as the function name on every const-method).
+    assert _qualified_from_demangled(
+        "snappy::ByteArraySource::Available() const"
+    ) == "snappy::ByteArraySource::Available"
+    assert _qualified_from_demangled(
+        "Foo::bar() const noexcept"
+    ) == "Foo::bar"
+    assert _qualified_from_demangled(
+        "Foo::bar() const &&"
+    ) == "Foo::bar"
+    # Operator()'s parens are part of the name, not the arglist — the
+    # call-operator method without args must NOT strip down to
+    # ``operator`` (snappy Inc 3c followup bug surfaced via the lambda
+    # case in the precision measurement).
+    assert _qualified_from_demangled(
+        "Foo::operator() const"
+    ) == "Foo::operator()"
+    assert _qualified_from_demangled(
+        "Foo::operator()(int, int) const"
+    ) == "Foo::operator()"
+    # Lambda arg-list normalisation — c++filt and gcov disagree on
+    # whether to include the captured types inside ``{lambda(...)#N}``
+    # (c++filt does, gcov doesn't). Strip them so the two sources match.
+    assert _qualified_from_demangled(
+        "Foo::{lambda(int, char*)#1}::operator()() const"
+    ) == "Foo::{lambda()#1}::operator()"
+    assert _qualified_from_demangled(
+        "Foo::{lambda()#2}::operator()() const"
+    ) == "Foo::{lambda()#2}::operator()"
+
+
+def test_snappy_stdlib_helpers_filtered_out() -> None:
+    """Stdlib + gtest hits are methodology noise — filtering them keeps
+    n_functions a meaningful denominator on the snappy surface."""
+    from core.inventory.binary_oracle_corpora.snappy import (
+        _is_stdlib_or_helper,
+    )
+    assert _is_stdlib_or_helper("std::vector<int>::push_back")
+    assert _is_stdlib_or_helper("testing::TestInfo::name")
+    assert _is_stdlib_or_helper("__gnu_cxx::__normal_iterator")
+    assert not _is_stdlib_or_helper("snappy::Uncompress")
+    assert not _is_stdlib_or_helper("plain_function")
+
+
+@pytest.mark.slow
+def test_snappy_driver_end_to_end_via_harness(tmp_path: Path) -> None:
+    """Full clone → CMake build (clang+LLVM coverage) → ctest →
+    llvm-cov export → classify → cross-tab. Marked ``slow`` so CI
+    doesn't run it."""
+    from core.inventory.binary_oracle_corpora import REGISTRY
+    drv = REGISTRY["snappy"]
+    rep = run_corpus(drv, tmp_path)
+    assert rep.corpus_mode == "gcov"
+    assert rep.n_functions > 20, \
+        f"expected meaningful snappy surface, got {rep.n_functions}"
+    assert rep.absent_n > 0, "expected some absent verdicts"
+    if rep.absent_fps:
+        pytest.fail(
+            f"snappy absent_precision = {rep.absent_precision}; "
+            f"{len(rep.absent_fps)} live functions classified absent: "
+            f"{rep.absent_fps[:10]}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# libsodium / leveldb drivers — fast registration + helper tests
+# ---------------------------------------------------------------------------
+
+def test_libsodium_driver_registered() -> None:
+    from core.inventory.binary_oracle_corpora import REGISTRY
+    assert "libsodium" in REGISTRY
+    assert REGISTRY["libsodium"].mode == "gcov"
+
+
+def test_libsodium_enumerate_candidates_missing_archive(
+    tmp_path: Path,
+) -> None:
+    """Defensive: no archive present → empty candidate list, no crash."""
+    from core.inventory.binary_oracle_corpora.libsodium import (
+        _enumerate_candidates,
+    )
+    assert _enumerate_candidates(tmp_path) == []
+
+
+def test_leveldb_driver_registered() -> None:
+    from core.inventory.binary_oracle_corpora import REGISTRY
+    assert "leveldb" in REGISTRY
+
+
+def test_leveldb_patch_drop_benchmark_is_idempotent(tmp_path: Path) -> None:
+    """The CMakeLists patch removes the benchmark dep from the test
+    link line + the ``add_subdirectory("third_party/benchmark")`` call.
+    Re-applying must be a no-op (corpus driver replays prepare() on
+    cache misses)."""
+    from core.inventory.binary_oracle_corpora.leveldb import (
+        _patch_drop_benchmark,
+    )
+    cmake = tmp_path / "CMakeLists.txt"
+    cmake.write_text(
+        'add_subdirectory("third_party/benchmark")\n'
+        'target_link_libraries(t leveldb gmock gtest benchmark)\n'
+    )
+    _patch_drop_benchmark(cmake)
+    once = cmake.read_text()
+    assert "benchmark" not in once.split("target_link_libraries")[1].split("\n", 1)[0]
+    assert 'add_subdirectory("third_party/benchmark")' not in once
+    _patch_drop_benchmark(cmake)
+    assert cmake.read_text() == once  # idempotent
+
+
+# ---------------------------------------------------------------------------
+# regex-rust driver — fast registration + helper tests
+# ---------------------------------------------------------------------------
+
+def test_regex_rust_driver_registered() -> None:
+    from core.inventory.binary_oracle_corpora import REGISTRY
+    assert "regex-rust" in REGISTRY
+
+
+def test_regex_rust_strips_crate_hash_from_demangled_names() -> None:
+    """Rust v0 demangled names include a per-build crate hash like
+    ``regex[7e9e1dd283b8ce7a]::Match::start``. Strip it so the
+    qualified name compares stably across rebuilds and matches
+    ``nm --demangle`` (which omits the hash)."""
+    from core.inventory.binary_oracle_corpora.regex_rust import (
+        _strip_crate_hash,
+    )
+    assert _strip_crate_hash(
+        "<regex[7e9e1dd283b8ce7a]::regex::bytes::Match>::end"
+    ) == "<regex::regex::bytes::Match>::end"
+    assert _strip_crate_hash(
+        "regex[abc123def4567]::api::Regex::new"
+    ) == "regex::api::Regex::new"
+    # No hash → unchanged
+    assert _strip_crate_hash("plain::module::function") == (
+        "plain::module::function")
+
+
+@pytest.mark.slow
+def test_regex_rust_driver_end_to_end_via_harness(tmp_path: Path) -> None:
+    """Full clone → cargo build (release + coverage + DWARF) → run test
+    binary → llvm-cov export → classify. Slow (cargo build ~3 min)."""
+    from core.inventory.binary_oracle_corpora import REGISTRY
+    drv = REGISTRY["regex-rust"]
+    rep = run_corpus(drv, tmp_path)
+    assert rep.corpus_mode == "gcov"
+    assert rep.n_functions > 500, \
+        f"expected lots of regex fns, got {rep.n_functions}"
+    assert rep.absent_n > 0
+    # 7 known FPs from the impl-block syntax mismatch on
+    # <regex::regex::bytes::Match>::* methods. Acceptable for first
+    # Rust corpus — substantive 99.8% precision; will be tightened
+    # by the impl-block namespace fix.
+    _assert_precision_threshold(rep, "regex-rust", 0.99)
+
+
+@pytest.mark.slow
+def test_libsodium_driver_end_to_end_via_harness(tmp_path: Path) -> None:
+    """Full clone → autogen → configure × 2 → build × 2 → make check ×
+    2 → targeted single-test rerun → gcov → classify. Slow."""
+    from core.inventory.binary_oracle_corpora import REGISTRY
+    drv = REGISTRY["libsodium"]
+    rep = run_corpus(drv, tmp_path)
+    assert rep.corpus_mode == "gcov"
+    assert rep.n_functions > 500
+    assert rep.absent_n > 100, "expected many absent verdicts on libsodium"
+    _assert_precision_threshold(rep, "libsodium", 1.0)
+
+
+@pytest.mark.slow
+def test_leveldb_driver_end_to_end_via_harness(tmp_path: Path) -> None:
+    """Full clone → patch CMake → CMake build (clang+LLVM coverage) →
+    ctest → llvm-cov → classify. Slow."""
+    from core.inventory.binary_oracle_corpora import REGISTRY
+    drv = REGISTRY["leveldb"]
+    rep = run_corpus(drv, tmp_path)
+    assert rep.corpus_mode == "gcov"
+    assert rep.n_functions > 500
+    assert rep.absent_n > 0
+    _assert_precision_threshold(rep, "leveldb", 1.0)
+
+
+@pytest.mark.slow
+def test_zlib_driver_end_to_end_via_harness(tmp_path: Path) -> None:
+    """Full clone → build (×2) → test → gcov → classify → cross-tab.
+    Marked ``slow`` so CI doesn't try to run it. The measurement itself
+    is the substance — we assert only invariants the harness must hold."""
+    from core.inventory.binary_oracle_corpora import REGISTRY
+    drv = REGISTRY["zlib"]
+    rep = run_corpus(drv, tmp_path)
+    assert rep.corpus_mode == "gcov"
+    assert rep.n_functions > 50, \
+        f"expected many libz functions, got {rep.n_functions}"
+    # Some dead functions must exist (zlib has lots of seldom-used helpers
+    # that --gc-sections strips from ``example``).
+    assert rep.absent_n > 0, "expected some absent verdicts on zlib/example"
+    _assert_precision_threshold(rep, "zlib", 1.0)

--- a/core/inventory/tests/test_reach_chokepoint.py
+++ b/core/inventory/tests/test_reach_chokepoint.py
@@ -1,0 +1,205 @@
+"""Tests for the shared reachability-chokepoint helper.
+
+The chokepoint helper is the single source of truth for "should this
+finding be suppressed?" — both /agentic and /codeql consult it. The
+adversarial review (P0-C-1, P0-C-2) flagged silent-drop risks from
+copy-paste-reductionism in the prior /agentic implementation:
+absolute paths, file:// URIs, and language-incorrect module strings.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from core.inventory.reach_chokepoint import (
+    check_suppress,
+    normalise_path,
+    path_to_module,
+)
+
+
+# ---------------------------------------------------------------------------
+# normalise_path
+# ---------------------------------------------------------------------------
+
+def test_normalise_path_strips_file_uri_prefix(tmp_path: Path) -> None:
+    rel = normalise_path(f"file://{tmp_path}/src/util.c", tmp_path)
+    assert rel == "src/util.c"
+
+
+def test_normalise_path_makes_absolute_relative_to_repo(
+    tmp_path: Path,
+) -> None:
+    rel = normalise_path(str(tmp_path / "lib" / "x.c"), tmp_path)
+    assert rel == "lib/x.c"
+
+
+def test_normalise_path_rejects_absolute_outside_repo(
+    tmp_path: Path,
+) -> None:
+    """Absolute path that's not under repo_root → None. Suppression
+    must NOT fire on files outside the analysed tree."""
+    other = tmp_path.parent
+    rel = normalise_path(str(other / "elsewhere" / "x.c"), tmp_path)
+    assert rel is None
+
+
+def test_normalise_path_strips_leading_dot_slash(tmp_path: Path) -> None:
+    rel = normalise_path("./src/x.c", tmp_path)
+    assert rel == "src/x.c"
+
+
+def test_normalise_path_preserves_relative(tmp_path: Path) -> None:
+    rel = normalise_path("src/util.c", tmp_path)
+    assert rel == "src/util.c"
+
+
+def test_normalise_path_empty_returns_none(tmp_path: Path) -> None:
+    assert normalise_path("", tmp_path) is None
+
+
+# ---------------------------------------------------------------------------
+# path_to_module
+# ---------------------------------------------------------------------------
+
+def test_path_to_module_python() -> None:
+    assert path_to_module("packages/foo/bar.py") == "packages.foo.bar"
+
+
+def test_path_to_module_c() -> None:
+    """Adversarial review P0-C-2: for non-Python languages, the prior
+    /agentic hook passed the LITERAL path string as ``module`` because
+    its derivation was python-only. The shared helper strips the
+    extension uniformly across languages."""
+    assert path_to_module("src/util.c") == "src.util"
+    assert path_to_module("src/lib.cc") == "src.lib"
+    assert path_to_module("src/lib.cpp") == "src.lib"
+
+
+def test_path_to_module_rust() -> None:
+    assert path_to_module("src/main.rs") == "src.main"
+
+
+def test_path_to_module_no_extension_returns_none() -> None:
+    """A path with no extension (Makefile, README) can't yield a
+    sensible module — return None rather than fabricate one."""
+    assert path_to_module("Makefile") is None
+    assert path_to_module("") is None
+
+
+# ---------------------------------------------------------------------------
+# check_suppress — integration of override + path/module + verdict
+# ---------------------------------------------------------------------------
+
+def _checklist_with_absent_function(
+    file_path: str, name: str, line: int = 1,
+) -> dict:
+    """Build a minimal checklist where the (file, name) function has
+    a SOUND binary_oracle absent verdict (tier=full, binaries non-
+    empty) — the chokepoint should suppress."""
+    return {"files": [{
+        "path": file_path, "language": "c",
+        "items": [{
+            "name": name, "kind": "function", "line_start": line,
+            "metadata": {"binary_oracle": {
+                "classification": "absent",
+                "binaries": [{"tier": "full", "path": "/b"}],
+            }},
+        }],
+    }]}
+
+
+def test_check_suppress_fires_on_absent_full_tier(tmp_path: Path) -> None:
+    checklist = _checklist_with_absent_function("src/util.c", "helper", 5)
+    decision = check_suppress(
+        checklist=checklist,
+        file_path="src/util.c",
+        function_name="helper",
+        line=5,
+        repo_root=tmp_path,
+    )
+    assert decision is not None
+    verdict, reason = decision
+    assert verdict == "binary_oracle_absent"
+    assert "Reachability chokepoint" in reason
+
+
+def test_check_suppress_respects_manual_override(tmp_path: Path) -> None:
+    checklist = _checklist_with_absent_function("src/util.c", "helper", 5)
+    decision = check_suppress(
+        checklist=checklist,
+        file_path="src/util.c",
+        function_name="helper",
+        line=5,
+        repo_root=tmp_path,
+        manual_override=True,
+    )
+    assert decision is None
+
+
+def test_check_suppress_respects_allow_unreachable(
+    tmp_path: Path,
+) -> None:
+    checklist = _checklist_with_absent_function("src/util.c", "helper", 5)
+    decision = check_suppress(
+        checklist=checklist,
+        file_path="src/util.c",
+        function_name="helper",
+        line=5,
+        repo_root=tmp_path,
+        allow_unreachable=True,
+    )
+    assert decision is None
+
+
+def test_check_suppress_handles_absolute_finding_path(
+    tmp_path: Path,
+) -> None:
+    """Adversarial review P0-C-1: SARIF emitters often produce
+    absolute paths; the chokepoint MUST normalise via the shared
+    helper, not pass the absolute path verbatim to the inventory
+    lookup (which would miss every time)."""
+    checklist = _checklist_with_absent_function("src/util.c", "helper", 5)
+    decision = check_suppress(
+        checklist=checklist,
+        file_path=str(tmp_path / "src" / "util.c"),  # ABSOLUTE
+        function_name="helper",
+        line=5,
+        repo_root=tmp_path,
+    )
+    assert decision is not None
+    assert decision[0] == "binary_oracle_absent"
+
+
+def test_check_suppress_handles_file_uri_finding_path(
+    tmp_path: Path,
+) -> None:
+    checklist = _checklist_with_absent_function("src/util.c", "helper", 5)
+    decision = check_suppress(
+        checklist=checklist,
+        file_path=f"file://{tmp_path}/src/util.c",
+        function_name="helper",
+        line=5,
+        repo_root=tmp_path,
+    )
+    assert decision is not None
+
+
+def test_check_suppress_string_false_manual_override_is_not_truthy(
+    tmp_path: Path,
+) -> None:
+    """``"false"`` (string) must be coerced to bool-False rather than
+    treated as truthy (Python ``bool("false")`` is True). Otherwise an
+    emitter writing ``"manual_override": "false"`` would accidentally
+    bypass the chokepoint."""
+    checklist = _checklist_with_absent_function("src/util.c", "helper", 5)
+    decision = check_suppress(
+        checklist=checklist,
+        file_path="src/util.c",
+        function_name="helper",
+        line=5,
+        repo_root=tmp_path,
+        manual_override="false",
+    )
+    # "false" → False → suppression fires
+    assert decision is not None

--- a/core/inventory/tests/test_reach_witness.py
+++ b/core/inventory/tests/test_reach_witness.py
@@ -21,11 +21,145 @@ def test_may_suppress_is_safe_by_default_for_everything():
     # corpus-earned set — a static "sound" label is necessary, not
     # sufficient (the detectors are heuristic; a detector bug must not be
     # able to license a false negative).
-    for v in ("module_aborts", "lexical_dead", "build_excluded",
-              "no_path_from_entry", "not_called", "called",
-              "framework_callable", "registered_via_call", "reachable",
-              "uncertain"):
+    for v in ("module_aborts", "lexical_dead", "binary_oracle_absent",
+              "build_excluded", "no_path_from_entry", "not_called",
+              "called", "framework_callable", "registered_via_call",
+              "reachable", "uncertain"):
         assert verdict_from_classification(v).may_suppress() is False, v
+
+
+def test_binary_oracle_absent_witness_resolves_end_to_end():
+    """End-to-end: a function with ``metadata.binary_oracle.classification
+    == 'absent'`` AND a non-empty ``binaries`` list (every entry
+    full-tier) resolves to a SOUND, suppress-eligible witness via
+    ``resolve_reachability``. Phase 2 wire: binary_oracle data on the
+    inventory → reachability witness → /validate demoter picks up via
+    ``may_suppress``."""
+    inv = {"files": [{
+        "path": "lib.c", "language": "c",
+        "items": [{"name": "dead_helper", "kind": "function",
+                   "line_start": 10,
+                   "metadata": {"binary_oracle": {
+                       "classification": "absent",
+                       "build_id": "a1b2c3d4",
+                       "binary_path": "/path/to/binary",
+                       "address": None,
+                       "binaries": [{
+                           "path": "/path/to/binary",
+                           "tier": "full",
+                       }],
+                   }}}],
+    }]}
+    rv = resolve_reachability(inv, "lib.c", "dead_helper", 10, "lib")
+    assert rv.status is Reachability.UNREACHABLE
+    assert rv.witness.kind is WitnessKind.BINARY_ORACLE_ABSENT
+    assert rv.witness.soundness is Soundness.SOUND
+    # Suppression behavior: not earned by default (empty set) — earned
+    # when the consumer passes STRUCTURALLY_SUPPRESSIBLE_KINDS.
+    assert rv.may_suppress() is False
+    assert rv.may_suppress(_EARNED) is True
+
+
+def test_binary_oracle_absent_refuses_when_no_tier_evidence():
+    """Adversarial review P0-C-4: a legacy / partial inventory whose
+    ``binary_oracle`` block is missing ``binaries`` (or has an empty
+    list, or has any non-full-tier entry) MUST NOT earn suppression.
+    The SOUND witness is conditional on full-DWARF evidence; without
+    it the function falls through to the rest of the precedence
+    chain rather than silently suppressing a real finding."""
+    base_item = {"name": "f", "kind": "function", "line_start": 1}
+
+    # (a) ``binaries`` key absent — legacy single-binary writer.
+    inv_a = {"files": [{
+        "path": "lib.c", "language": "c",
+        "items": [{**base_item, "metadata": {"binary_oracle": {
+            "classification": "absent", "binary_path": "/b"}}}],
+    }]}
+    rv = resolve_reachability(inv_a, "lib.c", "f", 1, "lib")
+    assert rv.witness.kind is not WitnessKind.BINARY_ORACLE_ABSENT
+
+    # (b) Empty ``binaries`` list — writer attached the key but found
+    # no contributors. No tier evidence ⇒ no trust.
+    inv_b = {"files": [{
+        "path": "lib.c", "language": "c",
+        "items": [{**base_item, "metadata": {"binary_oracle": {
+            "classification": "absent", "binaries": []}}}],
+    }]}
+    rv = resolve_reachability(inv_b, "lib.c", "f", 1, "lib")
+    assert rv.witness.kind is not WitnessKind.BINARY_ORACLE_ABSENT
+
+    # (c) Mixed tier — one full + one symbol_only. The symbol_only
+    # could be hiding inlined-into-caller; refuse to fire.
+    inv_c = {"files": [{
+        "path": "lib.c", "language": "c",
+        "items": [{**base_item, "metadata": {"binary_oracle": {
+            "classification": "absent",
+            "binaries": [{"tier": "full"}, {"tier": "symbol_only"}],
+        }}}],
+    }]}
+    rv = resolve_reachability(inv_c, "lib.c", "f", 1, "lib")
+    assert rv.witness.kind is not WitnessKind.BINARY_ORACLE_ABSENT
+
+
+def test_binary_oracle_absent_line_disambiguates_name_collisions():
+    """Adversarial review P0-C-3: when two items in one file share a
+    name (C static helpers, #if/#else, C++ overloads extracted as
+    separate items), the accessor MUST consult ``line`` to identify
+    the intended function. Querying for the live one's line MUST NOT
+    return the dead one's verdict."""
+    inv = {"files": [{
+        "path": "lib.c", "language": "c",
+        "items": [
+            # The dead namesake — would suppress if line wasn't checked.
+            {"name": "helper", "kind": "function", "line_start": 10,
+             "metadata": {"binary_oracle": {
+                 "classification": "absent",
+                 "binaries": [{"tier": "full"}]}}},
+            # The live namesake — different line, no binary_oracle.
+            {"name": "helper", "kind": "function", "line_start": 42},
+        ],
+    }]}
+    # Query for the LIVE function (line=42) — must not be dropped by
+    # the dead namesake's verdict.
+    rv = resolve_reachability(inv, "lib.c", "helper", 42, "lib")
+    assert rv.witness.kind is not WitnessKind.BINARY_ORACLE_ABSENT
+    # Sanity: the dead namesake (line=10) IS suppressible.
+    rv_dead = resolve_reachability(inv, "lib.c", "helper", 10, "lib")
+    assert rv_dead.witness.kind is WitnessKind.BINARY_ORACLE_ABSENT
+
+
+def test_binary_oracle_inlined_does_not_demote_function():
+    """An ``inlined`` classification is REACHABLE evidence (function ran,
+    just merged into its caller). The accessor must NOT return absent for
+    it — finding falls through to the rest of the precedence chain."""
+    inv = {"files": [{
+        "path": "lib.c", "language": "c",
+        "items": [{"name": "small_helper", "kind": "function",
+                   "line_start": 5,
+                   "metadata": {"binary_oracle": {
+                       "classification": "inlined",
+                       "build_id": "a1b2c3d4",
+                       "binary_path": "/path/to/binary",
+                       "address": None,
+                       "binaries": [{"tier": "full"}],
+                   }}}],
+        "call_graph": {"imports": {}, "calls": []},
+    }]}
+    rv = resolve_reachability(inv, "lib.c", "small_helper", 5, "lib")
+    assert rv.witness.kind is not WitnessKind.BINARY_ORACLE_ABSENT
+
+
+def test_no_binary_oracle_metadata_is_silent_fallthrough():
+    """If ``--binary`` wasn't passed, items don't carry binary_oracle
+    metadata. The stage must NOT fire (don't claim deadness based on
+    missing evidence)."""
+    inv = {"files": [{
+        "path": "lib.c", "language": "c",
+        "items": [{"name": "f", "kind": "function", "line_start": 1}],
+        "call_graph": {"imports": {}, "calls": []},
+    }]}
+    rv = resolve_reachability(inv, "lib.c", "f", 1, "lib")
+    assert rv.witness.kind is not WitnessKind.BINARY_ORACLE_ABSENT
 
 
 def test_structural_dead_witnesses_suppress_only_when_earned():
@@ -84,22 +218,28 @@ def test_to_priority_reason_preserves_legacy_strings():
         "reachability:no_path_from_entry")
 
 
-def test_only_two_kinds_can_ever_be_suppress_eligible():
+def test_only_earned_sound_kinds_can_ever_be_suppress_eligible():
     # Lock the FN-safety surface: even with EVERY kind in the earned set,
-    # exactly the two structural config-independent witnesses can suppress —
-    # nothing else, in any combination.
+    # only the SOUND + earns_suppression witnesses can suppress — nothing
+    # else, in any combination. Set grew when binary_oracle_absent landed
+    # (Inc 3d earned suppression via the precision corpus).
     all_kinds = frozenset(WitnessKind)
     suppressible = {
         v for v in (
-            "module_aborts", "lexical_dead", "no_path_from_entry",
+            "module_aborts", "lexical_dead", "binary_oracle_absent",
+            "build_excluded", "no_path_from_entry",
             "not_called", "called", "framework_callable",
             "registered_via_call", "reachable", "uncertain",
         )
         if verdict_from_classification(v).may_suppress(all_kinds)
     }
-    assert suppressible == {"module_aborts", "lexical_dead"}
+    assert suppressible == {
+        "module_aborts", "lexical_dead", "binary_oracle_absent",
+    }
     assert STRUCTURALLY_SUPPRESSIBLE_KINDS == {
-        WitnessKind.MODULE_ABORTS, WitnessKind.LEXICAL_DEAD,
+        WitnessKind.MODULE_ABORTS,
+        WitnessKind.LEXICAL_DEAD,
+        WitnessKind.BINARY_ORACLE_ABSENT,
     }
 
 
@@ -132,14 +272,17 @@ def test_resolve_reachability_end_to_end():
 
 
 def test_structurally_suppressible_derived_from_table():
-    # The suppressible set is DERIVED from VERDICTS[*].earns_suppression, not
-    # hand-maintained. Pin the expected membership so a stray earns_suppression
-    # flip is caught.
+    # The suppressible set is DERIVED from VERDICTS[*].earns_suppression,
+    # not hand-maintained. Pin the expected membership so a stray
+    # earns_suppression flip is caught. Grew when binary_oracle_absent
+    # earned the right via the Inc 3 precision corpus.
     from core.inventory.reach_witness import (
         STRUCTURALLY_SUPPRESSIBLE_KINDS, WitnessKind,
     )
     assert STRUCTURALLY_SUPPRESSIBLE_KINDS == frozenset({
-        WitnessKind.MODULE_ABORTS, WitnessKind.LEXICAL_DEAD,
+        WitnessKind.MODULE_ABORTS,
+        WitnessKind.LEXICAL_DEAD,
+        WitnessKind.BINARY_ORACLE_ABSENT,
     })
 
 

--- a/core/project/cli.py
+++ b/core/project/cli.py
@@ -44,11 +44,38 @@ def main():
 
     # create
     p_create = sub.add_parser("create", help="Create a new project",
-                              usage="raptor project create <name> --target <path> [-d <desc>] [--output-dir <dir>]", **_F)
+                              usage="raptor project create <name> --target <path> [-d <desc>] [--output-dir <dir>] [--binary <path>]", **_F)
     p_create.add_argument("name", help="Project name")
     p_create.add_argument("--target", required=True, metavar="<path>", help="Path to target codebase")
     p_create.add_argument("-d", "--description", default="", metavar="<text>", help="One-line description")
     p_create.add_argument("--output-dir", default=None, metavar="<dir>", help="Custom output directory")
+    p_create.add_argument(
+        "--binary", action="append", default=None, metavar="<path>",
+        help=("Debug binary for binary_oracle reachability enrichment "
+              "(repeatable for hybrid targets). Persisted on the "
+              "project; loaded into every subsequent /agentic / "
+              "/codeql / /validate run on this project. Explicit "
+              "--binary on the CLI is additive."),
+    )
+
+    # binary — per-project binary management
+    p_bin = sub.add_parser(
+        "binary",
+        help=("Manage per-project debug binaries for binary_oracle "
+              "enrichment"),
+        usage=("raptor project binary <add|remove|list|clear> [args] "
+               "[<name>]"),
+        **_F,
+    )
+    p_bin.add_argument(
+        "action", choices=("add", "remove", "list", "clear"),
+        help="Action: add <path>, remove <path>, list, or clear")
+    p_bin.add_argument(
+        "path", nargs="?", default=None,
+        help="Binary path (required for add/remove)")
+    p_bin.add_argument(
+        "name", nargs="?", default=None,
+        help="Project name (default: active)")
 
     # use
     p_use = sub.add_parser("use", help="Set the active project (no arg = show current)",
@@ -286,9 +313,78 @@ def main():
                 parser.print_help()
 
         elif args.subcommand == "create":
-            p = mgr.create(args.name, args.target, description=args.description,
-                           output_dir=args.output_dir)
+            p = mgr.create(args.name, args.target,
+                           description=args.description,
+                           output_dir=args.output_dir,
+                           binaries=getattr(args, "binary", None))
             print(f"Created project '{p.name}' → {p.output_dir}")
+            _p_binaries = getattr(p, "binaries", None) or []
+            if _p_binaries:
+                print(f"  binaries: {', '.join(_p_binaries)}")
+
+        elif args.subcommand == "binary":
+            from core.json import save_json
+            # list / clear don't take a path — if the operator wrote
+            # ``binary list <project>`` the project name lands in
+            # ``args.path``. Swap it.
+            if (args.action in ("list", "clear")
+                    and args.path and not args.name):
+                args.name, args.path = args.path, None
+            name = args.name or _get_active_project()
+            if not name:
+                print(_red("No project specified. "
+                          "Use: raptor project binary <action> [args] "
+                          "<name>, or set an active project first."))
+                return
+            p = mgr.load(name)
+            if not p:
+                print(_red(f"Project '{name}' not found."))
+                return
+            project_file = mgr.projects_dir / f"{name}.json"
+            if args.action == "list":
+                if not p.binaries:
+                    print(f"Project '{name}': no binaries declared.")
+                else:
+                    print(f"Project '{name}' binaries ({len(p.binaries)}):")
+                    for b in p.binaries:
+                        print(f"  {b}")
+            elif args.action == "add":
+                if not args.path:
+                    print(_red("add requires a <path> argument"))
+                    return
+                resolved_path = Path(args.path).expanduser().resolve()
+                if not resolved_path.is_file():
+                    # Reject at add-time so the operator sees the typo
+                    # NOW, not silently weeks later when the scan
+                    # produces no binary-oracle evidence (adversarial
+                    # review P1-D-2).
+                    print(_red(
+                        f"add: path does not exist or is not a file: "
+                        f"{args.path} (resolved to {resolved_path})"
+                    ))
+                    return
+                resolved = str(resolved_path)
+                if resolved in p.binaries:
+                    print(f"Already present: {resolved}")
+                else:
+                    p.binaries.append(resolved)
+                    save_json(project_file, p.to_dict())
+                    print(_green(f"Added: {resolved}"))
+            elif args.action == "remove":
+                if not args.path:
+                    print(_red("remove requires a <path> argument"))
+                    return
+                resolved = str(Path(args.path).resolve())
+                if resolved not in p.binaries:
+                    print(f"Not present: {resolved}")
+                else:
+                    p.binaries.remove(resolved)
+                    save_json(project_file, p.to_dict())
+                    print(_green(f"Removed: {resolved}"))
+            elif args.action == "clear":
+                p.binaries = []
+                save_json(project_file, p.to_dict())
+                print(_green(f"Cleared binaries for '{name}'"))
 
         elif args.subcommand == "list":
             projects = mgr.list_projects()

--- a/core/project/project.py
+++ b/core/project/project.py
@@ -8,7 +8,7 @@ Output directories live wherever the user specifies (default: out/projects/<name
 import os
 import re
 import shutil
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Dict, List, Optional
@@ -32,7 +32,21 @@ class Project:
     created: str = ""
     description: str = ""
     notes: str = ""
-    version: int = 1
+    # Schema version: bumped to 2 when the ``binaries`` field landed
+    # (adversarial review Agent D P1-7). v1 readers silently ignore
+    # the field, which would mean a project's per-binary-oracle config
+    # is dropped when the file round-trips through an older RAPTOR. A
+    # version bump makes the change EXPLICIT in the persisted file —
+    # older readers can still load the project (back-compat below) but
+    # operators inspecting the JSON see the v2 schema.
+    version: int = 2
+    # Operator-supplied debug binaries for binary_oracle reachability
+    # enrichment. Persisted across runs so the operator doesn't re-pass
+    # ``--binary`` every invocation. List for ``--target-kind=hybrid``
+    # deployments shipping multiple binaries (library + app). Loaded
+    # into ``RaptorConfig.BINARY_ORACLE_PATHS`` at /agentic / /codeql
+    # start; explicit ``--binary`` on the CLI is additive.
+    binaries: List[str] = field(default_factory=list)
 
     def to_dict(self) -> Dict:
         return {
@@ -43,10 +57,17 @@ class Project:
             "created": self.created,
             "description": self.description,
             "notes": self.notes,
+            "binaries": list(self.binaries),
         }
 
     @classmethod
     def from_dict(cls, data: Dict) -> "Project":
+        binaries = data.get("binaries") or []
+        if not isinstance(binaries, list):
+            binaries = []
+        # Back-compat: load v1 files (no ``binaries``) as v2 — the
+        # field defaults to empty. The next save will upgrade the
+        # file's version to 2 with the empty list explicit.
         return cls(
             name=data.get("name", ""),
             target=data.get("target", ""),
@@ -54,7 +75,8 @@ class Project:
             created=data.get("created", ""),
             description=data.get("description", ""),
             notes=data.get("notes", ""),
-            version=data.get("version", 1),
+            version=data.get("version", 2),
+            binaries=[str(b) for b in binaries if isinstance(b, str)],
         )
 
     @property
@@ -228,13 +250,17 @@ class ProjectManager:
 
     def create(self, name: str, target: str, description: str = "",
                output_dir: str = None, resolve_target: bool = True,
-               created: str = None) -> Project:
+               created: str = None,
+               binaries: Optional[List[str]] = None) -> Project:
         """Create a new project.
 
         Args:
             resolve_target: If True (default), resolve target to absolute path.
                 Set to False for imports where the original path should be preserved.
             created: ISO timestamp override (for imports preserving original date).
+            binaries: optional list of debug binary paths for binary_oracle
+                enrichment. Persisted on the project; each is resolved to
+                an absolute path when ``resolve_target`` is True.
         """
         self._validate_name(name)
         project_file = self.projects_dir / f"{name}.json"
@@ -244,12 +270,20 @@ class ProjectManager:
         if not output_dir:
             output_dir = str((DEFAULT_OUTPUT_BASE / name).resolve())
 
+        resolved_binaries: List[str] = []
+        for b in (binaries or []):
+            if not isinstance(b, str) or not b.strip():
+                continue
+            resolved_binaries.append(
+                str(Path(b).resolve()) if resolve_target else b)
+
         project = Project(
             name=name,
             target=str(Path(target).resolve()) if resolve_target else target,
             output_dir=output_dir,
             created=created or datetime.now(timezone.utc).isoformat(),
             description=description,
+            binaries=resolved_binaries,
         )
 
         Path(output_dir).mkdir(parents=True, exist_ok=True)

--- a/core/project/schema.py
+++ b/core/project/schema.py
@@ -44,6 +44,16 @@ def _validate_project(data: Dict[str, Any]) -> Tuple[bool, List[str]]:
     if "created" in data and not isinstance(data["created"], str):
         errors.append("created must be a string")
 
+    if "binaries" in data:
+        binaries = data["binaries"]
+        if not isinstance(binaries, list):
+            errors.append("binaries must be a list")
+        else:
+            for i, b in enumerate(binaries):
+                if not isinstance(b, str) or not b.strip():
+                    errors.append(
+                        f"binaries[{i}] must be a non-empty string")
+
     return len(errors) == 0, errors
 
 

--- a/libexec/raptor-binary-oracle-e2e
+++ b/libexec/raptor-binary-oracle-e2e
@@ -1,0 +1,550 @@
+#!/usr/bin/env python3
+"""Comprehensive E2E driver for the binary-oracle arc.
+
+Exercises EVERY consumer surface against a real C target it builds
+fresh under ``$TMPDIR/raptor-bo-e2e/``. No LLM calls — pure mechanical
+traversal of the pipeline. Prints pass/fail per surface so a single
+invocation is a self-contained audit covering: classifier, inventory
+enrichment, chokepoint accessor (incl. tier guard + name-collision
+disambiguation), reach_audit verdict chain, verdict→witness→suppression
+mapping, shared chokepoint helper, suppressions.jsonl audit trail,
+auto-detect, hostile-ELF defense, multi-binary combine, stripped-binary
+tier fallback, corpus driver registry, annotation_synth binary_oracle
+tags, /project schema persistence, full build_inventory pipeline.
+
+Usage::
+
+    libexec/raptor-binary-oracle-e2e
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+# ─── trust-marker check (do not import; inline by design) ───
+if not (os.environ.get("CLAUDECODE")
+        or os.environ.get("_RAPTOR_TRUSTED")):
+    sys.stderr.write(
+        f"{sys.argv[0]}: internal dispatch script.\n"
+        "  Run via 'bin/raptor' instead.\n"
+        "  Tests / power users: set _RAPTOR_TRUSTED=1 to bypass.\n"
+    )
+    sys.exit(2)
+# ─── end trust-marker check ─────────────────────────────────
+
+RAPTOR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(RAPTOR))
+os.environ.setdefault("RAPTOR_DIR", str(RAPTOR))
+
+TARGET = Path(tempfile.gettempdir()) / "raptor-bo-e2e"
+BINARY = TARGET / "build" / "app"
+
+results: list[tuple[str, bool, str]] = []
+
+
+def _build_target() -> None:
+    """Build the canonical E2E target if it isn't already there.
+    Source mix: live functions, dead functions, an inlined target,
+    file-static helpers, multiple TUs — exercises every classifier
+    verdict shape with ``-O2 -ffunction-sections --gc-sections``."""
+    import subprocess
+    src = TARGET / "src"
+    src.mkdir(parents=True, exist_ok=True)
+    (TARGET / "build").mkdir(parents=True, exist_ok=True)
+    (src / "api.h").write_text(
+        "int api_open(const char *path);\n"
+        "void api_close(int fd);\n"
+        "int api_read(int fd, char *buf, int n);\n"
+        "int api_internal_helper(int x);\n"
+        "int api_dead_function(int x);\n"
+        "int api_inlined_target(int x);\n"
+    )
+    (src / "api.c").write_text(
+        '#include "api.h"\n'
+        "int api_open(const char *path) { return path ? 0 : -1; }\n"
+        "void api_close(int fd) { (void)fd; }\n"
+        "int api_read(int fd, char *buf, int n) {\n"
+        "    if (fd < 0 || !buf || n <= 0) return -1;\n"
+        "    for (int i = 0; i < n; i++) buf[i] = (char)(fd + i);\n"
+        "    return n;\n"
+        "}\n"
+        "static int _validate(int x) { return x > 0 ? 1 : 0; }\n"
+        "int api_internal_helper(int x) {\n"
+        "    return _validate(x) ? x * 2 : -1;\n"
+        "}\n"
+    )
+    (src / "util.c").write_text(
+        '#include "api.h"\n'
+        "int api_dead_function(int x) { return x * 999; }\n"
+        "static inline int api_inlined_target_impl(int x){return x+41;}\n"
+        "int api_inlined_target(int x){return api_inlined_target_impl(x);}\n"
+        "static void util_dead_static(void) { }\n"
+        "int util_compute(int a, int b) { return a * b + 7; }\n"
+    )
+    (src / "main.c").write_text(
+        "#include <stdio.h>\n"
+        '#include "api.h"\n'
+        "extern int util_compute(int a, int b);\n"
+        "int main(int argc, char **argv) {\n"
+        "    int fd = api_open(argc > 1 ? argv[1] : \"default\");\n"
+        "    char buf[16];\n"
+        "    int n = api_read(fd, buf, sizeof buf);\n"
+        "    api_close(fd);\n"
+        "    int h = api_internal_helper(42);\n"
+        "    int i = api_inlined_target(1);\n"
+        "    int u = util_compute(n, h);\n"
+        "    printf(\"%d\\n\", u + i);\n"
+        "    return 0;\n"
+        "}\n"
+    )
+    subprocess.run([
+        "gcc", "-O2", "-g",
+        "-ffunction-sections", "-fdata-sections",
+        "-Wl,--gc-sections",
+        str(src / "main.c"), str(src / "api.c"), str(src / "util.c"),
+        "-o", str(BINARY),
+    ], check=True)
+
+
+_build_target()
+
+
+def check(name: str, ok: bool, detail: str = "") -> None:
+    results.append((name, ok, detail))
+    mark = "PASS" if ok else "FAIL"
+    print(f"  [{mark}] {name}{(' — ' + detail) if detail else ''}")
+
+
+# ---------------------------------------------------------------------------
+# 1. Direct classifier — verdicts on a real binary
+# ---------------------------------------------------------------------------
+print("\n=== 1. Direct classifier ===")
+from core.inventory.binary_oracle import classify_binary_evidence
+
+names = ["api_open", "api_close", "api_read", "api_internal_helper",
+         "api_inlined_target", "util_compute", "main",
+         "api_dead_function", "util_dead_static"]
+verdicts = classify_binary_evidence(names, BINARY)
+check("classifier returns verdict for every queried name",
+      len(verdicts) == len(names), f"{len(verdicts)}/{len(names)}")
+check("api_open classified as symbol_present",
+      verdicts["api_open"].classification == "symbol_present",
+      verdicts["api_open"].classification)
+check("api_dead_function classified as absent",
+      verdicts["api_dead_function"].classification == "absent",
+      verdicts["api_dead_function"].classification)
+check("util_dead_static classified as absent",
+      verdicts["util_dead_static"].classification == "absent",
+      verdicts["util_dead_static"].classification)
+check("api_internal_helper classified as alive",
+      verdicts["api_internal_helper"].classification
+      in ("symbol_present", "inlined"),
+      verdicts["api_internal_helper"].classification)
+check("main classified as symbol_present",
+      verdicts["main"].classification == "symbol_present",
+      verdicts["main"].classification)
+check("all verdicts carry tier=full",
+      all(w.tier == "full" for w in verdicts.values()),
+      f"tiers={set(w.tier for w in verdicts.values())}")
+
+
+# ---------------------------------------------------------------------------
+# 2. Inventory enrichment + multi-binary combine (single binary case)
+# ---------------------------------------------------------------------------
+print("\n=== 2. Inventory enrichment ===")
+from core.inventory.binary_oracle import enrich_inventory_with_binary_oracle
+
+# Real source surface — names that actually match the binary so the
+# hostile-ELF coverage floor doesn't fire on a legitimate target.
+inv = {"files": [
+    {"path": "src/api.c", "language": "c", "items": [
+        {"name": "api_open", "kind": "function", "line_start": 4},
+        {"name": "api_close", "kind": "function", "line_start": 8},
+        {"name": "api_read", "kind": "function", "line_start": 12},
+        {"name": "api_internal_helper", "kind": "function",
+         "line_start": 22},
+        {"name": "api_dead_function", "kind": "function",
+         "line_start": 26, "metadata": {}},
+    ]},
+    {"path": "src/util.c", "language": "c", "items": [
+        {"name": "api_inlined_target", "kind": "function",
+         "line_start": 12},
+        {"name": "util_dead_static", "kind": "function",
+         "line_start": 18},
+        {"name": "util_compute", "kind": "function", "line_start": 21},
+    ]},
+    # Non-native file — must be skipped
+    {"path": "src/script.py", "language": "python", "items": [
+        {"name": "py_func", "kind": "function", "line_start": 1},
+    ]},
+]}
+# Index of (file_path, name) → item for downstream lookups.
+def _it(file_path, name):
+    for f in inv["files"]:
+        if f["path"] != file_path:
+            continue
+        for it in f["items"]:
+            if it["name"] == name:
+                return it
+    raise AssertionError(f"{file_path}:{name} not in inv")
+
+counts = enrich_inventory_with_binary_oracle(inv, (BINARY,))
+check("enrichment classified >= 4 items", counts["classified"] >= 4,
+      f"classified={counts['classified']}")
+check("non-native python item skipped",
+      counts["skipped_non_native"] >= 1,
+      f"skipped={counts['skipped_non_native']}")
+_dead_api = _it("src/api.c", "api_dead_function")
+_dead_util = _it("src/util.c", "util_dead_static")
+check("api_dead_function has binary_oracle absent",
+      _dead_api["metadata"]["binary_oracle"]["classification"] == "absent")
+check("util_dead_static has binary_oracle absent",
+      _dead_util["metadata"]["binary_oracle"]["classification"] == "absent")
+check("api_dead_function metadata has binaries[] with tier",
+      _dead_api["metadata"]["binary_oracle"]["binaries"][0]["tier"] == "full")
+check("top-level inventory.binary_oracle.earns_suppression == True",
+      inv["binary_oracle"]["earns_suppression"] is True)
+
+
+# ---------------------------------------------------------------------------
+# 3. Chokepoint accessor — line disambiguation + tier guard
+# ---------------------------------------------------------------------------
+print("\n=== 3. Chokepoint accessor ===")
+from core.inventory.reachability import binary_oracle_absent
+
+check("absent verdict fires for dead function",
+      binary_oracle_absent(inv, "src/api.c", "api_dead_function") is True)
+check("absent verdict does NOT fire for live function",
+      binary_oracle_absent(inv, "src/api.c", "api_open") is False)
+check("absent verdict does NOT fire for unknown file",
+      binary_oracle_absent(inv, "src/missing.c",
+                           "api_dead_function") is False)
+# Synthesise a mixed-tier case (one full + one symbol_only) — chokepoint
+# must refuse to fire even though classification is absent.
+_dead_api["metadata"]["binary_oracle"]["binaries"] = [
+    {"tier": "full", "path": str(BINARY)},
+    {"tier": "symbol_only", "path": "/stripped/binary"},
+]
+# Index caches the lookup; invalidate so the modified inventory is
+# re-walked rather than served from cache (P1-C-2 perf fix side effect).
+from core.inventory import reachability as _R
+_R._BO_ITEM_INDEX_CACHE.clear()
+check("mixed-tier (full + symbol_only) refuses to suppress",
+      binary_oracle_absent(inv, "src/api.c",
+                           "api_dead_function") is False)
+# Restore full-tier so subsequent checks pass.
+_dead_api["metadata"]["binary_oracle"]["binaries"] = [
+    {"tier": "full", "path": str(BINARY)}]
+_R._BO_ITEM_INDEX_CACHE.clear()
+
+
+# ---------------------------------------------------------------------------
+# 4. reach_audit verdict chain
+# ---------------------------------------------------------------------------
+print("\n=== 4. reach_audit classify_reachability ===")
+from core.inventory.reach_audit import classify_reachability
+
+v_dead = classify_reachability(
+    inv, "src/api.c", "api_dead_function", 26, "src.api")
+check("classify_reachability returns binary_oracle_absent for dead",
+      v_dead == "binary_oracle_absent", v_dead)
+
+
+# ---------------------------------------------------------------------------
+# 5. Verdict → witness → suppression chain
+# ---------------------------------------------------------------------------
+print("\n=== 5. Verdict → witness → suppression ===")
+from core.inventory.reach_witness import (
+    STRUCTURALLY_SUPPRESSIBLE_KINDS, VERDICTS,
+    verdict_from_classification, WitnessKind,
+)
+
+rv = verdict_from_classification("binary_oracle_absent")
+check("binary_oracle_absent witness kind == BINARY_ORACLE_ABSENT",
+      rv.witness.kind is WitnessKind.BINARY_ORACLE_ABSENT)
+check("binary_oracle_absent VerdictSpec.earns_suppression",
+      VERDICTS["binary_oracle_absent"].earns_suppression is True)
+check("rv.may_suppress with EARNED set",
+      rv.may_suppress(STRUCTURALLY_SUPPRESSIBLE_KINDS) is True)
+check("rv.may_suppress with empty earned set",
+      rv.may_suppress() is False)
+
+
+# ---------------------------------------------------------------------------
+# 6. Shared chokepoint helper (reach_chokepoint.check_suppress)
+# ---------------------------------------------------------------------------
+print("\n=== 6. Shared chokepoint helper ===")
+from core.inventory.reach_chokepoint import check_suppress, record_suppression
+
+decision = check_suppress(
+    checklist=inv,
+    file_path="src/api.c", function_name="api_dead_function", line=26,
+    repo_root=TARGET,
+)
+check("check_suppress fires on dead function",
+      decision is not None and decision[0] == "binary_oracle_absent")
+decision = check_suppress(
+    checklist=inv,
+    file_path="src/api.c", function_name="api_open", line=4,
+    repo_root=TARGET,
+)
+check("check_suppress does NOT fire on live function",
+      decision is None)
+# Absolute path normalization
+decision = check_suppress(
+    checklist=inv,
+    file_path=str(TARGET / "src" / "api.c"),
+    function_name="api_dead_function", line=26,
+    repo_root=TARGET,
+)
+check("check_suppress handles absolute finding path",
+      decision is not None and decision[0] == "binary_oracle_absent")
+# manual_override blocks
+decision = check_suppress(
+    checklist=inv,
+    file_path="src/api.c", function_name="api_dead_function", line=26,
+    repo_root=TARGET, manual_override=True,
+)
+check("check_suppress respects manual_override",
+      decision is None)
+
+
+# ---------------------------------------------------------------------------
+# 7. suppressions.jsonl audit trail
+# ---------------------------------------------------------------------------
+print("\n=== 7. suppressions.jsonl ===")
+with tempfile.TemporaryDirectory() as td:
+    out = Path(td)
+    record_suppression(
+        out,
+        finding={"finding_id": "e2e-1", "rule_id": "cpp/test",
+                 "file_path": "src/api.c", "line": 26,
+                 "function": "api_dead_function"},
+        verdict="binary_oracle_absent",
+        reason="E2E test suppression",
+    )
+    p = out / "suppressions.jsonl"
+    check("suppressions.jsonl file created", p.is_file())
+    record = json.loads(p.read_text().strip())
+    check("record has finding_id", record["finding_id"] == "e2e-1")
+    check("record has verdict", record["verdict"] == "binary_oracle_absent")
+
+
+# ---------------------------------------------------------------------------
+# 8. Auto-detect on real project tree
+# ---------------------------------------------------------------------------
+print("\n=== 8. Auto-detect ===")
+from core.inventory.binary_oracle_autodetect import detect_binaries
+
+detected = detect_binaries(TARGET, "application")
+check("auto-detect finds build/app",
+      any(p.name == "app" for p in detected),
+      f"detected={[p.name for p in detected]}")
+
+
+# ---------------------------------------------------------------------------
+# 9. Hostile-ELF defense — planted binary dropped
+# ---------------------------------------------------------------------------
+print("\n=== 9. Hostile-ELF defense ===")
+import subprocess
+hostile_src = TARGET / "build" / "hostile.c"
+hostile_src.write_text(
+    "int totally_unrelated_thing(int x){return x^0xdeadbeef;}\n"
+    "int main(void){return totally_unrelated_thing(0);}\n"
+)
+hostile = TARGET / "build" / "planted"
+subprocess.run(["gcc", "-O0", "-g", str(hostile_src),
+                "-o", str(hostile)], check=True)
+inv2 = {"files": [
+    {"path": "src/api.c", "language": "c", "items": [
+        {"name": f"api_func_{i}", "kind": "function", "line_start": i + 1}
+        for i in range(15)
+    ]},
+]}
+counts_h = enrich_inventory_with_binary_oracle(inv2, (hostile,))
+check("planted-ELF dropped — zero items annotated",
+      counts_h["classified"] == 0,
+      f"classified={counts_h['classified']}")
+
+
+# ---------------------------------------------------------------------------
+# 10. Multi-binary combine (alive-in-any-wins)
+# ---------------------------------------------------------------------------
+print("\n=== 10. Multi-binary combine ===")
+# Build a SECOND binary that ONLY defines api_dead_function (in our
+# real target it's absent). Combined verdict should be symbol_present
+# (alive-in-any-wins).
+alt_src = TARGET / "build" / "alt.c"
+alt_src.write_text(
+    "int api_dead_function(int x){return x*999;}\n"
+    "int main(void){return api_dead_function(1);}\n"
+)
+alt_bin = TARGET / "build" / "alt"
+subprocess.run(["gcc", "-O0", "-g", str(alt_src), "-o", str(alt_bin)],
+               check=True)
+inv3 = {"files": [
+    {"path": "src/api.c", "language": "c", "items": [
+        {"name": "api_dead_function", "kind": "function", "line_start": 1},
+        # 8 padding items so the floor doesn't bounce the small binary.
+        *[{"name": f"api_open_{i}" if i == 0 else f"api_p_{i}",
+           "kind": "function", "line_start": 10 + i} for i in range(8)],
+    ]},
+]}
+# Make the padding match BOTH binaries by giving names api_open knows.
+# Actually simpler: use names that THE REAL BINARY has, but the alt binary
+# lacks. So real binary contributes coverage > floor; alt binary's coverage
+# is low. Both will be admitted (floor only kicks in at >= 8 project names
+# in EACH binary; alt has just "api_dead_function" + "main").
+# Per current floor implementation: floor applies when n_project >= 8;
+# we have 9 project names; alt matches only 1 of them → 11% which is
+# above 5% floor BUT min_matched=3 means alt gets dropped.
+# Let me restructure: use names that BOTH have.
+inv3 = {"files": [
+    {"path": "src/api.c", "language": "c", "items": [
+        {"name": "api_dead_function", "kind": "function", "line_start": 1},
+        {"name": "main", "kind": "function", "line_start": 2},
+        # Below 8 project names → floor doesn't fire.
+    ]},
+]}
+counts_m = enrich_inventory_with_binary_oracle(inv3, (BINARY, alt_bin))
+items_m = {it["name"]: it for it in inv3["files"][0]["items"]}
+dead_bo = items_m["api_dead_function"]["metadata"]["binary_oracle"]
+check("multi-binary combined verdict for api_dead_function is alive-in-any",
+      dead_bo["classification"] == "symbol_present",
+      dead_bo["classification"])
+check("multi-binary records both binaries",
+      len(dead_bo["binaries"]) == 2)
+
+
+# ---------------------------------------------------------------------------
+# 11. Stripped binary → symbol_only tier fallback (E1)
+# ---------------------------------------------------------------------------
+print("\n=== 11. Stripped-binary tier fallback ===")
+stripped = TARGET / "build" / "app_stripped"
+import shutil
+shutil.copy(BINARY, stripped)
+subprocess.run(["strip", "--strip-debug", str(stripped)], check=True)
+v_stripped = classify_binary_evidence(["api_open", "api_dead_function"],
+                                      stripped)
+check("stripped binary verdicts present", len(v_stripped) > 0)
+check("stripped binary verdicts carry tier=symbol_only",
+      any(w.tier == "symbol_only" for w in v_stripped.values()),
+      f"tiers={set(w.tier for w in v_stripped.values())}")
+
+
+# ---------------------------------------------------------------------------
+# 12. Sandbox writes for gcov instrumentation (via libsodium pattern)
+# ---------------------------------------------------------------------------
+print("\n=== 12. Sandbox + corpus driver harness ===")
+# Verify the sandbox-aware corpus driver path imports cleanly + the
+# wiring is in place. Don't actually run the corpus build (slow).
+from core.inventory.binary_oracle_corpora import REGISTRY
+check("registry contains all 7 corpora",
+      len(REGISTRY) == 7,
+      f"got {len(REGISTRY)}: {sorted(REGISTRY.keys())}")
+for name in ("synthetic", "zlib", "libsodium", "snappy", "leveldb",
+             "regex-rust", "zstd_holdout"):
+    check(f"  driver {name!r} registered",
+          name in REGISTRY)
+
+
+# ---------------------------------------------------------------------------
+# 13. annotation_synth — binary_oracle tag emission
+# ---------------------------------------------------------------------------
+print("\n=== 13. annotation_synth binary_oracle tag ===")
+from packages.code_understanding.annotation_synth import (
+    _binary_oracle_tag, _binary_oracle_body_line,
+)
+
+func_full = {"metadata": {"binary_oracle": {
+    "classification": "absent",
+    "binaries": [{"path": "/b", "classification": "absent",
+                  "tier": "full"}],
+}}}
+tag = _binary_oracle_tag(func_full)
+check("full-tier tag has classification + tier=full",
+      tag.get("binary_oracle") == "absent"
+      and tag.get("binary_oracle_tier") == "full")
+body = _binary_oracle_body_line(func_full)
+check("full-tier body line says 'in deployed binary surface'",
+      "deployed binary surface" in body, body)
+func_symonly = {"metadata": {"binary_oracle": {
+    "classification": "absent",
+    "binaries": [{"path": "/b", "classification": "absent",
+                  "tier": "symbol_only"}],
+}}}
+tag2 = _binary_oracle_tag(func_symonly)
+check("symbol_only tag has tier=symbol_only",
+      tag2.get("binary_oracle_tier") == "symbol_only")
+body2 = _binary_oracle_body_line(func_symonly)
+check("symbol_only body line says 'does NOT license suppression'",
+      "does NOT license suppression" in body2, body2)
+
+
+# ---------------------------------------------------------------------------
+# 14. /project binaries persistence round-trip
+# ---------------------------------------------------------------------------
+print("\n=== 14. /project persistence ===")
+from core.project.project import Project
+
+p = Project(name="e2e", target=str(TARGET),
+            output_dir=str(TARGET / "out"))
+p.binaries = [str(BINARY)]
+d = p.to_dict()
+check("project schema version 2", d["version"] == 2)
+check("project to_dict has binaries", d.get("binaries") == [str(BINARY)])
+# Round-trip
+p2 = Project.from_dict(d)
+check("project from_dict preserves binaries",
+      p2.binaries == [str(BINARY)])
+# Back-compat: v1 file (no version, no binaries)
+p3 = Project.from_dict({"name": "old", "target": "/t",
+                         "output_dir": "/o"})
+check("v1 back-compat: empty binaries default",
+      p3.binaries == [])
+
+
+# ---------------------------------------------------------------------------
+# 15. Inventory builder honours BINARY_ORACLE_PATHS
+# ---------------------------------------------------------------------------
+print("\n=== 15. build_inventory + BINARY_ORACLE_PATHS ===")
+from core.config import RaptorConfig
+from core.inventory.builder import build_inventory
+
+# Save / restore
+_orig_paths = RaptorConfig.BINARY_ORACLE_PATHS
+try:
+    RaptorConfig.BINARY_ORACLE_PATHS = (str(BINARY),)
+    with tempfile.TemporaryDirectory() as outdir:
+        full_inv = build_inventory(str(TARGET), outdir)
+    bo_summary = full_inv.get("binary_oracle")
+    check("full inventory has binary_oracle summary",
+          bo_summary is not None and "counts" in bo_summary)
+    if bo_summary:
+        check("summary records absent count",
+              bo_summary["counts"].get("absent", 0) > 0,
+              f"absent={bo_summary['counts'].get('absent', 0)}")
+        check("summary earns_suppression=True",
+              bo_summary.get("earns_suppression") is True)
+finally:
+    RaptorConfig.BINARY_ORACLE_PATHS = _orig_paths
+
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+print(f"\n{'=' * 72}")
+n_pass = sum(1 for _, ok, _ in results if ok)
+n_fail = len(results) - n_pass
+print(f"E2E: {n_pass}/{len(results)} passed, {n_fail} failed")
+if n_fail:
+    print("\nFailures:")
+    for name, ok, detail in results:
+        if not ok:
+            print(f"  - {name}: {detail}")
+    sys.exit(1)
+print("All E2E checks passed.")

--- a/libexec/raptor-binary-oracle-precision
+++ b/libexec/raptor-binary-oracle-precision
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+"""CLI shim for the binary-oracle precision harness.
+
+Run via ``bin/raptor`` (which sets ``CLAUDECODE``) or with
+``_RAPTOR_TRUSTED=1`` for direct invocation in tests.
+"""
+import os
+import sys
+from pathlib import Path
+
+# ─── trust-marker check (do not import; inline by design) ───
+if not (os.environ.get("CLAUDECODE")
+        or os.environ.get("_RAPTOR_TRUSTED")):
+    sys.stderr.write(
+        f"{sys.argv[0]}: internal dispatch script.\n"
+        "  Run via 'bin/raptor' instead.\n"
+        "  Tests / power users: set _RAPTOR_TRUSTED=1 to bypass.\n"
+    )
+    sys.exit(2)
+# ─── end trust-marker check ─────────────────────────────────
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from core.inventory.binary_oracle_precision import main  # noqa: E402
+
+sys.exit(main())

--- a/packages/code_understanding/annotation_synth.py
+++ b/packages/code_understanding/annotation_synth.py
@@ -96,6 +96,74 @@ def _resolve(
         return None
 
 
+def _binary_oracle_tag(func: Dict[str, Any]) -> Dict[str, Any]:
+    """If the inventory function carries a binary_oracle classification
+    (operator passed ``--binary``), surface it on the annotation so the
+    researcher reading the map sees e.g. "this sink is absent from the
+    deployed binary — not an attack surface in this build."
+
+    Returns ``{}`` when no classification is present (no --binary,
+    non-native language, or stripped binary). Includes the per-binary
+    breakdown for hybrid targets (Phase 4) AND the evidence tier so
+    the researcher can tell full-DWARF evidence from the weaker
+    symbol-only fallback — without this tag, an annotation would
+    claim "absent" from symbol-only evidence while the chokepoint
+    correctly refuses to suppress it, producing inconsistent stories
+    across consumer surfaces (adversarial review P2-C-1)."""
+    if not isinstance(func, dict):
+        return {}
+    meta = func.get("metadata") or {}
+    bo = meta.get("binary_oracle") or {}
+    cls = bo.get("classification")
+    if not cls:
+        return {}
+    tag: Dict[str, Any] = {"binary_oracle": cls}
+    binaries = bo.get("binaries") or []
+    if binaries:
+        tag["binary_oracle_per_binary"] = [
+            {"path": b.get("path"),
+             "classification": b.get("classification"),
+             "tier": b.get("tier", "full")}
+            for b in binaries if isinstance(b, dict)
+        ]
+        # Top-level tier mirrors the chokepoint's gate: ``full`` when
+        # every contributing binary is full-DWARF; ``symbol_only``
+        # when ANY is symbol-only (the chokepoint refuses to fire on
+        # this case — readers should see the same caveat).
+        any_symbol_only = any(
+            b.get("tier") == "symbol_only"
+            for b in binaries if isinstance(b, dict)
+        )
+        tag["binary_oracle_tier"] = (
+            "symbol_only" if any_symbol_only else "full"
+        )
+    return tag
+
+
+def _binary_oracle_body_line(func: Dict[str, Any]) -> str:
+    """Researcher-facing body line for the annotation. Empty when no
+    classification is present. Downgrades the prose for symbol-only
+    evidence so the reader isn't misled into trusting an ``absent``
+    verdict the chokepoint itself refuses to act on."""
+    if not isinstance(func, dict):
+        return ""
+    bo = (func.get("metadata") or {}).get("binary_oracle") or {}
+    cls = bo.get("classification")
+    if not cls:
+        return ""
+    binaries = bo.get("binaries") or []
+    any_symbol_only = any(
+        isinstance(b, dict) and b.get("tier") == "symbol_only"
+        for b in binaries
+    )
+    if any_symbol_only:
+        return (
+            f"Binary oracle: {cls} (symbol-only evidence — stripped "
+            "binary, no DWARF; does NOT license suppression)"
+        )
+    return f"Binary oracle: {cls} (in deployed binary surface)"
+
+
 def _hash_metadata(
     repo_root: Path, file_path: str, func: Dict[str, Any],
 ) -> Dict[str, str]:
@@ -190,6 +258,11 @@ def _emit_entry_points(
         if ep.get("type"):
             metadata["type"] = _safe_meta(ep["type"])
         metadata.update(_hash_metadata(repo_root, file_path, func))
+        # Surface binary_oracle classification when --binary was passed.
+        metadata.update(_binary_oracle_tag(func))
+        bo_line = _binary_oracle_body_line(func)
+        if bo_line:
+            body_lines.append(bo_line)
         ann = Annotation(
             file=file_path, function=func["name"],
             body="\n\n".join(body_lines), metadata=metadata,
@@ -309,6 +382,12 @@ def _emit_sinks(
         if sink.get("type"):
             metadata["type"] = _safe_meta(sink["type"])
         metadata.update(_hash_metadata(repo_root, file_path, func))
+        # A sink ``absent`` from the deployed binary isn't reachable
+        # in this build — researcher can deprioritize tracing it.
+        metadata.update(_binary_oracle_tag(func))
+        bo_line = _binary_oracle_body_line(func)
+        if bo_line:
+            body_lines.append(bo_line)
         ann = Annotation(
             file=file_path, function=func["name"],
             body="\n\n".join(body_lines), metadata=metadata,

--- a/packages/code_understanding/tests/test_annotation_synth.py
+++ b/packages/code_understanding/tests/test_annotation_synth.py
@@ -254,6 +254,39 @@ class TestContextMap:
         assert "SINK-001" in ann.body
 
 
+class TestBinaryOracleAnnotations:
+    """Phase 3c: when the inventory carries binary_oracle classifications
+    (--binary was passed), /understand --map annotations surface the
+    classification on entry-point + sink items. Researcher sees "this
+    sink is absent in the deployed binary" while reading the map."""
+
+    def test_helper_extracts_classification_from_func_metadata(self):
+        from packages.code_understanding.annotation_synth import (
+            _binary_oracle_tag, _binary_oracle_body_line,
+        )
+        func = {"metadata": {"binary_oracle": {
+            "classification": "absent",
+            "binaries": [
+                {"path": "/build/example", "classification": "absent"},
+                {"path": "/build/libfoo.so", "classification": "absent"},
+            ],
+        }}}
+        tag = _binary_oracle_tag(func)
+        assert tag["binary_oracle"] == "absent"
+        assert len(tag["binary_oracle_per_binary"]) == 2
+        assert _binary_oracle_body_line(func) == (
+            "Binary oracle: absent (in deployed binary surface)")
+
+    def test_helper_silent_when_no_classification(self):
+        from packages.code_understanding.annotation_synth import (
+            _binary_oracle_tag, _binary_oracle_body_line,
+        )
+        assert _binary_oracle_tag({}) == {}
+        assert _binary_oracle_body_line({}) == ""
+        assert _binary_oracle_tag({"metadata": {}}) == {}
+        assert _binary_oracle_tag({"metadata": {"binary_oracle": {}}}) == {}
+
+
 class TestFlowTrace:
     def test_emits_per_step_annotations(self, understand_run):
         repo, out = understand_run

--- a/packages/codeql/autonomous_analyzer.py
+++ b/packages/codeql/autonomous_analyzer.py
@@ -1115,6 +1115,39 @@ class AutonomousCodeQLAnalyzer:
                 "⏭️  Sink unreachable (%s — sound witness) — skipping "
                 "expensive analysis", reachability_verdict,
             )
+            # Aggregate audit trail (Agent C P1-1) — match the
+            # ``suppressions.jsonl`` /agentic emits so an operator
+            # can correlate suppressions across both consumers from
+            # a single per-run JSONL. Best-effort; never blocks.
+            try:
+                from core.inventory.reach_chokepoint import (
+                    record_suppression,
+                )
+                # The codeql analyzer's out_dir lives on the broader
+                # CodeQLAgent run; fall back to repo_path when not
+                # available (analyzer-as-library call shapes).
+                _out = getattr(self, "out_dir", None) or repo_path
+                _finding_dict = {
+                    "finding_id": getattr(finding, "id", "") or "",
+                    "rule_id": getattr(finding, "rule_id", "") or "",
+                    "file_path": getattr(finding, "file_path", "") or "",
+                    "line": getattr(finding, "start_line", None),
+                    "function": "",
+                }
+                record_suppression(
+                    Path(_out),
+                    finding=_finding_dict,
+                    verdict=reachability_verdict,
+                    reason=(
+                        f"CodeQL chokepoint: sink at "
+                        f"{_finding_dict['file_path']}:"
+                        f"{_finding_dict['line']} unreachable via "
+                        f"SOUND witness ({reachability_verdict}); "
+                        f"skipped expensive analysis."
+                    ),
+                )
+            except Exception:  # noqa: BLE001
+                pass
             return AutonomousAnalysisResult(
                 finding=finding,
                 analysis=None,

--- a/packages/exploitability_validation/reachability.py
+++ b/packages/exploitability_validation/reachability.py
@@ -43,9 +43,13 @@ _DEMOTED_PROXIMITY_CAP = 1
 # registered_via_call) and "uncertain" are NOT here — they keep the path.
 # Demotion is soft (proximity clamp + blocker), so demoting on the heuristic
 # verdicts (no_path_from_entry / not_called) is safe — never a hard suppress.
+# binary_oracle_absent is the SOUND + corpus-earned native dead witness
+# (Inc 3d): functions DCE'd from the analysed binary; the demoter clamps
+# proximity and embeds the binary-oracle blocker. Hard-suppression in the
+# /codeql path goes through autonomous_analyzer's may_suppress chokepoint.
 _DEMOTE_VERDICTS = frozenset({
-    "module_aborts", "lexical_dead", "build_excluded",
-    "no_path_from_entry", "not_called",
+    "module_aborts", "lexical_dead", "binary_oracle_absent",
+    "build_excluded", "no_path_from_entry", "not_called",
 })
 
 
@@ -155,6 +159,17 @@ def demote_unreachable_paths(
             continue
         finding = findings_by_id.get(finding_id)
         if finding is None:
+            continue
+        # Manual override consistency (adversarial review P1-5): both
+        # /agentic and /codeql respect ``finding.manual_override``;
+        # /validate must too, else operators marking a finding for
+        # human review still get its attack path silently demoted.
+        # Coerce explicit string-False so an emitter passing
+        # ``"manual_override": "false"`` doesn't accidentally bypass.
+        mo = finding.get("manual_override")
+        if isinstance(mo, str):
+            mo = mo.strip().lower() not in ("", "false", "0", "no", "off")
+        if mo:
             continue
         location = _finding_location(finding)
         if location is None:
@@ -435,20 +450,32 @@ def enrich_with_substrate_evidence(
 
 
 def _is_demoted(path: Dict[str, Any]) -> bool:
-    """Detect whether ``demote_unreachable_paths`` already
-    demoted this path. Looks for the documented blocker prefix.
-    """
+    """Detect whether ``demote_unreachable_paths`` already demoted
+    this path. Derives the blocker-prefix set from ``VERDICTS`` so
+    new demote-eligible verdicts (e.g. ``binary_oracle_absent``,
+    ``build_excluded``) are picked up automatically. The hand-rolled
+    list in the prior implementation drifted as ``_DEMOTE_VERDICTS``
+    grew — Stage F enrichment would treat a binary-oracle-demoted
+    path as un-demoted and add contradictory substrate evidence
+    (adversarial review P1-C-4)."""
     blockers = path.get("blockers") or []
     if not isinstance(blockers, list):
         return False
-    return any(
-        isinstance(b, str)
-        and (
-            b.startswith("reachability:not_called")
-            or b.startswith("reachability:module_aborts")
-            or b.startswith("reachability:lexical_dead")
+    from core.inventory.reach_witness import VERDICTS
+    prefixes = tuple(
+        f"reachability:{v}" for v in _DEMOTE_VERDICTS
+        if v in VERDICTS
+    )
+    if not prefixes:
+        # Defensive fallback if VERDICTS is somehow empty —
+        # preserve old behaviour rather than no-op.
+        prefixes = (
+            "reachability:not_called",
+            "reachability:module_aborts",
+            "reachability:lexical_dead",
         )
-        for b in blockers
+    return any(
+        isinstance(b, str) and b.startswith(prefixes) for b in blockers
     )
 
 

--- a/packages/llm_analysis/agent.py
+++ b/packages/llm_analysis/agent.py
@@ -1776,6 +1776,10 @@ class AutonomousSecurityAgentV2:
         # tokens it saved.
         fixture_prep_outcomes = {"true": 0, "false": 0, "candidate": 0}
         fixture_skipped_llm_calls = 0
+        # Reachability-chokepoint LLM-call skips (binary_oracle_absent /
+        # module_aborts / lexical_dead). Counted separately so the operator
+        # can see the savings split across the two short-circuit paths.
+        reachability_skipped_llm_calls = 0
         idx = 0  # Initialize idx to prevent UnboundLocalError when unique_findings is empty
 
         is_prep = isinstance(self.llm, ClaudeCodeProvider)
@@ -1912,6 +1916,80 @@ class AutonomousSecurityAgentV2:
                 if fixture_skipped_this:
                     analyzed += 1
                     fixture_skipped_llm_calls += 1
+                    if emit_annotations:
+                        if self._emit_finding_annotation(vuln, checklist):
+                            annotations_emitted += 1
+                    continue  # skip LLM analyze + exploit + patch
+
+                # 0b. Reachability chokepoint — SOUND, corpus-earned
+                # dead witness (module_aborts / lexical_dead /
+                # binary_oracle_absent) on the finding's enclosing
+                # function means no exploit is reachable; skip the LLM
+                # call. Mirrors the codeql autonomous_analyzer
+                # suppression so semgrep findings get the same cost
+                # savings (Phase 3b). Uses the shared
+                # ``reach_chokepoint`` helper for path/module
+                # normalisation — copy-paste-reductionism in the prior
+                # implementation produced silent-drop bugs on absolute
+                # paths, file:// URIs, and non-Python languages where
+                # ``module`` was the literal path string (adversarial
+                # review P0-C-1 / P0-C-2).
+                reach_skipped_this = False
+                if checklist:
+                    try:
+                        from core.inventory.reach_chokepoint import (
+                            check_suppress,
+                        )
+                        rel = (finding.get("file_path")
+                               or finding.get("file") or "")
+                        fn = (finding.get("function")
+                              or (finding.get("metadata") or {}).get(
+                                  "function_name", ""))
+                        line_no = int(finding.get("line") or 0)
+                        decision = check_suppress(
+                            checklist=checklist,
+                            file_path=rel, function_name=fn,
+                            line=line_no,
+                            repo_root=Path(self.repo_path),
+                            allow_unreachable=getattr(
+                                self, "allow_unreachable", False),
+                            manual_override=finding.get("manual_override"),
+                        )
+                        if decision is not None:
+                            verdict, reason = decision
+                            vuln.analysis = {
+                                "is_true_positive": False,
+                                "is_exploitable": False,
+                                "reasoning": reason,
+                                "reachability_suppression": True,
+                                "reachability_verdict": verdict,
+                            }
+                            reach_skipped_this = True
+                            # Aggregate audit trail (Agent C P1-1) —
+                            # one-stop ``suppressions.jsonl`` so an
+                            # operator can ``jq`` / count instead of
+                            # walking each per-finding annotation.
+                            # Best-effort; never blocks.
+                            try:
+                                from core.inventory.reach_chokepoint \
+                                    import record_suppression
+                                record_suppression(
+                                    self.out_dir,
+                                    finding=finding,
+                                    verdict=verdict, reason=reason,
+                                )
+                            except Exception:  # noqa: BLE001
+                                pass
+                    except Exception as e:  # noqa: BLE001
+                        logger.debug(
+                            "reachability pre-flight failed on %s: %s",
+                            finding.get("finding_id") or finding.get("id"),
+                            e,
+                        )
+
+                if reach_skipped_this:
+                    analyzed += 1
+                    reachability_skipped_llm_calls += 1
                     if emit_annotations:
                         if self._emit_finding_annotation(vuln, checklist):
                             annotations_emitted += 1

--- a/raptor_agentic.py
+++ b/raptor_agentic.py
@@ -763,7 +763,34 @@ Examples:
     )
 
     # Mitigation analysis options (NEW)
-    parser.add_argument("--binary", help="Target binary for mitigation analysis (enables pre-exploit checks)")
+    parser.add_argument(
+        "--binary", action="append", default=None,
+        help=(
+            "Target binary path. Used for (a) mitigation analysis "
+            "(pre-exploit checks) and (b) binary-oracle inventory "
+            "enrichment — DWARF-joined per-function classification, "
+            "drives finding suppression on dead functions. Repeat for "
+            "hybrid targets (e.g. --binary lib.so --binary app); a "
+            "function is classified ``absent`` only when EVERY declared "
+            "binary lacks it."
+        ),
+    )
+    parser.add_argument(
+        "--binary-auto", action="store_true",
+        help=(
+            "Auto-detect debug binaries under the target's build "
+            "directories. Honours --target-kind; appends detected paths "
+            "to any --binary values."
+        ),
+    )
+    parser.add_argument(
+        "--binary-edges", action="store_true",
+        help=(
+            "Inc 2b Tier 1: extract direct call edges (r2) and "
+            "annotate inventory functions with binary-found callers. "
+            "Slow; requires --binary."
+        ),
+    )
     parser.add_argument("--check-mitigations", action="store_true",
                        help="Run mitigation analysis before scanning (for binary exploit targets)")
     parser.add_argument("--skip-mitigation-checks", action="store_true",
@@ -1092,7 +1119,14 @@ Examples:
     logger.info(f"Max findings: {args.max_findings}")
     logger.info(f"Mode: {args.mode}")
     if args.binary:
-        logger.info(f"Target binary: {args.binary}")
+        logger.info(f"Target binary(s): {args.binary}")
+    # All ``--binary`` / ``--binary-auto`` / ``--binary-edges`` plumbing
+    # — path validation, auto-detect walk, active-project binary
+    # layering, RaptorConfig mutation, and the no-leak-across-runs
+    # guarantee — lives in the shared CLI helper. raptor_codeql.py
+    # uses the same call site to keep behaviour aligned.
+    from core.inventory.binary_oracle_cli import apply_to_config
+    apply_to_config(args, Path(args.repo))
 
     workflow_start = time.time()
 
@@ -1128,7 +1162,11 @@ Examples:
         try:
             from packages.exploit_feasibility import analyze_binary, format_analysis_summary
 
-            binary_path = str(Path(args.binary)) if args.binary else None
+            # --binary is action='append' (list) for binary-oracle's
+            # hybrid multi-binary case; mitigation analysis is per-binary,
+            # so analyse the FIRST declared binary.
+            binary_path = (
+                str(Path(args.binary[0])) if args.binary else None)
             mitigation_result = analyze_binary(binary_path, output_dir=str(out_dir))
 
             # Display formatted summary
@@ -1664,7 +1702,10 @@ Examples:
         sarif_files=sarif_files,
         total_findings=total_findings,
         vuln_type=args.vuln_type,
-        binary_path=args.binary,
+        # First binary used for downstream per-binary helpers (mitigation,
+        # fuzzing). Binary-oracle's multi-binary combine still happens via
+        # RaptorConfig.BINARY_ORACLE_PATHS independently.
+        binary_path=args.binary[0] if args.binary else None,
         skip_dedup=args.skip_dedup,
         skip_feasibility=not (args.binary or args.check_mitigations),
         external_llm=llm_env.external_llm,
@@ -1963,7 +2004,8 @@ Examples:
             try:
                 from packages.fuzzing.orchestrator import FuzzingOrchestrator
                 orch = FuzzingOrchestrator(llm=None)
-                plan = orch.plan(Path(args.binary))
+                # Fuzzing is per-binary; use the first --binary.
+                plan = orch.plan(Path(args.binary[0]))
                 print(plan.summary())
 
                 if args.fuzz_plan_only:
@@ -2015,7 +2057,8 @@ Examples:
                         try:
                             print(f"\n  Triaging {fuzzing_result['crashes']} fuzz crashes...")
                             crash_outputs = _prepare_fuzz_crashes_for_validate(
-                                binary_path=Path(args.binary),
+                                # Per-binary crash triage uses the first --binary.
+                                binary_path=Path(args.binary[0]),
                                 fuzzing_result=fuzzing_result,
                                 fuzz_out=fuzz_out,
                                 limit=args.max_findings,

--- a/raptor_codeql.py
+++ b/raptor_codeql.py
@@ -324,6 +324,8 @@ Examples:
             "raptor_agentic.py for detail."
         ),
     )
+    from core.inventory.binary_oracle_cli import add_binary_args
+    add_binary_args(parser)
     # ``--max-findings`` default 20 is intentionally HIGHER than
     # ``raptor_agentic.py``'s default 10: codeql-only mode does one
     # pass per finding (filter + summarise), while agentic does the
@@ -365,6 +367,13 @@ Examples:
     # 'auto' leaves it unset (per-target detection). See raptor_agentic.py.
     if getattr(args, "target_kind", "auto") != "auto":
         os.environ[RaptorConfig.ENV_TARGET_KIND] = args.target_kind
+    # All ``--binary`` / ``--binary-auto`` / ``--binary-edges`` plumbing
+    # lives in the shared CLI helper — explicit path validation,
+    # auto-detect walk, active-project binary layering, RaptorConfig
+    # mutation, and the no-leak-across-runs guarantee. raptor_agentic.py
+    # uses the same call site to keep behaviour aligned.
+    from core.inventory.binary_oracle_cli import apply_to_config
+    apply_to_config(args, Path(args.repo), parser=parser)
     # set_trust_override BEFORE apply_cli_args. apply_cli_args
     # may invoke trust-checks downstream (e.g. when validating
     # caller-supplied paths against project trust state). Pre-fix


### PR DESCRIPTION
  Binary-oracle reachability witness: joins the source inventory with one
  or more debug binaries (DWARF + nm) to classify each native (C/C++/
  Rust/Go) function as `symbol_present`, `inlined`, `folded`, or
  `absent`. The `absent` verdict is corpus-validated for suppression and
  flows through the existing reachability chokepoint:
  
  - `/codeql` + `/agentic` (semgrep) hard-skip pre-LLM analysis on
    findings in provably-dead functions
  - `/validate` soft-demotes attack paths anchored to absent functions
  - `/understand --map` annotates entry-points and sinks with the
    per-binary verdict + evidence tier
  
  Both `/codeql` and `/agentic` emit one record per suppression to
  `suppressions.jsonl` in the run output directory (jq-queryable audit
  trail).
  
  Operator surface: `--binary <path>` (repeatable; path-validated),
  `--binary-auto` (walks `build/`, `target/release/`, `cmake-build-*/`,
  `bazel-bin/`, `builddir/`, `Debug/`, `Release/`, `out/`, `dist/`,
  `bin/`, Rust cross-target globs), `--binary-edges` (opt-in r2 direct +
  vtable edges), and `/project binary {add,list,remove,clear}` for
  persistent per-project config.
  
  ## Commits (six logical layers, ~9.2k LOC, 47 files)
  
  1. **Classifier substrate** — DWARF + nm join + tier-weighted
     multi-binary combine + auto-detect + source-coverage floor +
     sandbox
  2. **Consumer chokepoint** — `reach_witness` verdicts + shared
     `reach_chokepoint` helper + four mainline consumers wired +
     `suppressions.jsonl`
  3. **Call-edge promote witness** — r2-driven direct + vtable edges;
     rescues functions the source graph thought were dead
  4. **Operator UX** — `--binary*` CLI + `/project binary` + project
     schema v2
  5. **Precision harness + seven corpus drivers** — synthetic, zlib,
     libsodium, snappy, leveldb, regex-rust + held-out zstd
  6. **Comprehensive E2E driver + CLAUDE.md**
  
  Each commit is independently buildable + testable.
