### PR TITLE
fix(ci): make Nightly binary-oracle corpus tests runnable + self-skipping

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -63,6 +63,43 @@ jobs:
           source $VENV_PATH/bin/activate
           uv pip install -r requirements-dev.txt
 
+      - name: Install binary-analysis toolchain (radare2 + LLVM 21)
+        # The binary-oracle precision/edge corpora (core/inventory) are the
+        # only @pytest.mark.slow tests needing system tooling beyond the
+        # gcc/gcov ubuntu-latest already ships:
+        #   * radare2 (r2)        — direct-call-edge extraction
+        #   * LLVM 21 + clang-21  — snappy/leveldb LLVM source-based coverage
+        #                           (snappy's cmake calls plain clang/clang++
+        #                           with a clang-21 diagnostic flag) and the
+        #                           regex-rust llvm-cov/llvm-profdata path.
+        # continue-on-error: an apt / apt.llvm.org hiccup must not red-fail
+        # the nightly — the corpus tests skip themselves when a tool is
+        # absent (skipif guards), so a provisioning miss degrades to
+        # skipped-not-failed and shows up as a SKIP reason in the run log.
+        continue-on-error: true
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends radare2
+          wget -qO /tmp/llvm.sh https://apt.llvm.org/llvm.sh
+          chmod +x /tmp/llvm.sh
+          sudo /tmp/llvm.sh 21
+          # llvm-21 carries llvm-cov / llvm-profdata; clang-21 is the
+          # compiler. The drivers prefer the -21 suffixed binaries.
+          sudo apt-get install -y --no-install-recommends llvm-21 clang-21
+          # snappy's cmake invokes plain ``clang`` / ``clang++``.
+          sudo update-alternatives --install /usr/bin/clang clang \
+            /usr/bin/clang-21 100
+          sudo update-alternatives --install /usr/bin/clang++ clang++ \
+            /usr/bin/clang++-21 100
+          # Make the unsuffixed llvm-cov / llvm-profdata resolvable too.
+          echo "/usr/lib/llvm-21/bin" >> "$GITHUB_PATH"
+          # Sanity (non-fatal — the tests guard on presence regardless).
+          r2 -v || true
+          clang --version || true
+          /usr/lib/llvm-21/bin/llvm-cov --version || true
+          /usr/lib/llvm-21/bin/llvm-profdata --version || true
+
       - name: Run slow tests (deterministic — failure is a real regression)
         run: |
           source $VENV_PATH/bin/activate

--- a/core/inventory/binary_oracle_corpora/leveldb.py
+++ b/core/inventory/binary_oracle_corpora/leveldb.py
@@ -39,10 +39,14 @@ from .snappy import (
 logger = logging.getLogger(__name__)
 
 LEVELDB_URL = "https://github.com/google/leveldb.git"
-# Most-recent commit on main as of 2026-05-30. "Bump third_party/
-# dependencies." — necessary because the v1.23 tag's gtest submodule
-# pin doesn't compile with clang-21.
-LEVELDB_SHA = "7ee830d6c12fec2e02a4dde0adf6db1ed1afc4b8"
+# Most-recent commit on main as of 2026-05-30 ("Bump third_party/
+# dependencies.") — necessary because the v1.23 tag's gtest submodule
+# pin doesn't compile with clang-21. Verified against the live repo:
+# the prior value (7ee830d6c12f…) was never a real leveldb commit
+# ("upload-pack: not our ref"), which is why the pinned checkout 128'd
+# every nightly. This is the actual main HEAD SHA (same 7ee830d prefix
+# — the old value was a corrupted full SHA).
+LEVELDB_SHA = "7ee830d02b623e8ffe0b95d59a74db1e58da04c5"
 # In case the SHA isn't reachable, fall back to whatever ``main`` HEAD
 # is now — leveldb's main has been stable for years.
 LEVELDB_FALLBACK_BRANCH = "main"
@@ -93,18 +97,30 @@ def _build_and_run(sha_dir: Path, build_dir: Path, profdata: Path) -> None:
     logger.info("leveldb: cloning %s → %s", LEVELDB_URL, src)
     if not clone_repository(LEVELDB_URL, src, depth=None):
         raise RuntimeError(f"leveldb: clone failed for {LEVELDB_URL}")
-    # Hard-pin: check out the pinned SHA. If the local clone history
-    # doesn't reach it (depth-limited clone, force-pushed history),
-    # FAIL rather than fall back to ``main`` HEAD — silently using a
-    # different revision destroys reproducibility of the precision
-    # claim and makes corpus FPs unfalsifiable ("is this drift in the
-    # classifier, or drift in upstream HEAD?"). Adversarial review
-    # E P2-1. Operators wanting a different revision bump
-    # ``LEVELDB_SHA`` explicitly.
-    subprocess.run(
+    # Hard-pin: check out the pinned SHA. The clone fetches branch heads
+    # + their history, but the pinned commit may not be reachable from
+    # the default branch (shallow clone, or the commit sits behind a
+    # later force-push / on a now-deleted branch). In that case fetch the
+    # exact object explicitly, then check it out — GitHub honours fetching
+    # an arbitrary reachable SHA. We still check out ``LEVELDB_SHA`` and
+    # never fall back to ``main`` HEAD, so reproducibility of the precision
+    # claim is preserved (Adversarial review E P2-1): an unfetchable object
+    # is a hard error, never a silent revision swap. Operators wanting a
+    # different revision bump ``LEVELDB_SHA`` explicitly.
+    checkout = subprocess.run(
         safe_git_command("-C", str(src), "checkout", LEVELDB_SHA),
-        env=get_safe_git_env(), check=True, timeout=60,
+        env=get_safe_git_env(), check=False, timeout=60,
     )
+    if checkout.returncode != 0:
+        subprocess.run(
+            safe_git_command("-C", str(src), "fetch", "--depth", "1",
+                             "origin", LEVELDB_SHA),
+            env=get_safe_git_env(), check=True, timeout=120,
+        )
+        subprocess.run(
+            safe_git_command("-C", str(src), "checkout", LEVELDB_SHA),
+            env=get_safe_git_env(), check=True, timeout=60,
+        )
 
     subprocess.run(
         safe_git_command("-C", str(src), "submodule", "update",

--- a/core/inventory/tests/test_binary_oracle_edges.py
+++ b/core/inventory/tests/test_binary_oracle_edges.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import shutil
 from pathlib import Path
 
 import pytest
@@ -306,6 +307,11 @@ def test_cache_round_trips_edges_under_build_id(tmp_path, monkeypatch) -> None:
 
 
 @pytest.mark.slow
+@pytest.mark.skipif(
+    shutil.which("r2") is None,
+    reason="radare2 (r2) not installed — direct-edge extraction returns an "
+    "empty index by design, so there is nothing to assert",
+)
 def test_extract_direct_call_edges_on_synthetic_fixture(
     tmp_path: Path,
 ) -> None:

--- a/core/inventory/tests/test_binary_oracle_precision.py
+++ b/core/inventory/tests/test_binary_oracle_precision.py
@@ -3,11 +3,16 @@
 from __future__ import annotations
 
 import json
+import shutil
 from pathlib import Path
 
 import pytest
 
 from core.inventory.binary_oracle import BinaryOracleWitness
+from core.inventory.binary_oracle_corpora.snappy import (
+    _LLVM_COV_CANDIDATES,
+    _LLVM_PROFDATA_CANDIDATES,
+)
 from core.inventory.binary_oracle_precision import (
     CorpusReport,
     FunctionMeasurement,
@@ -15,6 +20,41 @@ from core.inventory.binary_oracle_precision import (
     _cross_tab_synthetic,
     run_corpus,
     write_report,
+)
+
+
+# ---------------------------------------------------------------------------
+# Toolchain availability — the ``*_driver_end_to_end_via_harness`` tests
+# clone + build real projects, so they need system tooling beyond the
+# Python deps. They are @pytest.mark.slow (nightly-only); the skipif guards
+# below make a missing toolchain degrade to SKIP-with-reason rather than a
+# red FAIL that looks like a precision regression. The nightly workflow
+# provisions radare2 + LLVM 21 so these actually run there.
+# ---------------------------------------------------------------------------
+def _which_any(candidates: tuple) -> bool:
+    return any(shutil.which(c) for c in candidates)
+
+
+_HAVE_LLVM = _which_any(_LLVM_COV_CANDIDATES) and _which_any(
+    _LLVM_PROFDATA_CANDIDATES)
+_HAVE_CLANG = bool(shutil.which("clang") and shutil.which("clang++"))
+_HAVE_CMAKE = shutil.which("cmake") is not None
+_HAVE_CARGO = shutil.which("cargo") is not None
+_HAVE_GCOV = shutil.which("gcov") is not None
+_HAVE_MAKE = shutil.which("make") is not None
+
+_NEED_LLVM_CXX = pytest.mark.skipif(
+    not (_HAVE_CLANG and _HAVE_CMAKE and _HAVE_LLVM),
+    reason="needs clang/clang++ + cmake + LLVM coverage tools "
+    "(llvm-cov / llvm-profdata)",
+)
+_NEED_LLVM_RUST = pytest.mark.skipif(
+    not (_HAVE_CARGO and _HAVE_LLVM),
+    reason="needs cargo + LLVM coverage tools (llvm-cov / llvm-profdata)",
+)
+_NEED_GCOV_BUILD = pytest.mark.skipif(
+    not (_HAVE_GCOV and _HAVE_MAKE),
+    reason="needs gcc/gcov + make",
 )
 
 
@@ -415,6 +455,7 @@ def test_snappy_stdlib_helpers_filtered_out() -> None:
 
 
 @pytest.mark.slow
+@_NEED_LLVM_CXX
 def test_snappy_driver_end_to_end_via_harness(tmp_path: Path) -> None:
     """Full clone → CMake build (clang+LLVM coverage) → ctest →
     llvm-cov export → classify → cross-tab. Marked ``slow`` so CI
@@ -509,6 +550,7 @@ def test_regex_rust_strips_crate_hash_from_demangled_names() -> None:
 
 
 @pytest.mark.slow
+@_NEED_LLVM_RUST
 def test_regex_rust_driver_end_to_end_via_harness(tmp_path: Path) -> None:
     """Full clone → cargo build (release + coverage + DWARF) → run test
     binary → llvm-cov export → classify. Slow (cargo build ~3 min)."""
@@ -527,6 +569,7 @@ def test_regex_rust_driver_end_to_end_via_harness(tmp_path: Path) -> None:
 
 
 @pytest.mark.slow
+@_NEED_GCOV_BUILD
 def test_libsodium_driver_end_to_end_via_harness(tmp_path: Path) -> None:
     """Full clone → autogen → configure × 2 → build × 2 → make check ×
     2 → targeted single-test rerun → gcov → classify. Slow."""
@@ -540,6 +583,7 @@ def test_libsodium_driver_end_to_end_via_harness(tmp_path: Path) -> None:
 
 
 @pytest.mark.slow
+@_NEED_LLVM_CXX
 def test_leveldb_driver_end_to_end_via_harness(tmp_path: Path) -> None:
     """Full clone → patch CMake → CMake build (clang+LLVM coverage) →
     ctest → llvm-cov → classify. Slow."""
@@ -553,6 +597,7 @@ def test_leveldb_driver_end_to_end_via_harness(tmp_path: Path) -> None:
 
 
 @pytest.mark.slow
+@_NEED_GCOV_BUILD
 def test_zlib_driver_end_to_end_via_harness(tmp_path: Path) -> None:
     """Full clone → build (×2) → test → gcov → classify → cross-tab.
     Marked ``slow`` so CI doesn't try to run it. The measurement itself


### PR DESCRIPTION
The binary-oracle precision/edge tests (core/inventory) are @pytest.mark.slow, so they run only in nightly.yml — which provisioned no system tooling beyond the Python deps. On the bare ubuntu-latest runner they hard-failed:
  * synthetic call-edge test — radare2 absent; the extractor returns an empty index by design, so the >=1-edge assertion failed.
  * snappy / regex-rust e2e — clang-21 + llvm-cov / llvm-profdata absent.
  * leveldb e2e — checkout 128: the pinned LEVELDB_SHA (7ee830d6c12f…) was never a real leveldb commit ("upload-pack: not our ref") — a corrupted copy of the intended main HEAD (same 7ee830d prefix). The gcc/gcov corpora (libsodium, zlib) passed because ubuntu-latest ships them.

- nightly.yml: install radare2 + LLVM 21 (clang-21, llvm-cov / llvm-profdata) before the slow run, and alternative plain clang/clang++ to clang-21 (snappy's cmake invokes them unsuffixed). continue-on-error so a provisioning hiccup degrades to skipped-not-failed via the guards below.
- Skip guards: each *_driver_end_to_end_via_harness test and the synthetic edge test now skipif its required tool is absent (r2 / clang+cmake+LLVM / cargo+LLVM / gcov+make), so a missing toolchain is a SKIP-with-reason rather than a red FAIL that mimics a precision regression.
- leveldb.py: re-pin LEVELDB_SHA to the real main HEAD 7ee830d02b623e8ffe0b95d59a74db1e58da04c5 ("Bump third_party/ dependencies.", the intended commit). Verified end-to-end on a provisioned box: clone → clang coverage build → ctest → llvm-cov → classify passes with the precision threshold held. Plus a fetch-fallback so a future pin unreachable from the clone is fetched explicitly (still the pinned SHA, never main HEAD).