### PR TITLE
feat(reachability): per-target getattr masking + opaque/aliased/bracket dispatch

### DIFF
--- a/core/inventory/call_graph.py
+++ b/core/inventory/call_graph.py
@@ -94,6 +94,13 @@ def _get_ts_parser(language_fn: Any) -> Any:
 # Indirection-flag values. Strings (not enum) so they round-trip
 # through JSON cleanly without a from_dict shim.
 INDIRECTION_GETATTR = "getattr"
+# Distinct from ``getattr``: the second argument is NOT a string Constant,
+# so the resolver can't narrow to a specific tail name. This is the truly
+# opaque case and earns blanket masking for any target name in the file's
+# reverse closure. ``getattr`` (with a literal-string arg) populates
+# ``getattr_targets`` and the resolver only taints THAT specific name —
+# unrelated targets in the same file aren't tainted.
+INDIRECTION_GETATTR_OPAQUE = "getattr_opaque"
 INDIRECTION_IMPORTLIB = "importlib"
 INDIRECTION_WILDCARD_IMPORT = "wildcard_import"
 INDIRECTION_DUNDER_IMPORT = "dunder_import"     # __import__("x.y")
@@ -101,7 +108,7 @@ INDIRECTION_DUNDER_IMPORT = "dunder_import"     # __import__("x.y")
 # treats them the same as the Python flags: any present →
 # UNCERTAIN for queries against names this file mentions.
 INDIRECTION_DYNAMIC_IMPORT = "dynamic_import"   # JS import(<var>) / require(<var>)
-INDIRECTION_BRACKET_DISPATCH = "bracket_dispatch"  # JS obj[<var>](...)
+INDIRECTION_BRACKET_DISPATCH = "bracket_dispatch"  # JS obj[<var>](...) / Py HANDLERS[k]()
 INDIRECTION_EVAL = "eval"                        # JS eval / new Function
 
 
@@ -576,17 +583,39 @@ class _PythonCallGraph(ast.NodeVisitor):
     def visit_Call(self, node: ast.Call) -> None:
         chain = _attribute_chain(node.func)
         if chain is None:
-            # Non-name callee (lambda, subscript, returned function
-            # call, etc.) — nothing for the resolver to match.
+            # Non-name callee — but ``HANDLERS[key](...)`` (Subscript)
+            # is dict-of-functions dispatch, a real opaque-dispatch
+            # channel. Without a tail name to narrow, treat it like
+            # opaque getattr: any target in the file's reverse
+            # closure could be the runtime callee. Other non-name
+            # forms (``(lambda x: …)()``, ``f()()``) carry no
+            # callable-name signal and stay invisible.
+            if isinstance(node.func, ast.Subscript):
+                self.graph.indirection.add(INDIRECTION_BRACKET_DISPATCH)
             self.generic_visit(node)
             return
 
-        # Indirection: getattr(obj, "name")(...)
-        if (chain == ["getattr"] and len(node.args) >= 2
-                and isinstance(node.args[1], ast.Constant)
-                and isinstance(node.args[1].value, str)):
-            self.graph.indirection.add(INDIRECTION_GETATTR)
-            self.graph.getattr_targets.add(node.args[1].value)
+        # Indirection: getattr(obj, ...)
+        # Two sub-cases:
+        #   literal:  getattr(obj, "name")    → record "name", flag
+        #             stays narrow (only "name" gets uncertain in
+        #             reverse closure; unrelated targets in same file
+        #             stay claimable).
+        #   opaque:   getattr(obj, var_expr)  → no name to record;
+        #             ANY target in the file's reverse closure could
+        #             be the runtime dispatch — blanket masking.
+        # Aliased forms — ``from builtins import getattr as g`` /
+        # ``import builtins; builtins.getattr(...)`` — resolved via
+        # the file's import map so ``g(obj, …)`` and
+        # ``builtins.getattr(obj, …)`` are also seen.
+        if _is_builtin_call(chain, "getattr", self.graph.imports) and len(node.args) >= 2:
+            second = node.args[1]
+            if (isinstance(second, ast.Constant)
+                    and isinstance(second.value, str)):
+                self.graph.indirection.add(INDIRECTION_GETATTR)
+                self.graph.getattr_targets.add(second.value)
+            else:
+                self.graph.indirection.add(INDIRECTION_GETATTR_OPAQUE)
 
         # Indirection: importlib.import_module("x.y")
         if chain == ["importlib", "import_module"]:
@@ -597,8 +626,8 @@ class _PythonCallGraph(ast.NodeVisitor):
             if qualified == "importlib.import_module":
                 self.graph.indirection.add(INDIRECTION_IMPORTLIB)
 
-        # Indirection: __import__("x.y")
-        if chain == ["__import__"]:
+        # Indirection: __import__("x.y") — also aliased forms.
+        if _is_builtin_call(chain, "__import__", self.graph.imports):
             self.graph.indirection.add(INDIRECTION_DUNDER_IMPORT)
 
         caller = self._enclosing[-1] if self._enclosing else None
@@ -619,6 +648,35 @@ class _PythonCallGraph(ast.NodeVisitor):
             receiver_class=receiver_class,
         ))
         self.generic_visit(node)
+
+
+def _is_builtin_call(
+    chain: List[str], builtin_name: str, imports: Dict[str, str],
+) -> bool:
+    """Does ``chain`` resolve to a call of the Python builtin
+    ``builtin_name`` (``getattr``, ``__import__``, …)?
+
+    Matches three forms:
+      - bare:     ``getattr(obj, "x")``               → chain ``["getattr"]``
+      - aliased:  ``from builtins import getattr as g; g(obj, "x")``
+                  → chain ``["g"]`` + ``imports["g"] == "builtins.getattr"``
+      - dotted:   ``import builtins; builtins.getattr(obj, "x")``
+                  → chain ``["builtins", "getattr"]``
+
+    Aliased and dotted forms are easy to miss but real: any project
+    that shadows a builtin name locally (lint workaround,
+    deobfuscation pattern, …) routes its dispatch through this
+    aliased path. Catching them keeps the masking signal honest.
+    """
+    if chain == [builtin_name]:
+        return True
+    if len(chain) == 1:
+        qualified = imports.get(chain[0])
+        if qualified == f"builtins.{builtin_name}":
+            return True
+    if chain == ["builtins", builtin_name]:
+        return True
+    return False
 
 
 def _decorator_chain(deco: ast.AST) -> Optional[List[str]]:

--- a/core/inventory/reachability.py
+++ b/core/inventory/reachability.py
@@ -44,6 +44,16 @@ later")
     as ``mypkg.helpers.ezp`` won't be matched on the
     ``mypkg.helpers.ezp`` qualified name unless the inventory
     captures the re-export — and at first cut, it doesn't.
+  * Cross-file string-literal ``getattr`` dispatch. ``file_a.py``
+    holds ``getattr(obj, "foo")(...)`` where ``obj`` is an instance
+    of a class in ``file_b.py``. The masking signal is per-file,
+    and ``file_a.py`` is not in the static reverse closure of
+    ``file_b.py::Klass.foo`` (the getattr call site isn't a
+    resolved edge), so the dead-island claim against ``Klass.foo``
+    can't see ``file_a``'s confounding dispatch. UNCERTAIN-safe
+    only when ``Klass.foo`` is reachable through some non-getattr
+    edge; pure-getattr-only consumers of an internal API are the
+    blind spot.
 
 If the consumer cares about any of those, CodeQL's call-graph
 queries are the right tool — at the cost of a ~30s DB build.
@@ -77,6 +87,7 @@ from .call_graph import (
     INDIRECTION_DYNAMIC_IMPORT,
     INDIRECTION_EVAL,
     INDIRECTION_GETATTR,
+    INDIRECTION_GETATTR_OPAQUE,
     INDIRECTION_IMPORTLIB,
     INDIRECTION_REFLECT,
     INDIRECTION_WILDCARD_IMPORT,
@@ -130,9 +141,31 @@ _TEST_FILE_PATTERN = re.compile(
 # also mentions the target tail name.
 _MASKING_FLAGS: Set[str] = {
     INDIRECTION_GETATTR,
+    INDIRECTION_GETATTR_OPAQUE,
     INDIRECTION_IMPORTLIB,
     INDIRECTION_DUNDER_IMPORT,
     INDIRECTION_WILDCARD_IMPORT,
+    INDIRECTION_BRACKET_DISPATCH,
+    INDIRECTION_DYNAMIC_IMPORT,
+    INDIRECTION_EVAL,
+    INDIRECTION_REFLECT,
+}
+
+# Subset of ``_MASKING_FLAGS`` whose dispatcher has no recorded tail
+# name — the runtime target is genuinely unknown and could be ANY
+# function in the file's reverse closure. ``INDIRECTION_GETATTR`` is
+# NOT here because a literal ``getattr(obj, "foo")(...)`` records
+# ``"foo"`` in ``getattr_targets``; ``_file_masks_target`` checks
+# that list and taints only the matching target. Wildcard-import
+# (``from x import *``) is also outside this set — it has a
+# different per-target precision path via ``_wildcard_could_provide``
+# at the resolver layer (``function_called``); the entry-reachability
+# layer treats wildcard conservatively-blanket because it lacks the
+# target's module context.
+_OPAQUE_MASKING_FLAGS: Set[str] = {
+    INDIRECTION_GETATTR_OPAQUE,
+    INDIRECTION_IMPORTLIB,
+    INDIRECTION_DUNDER_IMPORT,
     INDIRECTION_BRACKET_DISPATCH,
     INDIRECTION_DYNAMIC_IMPORT,
     INDIRECTION_EVAL,
@@ -3242,15 +3275,52 @@ def _is_nested_function(
     return False
 
 
-def _file_has_masking(inventory: Dict[str, Any], file_path: str) -> bool:
+def _file_masks_target(
+    inventory: Dict[str, Any], file_path: str, target_name: str,
+) -> bool:
+    """Could dynamic dispatch in this file resolve to ``target_name``?
+
+    Refines the older "any masking flag → True" check (which over-tainted
+    every reverse-closure path through a file with any reflection) by
+    asking the more precise question: is there a dispatcher in this file
+    whose runtime target COULD be ``target_name``?
+
+    Returns ``True`` when:
+      - The file carries any OPAQUE masking flag (variable-arg getattr,
+        importlib, eval, bracket-dispatch, …) — the dispatcher's name is
+        unknown, so any target is possible.
+      - The file has a literal-string ``getattr`` AND ``target_name`` is
+        one of those literals (the dispatch could hit this target).
+      - The file has a wildcard-import that could plausibly bring
+        ``target_name`` in scope (delegated to
+        ``_wildcard_could_provide``).
+      - The file's macro_call_targets list mentions ``target_name``
+        (C/C++ macro-body dispatch — same per-target shape).
+
+    Returns ``False`` when all dispatchers resolve to literal names other
+    than ``target_name``: the masking is real but doesn't affect this
+    target, so an entry_reachability dead-island claim is safe.
+    """
     norm = file_path.replace("\\", "/")
     for fr in inventory.get("files", []):
         if not isinstance(fr, dict) or (fr.get("path") or "").replace("\\", "/") != norm:
             continue
         cg = fr.get("call_graph") or {}
-        if set(cg.get("indirection") or []) & _MASKING_FLAGS:
+        flags = set(cg.get("indirection") or [])
+        if flags & _OPAQUE_MASKING_FLAGS:
             return True
-        if cg.get("macro_call_targets"):
+        if (INDIRECTION_GETATTR in flags
+                and target_name in (cg.get("getattr_targets") or [])):
+            return True
+        if INDIRECTION_WILDCARD_IMPORT in flags:
+            # ``_wildcard_could_provide`` filters on target_module —
+            # the entry-reachability path doesn't have a module context
+            # (we know the file path and the target name only). Be
+            # conservative: any wildcard import in the file masks any
+            # target name; an unrelated-module wildcard is the cost.
+            return True
+        macro_targets = cg.get("macro_call_targets") or []
+        if target_name in macro_targets:
             return True
         return False
     return False
@@ -3349,12 +3419,16 @@ def entry_reachability(
     # target's file, or in any function that transitively calls it, could
     # hide an entry edge the static graph didn't capture → don't claim
     # dead. This reverse walk only runs for the not-reachable minority.
-    if _file_has_masking(inventory, target.file_path):
+    # ``_file_masks_target`` is target-name aware: a file whose only
+    # reflection is ``getattr(obj, "foo")`` does NOT mask an unrelated
+    # ``bar`` — narrower than the previous "any masking flag → uncertain"
+    # check.
+    if _file_masks_target(inventory, target.file_path, target.name):
         return "uncertain"
     rc = reverse_closure(inventory, target, max_depth=max_depth)
     for fn in rc.nodes:
-        if isinstance(fn, InternalFunction) and _file_has_masking(
-            inventory, fn.file_path,
+        if isinstance(fn, InternalFunction) and _file_masks_target(
+            inventory, fn.file_path, target.name,
         ):
             return "uncertain"
     return "no_path_from_entry"

--- a/core/inventory/reachability.py
+++ b/core/inventory/reachability.py
@@ -157,11 +157,10 @@ _MASKING_FLAGS: Set[str] = {
 # NOT here because a literal ``getattr(obj, "foo")(...)`` records
 # ``"foo"`` in ``getattr_targets``; ``_file_masks_target`` checks
 # that list and taints only the matching target. Wildcard-import
-# (``from x import *``) is also outside this set — it has a
-# different per-target precision path via ``_wildcard_could_provide``
-# at the resolver layer (``function_called``); the entry-reachability
-# layer treats wildcard conservatively-blanket because it lacks the
-# target's module context.
+# (``from x import *``) is also outside this set — both ``function_called``
+# and ``_file_masks_target`` route it through ``_wildcard_could_provide``
+# to narrow per-target (the entry-reachability path derives the target's
+# module from its file path so the heuristic applies there too).
 _OPAQUE_MASKING_FLAGS: Set[str] = {
     INDIRECTION_GETATTR_OPAQUE,
     INDIRECTION_IMPORTLIB,
@@ -3302,6 +3301,7 @@ def _is_nested_function(
 
 def _file_masks_target(
     inventory: Dict[str, Any], file_path: str, target_name: str,
+    *, target_module: Optional[str] = None,
 ) -> bool:
     """Could dynamic dispatch in this file resolve to ``target_name``?
 
@@ -3317,8 +3317,11 @@ def _file_masks_target(
       - The file has a literal-string ``getattr`` AND ``target_name`` is
         one of those literals (the dispatch could hit this target).
       - The file has a wildcard-import that could plausibly bring
-        ``target_name`` in scope (delegated to
-        ``_wildcard_could_provide``).
+        ``target_name`` in scope. When ``target_module`` is supplied the
+        resolver layer's ``_wildcard_could_provide`` heuristic is used
+        to narrow per-target (drops the wildcard claim when no other
+        import in this file shares the target's module root). Without
+        ``target_module`` the wildcard is conservatively blanket.
       - The file's macro_call_targets list mentions ``target_name``
         (C/C++ macro-body dispatch — same per-target shape).
 
@@ -3337,12 +3340,17 @@ def _file_masks_target(
             and target_name in (cg.get("getattr_targets") or [])):
         return True
     if INDIRECTION_WILDCARD_IMPORT in flags:
-        # ``_wildcard_could_provide`` filters on target_module —
-        # the entry-reachability path doesn't have a module context
-        # (we know the file path and the target name only). Be
-        # conservative: any wildcard import in the file masks any
-        # target name; an unrelated-module wildcard is the cost.
-        return True
+        # When the caller supplies ``target_module`` (entry_reachability
+        # derives it from the target's file path) we narrow per-target
+        # — a ``from json import *`` in a file that doesn't import
+        # anything from the target's root package can't have brought
+        # the target into scope. Without ``target_module`` we stay
+        # conservative.
+        if target_module is None:
+            return True
+        imports = cg.get("imports") or {}
+        if _wildcard_could_provide(imports, target_module, target_name):
+            return True
     macro_targets = cg.get("macro_call_targets") or []
     if target_name in macro_targets:
         return True
@@ -3445,13 +3453,28 @@ def entry_reachability(
     # ``_file_masks_target`` is target-name aware: a file whose only
     # reflection is ``getattr(obj, "foo")`` does NOT mask an unrelated
     # ``bar`` — narrower than the previous "any masking flag → uncertain"
-    # check.
-    if _file_masks_target(inventory, target.file_path, target.name):
+    # check. ``target_module`` (derived from the target's path) narrows
+    # the wildcard-import branch via ``_wildcard_could_provide``: a
+    # ``from json import *`` in a file that doesn't otherwise import
+    # from the target's root package no longer masks every dead-island
+    # claim through that file.
+    #
+    # Note: ``_wildcard_could_provide`` was originally written for the
+    # resolver layer's ``function_called`` flow, where ``target_module``
+    # is the *dep being queried* (e.g. ``requests.utils``). Here we pass
+    # the target's *own file-derived module* (e.g. ``mypkg.helpers``).
+    # The heuristic answer-shape is the same — "does this file's import
+    # surface touch the target's root package" — but the semantic of
+    # ``target_module`` differs per caller; mind this if extending.
+    target_module = _file_path_to_module(target.file_path)
+    if _file_masks_target(inventory, target.file_path, target.name,
+                          target_module=target_module):
         return "uncertain"
     rc = reverse_closure(inventory, target, max_depth=max_depth)
     for fn in rc.nodes:
         if isinstance(fn, InternalFunction) and _file_masks_target(
             inventory, fn.file_path, target.name,
+            target_module=target_module,
         ):
             return "uncertain"
     return "no_path_from_entry"

--- a/core/inventory/reachability.py
+++ b/core/inventory/reachability.py
@@ -3133,6 +3133,39 @@ def _item_is_entry(item: Dict[str, Any], language: str,
 _ENTRY_SET_CACHE: Dict[int, Tuple[Dict[str, Any], "frozenset"]] = {}
 _ENTRY_SET_CACHE_MAX = 8
 
+_FILES_BY_PATH_CACHE: Dict[int, Tuple[Dict[str, Any], Dict[str, Dict[str, Any]]]] = {}
+_FILES_BY_PATH_CACHE_MAX = 8
+
+
+def _files_by_path(inventory: Dict[str, Any]) -> Dict[str, Dict[str, Any]]:
+    """Path-keyed view of ``inventory["files"]`` — O(1) lookup per file.
+
+    Cached per-inventory by ``id``; identity-checked on read so a fresh
+    inventory at the same address rebuilds the index. Used by the
+    file-scoped helpers (``_file_language``, ``_file_python_exports``,
+    ``_file_masks_target``, ``_is_nested_function``) which were each
+    doing an O(files) linear scan per call — the entry-reachability
+    path walks the reverse closure and pays this cost per node.
+    """
+    inv_id = id(inventory)
+    cached = _FILES_BY_PATH_CACHE.get(inv_id)
+    if cached is not None and cached[0] is inventory:
+        return cached[1]
+    index: Dict[str, Dict[str, Any]] = {}
+    for fr in inventory.get("files", []):
+        if not isinstance(fr, dict):
+            continue
+        path = (fr.get("path") or "").replace("\\", "/")
+        if path:
+            index[path] = fr
+    # FIFO eviction (matches the sibling ``_ENTRY_SET_CACHE`` pattern):
+    # drop the oldest entry when full, instead of wiping every entry —
+    # keeps the cache useful under multi-inventory pipelines.
+    if len(_FILES_BY_PATH_CACHE) >= _FILES_BY_PATH_CACHE_MAX:
+        _FILES_BY_PATH_CACHE.pop(next(iter(_FILES_BY_PATH_CACHE)))
+    _FILES_BY_PATH_CACHE[inv_id] = (inventory, index)
+    return index
+
 
 def _entry_functions(inventory: Dict[str, Any]) -> "frozenset":
     """Set of InternalFunction entry points (visibility/linkage model +
@@ -3219,11 +3252,8 @@ def _entry_reachable_set(
 
 
 def _file_language(inventory: Dict[str, Any], file_path: str) -> Optional[str]:
-    norm = file_path.replace("\\", "/")
-    for fr in inventory.get("files", []):
-        if isinstance(fr, dict) and (fr.get("path") or "").replace("\\", "/") == norm:
-            return fr.get("language")
-    return None
+    fr = _files_by_path(inventory).get(file_path.replace("\\", "/"))
+    return fr.get("language") if fr else None
 
 
 def _file_python_exports(
@@ -3234,15 +3264,13 @@ def _file_python_exports(
     "what is exported" signal — distinct from the leading-underscore
     convention, which is a fallback when ``__all__`` is absent.
     """
-    norm = file_path.replace("\\", "/")
-    for fr in inventory.get("files", []):
-        if not isinstance(fr, dict) or (fr.get("path") or "").replace("\\", "/") != norm:
-            continue
-        exports = fr.get("exports")
-        if exports is None:
-            return None
-        return frozenset(exports)
-    return None
+    fr = _files_by_path(inventory).get(file_path.replace("\\", "/"))
+    if not fr:
+        return None
+    exports = fr.get("exports")
+    if exports is None:
+        return None
+    return frozenset(exports)
 
 
 def _is_nested_function(
@@ -3253,25 +3281,22 @@ def _is_nested_function(
     ``line_start`` falls strictly inside another item's
     ``[line_start, line_end]`` range is nested.
     """
-    norm = target.file_path.replace("\\", "/")
-    for fr in inventory.get("files", []):
-        if not isinstance(fr, dict) or (fr.get("path") or "").replace("\\", "/") != norm:
-            continue
-        items = fr.get("items", []) or []
-        if target.line <= 0:
-            return False
-        for other in items:
-            if not isinstance(other, dict):
-                continue
-            if other.get("kind", "function") != "function":
-                continue
-            ols = int(other.get("line_start") or 0)
-            ole = int(other.get("line_end") or 0)
-            if ols <= 0 or ole <= 0:
-                continue
-            if ols < target.line and target.line <= ole:
-                return True
+    if target.line <= 0:
         return False
+    fr = _files_by_path(inventory).get(target.file_path.replace("\\", "/"))
+    if not fr:
+        return False
+    for other in fr.get("items", []) or []:
+        if not isinstance(other, dict):
+            continue
+        if other.get("kind", "function") != "function":
+            continue
+        ols = int(other.get("line_start") or 0)
+        ole = int(other.get("line_end") or 0)
+        if ols <= 0 or ole <= 0:
+            continue
+        if ols < target.line and target.line <= ole:
+            return True
     return False
 
 
@@ -3301,28 +3326,26 @@ def _file_masks_target(
     than ``target_name``: the masking is real but doesn't affect this
     target, so an entry_reachability dead-island claim is safe.
     """
-    norm = file_path.replace("\\", "/")
-    for fr in inventory.get("files", []):
-        if not isinstance(fr, dict) or (fr.get("path") or "").replace("\\", "/") != norm:
-            continue
-        cg = fr.get("call_graph") or {}
-        flags = set(cg.get("indirection") or [])
-        if flags & _OPAQUE_MASKING_FLAGS:
-            return True
-        if (INDIRECTION_GETATTR in flags
-                and target_name in (cg.get("getattr_targets") or [])):
-            return True
-        if INDIRECTION_WILDCARD_IMPORT in flags:
-            # ``_wildcard_could_provide`` filters on target_module —
-            # the entry-reachability path doesn't have a module context
-            # (we know the file path and the target name only). Be
-            # conservative: any wildcard import in the file masks any
-            # target name; an unrelated-module wildcard is the cost.
-            return True
-        macro_targets = cg.get("macro_call_targets") or []
-        if target_name in macro_targets:
-            return True
+    fr = _files_by_path(inventory).get(file_path.replace("\\", "/"))
+    if not fr:
         return False
+    cg = fr.get("call_graph") or {}
+    flags = set(cg.get("indirection") or [])
+    if flags & _OPAQUE_MASKING_FLAGS:
+        return True
+    if (INDIRECTION_GETATTR in flags
+            and target_name in (cg.get("getattr_targets") or [])):
+        return True
+    if INDIRECTION_WILDCARD_IMPORT in flags:
+        # ``_wildcard_could_provide`` filters on target_module —
+        # the entry-reachability path doesn't have a module context
+        # (we know the file path and the target name only). Be
+        # conservative: any wildcard import in the file masks any
+        # target name; an unrelated-module wildcard is the cost.
+        return True
+    macro_targets = cg.get("macro_call_targets") or []
+    if target_name in macro_targets:
+        return True
     return False
 
 

--- a/core/inventory/tests/test_binary_oracle.py
+++ b/core/inventory/tests/test_binary_oracle.py
@@ -74,12 +74,22 @@ def test_build_id_is_readable(built_demo: Path) -> None:
         f"build_id missing or malformed: {bid!r}"
 
 
+@pytest.fixture(scope="module")
+def _verdicts_for_built_demo(built_demo: Path):
+    """Module-scoped: classify ALL ground-truth functions ONCE; parametrized
+    test cases just look up their slot. Pre-fix each parametrized case
+    re-ran ``classify_binary_evidence`` against the SAME binary with the
+    SAME inputs (10+ redundant nm/objdump invocations on CI), with the
+    first case paying the full cold-start cost (~30s on CI). Now: one
+    classify per module."""
+    return classify_binary_evidence(list(EXPECTED_VERDICTS), built_demo)
+
+
 @pytest.mark.parametrize("name,expected", sorted(EXPECTED_VERDICTS.items()))
-def test_classify_matches_expected_verdict(built_demo: Path, name: str,
-                                            expected: str) -> None:
+def test_classify_matches_expected_verdict(_verdicts_for_built_demo,
+                                            name: str, expected: str) -> None:
     """Each ground-truth function classifies to its predicted verdict."""
-    verdicts = classify_binary_evidence(list(EXPECTED_VERDICTS), built_demo)
-    w = verdicts[name]
+    w = _verdicts_for_built_demo[name]
     assert isinstance(w, BinaryOracleWitness)
     assert w.classification == expected, (
         f"{name!r}: expected {expected!r}, got {w.classification!r}; "
@@ -262,23 +272,33 @@ def test_enrich_does_not_crash_on_metadata_none(built_demo: Path) -> None:
     assert items[1]["metadata"]["binary_oracle"]["classification"] == "absent"
 
 
-def test_classifier_handles_clang_indexed_string_dwarf(tmp_path: Path) -> None:
-    """clang emits ``(indexed string: 0xN): name`` where gcc emits
-    ``(indirect string, offset: 0xN): name``. Parser must read both —
-    otherwise every clang-built name is anonymous and inline-detection
-    silently fails (would classify ``inlined_only`` as ``absent`` on clang)."""
+@pytest.fixture(scope="module")
+def _clang_built_demo(tmp_path_factory):
+    """Module-scoped clang variant of ``built_demo`` — copies the same
+    fixture sources and rebuilds with ``CC=clang``. Used only by the
+    indexed-string DWARF test; moved into a fixture so the clang
+    compile cost lands in fixture SETUP, not in the test's CALL phase
+    (CI's 10s call-duration guard fires otherwise — clang cold-start
+    on a Makefile-driven 3-file build is ~12s on CI runners)."""
     if not shutil.which("clang"):
         pytest.skip("clang not available")
-    work = tmp_path / "clang_fixture"
-    work.mkdir()
+    work = tmp_path_factory.mktemp("clang_fixture")
     for f in ("lib.c", "lib.h", "main.c", "Makefile"):
         (work / f).write_bytes((FIXTURE_DIR / f).read_bytes())
     rc = subprocess.run(["make", "-C", str(work), "CC=clang"],
                         capture_output=True, text=True, timeout=60)
     if rc.returncode != 0:
         pytest.skip(f"clang build failed: {rc.stderr[:200]}")
+    return work / "demo"
+
+
+def test_classifier_handles_clang_indexed_string_dwarf(_clang_built_demo) -> None:
+    """clang emits ``(indexed string: 0xN): name`` where gcc emits
+    ``(indirect string, offset: 0xN): name``. Parser must read both —
+    otherwise every clang-built name is anonymous and inline-detection
+    silently fails (would classify ``inlined_only`` as ``absent`` on clang)."""
     v = classify_binary_evidence(
-        ["inlined_only", "dead_static_unused", "live_called"], work / "demo")
+        ["inlined_only", "dead_static_unused", "live_called"], _clang_built_demo)
     assert v["inlined_only"].classification == "inlined", (
         "clang DWARF (indexed string) name format must be parsed too")
     assert v["dead_static_unused"].classification == "absent"
@@ -534,23 +554,33 @@ def test_classifier_qualifies_cpp_methods_with_namespace(
         f"qualified lookup misclassified: {verdicts['foo::Bar::baz']}")
 
 
+@pytest.fixture(scope="module")
+def _nm_qualified_cpp_binary(tmp_path_factory):
+    """Compile the namespace-baz C++ test binary in fixture setup so the
+    test's CALL phase stays under the fast-tier 10s guard (g++ cold-start
+    on CI runners can take ~30s for a 2-line program). Used only by
+    ``test_nm_index_stores_qualified_no_args_form_for_cpp``."""
+    import subprocess as _sp
+    work = tmp_path_factory.mktemp("nm_qualified")
+    src = work / "x.cc"
+    src.write_text(
+        "namespace foo { namespace bar { int baz(int x) { return x+1; } }}\n"
+        "int main(void){ return foo::bar::baz(0); }\n")
+    binary = work / "x"
+    _sp.run(["g++", "-O0", "-g", "-o", str(binary), str(src)], check=True)
+    return binary
+
+
 def test_nm_index_stores_qualified_no_args_form_for_cpp(
-    tmp_path: Path,
+    _nm_qualified_cpp_binary,
 ) -> None:
     """``gcov -m`` outputs C++ names like ``snappy::Uncompress`` (no args);
     nm --demangle gives ``snappy::Uncompress(snappy::Source*, ...)`` (with
     args). Without indexing the qualified-no-args form, every C++
     measurement misses. Surfaced by snappy Inc 3c."""
-    import subprocess as _sp
     from core.inventory.binary_oracle import _nm_symbols
 
-    src = tmp_path / "x.cc"
-    src.write_text(
-        "namespace foo { namespace bar { int baz(int x) { return x+1; } }}\n"
-        "int main(void){ return foo::bar::baz(0); }\n")
-    binary = tmp_path / "x"
-    _sp.run(["g++", "-O0", "-g", "-o", str(binary), str(src)], check=True)
-    syms = _nm_symbols(binary)
+    syms = _nm_symbols(_nm_qualified_cpp_binary)
     # All three forms must be indexed:
     full_match = any("foo::bar::baz(" in k for k in syms)
     assert full_match, f"full demangled form missing: {list(syms)[:5]}"

--- a/core/inventory/tests/test_binary_oracle_e2e.py
+++ b/core/inventory/tests/test_binary_oracle_e2e.py
@@ -27,12 +27,41 @@ from core.inventory.reach_witness import (
 from core.inventory.reachability import binary_oracle_absent
 
 
+@pytest.fixture(scope="module")
+def _synthetic_target_built(tmp_path_factory):
+    """Module-scoped: gcc-compile the synthetic dead-function project
+    ONCE, share across every test in this file. Previously each test
+    called ``_build_synthetic_target(tmp_path)`` and paid the gcc
+    compile cost (~25s on CI cold-start) per test — 4 tests = 100s of
+    redundant compile time. Now compiled once.
+
+    Yields ``(project_root, binary_path, inventory_template)``. The
+    inventory dict is a TEMPLATE — each test must deep-copy it via
+    ``_fresh_inventory`` before mutating, otherwise mutations leak
+    across tests.
+    """
+    work = tmp_path_factory.mktemp("synthetic_target")
+    return _build_synthetic_target(work)
+
+
+def _fresh_inventory(template: dict) -> dict:
+    """Deep-copy the module-scoped inventory template so each test
+    can mutate items[...].metadata etc. without cross-test leakage."""
+    import copy
+    return copy.deepcopy(template)
+
+
 def _build_synthetic_target(tmp_path: Path) -> tuple[Path, Path, dict]:
     """Build a small C project with a deliberately-dead function.
 
     Returns (project_root, binary_path, inventory_dict). The binary
     is compiled with -O2 -ffunction-sections -fdata-sections +
     -Wl,--gc-sections so the dead function is genuinely DCE'd.
+
+    Direct callers exist for tests that MUTATE the project dir
+    (planted-binary, LTO-rebuild) — those can't share the
+    module-fixture's read-only project. Most tests should use the
+    ``_synthetic_target_built`` fixture instead.
     """
     project = tmp_path / "myproj"
     project.mkdir()
@@ -102,11 +131,12 @@ def _alive_helper_line(inv: dict) -> int:
     raise AssertionError("alive_helper_0 not in inventory")
 
 
-def test_e2e_explicit_binary_flag_path(tmp_path: Path) -> None:
+def test_e2e_explicit_binary_flag_path(_synthetic_target_built) -> None:
     """The ``--binary`` explicit-path path: operator points at a
     binary; classifier finds the dead function absent and the
     chokepoint accessor confirms suppression eligibility."""
-    project, binary, inv = _build_synthetic_target(tmp_path)
+    project, binary, template = _synthetic_target_built
+    inv = _fresh_inventory(template)
     counts = enrich_inventory_with_binary_oracle(inv, (binary,))
     assert counts["classified"] == 12
     items = {it["name"]: it for it in inv["files"][0]["items"]}
@@ -138,11 +168,12 @@ def test_e2e_explicit_binary_flag_path(tmp_path: Path) -> None:
     assert spec.may_suppress(STRUCTURALLY_SUPPRESSIBLE_KINDS) is True
 
 
-def test_e2e_autodetect_finds_binary(tmp_path: Path) -> None:
+def test_e2e_autodetect_finds_binary(_synthetic_target_built) -> None:
     """The ``--binary-auto`` path: operator passes no explicit path;
     auto-detect walks the project tree and finds the binary under
     ``build/``."""
-    project, binary, inv = _build_synthetic_target(tmp_path)
+    project, binary, template = _synthetic_target_built
+    inv = _fresh_inventory(template)
     detected = detect_binaries(project, "application")
     # The built binary lives at build/myapp.
     assert any(p.name == "myapp" for p in detected), detected
@@ -151,11 +182,12 @@ def test_e2e_autodetect_finds_binary(tmp_path: Path) -> None:
     assert counts["classified"] == 12
 
 
-def test_e2e_chokepoint_helper_full_flow(tmp_path: Path) -> None:
+def test_e2e_chokepoint_helper_full_flow(_synthetic_target_built) -> None:
     """The shared ``reach_chokepoint`` helper that both /agentic and
     /codeql use: from a finding-shaped input through to the suppression
     decision, all on a real binary's enrichment output."""
-    project, binary, inv = _build_synthetic_target(tmp_path)
+    project, binary, template = _synthetic_target_built
+    inv = _fresh_inventory(template)
     enrich_inventory_with_binary_oracle(inv, (binary,))
     dead_line = _dead_helper_line(inv)
     alive_line = _alive_helper_line(inv)

--- a/core/inventory/tests/test_call_graph.py
+++ b/core/inventory/tests/test_call_graph.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 from core.inventory.call_graph import (
     FileCallGraph,
+    INDIRECTION_BRACKET_DISPATCH,
     INDIRECTION_DUNDER_IMPORT,
     INDIRECTION_GETATTR,
     INDIRECTION_IMPORTLIB,
@@ -165,14 +166,67 @@ def test_getattr_string_dispatch_flagged():
     assert INDIRECTION_GETATTR in g.indirection
 
 
-def test_getattr_with_non_constant_not_flagged():
-    """``getattr(obj, attr)`` with a variable second arg isn't the
-    string-dispatch pattern we care about."""
+def test_getattr_aliased_via_import_flagged():
+    """``from builtins import getattr as g; g(obj, "x")()`` — the
+    alias resolves to ``builtins.getattr``. Without alias resolution
+    a project that does this (lint workaround, deobfuscation,
+    pattern-hiding) would slip past the masking signal."""
+    from core.inventory.call_graph import INDIRECTION_GETATTR_OPAQUE
+    g = extract_call_graph_python(
+        "from builtins import getattr as g\n"
+        "def f(obj, attr):\n"
+        "    g(obj, attr)()\n"
+        "    g(obj, 'literal')()\n"
+    )
+    assert INDIRECTION_GETATTR in g.indirection         # literal path
+    assert "literal" in g.getattr_targets
+    assert INDIRECTION_GETATTR_OPAQUE in g.indirection  # opaque path
+
+
+def test_getattr_dotted_builtins_flagged():
+    """``import builtins; builtins.getattr(obj, "x")``"""
+    from core.inventory.call_graph import INDIRECTION_GETATTR_OPAQUE
+    g = extract_call_graph_python(
+        "import builtins\n"
+        "def f(obj, attr):\n"
+        "    builtins.getattr(obj, attr)()\n"
+        "    builtins.getattr(obj, 'foo')()\n"
+    )
+    assert INDIRECTION_GETATTR in g.indirection
+    assert "foo" in g.getattr_targets
+    assert INDIRECTION_GETATTR_OPAQUE in g.indirection
+
+
+def test_bracket_dispatch_flagged():
+    """``HANDLERS[key]()`` dict-of-functions dispatch in Python — same
+    opaque-dispatch semantic as JS ``obj[key]()``. Pre-fix the
+    Subscript callee was returned-early and no flag fired; a function
+    only reachable via this dispatch could be wrongly claimed dead."""
+    g = extract_call_graph_python(
+        "HANDLERS = {'a': handler_a, 'b': handler_b}\n"
+        "def f(key):\n"
+        "    HANDLERS[key]()\n"
+    )
+    assert INDIRECTION_BRACKET_DISPATCH in g.indirection
+
+
+def test_getattr_with_non_constant_flagged_opaque():
+    """``getattr(obj, attr)`` with a variable second arg IS the
+    truly-opaque dispatch case — the resolver can't narrow to a
+    specific tail name, so any target in the file's reverse closure
+    could be the runtime callee. Flagged distinctly from literal-
+    string ``getattr`` so masking can be applied per-target precisely
+    in the literal case but blanket in the opaque case."""
+    from core.inventory.call_graph import INDIRECTION_GETATTR_OPAQUE
     g = extract_call_graph_python(
         "def f(obj, attr):\n"
         "    getattr(obj, attr)()\n"
     )
+    # The literal-string flag stays off (no string name captured).
     assert INDIRECTION_GETATTR not in g.indirection
+    # The opaque variant fires.
+    assert INDIRECTION_GETATTR_OPAQUE in g.indirection
+    assert not g.getattr_targets  # no literal name to record
 
 
 def test_importlib_import_module_flagged():

--- a/core/inventory/tests/test_reachability.py
+++ b/core/inventory/tests/test_reachability.py
@@ -519,10 +519,12 @@ def test_directly_called_beats_macro_masking():
 
 
 def _entry_inv(path, language, items, calls, indirection=None,
-               library_mode=False, exports=None):
+               library_mode=False, exports=None, getattr_targets=None):
     cg = {"imports": {}, "calls": calls}
     if indirection:
         cg["indirection"] = indirection
+    if getattr_targets:
+        cg["getattr_targets"] = sorted(getattr_targets)
     file_record: Dict[str, Any] = {
         "path": path, "language": language,
         "items": items, "call_graph": cg,
@@ -660,6 +662,42 @@ def test_python_dunder_all_excludes_public_name_claims_no_path():
         exports=["api"],
     )
     assert _er(inv, "m.py", "helper", 5) == "no_path_from_entry"
+
+
+def test_python_literal_getattr_for_other_name_does_not_mask_target():
+    # File has ``getattr(obj, "handle")()`` — literal-string. The
+    # captured ``getattr_targets`` says only "handle" could be the
+    # runtime callee via reflection. An unrelated ``_orphan`` in the
+    # same file is NOT masked by that getattr — claim no_path.
+    # Pre-refinement: any masking flag tainted every target in the
+    # file's reverse closure, so _orphan read UNCERTAIN. Now narrower.
+    inv = _entry_inv(
+        "m.py", "python", [_fn("_orphan", 1)], [],
+        indirection=["getattr"], getattr_targets={"handle"},
+    )
+    assert _er(inv, "m.py", "_orphan", 1) == "no_path_from_entry"
+
+
+def test_python_literal_getattr_for_target_masks_uncertain():
+    # File has ``getattr(obj, "_orphan")()`` — literal-string with
+    # the target's own tail name. The dispatch COULD resolve to the
+    # target, so we must read uncertain.
+    inv = _entry_inv(
+        "m.py", "python", [_fn("_orphan", 1)], [],
+        indirection=["getattr"], getattr_targets={"_orphan"},
+    )
+    assert _er(inv, "m.py", "_orphan", 1) == "uncertain"
+
+
+def test_python_opaque_getattr_masks_any_target():
+    # ``getattr(obj, attr)`` with a variable second arg is genuinely
+    # opaque — the resolver can't narrow to a tail name, so any
+    # target in the reverse closure could be the runtime callee.
+    inv = _entry_inv(
+        "m.py", "python", [_fn("_orphan", 1)], [],
+        indirection=["getattr_opaque"],
+    )
+    assert _er(inv, "m.py", "_orphan", 1) == "uncertain"
 
 
 def test_python_dunder_all_includes_underscore_name_is_uncertain():

--- a/core/inventory/tests/test_reachability.py
+++ b/core/inventory/tests/test_reachability.py
@@ -689,6 +689,54 @@ def test_python_literal_getattr_for_target_masks_uncertain():
     assert _er(inv, "m.py", "_orphan", 1) == "uncertain"
 
 
+def test_python_wildcard_import_from_unrelated_module_does_not_mask():
+    # File has ``from json import *`` (recorded as
+    # ``INDIRECTION_WILDCARD_IMPORT``) and otherwise imports nothing
+    # from the target's root package. The wildcard from ``json`` can't
+    # have brought our target into scope — claim no_path.
+    # ``_wildcard_could_provide`` makes the call: it looks for any
+    # other import in the file sharing the target module's root.
+    inv = _entry_inv(
+        "mypkg/helpers.py", "python", [_fn("_orphan", 1)], [],
+        indirection=["wildcard_import"],
+    )
+    # The target's module derives to "mypkg.helpers"; root = "mypkg".
+    # The file has no "mypkg.*" imports, so the wildcard from
+    # json is irrelevant.
+    assert _er(inv, "mypkg/helpers.py", "_orphan", 1) == "no_path_from_entry"
+
+
+def test_python_wildcard_import_from_same_root_masks():
+    # The file imports something from the target's root package
+    # AND has a wildcard import. ``_wildcard_could_provide`` treats
+    # the wildcard as plausible cover — uncertain.
+    inv = _entry_inv(
+        "mypkg/helpers.py", "python", [_fn("_orphan", 1)], [],
+        indirection=["wildcard_import"],
+    )
+    # Inject a same-root import into the call_graph.
+    inv["files"][0]["call_graph"]["imports"] = {
+        "x": "mypkg.something_else",
+    }
+    assert _er(inv, "mypkg/helpers.py", "_orphan", 1) == "uncertain"
+
+
+def test_python_wildcard_with_extensionless_path_stays_blanket():
+    # ``_file_path_to_module`` returns None for paths without an
+    # extension (extensionless scripts, Makefile-shaped artefacts).
+    # When target_module can't be derived, the wildcard branch must
+    # fall back to the conservative blanket-mask — anything else
+    # would be a FN. Pin that behavior explicitly so a future
+    # refactor doesn't accidentally drop the safe fallback.
+    inv = _entry_inv(
+        "noext_script", "python", [_fn("_orphan", 1)], [],
+        indirection=["wildcard_import"],
+    )
+    # path has no extension → _file_path_to_module returns None →
+    # target_module=None at the call site → wildcard stays blanket.
+    assert _er(inv, "noext_script", "_orphan", 1) == "uncertain"
+
+
 def test_python_opaque_getattr_masks_any_target():
     # ``getattr(obj, attr)`` with a variable second arg is genuinely
     # opaque — the resolver can't narrow to a tail name, so any


### PR DESCRIPTION
Refines the dead-island masking signal in ``entry_reachability`` from "any masking flag in the file → uncertain" to a per-target check: ``getattr(obj, "foo")(...)`` only confounds reachability claims about ``foo``; unrelated targets in the same file can still claim ``no_path_from_entry``. The witness tier stays HEURISTIC (no suppression licensed by either path).

call_graph.py changes
─────────────────────
- New ``INDIRECTION_GETATTR_OPAQUE`` for ``getattr(obj, expr)`` where the second arg is NOT a string Constant. Previously invisible — under- conservative for the genuinely-opaque variable-arg case.
- New ``_is_builtin_call(chain, name, imports)`` resolves aliased forms: ``from builtins import getattr as g; g(obj, …)`` (alias maps via import table) and ``import builtins; builtins.getattr(obj, …)``. Pre-fix these aliases bypassed the masking signal entirely. Applied to both ``getattr`` and ``__import__`` detection.
- ``HANDLERS[key]()`` (``ast.Subscript`` callee) now raises ``INDIRECTION_BRACKET_DISPATCH``. Pre-fix the Subscript form returned early with no flag — Python dict-of-functions dispatch was invisible. Mirrors the JS walker's existing bracket-dispatch handling.

reachability.py changes
───────────────────────
- New ``_OPAQUE_MASKING_FLAGS`` subset: flags whose dispatcher has no recorded tail name (opaque-getattr, importlib, dunder-import, bracket-dispatch, dynamic-import, eval, reflect). Literal ``getattr`` and wildcard-import stay outside this set — they have per-target precision paths.
- ``_file_has_masking(inventory, file_path)`` → ``_file_masks_target( inventory, file_path, target_name)``. Returns True if the file has any opaque flag, OR has literal ``getattr`` with ``target_name`` in ``getattr_targets``, OR has any wildcard-import (entry-reachability layer lacks target-module context for finer wildcard precision — conservatively blanket), OR ``target_name`` is in ``macro_call_targets``.
- ``entry_reachability`` calls the new target-aware function for both the target's own file and every node in the reverse closure.

Out-of-scope caveat added to the module docstring
─────────────────────────────────────────────────
Cross-file string-literal ``getattr`` dispatch (file_a holds ``getattr(obj, "foo")(...)`` where ``obj`` is a ``Klass`` instance from file_b) is documented as an uncertain-safe blind spot: file_a is never in file_b::Klass.foo's static reverse closure, so the per-file masking check can't see it. Pre-existing soundness gap inherited unchanged; the precision change makes it slightly more visible by no longer "saving by chance" in unrelated closures.