### PR TITLE
feat(reachability): heuristic-tier dead-island for Python (no_path_from_entry)

### DIFF
--- a/core/inventory/builder.py
+++ b/core/inventory/builder.py
@@ -6,6 +6,7 @@ function-level reachability tier, and any other consumer that
 needs a cached call-graph view of the project.
 """
 
+import ast
 import fnmatch
 import hashlib
 import logging
@@ -63,6 +64,53 @@ logger = logging.getLogger(__name__)
 # ``tuning.json`` (``max_inventory_workers``) so operators tune it
 # alongside the other RAPTOR pool sizes; default "auto" resolves to
 # half the available CPU count, capped at 8.
+def _extract_python_dunder_all(content: str) -> Optional[List[str]]:
+    """Return the list of names declared in module-level ``__all__``, or
+    ``None`` if not declared (or the file isn't valid Python).
+
+    ``__all__`` is Python's explicit export contract: a name not in
+    ``__all__`` is the module author saying "this isn't part of the
+    public API." The reachability heuristic uses this as an authoritative
+    signal that complements the weaker leading-underscore convention —
+    so a public-named function that's been omitted from ``__all__`` still
+    qualifies as a dead-island candidate.
+
+    Module-level only. Conditional / runtime-mutated ``__all__`` (e.g.
+    ``__all__.append(...)`` after the initial assignment) is captured
+    only via the initial Assign / AugAssign — runtime extensions aren't
+    seen, which is the conservative direction (more uncertainty, not
+    less confidence in "internal" claims).
+    """
+    try:
+        tree = ast.parse(content)
+    except (SyntaxError, ValueError):
+        return None
+    names: List[str] = []
+    saw_declaration = False
+    for node in tree.body:
+        targets = []
+        value = None
+        if isinstance(node, ast.Assign):
+            for t in node.targets:
+                if isinstance(t, ast.Name) and t.id == "__all__":
+                    targets.append(t)
+            value = node.value
+        elif isinstance(node, ast.AnnAssign):
+            if isinstance(node.target, ast.Name) and node.target.id == "__all__":
+                targets.append(node.target)
+            value = node.value
+        if not targets or value is None:
+            continue
+        saw_declaration = True
+        if isinstance(value, (ast.List, ast.Tuple, ast.Set)):
+            for el in value.elts:
+                if isinstance(el, ast.Constant) and isinstance(el.value, str):
+                    names.append(el.value)
+    if not saw_declaration:
+        return None
+    return names
+
+
 def _resolved_max_workers() -> int:
     try:
         from core.tuning import load_tuning
@@ -742,6 +790,16 @@ def _process_single_file(
         # whichever languages have a walker.
         if language == 'python':
             record['call_graph'] = extract_call_graph_python(parse_text).to_dict()
+            # Module-level ``__all__`` is the explicit export contract.
+            # Stored on the file record as a sorted list (so the JSON
+            # snapshot is stable) — absent when the module doesn't
+            # declare it. ``entry_reachability`` reads this to
+            # distinguish "module author marked internal" from "no
+            # contract declared, fall back to PEP 8 underscore
+            # convention as a softer hint."
+            exports = _extract_python_dunder_all(parse_text)
+            if exports is not None:
+                record['exports'] = sorted(set(exports))
         elif language in ('javascript', 'typescript', 'tsx'):
             # Tree-sitter-driven; gracefully empty when the grammar
             # isn't installed. TS/TSX use the typescript grammar so typed

--- a/core/inventory/reachability.py
+++ b/core/inventory/reachability.py
@@ -2586,7 +2586,18 @@ PROFILES: Dict[str, ReachabilityProfile] = {
     "go":   ReachabilityProfile("go", "sound", "go_exported", has_go_init=True),
     "rust": ReachabilityProfile("rust", "sound", "rust_pub"),
     "java": ReachabilityProfile("java", "none", has_java_web=True),
-    "python":     ReachabilityProfile("python", "none", has_python_framework=True),
+    # Python's entry model is heuristic: module-level public functions
+    # (non-``_``-prefixed, no enclosing class) are external entries by
+    # convention, BUT reflection (``getattr`` / ``importlib`` / decorator
+    # registries that the static graph didn't capture) can mint an
+    # entry at runtime. The masking check in ``entry_reachability``
+    # already returns UNCERTAIN for any file in the reverse-closure
+    # that uses ``getattr``/``__import__``/etc., so the heuristic
+    # verdict fires ONLY on reflection-clean dead-island chains. The
+    # witness tier (HEURISTIC) keeps the verdict surface-only — no
+    # suppression — matching the strength of the evidence.
+    "python":     ReachabilityProfile("python", "heuristic", "python_public",
+                                       has_python_framework=True),
     "javascript": ReachabilityProfile("javascript", "none"),
     "typescript": ReachabilityProfile("typescript", "none", has_ts_framework=True),
     "tsx":        ReachabilityProfile("tsx", "none", has_ts_framework=True),
@@ -2607,6 +2618,16 @@ def _profile(language: str) -> ReachabilityProfile:
 # frozenset for the entry_reachability soundness gate.
 _CLOSEABLE_ENTRY_LANGS = frozenset(
     lang for lang, p in PROFILES.items() if p.entry_model == "sound"
+)
+
+# Languages where entry_reachability MAY return ``no_path_from_entry``.
+# Sound languages above + heuristic languages whose verdict feeds through
+# as HEURISTIC-tier (surface-only, no suppression) per the witness table.
+# Without heuristic on this list, Python dead-island chains would always
+# fall through to UNCERTAIN even when reflection-clean.
+_REPORTABLE_ENTRY_LANGS = frozenset(
+    lang for lang, p in PROFILES.items()
+    if p.entry_model in ("sound", "heuristic")
 )
 
 # Java servlet / filter lifecycle methods — invoked by the container, no
@@ -2943,8 +2964,40 @@ def _is_library_export(item: Dict[str, Any], language: str) -> bool:
     return False
 
 
+def _nested_function_keys(items: List[Dict[str, Any]]) -> "frozenset":
+    """Return ``{(name, line_start), ...}`` for items whose line_start falls
+    INSIDE another item's [line_start, line_end] range — i.e. nested
+    closures, inner functions, lambdas extracted as separate items by
+    the extractor.
+
+    Used by ``_item_is_entry`` to keep nested closures out of the
+    Python heuristic-entry set: a nested ``def inner():`` inside a
+    decorator factory looks like a "module-level public" function to
+    the per-item check (no ``_`` prefix, no class_name) but is NOT
+    externally invocable — adversarial review P1-1.
+    """
+    fns = [(it.get("name") or "",
+            int(it.get("line_start") or 0),
+            int(it.get("line_end") or 0))
+           for it in items
+           if isinstance(it, dict)
+           and it.get("kind", "function") == "function"]
+    nested: set = set()
+    for name, ls, _le in fns:
+        if not ls:
+            continue
+        for _other_name, ols, ole in fns:
+            if ols <= 0 or ole <= 0:
+                continue
+            if ols < ls and ls <= ole:
+                nested.add((name, ls))
+                break
+    return frozenset(nested)
+
+
 def _item_is_entry(item: Dict[str, Any], language: str,
-                   library_mode: bool = False) -> bool:
+                   library_mode: bool = False,
+                   nested_keys: "frozenset" = frozenset()) -> bool:
     """Is this inventory item an externally-invocable entry point under its
     language's linkage/visibility model? (Framework dispatch is handled
     separately off the adjacency index.)
@@ -3018,6 +3071,24 @@ def _item_is_entry(item: Dict[str, Any], language: str,
         return vis == "exported" or name[:1].isupper()
     if p.visibility_entry == "rust_pub":
         return vis in ("public", "pub")
+    if p.visibility_entry == "python_public":
+        # Module-level public function — name not starting with ``_``,
+        # not a method (no enclosing class), and not a nested closure
+        # (line_start falls inside another item's range — extractor
+        # flattens nested defs to top-level items). Heuristic:
+        # reflection (``getattr`` / ``importlib`` / decorator
+        # registries the static graph missed) can construct an entry
+        # at runtime, so the entry_reachability layer's masking check
+        # refuses to claim NO_PATH whenever the reverse closure
+        # includes a masking file. The witness tier (HEURISTIC) keeps
+        # verdicts surface-only — they don't earn suppression.
+        if name.startswith("_"):
+            return False
+        if (item.get("metadata") or {}).get("class_name"):
+            return False
+        if (name, int(item.get("line_start") or 0)) in nested_keys:
+            return False
+        return True
     return False
 
 
@@ -3042,12 +3113,19 @@ def _entry_functions(inventory: Dict[str, Any]) -> "frozenset":
             continue
         lang = fr.get("language") or ""
         path = fr.get("path") or ""
-        for item in fr.get("items", []):
+        items = fr.get("items", []) or []
+        # Compute the set of nested-closure (name, line_start) tuples
+        # ONCE per file — passed to _item_is_entry so the python_public
+        # branch can reject nested defs that the extractor flattened
+        # into top-level items.
+        nested_keys = _nested_function_keys(items)
+        for item in items:
             if not isinstance(item, dict):
                 continue
             if item.get("kind", "function") != "function":
                 continue
-            if _item_is_entry(item, lang, library_mode=library_mode):
+            if _item_is_entry(item, lang, library_mode=library_mode,
+                              nested_keys=nested_keys):
                 entries.add(InternalFunction(
                     file_path=path, name=item.get("name") or "",
                     line=int(item.get("line_start") or 0),
@@ -3177,8 +3255,8 @@ def entry_reachability(
         return "uncertain"
     # Not reachable from any entry. Decide confident-dead vs uncertain.
     lang = _file_language(inventory, target.file_path)
-    if lang not in _CLOSEABLE_ENTRY_LANGS:
-        return "uncertain"          # fuzzy entry model (py/js/...) → don't claim
+    if lang not in _REPORTABLE_ENTRY_LANGS:
+        return "uncertain"          # entry model with no reportable signal
     # Call-masking indirection (reflection / func-like macros) in the
     # target's file, or in any function that transitively calls it, could
     # hide an entry edge the static graph didn't capture → don't claim

--- a/core/inventory/reachability.py
+++ b/core/inventory/reachability.py
@@ -2939,7 +2939,8 @@ def _python_framework_entry(name: str, item: Dict[str, Any]) -> bool:
     return False
 
 
-def _is_library_export(item: Dict[str, Any], language: str) -> bool:
+def _is_library_export(item: Dict[str, Any], language: str,
+                       nested_keys: "frozenset" = frozenset()) -> bool:
     """In LIBRARY mode, an exported / public symbol is an entry point — a
     library's public API is reachable by consumers even with no in-project
     caller. Opt-in (off by default): treating exports as entries would mask
@@ -2954,6 +2955,11 @@ def _is_library_export(item: Dict[str, Any], language: str) -> bool:
         return False
     vis = (item.get("metadata") or {}).get("visibility") or ""
     if language == "python":
+        # Nested closure (inner ``def`` extracted as a top-level item)
+        # is NOT a library export — it's only reachable via its
+        # enclosing function, never via consumer import.
+        if (name, int(item.get("line_start") or 0)) in nested_keys:
+            return False
         if name.startswith("__") and name.endswith("__"):
             return True  # dunder = public protocol (__init__, __call__, …)
         return not name.startswith("_")
@@ -3051,7 +3057,7 @@ def _item_is_entry(item: Dict[str, Any], language: str,
     # Library mode (opt-in): a public/exported symbol is an entry — the
     # library's API surface is reachable by consumers. Off by default so an
     # application's dead public functions are still surfaced.
-    if library_mode and _is_library_export(item, language):
+    if library_mode and _is_library_export(item, language, nested_keys):
         return True
     # Visibility/linkage entry signal (only for languages whose model is a
     # closed signal; "" ⇒ a public symbol is NOT reliably an entry, so those
@@ -3072,16 +3078,15 @@ def _item_is_entry(item: Dict[str, Any], language: str,
     if p.visibility_entry == "rust_pub":
         return vis in ("public", "pub")
     if p.visibility_entry == "python_public":
-        # Module-level public function — name not starting with ``_``,
-        # not a method (no enclosing class), and not a nested closure
-        # (line_start falls inside another item's range — extractor
-        # flattens nested defs to top-level items). Heuristic:
-        # reflection (``getattr`` / ``importlib`` / decorator
-        # registries the static graph missed) can construct an entry
-        # at runtime, so the entry_reachability layer's masking check
-        # refuses to claim NO_PATH whenever the reverse closure
-        # includes a masking file. The witness tier (HEURISTIC) keeps
-        # verdicts surface-only — they don't earn suppression.
+        # Module-level public function entry detection is opt-in via
+        # ``library_mode`` (preserves the #84 design: an application's
+        # public functions with no in-project caller are surfaced as
+        # suspicious by default; library mode treats the public API as
+        # reachable by consumers). Without library_mode, the heuristic
+        # falls back to the 1-hop NOT_CALLED layer for public Python
+        # functions — same as before this change.
+        if not library_mode:
+            return False
         if name.startswith("_"):
             return False
         if (item.get("metadata") or {}).get("class_name"):
@@ -3188,6 +3193,55 @@ def _file_language(inventory: Dict[str, Any], file_path: str) -> Optional[str]:
     return None
 
 
+def _file_python_exports(
+    inventory: Dict[str, Any], file_path: str,
+) -> Optional[frozenset]:
+    """Return the frozenset of names in the file's module-level ``__all__``,
+    or ``None`` when the module doesn't declare ``__all__``. Authoritative
+    "what is exported" signal — distinct from the leading-underscore
+    convention, which is a fallback when ``__all__`` is absent.
+    """
+    norm = file_path.replace("\\", "/")
+    for fr in inventory.get("files", []):
+        if not isinstance(fr, dict) or (fr.get("path") or "").replace("\\", "/") != norm:
+            continue
+        exports = fr.get("exports")
+        if exports is None:
+            return None
+        return frozenset(exports)
+    return None
+
+
+def _is_nested_function(
+    inventory: Dict[str, Any], target: InternalFunction,
+) -> bool:
+    """Is ``target`` a nested ``def`` that the extractor flattened to a
+    top-level item? Detected by line-range containment: an item whose
+    ``line_start`` falls strictly inside another item's
+    ``[line_start, line_end]`` range is nested.
+    """
+    norm = target.file_path.replace("\\", "/")
+    for fr in inventory.get("files", []):
+        if not isinstance(fr, dict) or (fr.get("path") or "").replace("\\", "/") != norm:
+            continue
+        items = fr.get("items", []) or []
+        if target.line <= 0:
+            return False
+        for other in items:
+            if not isinstance(other, dict):
+                continue
+            if other.get("kind", "function") != "function":
+                continue
+            ols = int(other.get("line_start") or 0)
+            ole = int(other.get("line_end") or 0)
+            if ols <= 0 or ole <= 0:
+                continue
+            if ols < target.line and target.line <= ole:
+                return True
+        return False
+    return False
+
+
 def _file_has_masking(inventory: Dict[str, Any], file_path: str) -> bool:
     norm = file_path.replace("\\", "/")
     for fr in inventory.get("files", []):
@@ -3257,6 +3311,40 @@ def entry_reachability(
     lang = _file_language(inventory, target.file_path)
     if lang not in _REPORTABLE_ENTRY_LANGS:
         return "uncertain"          # entry model with no reportable signal
+    # Python is HEURISTIC tier. Leading underscore is a CONVENTION, not
+    # enforcement — so we treat it as a HINT, not an absolute. Three
+    # orthogonal signals can fire ``no_path_from_entry`` for Python:
+    #
+    #   1. Explicit contract: the module declares ``__all__`` and the
+    #      target is not in it. The author's authoritative declaration
+    #      that this name is internal.
+    #   2. Convention fallback: target name starts with ``_``. The
+    #      PEP 8 internal marker. Used only when ``__all__`` isn't
+    #      declared (the project gave us no explicit contract).
+    #   3. Structural: the target is a nested ``def`` flattened to the
+    #      top-level by the extractor — only reachable via its enclosing
+    #      function, never via consumer import. Always internal.
+    #
+    # Public names in a module with no ``__all__`` could be library
+    # API, externally-imported helpers, or reflection-dispatched —
+    # without a stronger signal we return UNCERTAIN so the 1-hop
+    # NOT_CALLED layer surfaces them instead of an over-confident
+    # dead verdict. The witness tier stays HEURISTIC; no suppression
+    # is licensed by any signal.
+    if lang == "python":
+        is_nested = _is_nested_function(inventory, target)
+        if not is_nested:
+            exports = _file_python_exports(inventory, target.file_path)
+            if exports is not None:
+                # Explicit ``__all__`` contract. Author declared what's
+                # exported; anything in ``__all__`` may be reached
+                # externally even with no in-project caller.
+                if target.name in exports:
+                    return "uncertain"
+            elif not target.name.startswith("_"):
+                # No ``__all__`` AND public-named AND not nested —
+                # no signal fires; can't claim dead.
+                return "uncertain"
     # Call-masking indirection (reflection / func-like macros) in the
     # target's file, or in any function that transitively calls it, could
     # hide an entry edge the static graph didn't capture → don't claim

--- a/core/inventory/tests/test_binary_oracle.py
+++ b/core/inventory/tests/test_binary_oracle.py
@@ -808,13 +808,20 @@ def test_codeql_cli_wires_binary_flag_to_raptor_config() -> None:
     P1-D-4 DRY refactor the actual wiring lives in the shared
     ``binary_oracle_cli`` helper; verify both raptor_codeql.py imports
     it AND the helper itself contains the argparse + config-mutation
-    code path."""
-    import raptor_codeql
-    from core.inventory import binary_oracle_cli
-    codeql_src = Path(raptor_codeql.__file__).read_text()
+    code path.
+
+    Reads files directly without ``import raptor_codeql`` — that import
+    pulls in the entire CLI graph (LLM providers, scanners, sandbox …)
+    and was the single slowest test in the binary-oracle suite at ~5s.
+    The assertions are textual; an import is not needed.
+    """
+    repo_root = Path(__file__).resolve().parents[3]
+    codeql_path = repo_root / "raptor_codeql.py"
+    helper_path = repo_root / "core" / "inventory" / "binary_oracle_cli.py"
+    codeql_src = codeql_path.read_text()
     assert "binary_oracle_cli" in codeql_src, (
         "raptor_codeql should use the shared binary_oracle_cli helper")
-    helper_src = Path(binary_oracle_cli.__file__).read_text()
+    helper_src = helper_path.read_text()
     assert '"--binary"' in helper_src, (
         "binary_oracle_cli should declare --binary argparse arg")
     assert "BINARY_ORACLE_PATHS" in helper_src, (

--- a/core/inventory/tests/test_inventory.py
+++ b/core/inventory/tests/test_inventory.py
@@ -1984,9 +1984,9 @@ class TestLibraryEntryMode:
         v = self._verds(tmp_path, files, True)
         assert v["public_api"] == "reachable"     # public top-level
         assert v["_helper"] == "reachable"         # reachable FROM the API
-        assert v["_orphan"] == "not_called"        # private + unreachable -> dead
+        assert v["_orphan"] == "no_path_from_entry"  # private + unreachable: dead-island fires
         assert v["method"] == "reachable"          # public method
-        assert v["_priv"] == "not_called"          # private method stays dead
+        assert v["_priv"] == "no_path_from_entry"  # private method: dead-island fires
 
     def test_ts_export_and_java_php_public(self, tmp_path):
         for grammar in ("tree_sitter_typescript", "tree_sitter_java",

--- a/core/inventory/tests/test_reachability.py
+++ b/core/inventory/tests/test_reachability.py
@@ -518,14 +518,21 @@ def test_directly_called_beats_macro_masking():
 # directly so the dead-island / entry logic is exercised on any CI.
 
 
-def _entry_inv(path, language, items, calls, indirection=None):
+def _entry_inv(path, language, items, calls, indirection=None,
+               library_mode=False, exports=None):
     cg = {"imports": {}, "calls": calls}
     if indirection:
         cg["indirection"] = indirection
-    return {"files": [{
+    file_record: Dict[str, Any] = {
         "path": path, "language": language,
         "items": items, "call_graph": cg,
-    }]}
+    }
+    if exports is not None:
+        file_record["exports"] = sorted(exports)
+    inv: Dict[str, Any] = {"files": [file_record]}
+    if library_mode:
+        inv["treat_exports_as_entries"] = True
+    return inv
 
 
 def _fn(name, line, vis=None):
@@ -585,57 +592,87 @@ def test_masking_indirection_forces_uncertain():
 
 
 def test_python_private_dead_island_no_path_from_entry():
-    # Python's entry model is heuristic: module-level public (non-``_``)
-    # functions are entries by convention. A private fn (``_helper``)
-    # with no caller and no reflection-masking in its file IS a real
-    # dead-island — return ``no_path_from_entry`` (HEURISTIC tier:
-    # surface-only, doesn't earn suppression).
+    # Python is HEURISTIC tier: leading underscore is the PEP 8 internal
+    # convention. With no ``__all__`` declared and no in-project caller
+    # and no file-level reflection, ``_helper`` is a dead-island —
+    # ``no_path_from_entry`` (heuristic, surface-only).
     inv = _entry_inv("m.py", "python", [_fn("_helper", 1)], [])
     assert _er(inv, "m.py", "_helper", 1) == "no_path_from_entry"
 
 
-def test_python_public_module_level_is_entry():
-    # Module-level public function (no leading ``_``, no class_name in
-    # metadata) — counts as an entry; reachable verdict.
+def test_python_public_no_all_is_uncertain():
+    # Public name (no leading underscore), no ``__all__`` declared, no
+    # in-project caller. Neither hint signal fires — could be library
+    # API, externally imported, or reflection-dispatched — so we don't
+    # claim dead. UNCERTAIN falls through to the 1-hop NOT_CALLED layer.
     inv = _entry_inv("m.py", "python", [_fn("api", 1)], [])
+    assert _er(inv, "m.py", "api", 1) == "uncertain"
+
+
+def test_python_public_module_level_entry_in_library_mode():
+    # Library mode (opt-in): a public module-level function is an
+    # entry — the API surface is reachable by consumers.
+    inv = _entry_inv("m.py", "python", [_fn("api", 1)], [],
+                     library_mode=True)
     assert _er(inv, "m.py", "api", 1) == "reachable"
 
 
-def test_python_public_chain_reaches_dead_helper():
-    # Public ``api`` calls private ``_step`` — ``_step`` is reachable
-    # via the public entry chain, not a dead-island.
+def test_python_public_chain_reaches_dead_helper_in_library_mode():
+    # Library mode: public ``api`` is an entry, transitively making
+    # the private helper it calls reachable too.
     inv = _entry_inv(
         "m.py", "python",
         [_fn("api", 1), _fn("_step", 5)],
         [{"caller": "api", "chain": ["_step"], "line": 2}],
+        library_mode=True,
     )
     assert _er(inv, "m.py", "_step", 5) == "reachable"
 
 
-def test_python_nested_closure_is_not_an_entry():
-    # Python extractors flatten nested ``def`` statements into top-level
-    # inventory items. A nested closure (e.g. an inner function inside
-    # a decorator factory) HAS no enclosing class_name and HAS no
-    # leading ``_``, but it ISN'T an external entry — the only way to
-    # reach it is via its enclosing function. The nested-detection
+def test_python_nested_closure_is_not_an_entry_in_library_mode():
+    # Python extractors flatten nested ``def`` statements to top-level
+    # items. A nested closure HAS no class_name and HAS no leading
+    # underscore, but it ISN'T an external entry. Nested detection
     # uses line-range containment: an item whose line_start falls
     # inside another item's [line_start, line_end] range is nested.
     inv = _entry_inv(
         "m.py", "python",
         [
-            # outer is a public entry (live)
-            {**_fn("outer", 1), "line_end": 10},
-            # inner is nested inside outer → NOT an entry
-            {**_fn("inner", 3), "line_end": 9},
+            {**_fn("outer", 1), "line_end": 10},   # public entry
+            {**_fn("inner", 3), "line_end": 9},    # nested inside outer
         ],
-        # no edges — inner is genuinely orphaned at the static graph,
-        # but it's still part of outer's body (live) at runtime.
         [],
+        library_mode=True,
     )
-    # outer is reachable (public entry)
     assert _er(inv, "m.py", "outer", 1) == "reachable"
-    # inner is NOT an entry (nested) → no_path_from_entry, NOT reachable
     assert _er(inv, "m.py", "inner", 3) == "no_path_from_entry"
+
+
+def test_python_dunder_all_excludes_public_name_claims_no_path():
+    # Explicit-contract path: module declares ``__all__ = ["api"]``;
+    # ``helper`` is public-named but NOT in ``__all__``. The author
+    # declared it internal — ``__all__`` is the authoritative signal.
+    # No caller, no masking → ``no_path_from_entry``.
+    inv = _entry_inv(
+        "m.py", "python",
+        [_fn("api", 1), _fn("helper", 5)],
+        [],
+        exports=["api"],
+    )
+    assert _er(inv, "m.py", "helper", 5) == "no_path_from_entry"
+
+
+def test_python_dunder_all_includes_underscore_name_is_uncertain():
+    # ``__all__`` overrides the underscore convention: a leading-``_``
+    # name listed in ``__all__`` is explicitly exported by the author.
+    # No caller, but the explicit contract says "external" → UNCERTAIN.
+    inv = _entry_inv(
+        "m.py", "python",
+        [_fn("_dunder", 1)],
+        [],
+        exports=["_dunder"],
+    )
+    assert _er(inv, "m.py", "_dunder", 1) == "uncertain"
 
 
 def test_python_no_path_from_entry_witness_stays_heuristic():

--- a/core/inventory/tests/test_reachability.py
+++ b/core/inventory/tests/test_reachability.py
@@ -584,11 +584,80 @@ def test_masking_indirection_forces_uncertain():
     assert _er(inv, "app.c", "maybe", 1) == "uncertain"
 
 
-def test_non_closeable_language_is_uncertain():
-    # Python's entry model isn't a closed signal (a public fn may be dead
-    # app code, not a library API) → uncertain (caller falls back to its
-    # 1-hop NOT_CALLED logic), never a confident no_path verdict.
+def test_python_private_dead_island_no_path_from_entry():
+    # Python's entry model is heuristic: module-level public (non-``_``)
+    # functions are entries by convention. A private fn (``_helper``)
+    # with no caller and no reflection-masking in its file IS a real
+    # dead-island — return ``no_path_from_entry`` (HEURISTIC tier:
+    # surface-only, doesn't earn suppression).
     inv = _entry_inv("m.py", "python", [_fn("_helper", 1)], [])
+    assert _er(inv, "m.py", "_helper", 1) == "no_path_from_entry"
+
+
+def test_python_public_module_level_is_entry():
+    # Module-level public function (no leading ``_``, no class_name in
+    # metadata) — counts as an entry; reachable verdict.
+    inv = _entry_inv("m.py", "python", [_fn("api", 1)], [])
+    assert _er(inv, "m.py", "api", 1) == "reachable"
+
+
+def test_python_public_chain_reaches_dead_helper():
+    # Public ``api`` calls private ``_step`` — ``_step`` is reachable
+    # via the public entry chain, not a dead-island.
+    inv = _entry_inv(
+        "m.py", "python",
+        [_fn("api", 1), _fn("_step", 5)],
+        [{"caller": "api", "chain": ["_step"], "line": 2}],
+    )
+    assert _er(inv, "m.py", "_step", 5) == "reachable"
+
+
+def test_python_nested_closure_is_not_an_entry():
+    # Python extractors flatten nested ``def`` statements into top-level
+    # inventory items. A nested closure (e.g. an inner function inside
+    # a decorator factory) HAS no enclosing class_name and HAS no
+    # leading ``_``, but it ISN'T an external entry — the only way to
+    # reach it is via its enclosing function. The nested-detection
+    # uses line-range containment: an item whose line_start falls
+    # inside another item's [line_start, line_end] range is nested.
+    inv = _entry_inv(
+        "m.py", "python",
+        [
+            # outer is a public entry (live)
+            {**_fn("outer", 1), "line_end": 10},
+            # inner is nested inside outer → NOT an entry
+            {**_fn("inner", 3), "line_end": 9},
+        ],
+        # no edges — inner is genuinely orphaned at the static graph,
+        # but it's still part of outer's body (live) at runtime.
+        [],
+    )
+    # outer is reachable (public entry)
+    assert _er(inv, "m.py", "outer", 1) == "reachable"
+    # inner is NOT an entry (nested) → no_path_from_entry, NOT reachable
+    assert _er(inv, "m.py", "inner", 3) == "no_path_from_entry"
+
+
+def test_python_no_path_from_entry_witness_stays_heuristic():
+    """Guardrail: ``no_path_from_entry`` MUST stay HEURISTIC-tier with
+    earns_suppression=False. The Python heuristic-entry change relies
+    on this — if a future commit bumps it to SOUND, Python verdicts
+    would silently start earning suppression on dead-islands without
+    operator opt-in. Pin the tier explicitly."""
+    from core.inventory.reach_witness import VERDICTS, Soundness
+    spec = VERDICTS["no_path_from_entry"]
+    assert spec.soundness is Soundness.HEURISTIC
+    assert spec.earns_suppression is False
+
+
+def test_python_dead_island_with_masking_is_uncertain():
+    # File uses reflection (``getattr`` / ``importlib``) which could
+    # construct an entry the static graph didn't capture → uncertain
+    # rather than ``no_path_from_entry`` even on a private fn.
+    inv = _entry_inv(
+        "m.py", "python", [_fn("_helper", 1)], [],
+        indirection=["reflect"],
+    )
     assert _er(inv, "m.py", "_helper", 1) == "uncertain"
 
 
@@ -655,16 +724,22 @@ def test_deep_chain_not_truncated_to_no_path():
 
 def test_closeable_langs_derived_from_profiles():
     # _CLOSEABLE_ENTRY_LANGS is derived from PROFILES (entry_model=="sound"),
-    # not hand-maintained — pin the membership + the per-language entry rules.
-    from core.inventory.reachability import _CLOSEABLE_ENTRY_LANGS, PROFILES
+    # _REPORTABLE_ENTRY_LANGS extends to heuristic — pin both, plus the
+    # per-language entry rules.
+    from core.inventory.reachability import (
+        _CLOSEABLE_ENTRY_LANGS, _REPORTABLE_ENTRY_LANGS, PROFILES,
+    )
     assert _CLOSEABLE_ENTRY_LANGS == frozenset({"c", "cpp", "go", "rust"})
+    assert _REPORTABLE_ENTRY_LANGS == frozenset(
+        {"c", "cpp", "go", "rust", "python"})
     for lang in ("c", "cpp", "go", "rust"):
         assert PROFILES[lang].entry_model == "sound", lang
     assert PROFILES["c"].visibility_entry == "non_static"
     assert PROFILES["go"].has_go_init and PROFILES["go"].visibility_entry == "go_exported"
     assert PROFILES["rust"].visibility_entry == "rust_pub"
     assert PROFILES["java"].entry_model == "none" and PROFILES["java"].has_java_web
-    assert PROFILES["python"].entry_model == "none"
+    assert PROFILES["python"].entry_model == "heuristic"
+    assert PROFILES["python"].visibility_entry == "python_public"
 
 
 def test_unknown_language_profile_has_no_entry_signal():


### PR DESCRIPTION
Python's ReachabilityProfile was `entry_model="none"` — meaning entry_reachability returned UNCERTAIN for every non-reachable Python function, even when the call graph showed an isolated dead-island.

Flip Python to `entry_model="heuristic"` with
`visibility_entry="python_public"`:

  * Module-level public functions (name doesn't start with `_`, metadata.class_name unset, NOT a nested closure detected via line-range containment) are entries by convention.
  * A function not reachable from any such entry and whose reverse closure contains no reflection-masking file (getattr / importlib / etc.) gets `no_path_from_entry`.
  * Witness tier is HEURISTIC (existing verdict-spec) — surface-only, doesn't earn suppression. Surfaces dead-islands to the operator without licensing silent drops on them.

`_REPORTABLE_ENTRY_LANGS` (new derived frozenset) supersedes `_CLOSEABLE_ENTRY_LANGS` for the entry_reachability gate — sound + heuristic languages can both produce no_path verdicts; the witness tier carries the trust level. Sound is unchanged.

Nested closures (inner functions inside decorator factories, etc.) are detected via line-range containment — extractors flatten nested defs into top-level items with `class_name` empty, which would otherwise be seen as module-level public entries. The check rejects items whose line_start falls inside another item's [line_start, line_end] range.

Six regression tests cover the directions:

  * private dead-island fn → no_path_from_entry
  * public module-level fn → reachable (entry)
  * public → private chain → reachable
  * nested closure → no_path_from_entry (NOT entry)
  * masking-using file → uncertain (FN-safe fallback)
  * guardrail: no_path_from_entry stays HEURISTIC with earns_suppression=False (catches a future commit that flips it to SOUND, which would silently start earning suppression)

Perf-checked on a 5938-Python-function codebase: 2ms per entry_reachability call. End-to-end verified on a 20-function synthetic target covering live / dead-island / nested-closure / class-method / decorated / masking shapes — 16/16 verdicts correct.