### PR TITLE
ci: stop SCA data-refresh failing on forks + fix source_intel venv restore

### DIFF
--- a/.github/workflows/refit-sca-calibration.yml
+++ b/.github/workflows/refit-sca-calibration.yml
@@ -42,6 +42,14 @@ concurrency:
 
 jobs:
   refit:
+    # Refit is derived from the (deterministic, public) calibration corpus —
+    # identical for any runner, and forks consume the merged result from
+    # upstream. So the cron runs only on the canonical repo (otherwise every
+    # active fork runs its own copy and fails at the PR step, since gh defaults
+    # the base repo to the upstream parent on a fork). A fork can still refit
+    # on demand via workflow_dispatch; the gh commands pin --repo so the PR
+    # lands on the fork itself.
+    if: github.repository == 'gadievron/raptor' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -209,18 +217,22 @@ jobs:
           uses.
           EOF
           )
-          if ! gh pr view "$BRANCH" >/dev/null 2>&1; then
+          # --repo pins the running repo: without it gh defaults the base
+          # repo to the upstream parent on a fork, so a manual fork run would
+          # target (and fail against) the parent instead of the fork.
+          if ! gh pr view --repo "$GITHUB_REPOSITORY" "$BRANCH" >/dev/null 2>&1; then
             gh pr create \
+              --repo "$GITHUB_REPOSITORY" \
               --base main \
               --head "$BRANCH" \
               --title "chore(sca): refit risk-score multipliers" \
               --body "$BODY"
           else
-            gh pr edit "$BRANCH" --body "$BODY"
+            gh pr edit --repo "$GITHUB_REPOSITORY" "$BRANCH" --body "$BODY"
           fi
           # Labels best-effort (see sca-self-bump): a missing label must
           # never block the PR. Create them once under Settings → Labels.
           for lbl in automated sca; do
-            gh pr edit "$BRANCH" --add-label "$lbl" 2>/dev/null \
+            gh pr edit --repo "$GITHUB_REPOSITORY" "$BRANCH" --add-label "$lbl" 2>/dev/null \
               || echo "label '$lbl' not in repo; skipping (create it under Settings → Labels to auto-apply)"
           done

--- a/.github/workflows/refresh-sca-calibration.yml
+++ b/.github/workflows/refresh-sca-calibration.yml
@@ -35,6 +35,14 @@ concurrency:
 
 jobs:
   refresh:
+    # Public, deterministic sources (KEV / EPSS) — the corpus is identical no
+    # matter who runs it, and forks consume the merged result from upstream.
+    # So the cron runs only on the canonical repo (otherwise every active fork
+    # runs its own copy and fails at the PR step, since gh defaults the base
+    # repo to the upstream parent on a fork). A fork can still refresh on
+    # demand via workflow_dispatch; the gh commands pin --repo so the PR lands
+    # on the fork itself.
+    if: github.repository == 'gadievron/raptor' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -197,12 +205,16 @@ jobs:
           # Idempotent create-or-update: ``gh pr create`` exits non-zero
           # when a PR for the branch already exists — fall through to
           # ``gh pr edit`` to refresh the body. (Labels applied below.)
+          # --repo pins the running repo: without it gh defaults the base
+          # repo to the upstream parent on a fork, so a manual fork run would
+          # target (and fail against) the parent instead of the fork.
           if ! gh pr create \
+                --repo "$GITHUB_REPOSITORY" \
                 --base main \
                 --head "$BRANCH" \
                 --title "chore(sca): refresh calibration corpus" \
                 --body-file "$RUNNER_TEMP/pr-body.md" 2>/dev/null; then
-            gh pr edit "$BRANCH" --body-file "$RUNNER_TEMP/pr-body.md"
+            gh pr edit --repo "$GITHUB_REPOSITORY" "$BRANCH" --body-file "$RUNNER_TEMP/pr-body.md"
           fi
           # Labels best-effort (see sca-self-bump): pull-requests:write
           # applies EXISTING labels but can't create them, and
@@ -210,6 +222,6 @@ jobs:
           # (which killed this step in run #3). Create the canonical
           # labels once under Settings → Labels to auto-apply them.
           for lbl in automated sca data-refresh; do
-            gh pr edit "$BRANCH" --add-label "$lbl" 2>/dev/null \
+            gh pr edit --repo "$GITHUB_REPOSITORY" "$BRANCH" --add-label "$lbl" 2>/dev/null \
               || echo "label '$lbl' not in repo; skipping (create it under Settings → Labels to auto-apply)"
           done

--- a/.github/workflows/refresh-sca-data.yml
+++ b/.github/workflows/refresh-sca-data.yml
@@ -36,6 +36,15 @@ concurrency:
 
 jobs:
   refresh:
+    # These sources are public and deterministic — the lists are identical no
+    # matter who runs the refresh, and forks consume the merged result from
+    # upstream. So the weekly cron runs only on the canonical repo (otherwise
+    # every active fork runs its own copy and fails at the PR step, since gh
+    # defaults the base repo to the upstream parent on a fork). A fork that
+    # wants fresh data without syncing can still trigger it manually via
+    # workflow_dispatch; the gh commands below pin --repo so that lands a PR
+    # on the fork itself.
+    if: github.repository == 'gadievron/raptor' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -163,16 +172,20 @@ jobs:
           if [ -s "$CAND" ]; then
             BODY="$BODY"$'\n\n---\n\n'"$(cat "$CAND")"
           fi
+          # --repo pins the running repo: without it gh defaults the base
+          # repo to the upstream parent on a fork, so a manual fork run would
+          # target (and fail against) the parent instead of the fork.
           if ! gh pr create \
+                --repo "$GITHUB_REPOSITORY" \
                 --base main \
                 --head "$BRANCH" \
                 --title "chore(sca): refresh bundled popular-package lists" \
                 --body "$BODY" 2>/dev/null; then
-            gh pr edit "$BRANCH" --body "$BODY"
+            gh pr edit --repo "$GITHUB_REPOSITORY" "$BRANCH" --body "$BODY"
           fi
           # Labels best-effort (see sca-self-bump): a missing label must
           # never block the PR. Create them once under Settings → Labels.
           for lbl in automated sca data-refresh; do
-            gh pr edit "$BRANCH" --add-label "$lbl" 2>/dev/null \
+            gh pr edit --repo "$GITHUB_REPOSITORY" "$BRANCH" --add-label "$lbl" 2>/dev/null \
               || echo "label '$lbl' not in repo; skipping (create it under Settings → Labels to auto-apply)"
           done

--- a/.github/workflows/refresh-sca-project-samples.yml
+++ b/.github/workflows/refresh-sca-project-samples.yml
@@ -36,6 +36,14 @@ concurrency:
 
 jobs:
   collect:
+    # Deterministic refresh from public sources — identical for any runner,
+    # and forks consume the merged result from upstream. So the cron runs only
+    # on the canonical repo (otherwise every active fork runs its own copy and
+    # fails at the PR step, since gh defaults the base repo to the upstream
+    # parent on a fork). A fork can still refresh on demand via
+    # workflow_dispatch; the gh commands pin --repo so the PR lands on the
+    # fork itself.
+    if: github.repository == 'gadievron/raptor' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     # Higher than the daily refreshes — cloning + scanning the corpus is
     # the heaviest job. The collector now scans projects in parallel
@@ -169,16 +177,20 @@ jobs:
           - [ ] Tests pass
           EOF
           )
+          # --repo pins the running repo: without it gh defaults the base
+          # repo to the upstream parent on a fork, so a manual fork run would
+          # target (and fail against) the parent instead of the fork.
           if ! gh pr create \
+                --repo "$GITHUB_REPOSITORY" \
                 --base main \
                 --head "$BRANCH" \
                 --title "chore(sca): refresh calibration project samples" \
                 --body "$BODY" 2>/dev/null; then
-            gh pr edit "$BRANCH" --body "$BODY"
+            gh pr edit --repo "$GITHUB_REPOSITORY" "$BRANCH" --body "$BODY"
           fi
           # Labels best-effort (see sca-self-bump): a missing label must
           # never block the PR. Create them once under Settings → Labels.
           for lbl in automated sca data-refresh; do
-            gh pr edit "$BRANCH" --add-label "$lbl" 2>/dev/null \
+            gh pr edit --repo "$GITHUB_REPOSITORY" "$BRANCH" --add-label "$lbl" 2>/dev/null \
               || echo "label '$lbl' not in repo; skipping (create it under Settings → Labels to auto-apply)"
           done

--- a/.github/workflows/sca-self-bump.yml
+++ b/.github/workflows/sca-self-bump.yml
@@ -54,6 +54,14 @@ concurrency:
 
 jobs:
   self-bump:
+    # The self-bump target version is determined by upstream releases —
+    # identical for any runner, and forks consume the merged bump from
+    # upstream. So the cron runs only on the canonical repo (otherwise every
+    # active fork runs its own copy and fails at the PR step, since gh defaults
+    # the base repo to the upstream parent on a fork). A fork can still bump on
+    # demand via workflow_dispatch; the gh commands pin --repo so the PR lands
+    # on the fork itself.
+    if: github.repository == 'gadievron/raptor' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -225,13 +233,17 @@ jobs:
           # don't need a third-party action. Idempotent: if a PR for
           # ``sca-self-bump`` is already open we update its body
           # (preserving review comments), otherwise we open a new one.
+          # --repo pins the running repo: without it gh defaults the base
+          # repo to the upstream parent on a fork, so a manual fork run would
+          # target (and fail against) the parent instead of the fork.
           pr_num=$(gh pr list \
+            --repo "$GITHUB_REPOSITORY" \
             --head sca-self-bump \
             --state open \
             --json number \
             --jq '.[0].number // empty')
           if [[ -n "$pr_num" ]]; then
-            gh pr edit "$pr_num" --body-file "$RUNNER_TEMP/pr-body.md"
+            gh pr edit --repo "$GITHUB_REPOSITORY" "$pr_num" --body-file "$RUNNER_TEMP/pr-body.md"
             echo "Updated existing PR #$pr_num"
             pr_ref="$pr_num"
           else
@@ -241,6 +253,7 @@ jobs:
             # Labels are applied best-effort below so they can never block
             # the PR.
             pr_ref=$(gh pr create \
+              --repo "$GITHUB_REPOSITORY" \
               --base main \
               --head sca-self-bump \
               --title "chore: SCA-gated self-bump" \
@@ -252,6 +265,6 @@ jobs:
           # labels but can't create new ones, so create any you want
           # auto-applied once under Settings → Labels.
           for lbl in automated sca dependencies; do
-            gh pr edit "$pr_ref" --add-label "$lbl" 2>/dev/null \
+            gh pr edit --repo "$GITHUB_REPOSITORY" "$pr_ref" --add-label "$lbl" 2>/dev/null \
               || echo "label '$lbl' not in repo; skipping (create it under Settings → Labels to auto-apply)"
           done

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -522,11 +522,12 @@ jobs:
           sudo apt-get install -y --no-install-recommends coccinelle
           spatch --version
 
-      - name: Download venv artifact
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # was v8.0.1
+      - name: Restore venv from cache
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae  # was v5.0.5
         with:
-          name: venv-${{ github.run_id }}
           path: ${{ env.VENV_PATH }}
+          key: venv-${{ runner.os }}-py${{ env.PYTHON_VERSION }}-${{ hashFiles('requirements.txt', 'requirements-dev.txt') }}
+          fail-on-cache-miss: true
 
       - name: Restore venv permissions
         run: chmod +x $VENV_PATH/bin/*


### PR DESCRIPTION
  Two independent CI fixes, stacked.

  ## 1. Scope SCA data-refresh crons to the canonical repo + pin `gh --repo`

  The scheduled auto-PR workflows (`refresh-sca-data`, `refresh-sca-calibration`,
  `refresh-sca-project-samples`, `refit-sca-calibration`, `sca-self-bump`) are
  inherited by forks, and GitHub runs scheduled workflows in any active fork. On a
  fork they failed at the PR step: `gh` defaults the base repo to the upstream
  parent when run in a fork, so `gh pr create`/`edit` targeted the parent and the
  run aborted with `no pull requests found for branch`.

  These jobs pull deterministic public data (CISA KEV / FIRST EPSS /
  popular-package lists) or an upstream-determined version bump — identical for
  any runner — so a fork consumes the merged result from upstream and doesn't need
  its own run.

  - Guard each job to the canonical repo, keeping a manual escape hatch so a fork
    can still refresh on demand without rotting its bundled data:
    `if: github.repository == 'gadievron/raptor' || github.event_name == 'workflow_dispatch'`
  - Pin `--repo "$GITHUB_REPOSITORY"` on every `gh pr` command so the manual fork
    path lands a PR on the fork itself instead of the upstream parent.

  Read-only / PR-gate workflows (`sca-stress-sweep`, `sca-compromise-check`) are
  left untouched — they should keep running on fork PRs.
  
  ## 2. `source_intel` test job restores the venv from cache, not an artifact
  
  `tests.yml`'s `deps` job shares the build venv via `actions/cache`, but the
  `python-unit-tests-source-intel` job still fetched it with
  `actions/download-artifact name venv-${{ github.run_id }}` — an artifact nothing
  uploads anymore. The job failed at "Download venv artifact" every time it ran:
  `Artifact not found for name: venv-<run_id>`.

  Swap that step for the same `actions/cache/restore` (with `fail-on-cache-miss`)
  every other consumer job (fast / sca / sandbox / exploit_feasibility / codeql /
  llm_analysis / cve_diff / fuzzing) already uses, keyed on the OS + Python version
  + requirements hash. Audited the other 15 workflows — this was the only job still
  on the artifact pattern; `lint`/`nightly` build their own venv inline and the
  `_tier.yml` tiers run in the deps image.
