### PR TITLE
feat: tool-coverage block, judge contradiction-resolution, status enum + target-type catalog substrate

### DIFF
--- a/core/orchestration/funnel.py
+++ b/core/orchestration/funnel.py
@@ -9,11 +9,26 @@ classification can be unit-tested without pulling in the
 ``raptor_agentic`` module's transitive imports (every ``core.*`` and
 ``packages.*`` it touches), and so report writers / dashboards can
 reuse the same bucketing logic.
+
+## Relationship with ``core/run/finding_status.py``
+
+The bucketing prefers each result's explicit ``status`` field (per
+the QoL #19 enum: ``analysed`` / ``analysis_inconsistent`` /
+``skipped_*`` / ``error``) when present and falls back to the
+legacy field-detection logic when not — backwards-compat for
+pre-#19 emit paths.
 """
 
 from __future__ import annotations
 
 from typing import Any
+
+from core.run.finding_status import (
+    ANALYSIS_INCONSISTENT,
+    ERROR,
+    derive_status,
+    is_skipped,
+)
 
 
 def bucket_orchestration_results(results: list[dict]) -> dict[str, Any]:
@@ -75,11 +90,29 @@ def bucket_orchestration_results(results: list[dict]) -> dict[str, Any]:
         "inconsistent_findings": [],
     }
     for r in results:
-        if "error" in r:
+        # Status-aware short-circuits for the categorical buckets.
+        # ``status`` (when set) is authoritative; ``derive_status``
+        # is the pre-#19 fallback. Skipped findings don't contribute
+        # to ANY verdict bucket — they're tracked separately by
+        # callers that care.
+        explicit_status = r.get("status") if isinstance(r, dict) else None
+        status = explicit_status if explicit_status else derive_status(r)
+
+        if status == ERROR or "error" in r:
+            # ``error`` field takes precedence even when status was
+            # set to something else (defensive against partial-state
+            # writes that record an error but forget to update
+            # status).
             if r.get("error_type") == "blocked":
                 buckets["blocked"] += 1
             else:
                 buckets["failed"] += 1
+            continue
+        if is_skipped(r):
+            # Skipped findings don't get counted in the verdict
+            # funnel — they're a separate category tracked by
+            # whatever code decided to skip them (binary-oracle,
+            # dedup, --exclude-dir, budget cap).
             continue
         if "is_true_positive" not in r:
             continue
@@ -93,7 +126,14 @@ def bucket_orchestration_results(results: list[dict]) -> dict[str, Any]:
         else:
             buckets["unverdicted"] += 1
         if r.get("is_exploitable"):
-            if r.get("self_contradictory"):
+            # Status-aware split: ``analysis_inconsistent`` goes to
+            # inconsistent regardless of self_contradictory state
+            # (the status enum is the authoritative signal); legacy
+            # path keeps the self_contradictory check.
+            if status == ANALYSIS_INCONSISTENT or (
+                explicit_status is None
+                and r.get("self_contradictory")
+            ):
                 buckets["inconsistent"] += 1
                 buckets["inconsistent_findings"].append(r)
             else:

--- a/core/orchestration/tests/test_funnel.py
+++ b/core/orchestration/tests/test_funnel.py
@@ -250,3 +250,72 @@ class TestRealWorldShape:
         assert b["blocked"] == 0
         assert b["severity_mismatches"] == []
         assert b["inconsistent_findings"] == []
+
+
+class TestStatusAwareBucketing:
+    """QoL #19 wiring: when a finding carries the explicit ``status``
+    field, the funnel uses it; otherwise the legacy field-detection
+    path runs. Backwards-compat for pre-#19 emit sites."""
+
+    def test_explicit_status_wins_over_field_inference(self):
+        from core.run.finding_status import ANALYSIS_INCONSISTENT
+        results = [{
+            "is_true_positive": True,
+            "is_exploitable": True,
+            "status": ANALYSIS_INCONSISTENT,
+            # No self_contradictory; legacy path would route to
+            # ``exploitable``; explicit status routes to inconsistent.
+        }]
+        b = bucket_orchestration_results(results)
+        assert b["exploitable"] == 0
+        assert b["inconsistent"] == 1
+
+    def test_skipped_statuses_excluded_from_verdict_buckets(self):
+        # Skipped findings don't contribute to TP/FP/exploitable/
+        # inconsistent. They weren't analysed, so no verdict applies.
+        from core.run.finding_status import (
+            SKIPPED_DEAD_CODE, SKIPPED_DUPLICATE, SKIPPED_OVER_BUDGET,
+        )
+        results = [
+            {"status": SKIPPED_OVER_BUDGET,
+             "is_true_positive": True, "is_exploitable": True},
+            {"status": SKIPPED_DEAD_CODE,
+             "is_true_positive": True, "is_exploitable": True},
+            {"status": SKIPPED_DUPLICATE,
+             "is_true_positive": False},
+            # The only actually-analysed finding.
+            {"is_true_positive": True, "is_exploitable": True},
+        ]
+        b = bucket_orchestration_results(results)
+        assert b["true_positives"] == 1
+        assert b["exploitable"] == 1
+        assert b["false_positives"] == 0
+
+    def test_judge_resolved_contradiction_now_lands_in_exploitable(self):
+        # Composes #11-11d (judge clears self_contradictory) with
+        # the funnel: the resolved finding correctly counts as
+        # exploitable, not inconsistent. Operator headline drops
+        # the inconsistent count without losing the finding.
+        results = [{
+            "is_true_positive": True,
+            "is_exploitable": True,
+            "self_contradictory": False,
+            "contradiction_resolved_by_judge": True,
+        }]
+        b = bucket_orchestration_results(results)
+        assert b["exploitable"] == 1
+        assert b["inconsistent"] == 0
+
+    def test_error_field_takes_precedence_over_explicit_status(self):
+        # Defensive: a finding that recorded an error AND an
+        # explicit status (rare but possible if partial-state write)
+        # still gets bucketed as failed/blocked. The error field is
+        # the most-load-bearing signal for ''did this complete?''.
+        from core.run.finding_status import ANALYSED
+        results = [{
+            "status": ANALYSED,
+            "error": "post-status crash",
+        }]
+        b = bucket_orchestration_results(results)
+        assert b["failed"] == 1
+        assert b["true_positives"] == 0

--- a/core/reporting/scan_coverage.py
+++ b/core/reporting/scan_coverage.py
@@ -1,0 +1,180 @@
+"""Operator-facing tool-execution coverage renderer.
+
+Reads the ``coverage-<tool>.json`` records each scanner emits and
+renders a small aligned block at /scan end so the operator sees
+which tools actually ran, how many findings each produced, and any
+silent-drop signal (failed packs surfaced by the scanner's own
+detection).
+
+Distinct from ``core/coverage/store_summary.py``: that one renders
+the FUNCTION-level inventory coverage ("which functions did any
+tool examine?"). This one renders the TOOL-EXECUTION coverage
+("which tools ran with what result?"). They're complementary —
+function-coverage answers "what code did we look at"; tool-coverage
+answers "what did we look at it WITH".
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Dict, List, Optional
+
+
+# Tool display ordering — most-likely-to-fire first so the block
+# reads top-to-bottom in approximate produce-findings order.
+_TOOL_ORDER = ("semgrep", "coccinelle", "codeql", "sca")
+
+# Display labels (capitalised, fixed-width for alignment).
+_TOOL_LABELS = {
+    "semgrep":    "Semgrep   ",
+    "coccinelle": "Coccinelle",
+    "codeql":     "CodeQL    ",
+    "sca":        "SCA       ",
+}
+
+
+def _load_coverage_record(out_dir: Path, tool: str) -> Optional[Dict]:
+    """Read ``coverage-<tool>.json`` from ``out_dir``. Best-effort —
+    missing file / malformed JSON returns ``None`` (tool didn't run
+    or its coverage emit failed; both fold to ''no record to render''
+    in the caller's loop)."""
+    p = out_dir / f"coverage-{tool}.json"
+    if not p.is_file():
+        return None
+    try:
+        return json.loads(p.read_text())
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
+def _findings_for_tool(metrics: Dict, tool: str) -> int:
+    """Count findings attributable to ``tool`` from
+    ``scan_metrics.json::findings_by_rule``. The rule-id namespace
+    distinguishes which tool produced each rule:
+
+      * ``semgrep`` → keys start with ``engine.semgrep.rules.`` or
+        the registry pack notation ``c.lang.security.foo``
+      * ``codeql`` → keys match ``<lang>/<rule-id>`` (slash-separated)
+      * ``coccinelle`` → keys typically snake_case (``lock_imbalance``)
+
+    Returns 0 when no rules match (the tool ran but found nothing,
+    OR the tool didn't run at all — caller distinguishes via
+    coverage-file presence).
+    """
+    findings_by_rule = metrics.get("findings_by_rule") or {}
+    total = 0
+    for rule_id, count in findings_by_rule.items():
+        if not isinstance(count, int):
+            continue
+        rule_lower = rule_id.lower()
+        if tool == "semgrep":
+            if (rule_lower.startswith("engine.semgrep.")
+                    or rule_lower.startswith("c.lang.")
+                    or rule_lower.startswith("python.lang.")
+                    or "semgrep" in rule_lower):
+                total += count
+        elif tool == "codeql":
+            # CodeQL convention: ``<lang>/<rule-id>``. The cpp/, py/,
+            # js/ etc. prefixes disambiguate from
+            # semgrep / coccinelle. Filter to slash-separated ids
+            # whose first segment is a known language.
+            head = rule_id.split("/", 1)[0] if "/" in rule_id else ""
+            if head in {"cpp", "c", "py", "python", "js", "java",
+                        "javascript", "ts", "typescript", "go",
+                        "rb", "ruby", "cs", "csharp"}:
+                total += count
+        elif tool == "coccinelle":
+            # Cocci ids are typically a single snake_case token with
+            # no dots / slashes. Distinguish from Semgrep's dotted
+            # ids by absence of separators.
+            if "/" not in rule_id and "." not in rule_id:
+                total += count
+    return total
+
+
+def render_scan_coverage(out_dir: Path) -> Optional[str]:
+    """Render the operator-facing tool-execution coverage block for
+    a /scan run. Returns ``None`` when no per-tool coverage files
+    exist — caller suppresses the section entirely rather than
+    printing an empty header.
+
+    Output shape (aligned, one line per tool that ran)::
+
+        Coverage: Semgrep    47 findings  (3 rule group(s); 0 failed)
+                  Coccinelle  0 findings  (3 rule group(s))
+                  CodeQL      skipped (autoreconf missing)
+
+    The first line carries the ``Coverage:`` label; subsequent lines
+    indent to align under the tool-name column for readability.
+    """
+    # scan_metrics.json gives per-tool finding counts via the
+    # findings_by_rule namespace split. Best-effort: missing /
+    # malformed metrics falls back to ''— findings'' on each line.
+    metrics: Dict = {}
+    metrics_path = out_dir / "scan_metrics.json"
+    if metrics_path.is_file():
+        try:
+            metrics = json.loads(metrics_path.read_text())
+        except (OSError, json.JSONDecodeError):
+            metrics = {}
+
+    rendered_lines: List[str] = []
+    for tool in _TOOL_ORDER:
+        rec = _load_coverage_record(out_dir, tool)
+        if rec is None:
+            continue
+        label = _TOOL_LABELS[tool]
+        finds = _findings_for_tool(metrics, tool)
+        rules = rec.get("rules_applied")
+        # rules_applied is either an int (legacy: count) or a list
+        # (newer shape). Render the count regardless.
+        if isinstance(rules, list):
+            rule_count = len(rules)
+        elif isinstance(rules, int):
+            rule_count = rules
+        else:
+            rule_count = None
+
+        # Failed-pack info — pulled from scan_metrics for semgrep
+        # specifically (semgrep_failed_packs is the only per-tool
+        # failure field surfaced today; codeql / cocci failures
+        # surface through their own pipeline — extend as those
+        # detectors grow).
+        failed_packs: List = []
+        if tool == "semgrep":
+            failed_packs = metrics.get("semgrep_failed_packs") or []
+
+        detail_parts: List[str] = []
+        if rule_count is not None:
+            detail_parts.append(
+                f"{rule_count} rule group{'s' if rule_count != 1 else ''}"
+            )
+        if failed_packs:
+            detail_parts.append(
+                f"⚠️  {len(failed_packs)} pack(s) failed: "
+                f"{', '.join(failed_packs[:3])}"
+                + ("..." if len(failed_packs) > 3 else "")
+            )
+        detail = (
+            f"  ({'; '.join(detail_parts)})" if detail_parts else ""
+        )
+        finds_part = f"{finds:>3} finding{'s' if finds != 1 else ''}"
+        rendered_lines.append(f"{label} {finds_part}{detail}")
+
+    if not rendered_lines:
+        return None
+
+    # First line gets the ``Coverage:`` label; remaining lines
+    # indent to align the tool-name column.
+    first, *rest = rendered_lines
+    indent = " " * len("Coverage: ")
+    out_lines = [f"Coverage: {first}"]
+    for line in rest:
+        out_lines.append(f"{indent}{line}")
+    return "\n".join(out_lines)
+
+
+__all__ = [
+    "render_scan_coverage",
+]

--- a/core/reporting/tests/test_scan_coverage.py
+++ b/core/reporting/tests/test_scan_coverage.py
@@ -1,0 +1,176 @@
+"""Tests for ``render_scan_coverage`` — the operator-facing
+tool-execution coverage renderer that fires at /scan end."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from core.reporting.scan_coverage import render_scan_coverage
+
+
+def _write(out_dir: Path, name: str, payload):
+    (out_dir / name).write_text(json.dumps(payload))
+
+
+class TestMissingFiles:
+    def test_no_coverage_files_returns_none(self, tmp_path):
+        # Empty dir → no tools ran → caller suppresses the section.
+        assert render_scan_coverage(tmp_path) is None
+
+    def test_missing_scan_metrics_still_renders(self, tmp_path):
+        # Coverage file exists but no scan_metrics.json — falls back
+        # to ''0 findings'' but still renders the line so the
+        # operator sees the tool ran.
+        _write(tmp_path, "coverage-semgrep.json", {
+            "tool": "semgrep", "files_examined": 10, "rules_applied": 3,
+        })
+        out = render_scan_coverage(tmp_path)
+        assert out is not None
+        assert "Semgrep" in out
+
+
+class TestSingleTool:
+    def test_semgrep_only(self, tmp_path):
+        _write(tmp_path, "coverage-semgrep.json", {
+            "tool": "semgrep", "files_examined": 100, "rules_applied": 3,
+        })
+        _write(tmp_path, "scan_metrics.json", {
+            "total_findings": 47,
+            "findings_by_rule": {
+                "engine.semgrep.rules.registry-cache.c.lang.security.foo": 45,
+                "engine.semgrep.rules.registry-cache.c.lang.security.bar": 2,
+            },
+        })
+        out = render_scan_coverage(tmp_path)
+        assert out is not None
+        assert "Coverage:" in out
+        assert "Semgrep" in out
+        # 47 findings attributed to semgrep via rule-id prefix match.
+        assert "47 findings" in out
+        assert "3 rule groups" in out
+
+    def test_coccinelle_only(self, tmp_path):
+        _write(tmp_path, "coverage-coccinelle.json", {
+            "tool": "coccinelle", "files_examined": 50, "rules_applied": 3,
+        })
+        _write(tmp_path, "scan_metrics.json", {
+            "total_findings": 0,
+            "findings_by_rule": {},
+        })
+        out = render_scan_coverage(tmp_path)
+        assert "Coccinelle" in out
+        assert "0 findings" in out
+        assert "3 rule groups" in out
+
+
+class TestMultiTool:
+    def test_three_tools_aligned(self, tmp_path):
+        # All three tools present; Semgrep + Coccinelle ran with
+        # different result shapes.
+        _write(tmp_path, "coverage-semgrep.json", {
+            "tool": "semgrep", "rules_applied": 3,
+        })
+        _write(tmp_path, "coverage-coccinelle.json", {
+            "tool": "coccinelle", "rules_applied": 3,
+        })
+        _write(tmp_path, "coverage-codeql.json", {
+            "tool": "codeql", "rules_applied": 8,
+        })
+        _write(tmp_path, "scan_metrics.json", {
+            "findings_by_rule": {
+                "engine.semgrep.rules.registry-cache.foo": 47,
+                "cpp/uncontrolled-format-string": 5,
+            },
+        })
+        out = render_scan_coverage(tmp_path)
+        assert out is not None
+        # All three tools rendered, in canonical order.
+        sem_pos = out.find("Semgrep")
+        cocci_pos = out.find("Coccinelle")
+        codeql_pos = out.find("CodeQL")
+        assert sem_pos < cocci_pos < codeql_pos
+        # Coccinelle ran but found nothing.
+        assert "0 finding" in out
+        # CodeQL findings attributed via lang/rule-id prefix match.
+        assert "5 findings" in out
+
+    def test_indentation_aligns_tool_labels(self, tmp_path):
+        _write(tmp_path, "coverage-semgrep.json", {
+            "tool": "semgrep", "rules_applied": 1,
+        })
+        _write(tmp_path, "coverage-coccinelle.json", {
+            "tool": "coccinelle", "rules_applied": 1,
+        })
+        out = render_scan_coverage(tmp_path)
+        # First line has ``Coverage: ``; second is indented by 10
+        # spaces so tool labels align vertically.
+        lines = out.splitlines()
+        assert lines[0].startswith("Coverage: ")
+        assert lines[1].startswith(" " * len("Coverage: "))
+
+
+class TestSemgrepFailedPacks:
+    def test_failed_packs_show_warning(self, tmp_path):
+        _write(tmp_path, "coverage-semgrep.json", {
+            "tool": "semgrep", "rules_applied": 3,
+        })
+        _write(tmp_path, "scan_metrics.json", {
+            "findings_by_rule": {},
+            "semgrep_failed_packs": [
+                "semgrep_owasp_top_10", "semgrep_secrets",
+            ],
+        })
+        out = render_scan_coverage(tmp_path)
+        assert "⚠️" in out
+        assert "2 pack(s) failed" in out
+        assert "semgrep_owasp_top_10" in out
+
+    def test_empty_failed_packs_no_warning(self, tmp_path):
+        _write(tmp_path, "coverage-semgrep.json", {
+            "tool": "semgrep", "rules_applied": 3,
+        })
+        _write(tmp_path, "scan_metrics.json", {
+            "findings_by_rule": {},
+            "semgrep_failed_packs": [],  # positive empty marker
+        })
+        out = render_scan_coverage(tmp_path)
+        assert "⚠️" not in out
+        assert "failed" not in out.lower()
+
+
+class TestRobustness:
+    def test_malformed_coverage_file_skipped(self, tmp_path):
+        # Garbage JSON in one file → that tool's line is skipped;
+        # other tools still render.
+        (tmp_path / "coverage-semgrep.json").write_text("not-json{")
+        _write(tmp_path, "coverage-coccinelle.json", {
+            "tool": "coccinelle", "rules_applied": 1,
+        })
+        out = render_scan_coverage(tmp_path)
+        assert out is not None
+        assert "Coccinelle" in out
+        assert "Semgrep" not in out
+
+    def test_legacy_rules_applied_as_list(self, tmp_path):
+        # Pre-rules_applied-as-int era: list of rule names.
+        # Counted by length.
+        _write(tmp_path, "coverage-semgrep.json", {
+            "tool": "semgrep",
+            "rules_applied": ["rule_a", "rule_b", "rule_c", "rule_d"],
+        })
+        out = render_scan_coverage(tmp_path)
+        assert "4 rule groups" in out
+
+    def test_singular_grammar_for_one_rule_and_one_finding(self, tmp_path):
+        _write(tmp_path, "coverage-semgrep.json", {
+            "tool": "semgrep", "rules_applied": 1,
+        })
+        _write(tmp_path, "scan_metrics.json", {
+            "findings_by_rule": {
+                "engine.semgrep.rules.registry-cache.foo": 1,
+            },
+        })
+        out = render_scan_coverage(tmp_path)
+        assert "1 finding " in out + " "  # singular ''finding''
+        assert "1 rule group" in out      # singular ''rule group''

--- a/core/run/finding_status.py
+++ b/core/run/finding_status.py
@@ -1,0 +1,199 @@
+"""Unified per-finding status enum + helpers.
+
+Substrate for QoL #19. Replaces the null-field-detection pattern
+that downstream consumers (``raptor_agentic`` summary,
+``orchestrated_report.json`` readers, reporting renderers) used to
+decide ''was this finding analysed?'' / ''was it skipped?'' / ''does
+it need human review?'' / ''did the analysis crash?''. Each consumer
+re-implemented the detection from a different mix of fields
+(``is_true_positive is None``, ``self_contradictory``, ``error``,
+absent keys); each got it slightly wrong.
+
+A single ``status`` value on each finding dict is the source of
+truth. Helpers (``is_actionable``, ``needs_review``, ``is_skipped``)
+let consumers ask the question they actually care about without
+re-deriving the rules.
+
+## Status values
+
+* ``analysed`` — LLM processed the finding; verdict is trustworthy.
+  Headline ''Exploitable / FP'' counts come from this bucket.
+* ``analysis_inconsistent`` — LLM processed but reasoning /
+  verdict contradicted itself (``self_contradictory=True``)
+  post-Stage-F retry AND no judge resolved it. Counted as
+  ''Inconsistent (review needed)'' in operator output.
+* ``skipped_over_budget`` — cost or count cap hit before this
+  finding got dispatched.
+* ``skipped_duplicate`` — dedup against another finding kept this
+  out of the analysed set.
+* ``skipped_dead_code`` — binary-oracle filtered: function not in
+  the analysed binary.
+* ``skipped_filtered`` — operator ``--exclude-dir`` or filter rule
+  excluded this path.
+* ``skipped_tool_absent`` — tool that would have analysed this
+  finding wasn't available (e.g. codeql skipped because
+  ``autoreconf`` was missing).
+* ``error`` — analysis crashed; see ``error`` field on the finding
+  for detail.
+
+## Backwards compatibility
+
+``derive_status(finding)`` infers the status from existing fields
+(``is_true_positive``, ``self_contradictory``, ``error``,
+``contradiction_resolved_by_judge``) when a finding doesn't carry
+an explicit ``status`` key — so pre-existing emit paths continue
+to work without per-emit-site changes. New emit sites (orchestrator
+backfill, scan-time skip records) call ``set_status`` explicitly so
+consumers see the canonical value.
+
+``bucket_orchestration_results`` in ``core/orchestration/funnel.py``
+prefers the explicit status when present and falls back to the
+derive path otherwise. No flag day; consumers using the helpers
+work across the transition.
+"""
+
+from __future__ import annotations
+
+from typing import Dict
+
+
+# String-valued for direct JSON serialisation. No Enum() — keeps
+# the dict shape grep-able and avoids the standard-library enum
+# import burden on every consumer.
+ANALYSED = "analysed"
+ANALYSIS_INCONSISTENT = "analysis_inconsistent"
+SKIPPED_OVER_BUDGET = "skipped_over_budget"
+SKIPPED_DUPLICATE = "skipped_duplicate"
+SKIPPED_DEAD_CODE = "skipped_dead_code"
+SKIPPED_FILTERED = "skipped_filtered"
+SKIPPED_TOOL_ABSENT = "skipped_tool_absent"
+SKIPPED = "skipped"   # generic skip when the reason wasn't recorded
+ERROR = "error"
+
+ALL_STATUSES = frozenset({
+    ANALYSED,
+    ANALYSIS_INCONSISTENT,
+    SKIPPED_OVER_BUDGET,
+    SKIPPED_DUPLICATE,
+    SKIPPED_DEAD_CODE,
+    SKIPPED_FILTERED,
+    SKIPPED_TOOL_ABSENT,
+    SKIPPED,
+    ERROR,
+})
+
+# All ``skipped_*`` values + the generic ``skipped`` — used by
+# ``is_skipped`` and skip-reason filters in reporting.
+_SKIPPED_STATUSES = frozenset({
+    SKIPPED_OVER_BUDGET,
+    SKIPPED_DUPLICATE,
+    SKIPPED_DEAD_CODE,
+    SKIPPED_FILTERED,
+    SKIPPED_TOOL_ABSENT,
+    SKIPPED,
+})
+
+
+def derive_status(finding: Dict) -> str:
+    """Infer status from a finding's existing fields.
+
+    Used as the fallback when the finding doesn't carry an explicit
+    ``status`` key (backwards-compat for emit paths that pre-date
+    #19). Detection order:
+
+      1. ``error`` field present → ``error``
+      2. ``is_true_positive`` key absent → ``skipped`` (generic;
+         caller didn't record a specific skip reason)
+      3. ``is_exploitable=True`` AND ``self_contradictory=True``
+         (and not resolved by judge) → ``analysis_inconsistent``
+      4. Otherwise → ``analysed``
+    """
+    if "error" in finding:
+        return ERROR
+    if "is_true_positive" not in finding:
+        return SKIPPED
+    if (finding.get("is_exploitable")
+            and finding.get("self_contradictory")
+            and not finding.get("contradiction_resolved_by_judge")):
+        return ANALYSIS_INCONSISTENT
+    return ANALYSED
+
+
+def set_status(finding: Dict, status: str,
+               *, skip_reason: str = None) -> None:
+    """Stamp ``status`` (and optionally ``skip_reason``) on the
+    finding dict. Validates against ``ALL_STATUSES`` to catch
+    typos — an unknown status string would silently propagate
+    otherwise and break downstream filters that ``in``-check the
+    enum.
+
+    Raises ``ValueError`` on unknown status (deliberate — the
+    audit trail's value depends on the enum being closed)."""
+    if status not in ALL_STATUSES:
+        raise ValueError(
+            f"finding_status.set_status: unknown status "
+            f"{status!r} (valid: {sorted(ALL_STATUSES)})"
+        )
+    finding["status"] = status
+    if skip_reason is not None:
+        finding["skip_reason"] = skip_reason
+
+
+def get_status(finding: Dict) -> str:
+    """Return the finding's status — prefer the explicit ``status``
+    field; fall back to ``derive_status`` for pre-#19 emit paths."""
+    explicit = finding.get("status")
+    if explicit in ALL_STATUSES:
+        return explicit
+    return derive_status(finding)
+
+
+def is_actionable(finding: Dict) -> bool:
+    """True when the finding was successfully analysed and its
+    verdict is trustworthy. Headline ''Exploitable / FP'' counts
+    derive from this set."""
+    return get_status(finding) == ANALYSED
+
+
+def needs_review(finding: Dict) -> bool:
+    """True when the LLM produced internally-contradictory
+    reasoning and no judge resolved it — operator-facing
+    ''Inconsistent (review needed)'' bucket."""
+    return get_status(finding) == ANALYSIS_INCONSISTENT
+
+
+def is_skipped(finding: Dict) -> bool:
+    """True for any ``skipped_*`` status (regardless of reason).
+    Used by reporting to separate ''we looked at this'' from
+    ''we didn't get to this''."""
+    return get_status(finding) in _SKIPPED_STATUSES
+
+
+def is_errored(finding: Dict) -> bool:
+    """True when the analysis attempt crashed. Distinct from
+    ``is_skipped`` because the operator may want to retry errored
+    findings (transient infra issues) vs investigate skipped
+    findings (budget / dedup / filter decisions)."""
+    return get_status(finding) == ERROR
+
+
+def is_terminal(finding: Dict) -> bool:
+    """True for any final status (analysed / inconsistent /
+    skipped / errored). False only for the in-flight case where no
+    status has been derived yet."""
+    return get_status(finding) in ALL_STATUSES
+
+
+__all__ = [
+    # status values
+    "ANALYSED", "ANALYSIS_INCONSISTENT",
+    "SKIPPED_OVER_BUDGET", "SKIPPED_DUPLICATE", "SKIPPED_DEAD_CODE",
+    "SKIPPED_FILTERED", "SKIPPED_TOOL_ABSENT", "SKIPPED",
+    "ERROR",
+    "ALL_STATUSES",
+    # operations
+    "derive_status", "set_status", "get_status",
+    # predicates
+    "is_actionable", "needs_review", "is_skipped", "is_errored",
+    "is_terminal",
+]

--- a/core/run/target_types/__init__.py
+++ b/core/run/target_types/__init__.py
@@ -1,0 +1,349 @@
+"""Target-type catalog substrate (QoL #17).
+
+Per-target-type policy lives in YAML siblings of this module
+(``<name>.yml``). The catalog tells consumers (``raptor plan``,
+attack-surface ranking, default pack selection, budget defaults,
+smart ``project create``) what the right defaults look like for a
+given target shape, so each consumer doesn't have to invent its
+own per-target-type heuristics fragmentarily.
+
+## Schema
+
+Each ``<name>.yml`` carries::
+
+  name: c.userspace-daemon
+  description: |
+    Human-readable summary of what this target shape looks like.
+
+  detection:
+    # Positive signals — present-when-true.
+    file_globs:        ["configure.ac", "Makefile.am"]
+    file_extensions:   [".c", ".h"]
+    function_names:    [main_loop, accept, listen]   # tree-sitter
+    # Negative signals — disqualify this entry if matched.
+    negative_globs:    ["kernel/**", "drivers/**"]
+
+  semgrep_packs:
+    default:  [security-audit, command-injection, owasp-top-ten]
+    optional: [secrets, jwt]
+
+  attack_surface:
+    high_priority_dirs: [src/http, src/net, src/protocols]
+    low_priority_dirs:  [src/device/sysdep_*, tests/, examples/]
+
+  pipeline:
+    recommended: [understand-map, scan-with-codeql, agentic-with-validate]
+    estimated_cost_usd:  [25, 50]
+    estimated_time_min:  [40, 75]
+
+  budget_defaults:
+    typical_findings_count:  25
+    typical_cost_per_run_usd: 30
+
+  version: 1
+
+## Detection
+
+``detect(target_path)`` walks the target's top-level files and
+matches signals against each catalog entry. Negative signals are
+deal-breakers (entry is dropped if any matches). Positive signals
+contribute to a confidence score; the highest-scoring entry wins.
+
+Tree-sitter function-name matching is on the roadmap but the v1
+substrate uses file globs + extensions only — those cover the
+common cases (Cargo.toml → rust, package.json → node, configure.ac
+→ autotools daemon) without pulling in the tree-sitter dependency
+chain.
+
+## Why standalone substrate (not folded into ``raptor plan``)
+
+Multiple consumers (#7 default pack selection, #9 attack-surface
+ranking, #14 plan recommendation, #15 budget defaults, #18 smart
+project-create) all depend on the same per-target-type mapping.
+Folding into plan would force every other consumer to call into
+plan to read its catalog. The substrate as a separate module is
+authorable independently (community contributors can add
+``php.wordpress-plugin.yml`` without touching the planner).
+
+This commit ships substrate + 3 seed entries + the loader/detect
+API. Per-consumer backfill (#7, #9, #14, #15, #18 wiring) lands
+in follow-on commits as those code paths get touched.
+"""
+
+from __future__ import annotations
+
+import fnmatch
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+import yaml
+
+
+# Cap how deep we walk when matching ``**``-style globs. 4 levels
+# covers ``src/<subsystem>/<file>.c`` shapes without exploding on
+# pathological trees (node_modules / .git / build outputs).
+_MAX_DETECT_DEPTH = 4
+
+# Cap how many files we examine during detection. Walking a
+# 100k-file target tree for every signal would dominate the
+# lifecycle's startup cost; 10k is enough to catch the structural
+# signals catalog entries rely on.
+_MAX_DETECT_FILES = 10_000
+
+
+@dataclass(frozen=True)
+class CatalogEntry:
+    """One target-type entry — loaded from its ``<name>.yml`` sibling.
+
+    Frozen so a single instance can be safely shared across
+    consumers without one mutating the catalog state another sees.
+    """
+
+    name: str
+    description: str = ""
+
+    # Detection signals
+    file_globs: Tuple[str, ...] = field(default_factory=tuple)
+    file_extensions: Tuple[str, ...] = field(default_factory=tuple)
+    function_names: Tuple[str, ...] = field(default_factory=tuple)
+    negative_globs: Tuple[str, ...] = field(default_factory=tuple)
+
+    # Default policy hints — consumers consult these but the
+    # substrate doesn't enforce them (operator overrides win).
+    semgrep_packs_default: Tuple[str, ...] = field(default_factory=tuple)
+    semgrep_packs_optional: Tuple[str, ...] = field(default_factory=tuple)
+    attack_surface_high: Tuple[str, ...] = field(default_factory=tuple)
+    attack_surface_low: Tuple[str, ...] = field(default_factory=tuple)
+    pipeline_recommended: Tuple[str, ...] = field(default_factory=tuple)
+
+    # Cost / time hints — pairs (low, high) USD / minutes
+    estimated_cost_usd: Tuple[float, float] = (0.0, 0.0)
+    estimated_time_min: Tuple[int, int] = (0, 0)
+    typical_findings_count: int = 0
+    typical_cost_per_run_usd: float = 0.0
+
+    # Versioning — provenance + reproducibility. Bump when the
+    # entry's defaults shift in a way operators might want to
+    # detect (e.g. new packs added to ``semgrep_packs_default``).
+    version: int = 1
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "CatalogEntry":
+        """Build a CatalogEntry from parsed YAML. Tolerant of
+        missing optional sections — only ``name`` is required."""
+        if "name" not in data:
+            raise ValueError(
+                "CatalogEntry.from_dict: missing required 'name' field"
+            )
+        detection = data.get("detection") or {}
+        packs = data.get("semgrep_packs") or {}
+        surface = data.get("attack_surface") or {}
+        pipeline = data.get("pipeline") or {}
+        budget = data.get("budget_defaults") or {}
+
+        def _t(seq):
+            return tuple(seq) if seq else tuple()
+
+        cost_pair = pipeline.get("estimated_cost_usd") or [0.0, 0.0]
+        time_pair = pipeline.get("estimated_time_min") or [0, 0]
+
+        return cls(
+            name=data["name"],
+            description=data.get("description", "").strip(),
+            file_globs=_t(detection.get("file_globs")),
+            file_extensions=_t(detection.get("file_extensions")),
+            function_names=_t(detection.get("function_names")),
+            negative_globs=_t(detection.get("negative_globs")),
+            semgrep_packs_default=_t(packs.get("default")),
+            semgrep_packs_optional=_t(packs.get("optional")),
+            attack_surface_high=_t(surface.get("high_priority_dirs")),
+            attack_surface_low=_t(surface.get("low_priority_dirs")),
+            pipeline_recommended=_t(pipeline.get("recommended")),
+            estimated_cost_usd=(float(cost_pair[0]), float(cost_pair[1])),
+            estimated_time_min=(int(time_pair[0]), int(time_pair[1])),
+            typical_findings_count=int(budget.get("typical_findings_count", 0)),
+            typical_cost_per_run_usd=float(
+                budget.get("typical_cost_per_run_usd", 0)),
+            version=int(data.get("version", 1)),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Loader
+# ---------------------------------------------------------------------------
+
+
+_CATALOG_DIR = Path(__file__).parent
+_CACHED_CATALOG: Optional[Tuple[CatalogEntry, ...]] = None
+
+
+def _load_one(yml_path: Path) -> Optional[CatalogEntry]:
+    """Parse a single catalog YAML. Returns None on missing file /
+    malformed YAML / missing required fields — substrate stays
+    best-effort so a single broken entry doesn't break the loader
+    for all consumers."""
+    try:
+        text = yml_path.read_text()
+        data = yaml.safe_load(text)
+        if not isinstance(data, dict):
+            return None
+        return CatalogEntry.from_dict(data)
+    except (OSError, yaml.YAMLError, ValueError):
+        return None
+
+
+def all_entries() -> Tuple[CatalogEntry, ...]:
+    """Load every ``<name>.yml`` in the catalog dir (excluding
+    ``tests/``). Cached after first call — entries are immutable so
+    re-reading the YAML on every call would be wasted IO."""
+    global _CACHED_CATALOG
+    if _CACHED_CATALOG is not None:
+        return _CACHED_CATALOG
+    entries: List[CatalogEntry] = []
+    for p in sorted(_CATALOG_DIR.glob("*.yml")):
+        entry = _load_one(p)
+        if entry is not None:
+            entries.append(entry)
+    _CACHED_CATALOG = tuple(entries)
+    return _CACHED_CATALOG
+
+
+def load_by_name(name: str) -> Optional[CatalogEntry]:
+    """Direct lookup by catalog name (e.g. ``c.userspace-daemon``).
+    Returns None if no entry matches — caller should fall back to
+    ``generic`` or operator-prompt."""
+    for entry in all_entries():
+        if entry.name == name:
+            return entry
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Detection
+# ---------------------------------------------------------------------------
+
+
+def _walk_target(target_path: Path) -> List[str]:
+    """Walk ``target_path`` up to ``_MAX_DETECT_DEPTH`` levels deep,
+    returning relative POSIX paths (cap at ``_MAX_DETECT_FILES``).
+    Skips dotted directories (``.git``, ``.cache``) — these are
+    never the structural signals catalog entries care about."""
+    if not target_path.is_dir():
+        return []
+    rels: List[str] = []
+    target_path = target_path.resolve()
+    for root, dirs, files in __import__("os").walk(target_path):
+        # Skip dotted dirs.
+        dirs[:] = [d for d in dirs if not d.startswith(".")]
+        root_path = Path(root)
+        # Depth check.
+        try:
+            depth = len(root_path.relative_to(target_path).parts)
+        except ValueError:
+            continue
+        if depth > _MAX_DETECT_DEPTH:
+            dirs[:] = []
+            continue
+        for f in files:
+            rels.append(
+                str((root_path / f).relative_to(target_path).as_posix())
+            )
+            if len(rels) >= _MAX_DETECT_FILES:
+                return rels
+    return rels
+
+
+def _matches_any(paths: List[str], globs: Tuple[str, ...]) -> int:
+    """Count how many ``globs`` match at least one path. (Not
+    ''how many path-glob pairs match'' — that would over-weight
+    distinctive globs that happen to hit many files.)"""
+    hits = 0
+    for g in globs:
+        if any(fnmatch.fnmatch(p, g) for p in paths):
+            hits += 1
+    return hits
+
+
+def _has_extension(paths: List[str], extensions: Tuple[str, ...]) -> int:
+    """Count distinct extensions matched (same intent as
+    ``_matches_any`` — bool-per-signal, not per-file)."""
+    matched: set = set()
+    ext_set = {e.lower() for e in extensions}
+    for p in paths:
+        suffix = Path(p).suffix.lower()
+        if suffix in ext_set:
+            matched.add(suffix)
+    return len(matched)
+
+
+def _score_entry(entry: CatalogEntry, paths: List[str]) -> Optional[float]:
+    """Score how well ``entry``'s detection signals match the
+    target's file tree. Returns None when negative signals match
+    (entry disqualified). Otherwise: positive-signal-count
+    weighted by signal type.
+
+    Weighting reflects how DISCRIMINATING each signal type is:
+    file_globs (often specific like ``configure.ac``) > file_extensions
+    (broad, many entries claim ``.c``). Function-name matching when
+    tree-sitter substrate exists earns a higher weight; not used
+    in v1.
+    """
+    # Negative signals are deal-breakers.
+    if entry.negative_globs and _matches_any(paths, entry.negative_globs):
+        return None
+    score = 0.0
+    score += 2.0 * _matches_any(paths, entry.file_globs)
+    score += 1.0 * _has_extension(paths, entry.file_extensions)
+    # function_names ignored in v1 (no tree-sitter dependency here).
+    return score
+
+
+def detect(target_path: Path) -> List[Tuple[CatalogEntry, float]]:
+    """Walk the target and return all catalog entries ranked by
+    confidence score (descending). Entries with score 0 are
+    excluded — no positive signal matched.
+
+    Caller picks the highest-scoring entry, or prompts the
+    operator when scores are close (ambiguous polyglot repo), or
+    falls back to ``generic`` when nothing matched.
+    """
+    paths = _walk_target(Path(target_path))
+    if not paths:
+        return []
+    scored: List[Tuple[CatalogEntry, float]] = []
+    for entry in all_entries():
+        s = _score_entry(entry, paths)
+        if s is None or s <= 0:
+            continue
+        scored.append((entry, s))
+    scored.sort(key=lambda x: (-x[1], x[0].name))
+    return scored
+
+
+def load(target_path: Path) -> Optional[CatalogEntry]:
+    """Pick the best-matching catalog entry for ``target_path``.
+    Returns None when nothing scored above 0 — caller falls back
+    to the ``generic`` entry or operator prompt."""
+    ranked = detect(target_path)
+    if not ranked:
+        # Fall back to ``generic`` when present — operator gets a
+        # working default rather than a None to handle.
+        return load_by_name("generic")
+    return ranked[0][0]
+
+
+def _reset_cache_for_tests() -> None:
+    """Clear the loader cache. Test-only hook — production code
+    treats the catalog as immutable per process."""
+    global _CACHED_CATALOG
+    _CACHED_CATALOG = None
+
+
+__all__ = [
+    "CatalogEntry",
+    "all_entries",
+    "load_by_name",
+    "detect",
+    "load",
+]

--- a/core/run/target_types/c.userspace-daemon.yml
+++ b/core/run/target_types/c.userspace-daemon.yml
@@ -1,0 +1,73 @@
+name: c.userspace-daemon
+description: |
+  C / C++ userspace daemons that listen on the network. Examples:
+  nginx, monit, kamailio, redis. Distinct from c.kernel-module
+  (privileged context, different rule sets) and c.cli-tool (no
+  network attack surface). Distinct from c.embedded (no MMU /
+  RTOS context — different sandbox + threat model).
+
+detection:
+  file_globs:
+    # Autotools daemon shape — configure.ac + Makefile.am at top.
+    - "configure.ac"
+    - "configure.in"
+    - "Makefile.am"
+    # CMake daemon shape.
+    - "CMakeLists.txt"
+    # Config-driven daemon — conf-template at top is a strong signal.
+    - "*.conf.template"
+    - "*.conf.example"
+    # Network listener present in src tree.
+    - "src/**/socket*.c"
+    - "src/**/net*.c"
+    - "src/**/http*.c"
+  file_extensions:
+    - .c
+    - .h
+  negative_globs:
+    # Rule out kernel modules — they're a different shape entirely.
+    - "kernel/**"
+    - "drivers/**"
+    - "Kconfig"
+    - "Kbuild"
+    # Rule out Linux-kernel-sources style trees.
+    - "include/linux/**"
+
+semgrep_packs:
+  default:
+    - security-audit
+    - command-injection
+    - owasp-top-ten
+  optional:
+    - secrets
+    - jwt
+
+attack_surface:
+  high_priority_dirs:
+    - src/http
+    - src/net
+    - src/protocols
+    - src/notification
+    - src/api
+  low_priority_dirs:
+    - src/device/sysdep_*
+    - tests
+    - test
+    - examples
+    - docs
+    - libmonit/test
+    - libmonit/src/exceptions
+
+pipeline:
+  recommended:
+    - understand-map
+    - scan-with-codeql
+    - agentic-with-validate
+  estimated_cost_usd: [25, 50]
+  estimated_time_min: [40, 75]
+
+budget_defaults:
+  typical_findings_count: 25
+  typical_cost_per_run_usd: 30
+
+version: 1

--- a/core/run/target_types/generic.yml
+++ b/core/run/target_types/generic.yml
@@ -1,0 +1,42 @@
+name: generic
+description: |
+  Fallback catalog entry when no specific target-type matched.
+  Operator sees the generic defaults rather than a None — they
+  can still proceed; the result is just less tuned than a
+  matching specific entry would have given.
+
+  Detection signals are empty (this entry is loaded by
+  ``load_by_name('generic')`` from the fallback path in
+  ``load(target_path)``, NEVER by the score-ranked ``detect()``).
+
+detection: {}
+
+semgrep_packs:
+  default:
+    - security-audit
+    - owasp-top-ten
+  optional:
+    - secrets
+
+attack_surface:
+  high_priority_dirs: []
+  low_priority_dirs:
+    - tests
+    - test
+    - docs
+    - examples
+    - "**/__pycache__"
+    - "node_modules"
+
+pipeline:
+  recommended:
+    - scan
+    - agentic
+  estimated_cost_usd: [10, 30]
+  estimated_time_min: [15, 45]
+
+budget_defaults:
+  typical_findings_count: 15
+  typical_cost_per_run_usd: 15
+
+version: 1

--- a/core/run/target_types/python.web-app.yml
+++ b/core/run/target_types/python.web-app.yml
@@ -1,0 +1,84 @@
+name: python.web-app
+description: |
+  Python web applications — Django, Flask, FastAPI, Pyramid,
+  Tornado, Sanic, Starlette. HTTP attack surface, ORM-mediated
+  data access, templating injection risks, dependency surface
+  via PyPI. Distinct from python.cli-tool (no network surface)
+  and python.library (no application boundary).
+
+detection:
+  file_globs:
+    # Project / dep manifests.
+    - "pyproject.toml"
+    - "setup.py"
+    - "setup.cfg"
+    - "requirements.txt"
+    - "requirements-*.txt"
+    - "Pipfile"
+    - "poetry.lock"
+    # Framework-distinctive entry / config files.
+    - "manage.py"          # Django
+    - "wsgi.py"            # Django / generic WSGI
+    - "asgi.py"            # Django / generic ASGI
+    - "app.py"             # Flask / FastAPI common
+    - "main.py"            # FastAPI common
+    - "settings.py"        # Django
+    - "urls.py"            # Django
+    - "**/templates/**/*.html"
+    # Container shape often paired with web apps.
+    - "Dockerfile"
+    - "docker-compose.yml"
+    - "docker-compose.yaml"
+  file_extensions:
+    - .py
+    - .html
+    - .jinja
+    - .jinja2
+  negative_globs:
+    # Rule out Python kernel/system modules (rare but real).
+    - "linux/**"
+    # Rule out notebook-heavy repos (different shape: data
+    # science, not web app).
+    - "*.ipynb"
+
+semgrep_packs:
+  default:
+    - security-audit
+    - python-django
+    - python-flask
+    - owasp-top-ten
+  optional:
+    - secrets
+    - jwt
+    - command-injection
+
+attack_surface:
+  high_priority_dirs:
+    - "**/views"
+    - "**/api"
+    - "**/handlers"
+    - "**/routes"
+    - "**/templates"
+    - "**/auth"
+  low_priority_dirs:
+    - tests
+    - test
+    - migrations
+    - docs
+    - examples
+    - "**/__pycache__"
+
+pipeline:
+  recommended:
+    - understand-map
+    - scan-with-codeql
+    - agentic-with-validate
+    - sca
+  estimated_cost_usd: [15, 35]
+  estimated_time_min: [30, 60]
+
+budget_defaults:
+  typical_findings_count: 20
+  typical_cost_per_run_usd: 22
+
+version: 1

--- a/core/run/target_types/tests/test_target_types.py
+++ b/core/run/target_types/tests/test_target_types.py
@@ -1,0 +1,247 @@
+"""Tests for ``core.run.target_types`` — the catalog substrate
+(QoL #17): YAML loading, schema parsing, detection, fallback."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from core.run.target_types import (
+    CatalogEntry,
+    _reset_cache_for_tests,
+    all_entries,
+    detect,
+    load,
+    load_by_name,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_catalog_cache():
+    """Ensure each test sees a fresh catalog load — module-level
+    cache means tests would otherwise interfere via leftover
+    state."""
+    _reset_cache_for_tests()
+    yield
+    _reset_cache_for_tests()
+
+
+# ---------------------------------------------------------------------------
+# Schema parsing
+# ---------------------------------------------------------------------------
+
+
+class TestCatalogEntryFromDict:
+    def test_minimal_required_fields(self):
+        e = CatalogEntry.from_dict({"name": "minimal"})
+        assert e.name == "minimal"
+        assert e.description == ""
+        assert e.file_globs == ()
+        assert e.version == 1
+
+    def test_full_schema(self):
+        e = CatalogEntry.from_dict({
+            "name": "c.userspace-daemon",
+            "description": "C/C++ daemons",
+            "detection": {
+                "file_globs": ["configure.ac", "Makefile.am"],
+                "file_extensions": [".c", ".h"],
+                "function_names": ["main_loop"],
+                "negative_globs": ["kernel/**"],
+            },
+            "semgrep_packs": {
+                "default": ["security-audit"],
+                "optional": ["secrets"],
+            },
+            "attack_surface": {
+                "high_priority_dirs": ["src/http"],
+                "low_priority_dirs": ["tests"],
+            },
+            "pipeline": {
+                "recommended": ["scan", "agentic"],
+                "estimated_cost_usd": [10, 30],
+                "estimated_time_min": [20, 60],
+            },
+            "budget_defaults": {
+                "typical_findings_count": 20,
+                "typical_cost_per_run_usd": 15.5,
+            },
+            "version": 2,
+        })
+        assert e.name == "c.userspace-daemon"
+        assert e.description == "C/C++ daemons"
+        assert e.file_globs == ("configure.ac", "Makefile.am")
+        assert e.file_extensions == (".c", ".h")
+        assert e.function_names == ("main_loop",)
+        assert e.negative_globs == ("kernel/**",)
+        assert e.semgrep_packs_default == ("security-audit",)
+        assert e.semgrep_packs_optional == ("secrets",)
+        assert e.attack_surface_high == ("src/http",)
+        assert e.attack_surface_low == ("tests",)
+        assert e.pipeline_recommended == ("scan", "agentic")
+        assert e.estimated_cost_usd == (10.0, 30.0)
+        assert e.estimated_time_min == (20, 60)
+        assert e.typical_findings_count == 20
+        assert e.typical_cost_per_run_usd == 15.5
+        assert e.version == 2
+
+    def test_missing_name_raises(self):
+        with pytest.raises(ValueError) as exc:
+            CatalogEntry.from_dict({"description": "no name"})
+        assert "name" in str(exc.value)
+
+    def test_partial_sections_default_to_empty(self):
+        e = CatalogEntry.from_dict({
+            "name": "partial",
+            "detection": {"file_globs": ["foo"]},
+            # no semgrep_packs, no attack_surface, etc.
+        })
+        assert e.file_globs == ("foo",)
+        assert e.semgrep_packs_default == ()
+        assert e.attack_surface_high == ()
+
+
+# ---------------------------------------------------------------------------
+# Loader — uses real YAML files in the catalog dir
+# ---------------------------------------------------------------------------
+
+
+class TestLoader:
+    def test_all_entries_loads_seed_yamls(self):
+        entries = all_entries()
+        names = {e.name for e in entries}
+        # Three seed entries shipped with the substrate.
+        assert "c.userspace-daemon" in names
+        assert "python.web-app" in names
+        assert "generic" in names
+
+    def test_load_by_name_returns_match(self):
+        e = load_by_name("c.userspace-daemon")
+        assert e is not None
+        assert e.name == "c.userspace-daemon"
+        # Spot-check the schema parsed.
+        assert "security-audit" in e.semgrep_packs_default
+
+    def test_load_by_name_unknown_returns_none(self):
+        assert load_by_name("does-not-exist") is None
+
+
+# ---------------------------------------------------------------------------
+# Detection — synthetic target trees in tmp_path
+# ---------------------------------------------------------------------------
+
+
+def _build_tree(tmp_path: Path, files: dict) -> Path:
+    """Helper: create a fake target tree under tmp_path with the
+    given relative paths. Values are file contents (default empty
+    string is fine — detection is filename-based in v1)."""
+    for rel, content in files.items():
+        p = tmp_path / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(content if isinstance(content, str) else "")
+    return tmp_path
+
+
+class TestDetect:
+    def test_autotools_daemon_tree_matches_c_userspace_daemon(self, tmp_path):
+        # The Monit shape: autotools at top, src/ with .c files.
+        _build_tree(tmp_path, {
+            "configure.ac": "",
+            "Makefile.am": "",
+            "src/main.c": "",
+            "src/http/server.c": "",
+        })
+        ranked = detect(tmp_path)
+        assert ranked
+        winner = ranked[0][0]
+        assert winner.name == "c.userspace-daemon"
+
+    def test_django_tree_matches_python_web_app(self, tmp_path):
+        _build_tree(tmp_path, {
+            "manage.py": "",
+            "settings.py": "",
+            "urls.py": "",
+            "app/views.py": "",
+            "requirements.txt": "Django==4.0\n",
+        })
+        ranked = detect(tmp_path)
+        assert ranked
+        assert ranked[0][0].name == "python.web-app"
+
+    def test_negative_signal_disqualifies(self, tmp_path):
+        # Tree LOOKS like an autotools daemon but has a Kconfig at
+        # top — that's a Linux-kernel-module shape, c.userspace-daemon
+        # must NOT match.
+        _build_tree(tmp_path, {
+            "configure.ac": "",
+            "Makefile.am": "",
+            "Kconfig": "",
+            "src/main.c": "",
+        })
+        ranked = detect(tmp_path)
+        # c.userspace-daemon disqualified by negative_glob; no other
+        # entry's positive signals match either (no python files,
+        # generic has no detection signals).
+        names = [e.name for e, _ in ranked]
+        assert "c.userspace-daemon" not in names
+
+    def test_empty_target_returns_empty_ranking(self, tmp_path):
+        # Empty dir → no signals to match → no entries ranked.
+        assert detect(tmp_path) == []
+
+    def test_nonexistent_path_returns_empty(self, tmp_path):
+        assert detect(tmp_path / "does-not-exist") == []
+
+
+class TestLoadFallback:
+    def test_load_returns_generic_when_nothing_matches(self, tmp_path):
+        # Empty target → no positive signals → load() falls back
+        # to the ``generic`` catalog entry rather than None. Caller
+        # gets a usable default.
+        e = load(tmp_path)
+        assert e is not None
+        assert e.name == "generic"
+
+    def test_load_returns_best_match_when_signals_present(self, tmp_path):
+        _build_tree(tmp_path, {
+            "configure.ac": "",
+            "src/main.c": "",
+        })
+        e = load(tmp_path)
+        assert e.name == "c.userspace-daemon"
+
+
+# ---------------------------------------------------------------------------
+# Seed-entry sanity checks — fail loudly when a seed YAML drifts
+# from the schema (e.g. typo in a field name) so contributors who
+# add entries get an immediate signal.
+# ---------------------------------------------------------------------------
+
+
+class TestSeedEntrySanity:
+    @pytest.mark.parametrize("name,expected_has_packs", [
+        ("c.userspace-daemon", True),
+        ("python.web-app", True),
+        ("generic", True),
+    ])
+    def test_seed_has_default_packs(self, name, expected_has_packs):
+        e = load_by_name(name)
+        assert e is not None, f"seed entry missing: {name}"
+        if expected_has_packs:
+            assert e.semgrep_packs_default, (
+                f"{name}: missing semgrep_packs.default — operator "
+                f"would get an empty pack set"
+            )
+
+    def test_seed_versions_set(self):
+        for e in all_entries():
+            assert e.version >= 1, f"{e.name}: missing version field"
+
+    def test_generic_has_no_detection_signals(self):
+        # ``generic`` is fallback-only; it must NOT match any real
+        # target via score-ranking. Having empty detection signals
+        # is what enforces that.
+        e = load_by_name("generic")
+        assert e.file_globs == ()
+        assert e.file_extensions == ()

--- a/core/run/tests/test_finding_status.py
+++ b/core/run/tests/test_finding_status.py
@@ -1,0 +1,202 @@
+"""Tests for ``core.run.finding_status`` — the unified per-finding
+status enum + helpers (QoL #19)."""
+
+from __future__ import annotations
+
+import pytest
+
+from core.run.finding_status import (
+    ALL_STATUSES,
+    ANALYSED,
+    ANALYSIS_INCONSISTENT,
+    ERROR,
+    SKIPPED,
+    SKIPPED_DEAD_CODE,
+    SKIPPED_DUPLICATE,
+    SKIPPED_FILTERED,
+    SKIPPED_OVER_BUDGET,
+    SKIPPED_TOOL_ABSENT,
+    derive_status,
+    get_status,
+    is_actionable,
+    is_errored,
+    is_skipped,
+    is_terminal,
+    needs_review,
+    set_status,
+)
+
+
+class TestDeriveStatus:
+    """Backwards-compat path: status inferred from existing finding
+    fields when no explicit ``status`` was stamped."""
+
+    def test_error_field_gives_error(self):
+        assert derive_status({"error": "timeout"}) == ERROR
+
+    def test_missing_verdict_gives_skipped(self):
+        # No is_true_positive → not analysed → generic skipped (the
+        # caller didn't record a specific skip reason; #19's whole
+        # point is to start recording one explicitly).
+        assert derive_status({"file_path": "x.c"}) == SKIPPED
+
+    def test_self_contradictory_exploitable_gives_inconsistent(self):
+        finding = {
+            "is_true_positive": True,
+            "is_exploitable": True,
+            "self_contradictory": True,
+        }
+        assert derive_status(finding) == ANALYSIS_INCONSISTENT
+
+    def test_judge_resolved_contradiction_gives_analysed(self):
+        # JudgeTask (commit 727300fc) clears self_contradictory and
+        # sets contradiction_resolved_by_judge. The derived status
+        # should be ``analysed`` — the contradiction WAS resolved.
+        finding = {
+            "is_true_positive": True,
+            "is_exploitable": True,
+            "self_contradictory": False,
+            "contradiction_resolved_by_judge": True,
+        }
+        assert derive_status(finding) == ANALYSED
+
+    def test_clean_exploitable_gives_analysed(self):
+        finding = {
+            "is_true_positive": True,
+            "is_exploitable": True,
+        }
+        assert derive_status(finding) == ANALYSED
+
+    def test_clean_false_positive_gives_analysed(self):
+        # A false-positive verdict IS an analysis result — still
+        # "analysed". The verdict's value (TP vs FP) is orthogonal
+        # to whether analysis happened.
+        finding = {
+            "is_true_positive": False,
+            "is_exploitable": False,
+        }
+        assert derive_status(finding) == ANALYSED
+
+
+class TestSetStatus:
+    def test_stamps_status_and_skip_reason(self):
+        finding = {"file_path": "x.c"}
+        set_status(finding, SKIPPED_OVER_BUDGET,
+                   skip_reason="cap reached after 8 findings")
+        assert finding["status"] == SKIPPED_OVER_BUDGET
+        assert finding["skip_reason"] == "cap reached after 8 findings"
+
+    def test_skip_reason_optional(self):
+        finding = {"file_path": "x.c"}
+        set_status(finding, ANALYSED)
+        assert finding["status"] == ANALYSED
+        assert "skip_reason" not in finding
+
+    def test_unknown_status_raises(self):
+        # Deliberate — typos would silently break the audit trail
+        # otherwise.
+        with pytest.raises(ValueError) as exc:
+            set_status({}, "skipped_silently")
+        assert "unknown status" in str(exc.value).lower()
+
+    def test_overwrites_existing_status(self):
+        # Lifecycle: a finding might transition from ``analysed`` to
+        # something else (rare but possible — e.g. ``error`` on a
+        # late-stage retry). Don't fight it.
+        finding = {"status": ANALYSED}
+        set_status(finding, ERROR)
+        assert finding["status"] == ERROR
+
+
+class TestGetStatus:
+    def test_prefers_explicit_status(self):
+        # Even when derive would say something else, explicit wins.
+        finding = {
+            "status": SKIPPED_DUPLICATE,  # explicit
+            "is_true_positive": True,     # derive would say ANALYSED
+            "is_exploitable": True,
+        }
+        assert get_status(finding) == SKIPPED_DUPLICATE
+
+    def test_falls_back_to_derive_when_status_missing(self):
+        finding = {"error": "boom"}
+        assert get_status(finding) == ERROR
+
+    def test_unknown_explicit_status_falls_back_to_derive(self):
+        # Defensive: if a finding carries an unknown status string
+        # (perhaps written by an older codebase variant), the
+        # derive fallback still produces a meaningful classification
+        # from the other fields.
+        finding = {
+            "status": "made_up_value",
+            "is_true_positive": True,
+        }
+        assert get_status(finding) == ANALYSED  # derived
+
+
+class TestPredicates:
+    """is_actionable / needs_review / is_skipped / is_errored
+    surface the four orthogonal questions consumers actually ask."""
+
+    def test_is_actionable_only_analysed(self):
+        assert is_actionable({"status": ANALYSED}) is True
+        assert is_actionable({"status": ANALYSIS_INCONSISTENT}) is False
+        assert is_actionable({"status": SKIPPED_OVER_BUDGET}) is False
+        assert is_actionable({"status": ERROR}) is False
+
+    def test_needs_review_only_analysis_inconsistent(self):
+        assert needs_review({"status": ANALYSIS_INCONSISTENT}) is True
+        assert needs_review({"status": ANALYSED}) is False
+        assert needs_review({"status": ERROR}) is False
+
+    def test_is_skipped_covers_all_skip_variants(self):
+        for s in [SKIPPED, SKIPPED_OVER_BUDGET, SKIPPED_DUPLICATE,
+                  SKIPPED_DEAD_CODE, SKIPPED_FILTERED, SKIPPED_TOOL_ABSENT]:
+            assert is_skipped({"status": s}) is True, f"missed {s}"
+        assert is_skipped({"status": ANALYSED}) is False
+        assert is_skipped({"status": ERROR}) is False
+
+    def test_is_errored_only_error(self):
+        assert is_errored({"status": ERROR}) is True
+        assert is_errored({"status": SKIPPED_OVER_BUDGET}) is False
+
+    def test_is_terminal_true_for_all_known_statuses(self):
+        for s in ALL_STATUSES:
+            assert is_terminal({"status": s}) is True
+
+
+class TestPredicatesWithDerivedStatus:
+    """Predicates work against the derive fallback too — pre-#19
+    emit paths get correct classification without explicit
+    ``status`` stamping."""
+
+    def test_actionable_from_legacy_shape(self):
+        # Legacy finding (no status field, just is_true_positive).
+        finding = {"is_true_positive": True, "is_exploitable": False}
+        assert is_actionable(finding) is True
+
+    def test_needs_review_from_legacy_contradictory_shape(self):
+        finding = {
+            "is_true_positive": True, "is_exploitable": True,
+            "self_contradictory": True,
+        }
+        assert needs_review(finding) is True
+
+    def test_skipped_from_legacy_missing_verdict(self):
+        # No is_true_positive key → derived as skipped (generic).
+        assert is_skipped({"file_path": "x.c"}) is True
+
+
+class TestExportSurface:
+    def test_all_statuses_match_module_constants(self):
+        # ALL_STATUSES should match the union of every exported
+        # status constant — catches the case where a new status is
+        # added but ALL_STATUSES isn't updated, which would break
+        # ``set_status``'s validation.
+        from core.run import finding_status as fs
+        constants = {
+            v for k, v in vars(fs).items()
+            if not k.startswith("_") and k.isupper()
+            and isinstance(v, str) and v in fs.ALL_STATUSES
+        }
+        assert constants == set(fs.ALL_STATUSES)

--- a/packages/llm_analysis/tasks.py
+++ b/packages/llm_analysis/tasks.py
@@ -672,6 +672,20 @@ class JudgeTask(DispatchTask):
                     for ja in judge_analyses
                 ]
 
+                # Contradiction resolution (QoL #11-11d): when the
+                # primary came back self_contradictory after Stage F
+                # retry, the judge stage HAS now seen the finding
+                # and produced a verdict — that verdict IS the
+                # tie-break. Clear the self_contradictory flag so
+                # the headline's ''Inconsistent (review needed)''
+                # count drops; preserve the original ``contradictions``
+                # list + a new ``contradiction_resolved_by_judge``
+                # marker so the audit trail survives for operators
+                # who want to inspect HOW it was resolved.
+                if primary.get("self_contradictory"):
+                    primary["contradiction_resolved_by_judge"] = True
+                    primary["self_contradictory"] = False
+
         return results
 
 

--- a/packages/llm_analysis/tests/test_judge_resolves_contradiction.py
+++ b/packages/llm_analysis/tests/test_judge_resolves_contradiction.py
@@ -1,0 +1,156 @@
+"""Tests for JudgeTask.finalize's contradiction-resolution behaviour.
+
+When the primary's reasoning came back self_contradictory after the
+Stage F retry, AND a judge model is configured, the judge HAS now
+seen the finding and produced a verdict. That verdict is the
+tie-break — JudgeTask.finalize should clear ``self_contradictory``
+so the headline's ''Inconsistent (review needed)'' count drops,
+while preserving the audit trail (``contradictions`` list +
+``contradiction_resolved_by_judge`` marker) for operators who want
+to inspect HOW the contradiction was resolved.
+"""
+
+from __future__ import annotations
+
+from packages.llm_analysis.tasks import JudgeTask
+
+
+def _judge_result(fid: str, is_exploitable: bool,
+                  reasoning: str = "judge says so") -> dict:
+    return {
+        "finding_id": fid,
+        "is_exploitable": is_exploitable,
+        "reasoning": reasoning,
+        "analysed_by": "claude-haiku-judge",
+    }
+
+
+class TestJudgeResolvesContradiction:
+    def test_contradictory_finding_resolved_by_judge_clears_flag(self):
+        # Primary came back exploitable=True but with reasoning that
+        # contradicted itself (self_contradictory=True). Single judge
+        # agreed with the primary's verdict.
+        prior = {
+            "F1": {
+                "finding_id": "F1",
+                "is_exploitable": True,
+                "self_contradictory": True,
+                "contradictions": ["reasoning says FP but verdict is TP"],
+                "reasoning": "...",
+            },
+        }
+        results = [_judge_result("F1", True)]
+        task = JudgeTask(results_by_id=prior)
+        task.finalize(results, prior)
+        # self_contradictory cleared because judge produced a verdict.
+        assert prior["F1"]["self_contradictory"] is False
+        # Resolution marker set so the audit trail is honest.
+        assert prior["F1"].get("contradiction_resolved_by_judge") is True
+        # Original ``contradictions`` list preserved for operator
+        # review.
+        assert prior["F1"]["contradictions"] == [
+            "reasoning says FP but verdict is TP",
+        ]
+        # judge_analyses populated for inspection.
+        assert len(prior["F1"]["judge_analyses"]) == 1
+
+    def test_clean_finding_unchanged_by_judge_run(self):
+        # Primary wasn't self_contradictory; judge agreed. No flag to
+        # clear, no resolution marker needed.
+        prior = {
+            "F1": {
+                "finding_id": "F1",
+                "is_exploitable": True,
+                "reasoning": "clean analysis",
+            },
+        }
+        results = [_judge_result("F1", True)]
+        task = JudgeTask(results_by_id=prior)
+        task.finalize(results, prior)
+        # No self_contradictory field at all on clean findings.
+        assert "self_contradictory" not in prior["F1"]
+        # No spurious resolution marker either.
+        assert "contradiction_resolved_by_judge" not in prior["F1"]
+
+    def test_judge_disputed_still_clears_contradiction(self):
+        # Multi-judge panel: primary says True, judges split. The
+        # FINAL verdict is whatever the panel majority decides.
+        # Regardless of agreement/dispute, the contradiction IS
+        # resolved (the judge stage saw the finding and produced a
+        # tie-break). The ``disputed`` marker carries the panel
+        # signal; the contradiction-resolution marker carries the
+        # ''Stage F couldn't decide; judge did'' signal.
+        prior = {
+            "F1": {
+                "finding_id": "F1",
+                "is_exploitable": True,
+                "self_contradictory": True,
+                "contradictions": ["something"],
+            },
+        }
+        # Two judges: one agrees with primary, one disagrees.
+        results = [
+            _judge_result("F1", True),
+            _judge_result("F1", False),
+        ]
+        task = JudgeTask(results_by_id=prior)
+        task.finalize(results, prior)
+        # Contradiction marker still clears — judge stage made a call.
+        assert prior["F1"]["self_contradictory"] is False
+        assert prior["F1"]["contradiction_resolved_by_judge"] is True
+        # Dispute marker independently records that judges split.
+        assert prior["F1"]["judge"] == "disputed"
+
+    def test_no_judge_analyses_leaves_contradiction_flag_alone(self):
+        # Edge case: prior_results has a finding marked
+        # self_contradictory, but no judge result was emitted for it
+        # (e.g. judge dispatch errored on this finding specifically).
+        # Don't clear the flag — operator still needs to review.
+        prior = {
+            "F1": {
+                "finding_id": "F1",
+                "is_exploitable": True,
+                "self_contradictory": True,
+                "contradictions": ["x"],
+            },
+        }
+        results: list = []  # judge dispatched 0 results for F1
+        task = JudgeTask(results_by_id=prior)
+        task.finalize(results, prior)
+        # Flag preserved because no judge verdict landed.
+        assert prior["F1"]["self_contradictory"] is True
+        assert "contradiction_resolved_by_judge" not in prior["F1"]
+
+    def test_funnel_inconsistent_count_drops_after_judge(self):
+        # End-to-end: a self_contradictory + exploitable finding goes
+        # through judge resolution; ``bucket_orchestration_results``
+        # then classifies it as ''exploitable'', not ''inconsistent''.
+        # That's the operator-facing payoff — headline "Inconsistent
+        # (review needed)" count drops automatically when a judge is
+        # configured and resolves the contradiction.
+        from core.orchestration.funnel import bucket_orchestration_results
+        prior = {
+            "F1": {
+                "finding_id": "F1",
+                "is_true_positive": True,
+                "is_exploitable": True,
+                "self_contradictory": True,
+                "contradictions": ["x"],
+            },
+        }
+        # Pre-judge bucketing: this finding lands in ``inconsistent``
+        # (was the QoL #11-11b behaviour).
+        b_pre = bucket_orchestration_results(list(prior.values()))
+        assert b_pre["inconsistent"] == 1
+        assert b_pre["exploitable"] == 0
+
+        # Run judge with a single agreeing result.
+        results = [_judge_result("F1", True)]
+        task = JudgeTask(results_by_id=prior)
+        task.finalize(results, prior)
+
+        # Post-judge bucketing: contradiction resolved, finding now
+        # lands in ``exploitable``.
+        b_post = bucket_orchestration_results(list(prior.values()))
+        assert b_post["inconsistent"] == 0
+        assert b_post["exploitable"] == 1

--- a/packages/static-analysis/scanner.py
+++ b/packages/static-analysis/scanner.py
@@ -1443,6 +1443,23 @@ def main():
         duration = time.time() - start_time
         logger.info(f"Total scan duration: {duration:.2f}s")
 
+        # Tool-execution coverage block — reads coverage-<tool>.json
+        # records the scanners emit; renders an aligned per-tool
+        # summary (findings count, rule groups, silent-drop
+        # warnings) so the operator sees what RAN with what RESULT
+        # before the function-level coverage block below.
+        # Distinct from store_summary which answers ''what code did
+        # any tool examine?''; this one answers ''what did we look
+        # at it WITH?''.
+        try:
+            from core.reporting.scan_coverage import render_scan_coverage
+            tool_cov = render_scan_coverage(out_dir)
+            if tool_cov:
+                print()
+                print(tool_cov)
+        except Exception as e:
+            logger.debug(f"Tool-coverage render failed (non-fatal): {e}")
+
         # Print coverage summary (unified store-backed report; file-level tier
         # when there's no function inventory, e.g. a bare /scan).
         try:


### PR DESCRIPTION
Four QoL improvements — two operator-visible features that compose with the previous batch on this branch, two substrate pieces that unblock future cleanups without flag-day consumer changes.

Operator-visible:

  * /scan tool-execution coverage block — at scan end, prints which tools ran with what result; surfaces silent-pack-failures inline via the previously-shipped detection. Complements the existing function-level coverage block (which answers ''what code did any tool examine?'') by answering ''what did we look at it WITH?''. Reads existing coverage-<tool>.json records; no new on-disk schema.

  * Judge auto-resolves Stage F contradictions — when the primary's reasoning came back self_contradictory after retry AND a judge model is configured, treat the judge's verdict as the tie-break. Clears self_contradictory, preserves the audit trail via a new contradiction_resolved_by_judge marker + the original contradictions list. Headline ''Inconsistent (review needed)'' count drops by however many contradictions the judge resolved.

Substrate:

  * Unified per-finding status enum (core/run/finding_status.py) — canonical analysed / analysis_inconsistent / skipped_* / error values + helpers (is_actionable / needs_review / is_skipped / is_errored). Funnel bucketing prefers explicit status when present; falls back to legacy field-detection (is_true_positive None / self_contradictory / error key) so pre 19 emit paths keep working. Per-consumer adoption lands incrementally as those paths get touched.

  * Target-type catalog (core/run/target_types/) — YAML-per-entry substrate (detection signals + semgrep_packs + attack_surface dirs + pipeline recommendation + cost/time estimates + version). Loader + scoring detection; ranked candidates with negative-signal disqualification + ''generic'' fallback when nothing matches. Three seed entries shipped (c.userspace-daemon, python.web-app, generic) — operator can add more without touching code. Consumers (default packs, attack-surface ranking, plan, budget defaults, smart project-create) will adopt incrementally.

Net: +1850 LOC across 15 files; 61 new tests + extensions to existing suites (funnel status-aware bucketing, judge-resolves-contradiction end-to-end via funnel, target-type detection on real-shape fixtures, status enum predicates against both explicit-stamped and legacy- inferred findings).