### PR TITLE
fix(reachability): binary-oracle accessors match interior finding lines

### DIFF
--- a/core/inventory/reachability.py
+++ b/core/inventory/reachability.py
@@ -2340,7 +2340,10 @@ def binary_call_edge_present(
     reachability uncertainty for upstream consumers (Inc 2b Tier 1).
 
     Path-keyed lookup via the shared inverse index (avoids the
-    O(N_files × N_items) walk per call)."""
+    O(N_files × N_items) walk per call). When ``line`` is provided
+    AND there are multiple same-name candidates, pick the item whose
+    line range CONTAINS the query line (production callers pass the
+    line OF THE FINDING, not the function's first line)."""
     if not file_path or not name:
         return False
     normalised = file_path.replace("\\", "/")
@@ -2351,9 +2354,21 @@ def binary_call_edge_present(
     candidates = by_name.get(name)
     if not candidates:
         return False
+    if line and len(candidates) > 1:
+        enclosing = [
+            it for it in candidates
+            if int(it.get("line_start") or 0) <= line
+            and (int(it.get("line_end") or 0) == 0
+                 or line <= int(it.get("line_end") or 0))
+        ]
+        if enclosing:
+            candidates = [max(
+                enclosing,
+                key=lambda it: int(it.get("line_start") or 0),
+            )]
+        else:
+            candidates = candidates[:1]
     for item in candidates:
-        if line and int(item.get("line_start") or 0) != line:
-            continue
         meta = item.get("metadata")
         if not isinstance(meta, dict):
             return False
@@ -2407,13 +2422,29 @@ def binary_oracle_absent(
     candidates = by_name.get(name)
     if not candidates:
         return False
+    # Line disambiguation: production callers (semgrep, codeql) pass
+    # the line OF THE FINDING, which is typically INSIDE the function,
+    # not at its first line. Pick the item whose range
+    # [line_start, line_end] contains the query line; when line_end
+    # isn't set on the inventory item, fall back to "function whose
+    # line_start is the closest <= query line" (the standard
+    # function-containing-line heuristic). This subsumes the
+    # name-collision disambiguation case AND interior-line queries.
+    if line and len(candidates) > 1:
+        enclosing = [
+            it for it in candidates
+            if int(it.get("line_start") or 0) <= line
+            and (int(it.get("line_end") or 0) == 0
+                 or line <= int(it.get("line_end") or 0))
+        ]
+        if enclosing:
+            candidates = [max(
+                enclosing,
+                key=lambda it: int(it.get("line_start") or 0),
+            )]
+        else:
+            candidates = candidates[:1]
     for item in candidates:
-        # Line disambiguation: name-collisions inside a file are
-        # real (static helpers, #if/#else, overloads). Skip non-
-        # matching items so the caller's (name, line) tuple
-        # actually identifies the function it intended.
-        if line and int(item.get("line_start") or 0) != line:
-            continue
         meta = item.get("metadata")
         if not isinstance(meta, dict):
             return False

--- a/core/inventory/tests/test_reach_witness.py
+++ b/core/inventory/tests/test_reach_witness.py
@@ -128,6 +128,58 @@ def test_binary_oracle_absent_line_disambiguates_name_collisions():
     assert rv_dead.witness.kind is WitnessKind.BINARY_ORACLE_ABSENT
 
 
+def test_binary_oracle_absent_fires_on_interior_finding_line():
+    """Production scanners (semgrep, codeql) emit findings at the
+    line WHERE THE ISSUE IS, not at the function's first line.
+    The accessor must accept any line inside the function's range —
+    the strict ``line == line_start`` check the closed-loop test
+    surfaced was silently refusing to suppress every interior-line
+    finding on a dead function."""
+    inv = {"files": [{
+        "path": "lib.c", "language": "c",
+        "items": [{
+            "name": "dead_helper", "kind": "function",
+            "line_start": 140, "line_end": 180,
+            "metadata": {"binary_oracle": {
+                "classification": "absent",
+                "binaries": [{"tier": "full"}]}},
+        }],
+    }]}
+    # Finding emitted at line 154 (inside the function body).
+    rv = resolve_reachability(inv, "lib.c", "dead_helper", 154, "lib")
+    assert rv.witness.kind is WitnessKind.BINARY_ORACLE_ABSENT
+    # Single-candidate path with no line_end set works too — the
+    # function-containing-line heuristic accepts any line >= line_start.
+    inv["files"][0]["items"][0]["line_end"] = None
+    rv = resolve_reachability(inv, "lib.c", "dead_helper", 154, "lib")
+    assert rv.witness.kind is WitnessKind.BINARY_ORACLE_ABSENT
+
+
+def test_binary_oracle_absent_picks_innermost_enclosing_on_collision():
+    """When two same-name items both enclose the query line (line_end
+    missing on both), pick the one whose line_start is the LATEST
+    <= query line — the standard ``function containing this line''
+    heuristic."""
+    inv = {"files": [{
+        "path": "lib.c", "language": "c",
+        "items": [
+            # Outer (e.g. a top-level dead function)
+            {"name": "helper", "kind": "function", "line_start": 10,
+             "metadata": {"binary_oracle": {
+                 "classification": "absent",
+                 "binaries": [{"tier": "full"}]}}},
+            # Inner (e.g. a live namesake later in the file)
+            {"name": "helper", "kind": "function", "line_start": 100},
+        ],
+    }]}
+    # Query inside the second (live) helper — must NOT pick the dead one.
+    rv = resolve_reachability(inv, "lib.c", "helper", 150, "lib")
+    assert rv.witness.kind is not WitnessKind.BINARY_ORACLE_ABSENT
+    # Query inside the first (dead) helper — must pick that one.
+    rv = resolve_reachability(inv, "lib.c", "helper", 20, "lib")
+    assert rv.witness.kind is WitnessKind.BINARY_ORACLE_ABSENT
+
+
 def test_binary_oracle_inlined_does_not_demote_function():
     """An ``inlined`` classification is REACHABLE evidence (function ran,
     just merged into its caller). The accessor must NOT return absent for


### PR DESCRIPTION
`binary_oracle_absent` and `binary_call_edge_present` did strict `line == line_start` matching for name-collision disambiguation. Production scanners emit findings at the line OF THE ISSUE — which is typically INSIDE the function body, not at its first line. The strict match silently refused to suppress every interior-line finding on a dead function, defeating the consumer chokepoint for real semgrep / codeql output.

Switch to a function-containing-line heuristic: pick the same-name item whose [line_start, line_end] range encloses the query line; when line_end isn't set on the inventory item, fall back to "the latest line_start ≤ query line" (standard nested-function disambiguation). Subsumes the prior name-collision case AND interior-line queries.

Found by an internal-consistency closed-loop test on zlib v1.3.1: 58 real semgrep findings, 6 in functions binary-oracle classified `absent` — none of which the chokepoint suppressed under the strict match. After the fix: 6/6 suppressed, zero silent-drop bugs, zero spurious suppressions.

Two regression tests:

  * test_binary_oracle_absent_fires_on_interior_finding_line — query line 154 inside a function spanning lines 140–180 must match; also covers the line_end=None fallback path.
  * test_binary_oracle_absent_picks_innermost_enclosing_on_collision — two same-name items, both with line_start ≤ query line, must pick the one whose line_start is the LATEST <= query line.