### PR TITLE
feat(reachability): per-language verdict-frequency log

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -27,6 +27,14 @@ from pathlib import Path
 
 os.environ.setdefault("_RAPTOR_TRUSTED", "1")
 
+# Disable reach_verdict_log atexit flush during tests so the synthetic
+# inventories that test suites build don't pollute the operator-facing
+# sidecar (the cross-project verdict-frequency log is supposed to
+# reflect real operator runs, not the test corpus). Tests that
+# exercise the log directly opt back in via ``RAPTOR_REACH_VERDICT_LOG``
+# pointing at a tmp file (see core/inventory/tests/test_reach_verdict_log.py).
+os.environ.setdefault("RAPTOR_REACH_VERDICT_LOG_DISABLED", "1")
+
 # Force RAPTOR_DIR to point at THIS worktree, not whatever the
 # developer's login shell exports. ``setdefault`` is a no-op when the
 # env var is already set, so a developer with multiple checkouts who

--- a/core/inventory/reach_audit.py
+++ b/core/inventory/reach_audit.py
@@ -217,19 +217,31 @@ def classify_reachability(
     """Strongest applicable reachability verdict for one function — the first
     stage in :data:`PRECEDENCE` that fires, else ``"uncertain"``. Single
     source of truth consumed by the CodeQL prefilter, the /agentic enrichment
-    prepass, and the /validate demoter."""
+    prepass, and the /validate demoter.
+
+    Every verdict is also recorded into the per-language verdict-frequency
+    log (see ``core.inventory.reach_verdict_log``). Counts accumulate
+    in-memory and flush to a sidecar at process exit — gives empirical
+    grounding for "which language needs better framework-catalog
+    coverage" questions without burdening any consumer.
+    """
     from core.inventory import reachability as R
+    from core.inventory import reach_verdict_log
     ctx = _ClassifyCtx(
         inventory=inventory, file_path=file_path, name=name, line=line,
         module=module,
         target=R.InternalFunction(file_path=file_path, name=name, line=line),
         class_name=_lookup_class_name(inventory, file_path, name, line),
     )
+    verdict = "uncertain"
     for stage in PRECEDENCE:
-        verdict = stage(ctx, R)
-        if verdict:
-            return verdict
-    return "uncertain"
+        result = stage(ctx, R)
+        if result:
+            verdict = result
+            break
+    reach_verdict_log.record_verdict(
+        R._file_language(inventory, file_path), verdict)
+    return verdict
 
 
 @dataclass

--- a/core/inventory/reach_verdict_log.py
+++ b/core/inventory/reach_verdict_log.py
@@ -1,0 +1,277 @@
+"""Per-language reachability-verdict distribution log.
+
+A telemetry sidecar that aggregates how many times each (language,
+verdict) pair fires across all ``classify_reachability`` calls. The
+chokepoint records every verdict it produces; counts accumulate
+in-memory and flush to a JSON sidecar at process exit (or via explicit
+:func:`flush`).
+
+**Why it exists.** Reachability accuracy work (framework entry catalog,
+ServiceLoader/setuptools parsers, JS/Java dead-island, CHA precision)
+all need an empirical signal: "how often does verdict X fire on
+language Y across real operator runs?" Without that signal we'd be
+optimising blind. The reach_audit corpus measures verdict CORRECTNESS
+on a labelled fixture; this log measures verdict FREQUENCY on whatever
+the operator actually scans.
+
+**Schema** (``out/reach_verdict_log.json`` by default)::
+
+    {
+      "version": 1,
+      "languages": {
+        "python": {
+          "verdicts": {"reachable": 1023, "no_path_from_entry": 47, ...},
+          "last_seen_at": "2026-06-01T14:23:00Z"
+        },
+        "c": {...},
+        ...
+      }
+    }
+
+**Privacy.** Records only ``(language, verdict_string)`` pairs — never
+source code, finding details, function names, or file paths. Safe to
+pool across projects (the cross-project signal is the point).
+
+**Concurrency.** Writes go through ``_with_lock`` (``flock`` on the
+sidecar), so multi-process raptor runs accumulate without losing
+increments. Same pattern as ``llm_scorecard`` (q.v.).
+
+**Cost.** Schema is bounded: ``num_languages × num_verdict_strings ≈
+100 entries``. JSON stays tiny (a few KB after years of use).
+"""
+
+from __future__ import annotations
+
+import atexit
+import fcntl
+import os
+import threading
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from core.json import load_json, save_json
+from core.logging import get_logger
+
+logger = get_logger()
+
+SCHEMA_VERSION = 1
+
+# In-memory accumulator, keyed by (language, verdict) → count. Module-
+# level so every ``record_verdict`` call within the process aggregates;
+# ``flush`` reads + clears this buffer in one shot under the lock.
+_IN_MEMORY: Dict[str, Dict[str, int]] = {}
+_LOCK = threading.Lock()
+
+
+def _sidecar_path() -> Path:
+    """Resolve the sidecar JSON location.
+
+    Honours ``RAPTOR_REACH_VERDICT_LOG`` env var if set (tests use this
+    to redirect into a tmp dir). Otherwise lands under the RAPTOR repo's
+    ``out/`` directory — the same shape as ``llm_scorecard.json``.
+    """
+    override = os.environ.get("RAPTOR_REACH_VERDICT_LOG")
+    if override:
+        return Path(override)
+    raptor_dir = os.environ.get("RAPTOR_DIR")
+    if raptor_dir:
+        return Path(raptor_dir) / "out" / "reach_verdict_log.json"
+    # Fall back to cwd-relative — defensive; the launcher always sets
+    # RAPTOR_DIR, but tests that don't go through the launcher hit this
+    # branch.
+    return Path("out") / "reach_verdict_log.json"
+
+
+def record_verdict(language: Optional[str], verdict: Optional[str]) -> None:
+    """Increment the in-memory counter for ``(language, verdict)``.
+
+    Both arguments may be ``None`` — typically ``language`` is unknown
+    when the inventory has no file record for the target's path; the
+    call becomes a no-op rather than failing the chokepoint. Same for
+    a verdict that's somehow empty.
+
+    Threadsafe: a process-wide :class:`threading.Lock` guards the
+    in-memory dict so concurrent calls from a ``ThreadPoolExecutor``
+    don't race. Cross-process safety is provided by :func:`flush`'s
+    flock at write time.
+    """
+    if not language or not verdict:
+        return
+    # ``RAPTOR_REACH_VERDICT_LOG_DISABLED`` is the operator opt-out (and
+    # the test-suite default via conftest). Checking it per-call keeps
+    # the in-memory dict empty so a long-running disabled process never
+    # carries stale counters, AND lets a test fixture toggle telemetry
+    # mid-process by tweaking the env. Cheap: env-var lookup is a hash
+    # probe, fires before the lock.
+    if os.environ.get("RAPTOR_REACH_VERDICT_LOG_DISABLED"):
+        return
+    with _LOCK:
+        per_lang = _IN_MEMORY.setdefault(language, {})
+        per_lang[verdict] = per_lang.get(verdict, 0) + 1
+
+
+def _drain_in_memory() -> Dict[str, Dict[str, int]]:
+    """Atomically swap the in-memory accumulator for an empty dict and
+    return the prior contents. Holding ``_LOCK`` for the swap ensures no
+    increment is lost between the read and the reset.
+    """
+    with _LOCK:
+        # Snapshot then clear-in-place. Can't reassign module-level
+        # from inside a function without ``global``; clear-in-place
+        # preserves the reference for any concurrent recorder.
+        out = {lang: dict(v) for lang, v in _IN_MEMORY.items()}
+        _IN_MEMORY.clear()
+        return out
+
+
+def _merge_disk(path: Path, increments: Dict[str, Dict[str, int]]) -> None:
+    """Read-modify-write the sidecar under flock.
+
+    Schema-version-strict: refuses to write back data of an unrecognised
+    schema — better to surface than silently downgrade.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    lock_path = path.with_suffix(path.suffix + ".lock")
+    # ``a+`` semantics — create if absent, never written to. flock
+    # operates on the inode so the lock-file's contents are irrelevant.
+    with open(lock_path, "a+") as lock_fh:
+        fcntl.flock(lock_fh.fileno(), fcntl.LOCK_EX)
+        try:
+            if path.exists():
+                try:
+                    data = load_json(path)
+                except Exception as e:
+                    logger.warning(
+                        "reach_verdict_log: corrupt JSON at %s — "
+                        "reading as empty (%s)", path, e)
+                    data = None
+            else:
+                data = None
+            if data is None:
+                data = {"version": SCHEMA_VERSION, "languages": {}}
+            version = data.get("version")
+            if version != SCHEMA_VERSION:
+                raise RuntimeError(
+                    f"reach_verdict_log: refusing to write — sidecar at "
+                    f"{path} has version={version!r}, expected "
+                    f"{SCHEMA_VERSION!r}. Delete the sidecar to reset."
+                )
+            languages: Dict[str, Any] = data.setdefault("languages", {})
+            now = datetime.now(timezone.utc).isoformat(timespec="seconds")
+            for lang, verdicts in increments.items():
+                slot = languages.setdefault(
+                    lang, {"verdicts": {}, "last_seen_at": now})
+                vs = slot.setdefault("verdicts", {})
+                for v, n in verdicts.items():
+                    vs[v] = int(vs.get(v, 0)) + int(n)
+                slot["last_seen_at"] = now
+            save_json(path, data)
+        finally:
+            fcntl.flock(lock_fh.fileno(), fcntl.LOCK_UN)
+
+
+def _redeposit(increments: Dict[str, Dict[str, int]]) -> None:
+    """Merge ``increments`` back into the in-memory accumulator. Used
+    when a flush attempt fails — the drained counts MUST NOT be lost,
+    so we put them back where they were and let the next flush try
+    again (or the operator notice via the warning log and recover)."""
+    if not increments:
+        return
+    with _LOCK:
+        for lang, verdicts in increments.items():
+            per_lang = _IN_MEMORY.setdefault(lang, {})
+            for v, n in verdicts.items():
+                per_lang[v] = per_lang.get(v, 0) + int(n)
+
+
+def flush(path: Optional[Path] = None) -> None:
+    """Drain the in-memory accumulator and merge into the sidecar.
+
+    ``path`` defaults to :func:`_sidecar_path`. Tests pass an explicit
+    path. Safe to call repeatedly — drains each time, no-ops if empty.
+    Safe to call from atexit; suppresses every exception (telemetry
+    must never block process exit).
+
+    Failure mode: if the disk merge raises (corrupt sidecar that even
+    the fallback can't read, schema-version refusal, EIO, …), the
+    drained increments are **re-deposited** into the in-memory
+    accumulator. Without this, a schema-version mismatch would silently
+    discard every recorded verdict for the rest of the process lifetime
+    — one of those bugs that looks fine in tests and bleeds data in
+    production.
+    """
+    increments = _drain_in_memory()
+    if not increments:
+        return
+    try:
+        _merge_disk(path or _sidecar_path(), increments)
+    except Exception as e:
+        logger.warning("reach_verdict_log: flush failed, "
+                       "preserving increments in memory (%s)", e)
+        _redeposit(increments)
+
+
+def summarize(path: Optional[Path] = None) -> Dict[str, Dict[str, int]]:
+    """Return the on-disk verdict distribution as
+    ``{language: {verdict: count}}``. Empty dict if the sidecar doesn't
+    exist or is unreadable. For CLI inspection — does not flush.
+    """
+    p = path or _sidecar_path()
+    if not p.exists():
+        return {}
+    try:
+        data = load_json(p)
+    except Exception as e:
+        logger.warning("reach_verdict_log: read failed (%s)", e)
+        return {}
+    if not isinstance(data, dict):
+        return {}
+    languages = data.get("languages") or {}
+    return {
+        lang: dict(slot.get("verdicts") or {})
+        for lang, slot in languages.items()
+        if isinstance(slot, dict)
+    }
+
+
+def reset(path: Optional[Path] = None) -> None:
+    """Clear in-memory counter AND delete the sidecar. Used by tests
+    and the operator-facing ``--reset`` CLI flag."""
+    with _LOCK:
+        _IN_MEMORY.clear()
+    p = path or _sidecar_path()
+    if p.exists():
+        p.unlink()
+    lock_path = p.with_suffix(p.suffix + ".lock")
+    if lock_path.exists():
+        lock_path.unlink()
+
+
+def _clear_after_fork_in_child() -> None:
+    """Reset the in-memory accumulator in a forked child.
+
+    Without this, a ``multiprocessing.Process`` / ``os.fork`` child
+    inherits the parent's accumulator AND atexit registration: at
+    child exit it flushes the inherited counts (already attributable
+    to the parent's eventual flush), so the same increments are written
+    twice. Clearing in-place at the after-fork-in-child hook is the
+    standard pattern for "this state belongs to a single process,
+    not a process tree."
+
+    The atexit-registered ``flush`` still fires in the child, but it
+    drains an empty accumulator → no-op write → no double-count.
+    """
+    with _LOCK:
+        _IN_MEMORY.clear()
+
+
+if hasattr(os, "register_at_fork"):
+    os.register_at_fork(after_in_child=_clear_after_fork_in_child)
+
+
+# atexit registration — opt-out via ``RAPTOR_REACH_VERDICT_LOG_DISABLED``
+# (test suites that don't want their stray verdicts to land in the real
+# sidecar should set this OR redirect with ``RAPTOR_REACH_VERDICT_LOG``).
+if not os.environ.get("RAPTOR_REACH_VERDICT_LOG_DISABLED"):
+    atexit.register(flush)

--- a/core/inventory/reach_verdict_log_cli.py
+++ b/core/inventory/reach_verdict_log_cli.py
@@ -1,0 +1,91 @@
+"""CLI entry point for ``raptor-reach-verdict-log``.
+
+Inspects + maintains the per-language reachability verdict-frequency
+log (``core.inventory.reach_verdict_log``).
+
+Default action prints a human-readable per-language table:
+
+    reach verdicts (out/reach_verdict_log.json):
+      python:
+        reachable           : 1023
+        no_path_from_entry  :   47
+        uncertain           :   12
+      c:
+        ...
+
+Flags:
+  --json      Emit the raw verdict distribution as JSON
+  --reset     Delete the sidecar and clear in-memory counts
+  --path P    Override sidecar location (else env/default resolution)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from core.inventory.reach_verdict_log import (
+    SCHEMA_VERSION,
+    _sidecar_path,
+    reset,
+    summarize,
+)
+
+
+def _format_table(data: dict) -> str:
+    if not data:
+        return "no verdicts recorded yet"
+    lines = []
+    for lang in sorted(data):
+        verdicts = data[lang]
+        if not verdicts:
+            continue
+        lines.append(f"  {lang}:")
+        # Sort by count desc, then verdict name for tie-break.
+        items = sorted(verdicts.items(), key=lambda kv: (-kv[1], kv[0]))
+        width = max(len(v) for v, _ in items)
+        for v, n in items:
+            lines.append(f"    {v:<{width}} : {n:>6}")
+    if not lines:
+        return "no verdicts recorded yet"
+    return "\n".join(lines)
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(
+        prog="raptor-reach-verdict-log",
+        description=(
+            "Inspect the per-language reachability verdict-frequency log. "
+            "Sidecar accumulates (language, verdict) counts from every "
+            "classify_reachability call; flushes at process exit."
+        ),
+    )
+    p.add_argument("--json", action="store_true",
+                   help="Emit the raw counts as JSON instead of a table.")
+    p.add_argument("--reset", action="store_true",
+                   help="Delete the sidecar and clear in-memory counts.")
+    p.add_argument("--path", type=Path, default=None,
+                   help="Override sidecar location (default: $RAPTOR_DIR/out/reach_verdict_log.json).")
+    args = p.parse_args()
+
+    path = args.path or _sidecar_path()
+
+    if args.reset:
+        reset(path)
+        print(f"reset {path}")
+        return 0
+
+    data = summarize(path)
+    if args.json:
+        print(json.dumps(data, indent=2, sort_keys=True))
+        return 0
+
+    print(f"reach verdicts ({path}, schema v{SCHEMA_VERSION}):")
+    print(_format_table(data))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/core/inventory/tests/test_reach_verdict_log.py
+++ b/core/inventory/tests/test_reach_verdict_log.py
@@ -1,0 +1,291 @@
+"""Tests for the reachability verdict-frequency log.
+
+The substrate is a process-wide accumulator (in-memory) with a
+flock-guarded JSON sidecar for cross-process safety. Tests must NOT
+contaminate the real sidecar — each test isolates via the
+``RAPTOR_REACH_VERDICT_LOG`` env var or an explicit ``path`` argument.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from core.inventory import reach_verdict_log
+
+
+@pytest.fixture(autouse=True)
+def _isolated_sidecar(tmp_path, monkeypatch):
+    """Redirect the sidecar to a tmp path AND clear in-memory state
+    before every test. Without this the real sidecar would accumulate
+    test-run garbage across the suite.
+
+    Conftest sets ``RAPTOR_REACH_VERDICT_LOG_DISABLED=1`` by default
+    (so unrelated tests don't pollute the real sidecar), but this
+    test file IS the one exercising the substrate — unset it locally
+    so ``record_verdict`` actually records.
+    """
+    sidecar = tmp_path / "reach_verdict_log.json"
+    monkeypatch.setenv("RAPTOR_REACH_VERDICT_LOG", str(sidecar))
+    monkeypatch.delenv("RAPTOR_REACH_VERDICT_LOG_DISABLED", raising=False)
+    reach_verdict_log._IN_MEMORY.clear()
+    yield sidecar
+    reach_verdict_log._IN_MEMORY.clear()
+
+
+def test_record_accumulates_in_memory(_isolated_sidecar):
+    reach_verdict_log.record_verdict("python", "reachable")
+    reach_verdict_log.record_verdict("python", "reachable")
+    reach_verdict_log.record_verdict("python", "no_path_from_entry")
+    reach_verdict_log.record_verdict("c", "reachable")
+    assert reach_verdict_log._IN_MEMORY == {
+        "python": {"reachable": 2, "no_path_from_entry": 1},
+        "c": {"reachable": 1},
+    }
+
+
+def test_record_none_args_is_noop(_isolated_sidecar):
+    # The chokepoint calls record_verdict(None, ...) when the file has
+    # no language (e.g. an extension we don't recognise). Must not blow
+    # up — telemetry never blocks the chokepoint.
+    reach_verdict_log.record_verdict(None, "reachable")
+    reach_verdict_log.record_verdict("python", None)
+    reach_verdict_log.record_verdict(None, None)
+    reach_verdict_log.record_verdict("", "reachable")
+    assert reach_verdict_log._IN_MEMORY == {}
+
+
+def test_flush_writes_sidecar(_isolated_sidecar):
+    reach_verdict_log.record_verdict("python", "reachable")
+    reach_verdict_log.record_verdict("python", "reachable")
+    reach_verdict_log.flush()
+    assert _isolated_sidecar.exists()
+    data = json.loads(_isolated_sidecar.read_text())
+    assert data["version"] == reach_verdict_log.SCHEMA_VERSION
+    assert data["languages"]["python"]["verdicts"]["reachable"] == 2
+    assert "last_seen_at" in data["languages"]["python"]
+    # In-memory drained after flush.
+    assert reach_verdict_log._IN_MEMORY == {}
+
+
+def test_flush_merges_with_existing(_isolated_sidecar):
+    # First flush creates the file.
+    reach_verdict_log.record_verdict("python", "reachable")
+    reach_verdict_log.flush()
+    # Second flush MUST add to existing counts, not overwrite.
+    reach_verdict_log.record_verdict("python", "reachable")
+    reach_verdict_log.record_verdict("python", "not_called")
+    reach_verdict_log.flush()
+    data = json.loads(_isolated_sidecar.read_text())
+    assert data["languages"]["python"]["verdicts"]["reachable"] == 2
+    assert data["languages"]["python"]["verdicts"]["not_called"] == 1
+
+
+def test_flush_empty_is_noop(_isolated_sidecar):
+    reach_verdict_log.flush()
+    assert not _isolated_sidecar.exists()
+
+
+def test_summarize_returns_disk_state(_isolated_sidecar):
+    reach_verdict_log.record_verdict("c", "reachable")
+    reach_verdict_log.record_verdict("c", "no_path_from_entry")
+    reach_verdict_log.flush()
+    s = reach_verdict_log.summarize()
+    assert s == {"c": {"reachable": 1, "no_path_from_entry": 1}}
+
+
+def test_summarize_missing_sidecar_returns_empty(_isolated_sidecar):
+    assert reach_verdict_log.summarize() == {}
+
+
+def test_reset_clears_both(_isolated_sidecar):
+    reach_verdict_log.record_verdict("python", "reachable")
+    reach_verdict_log.flush()
+    assert _isolated_sidecar.exists()
+    # Re-stage in-memory and reset.
+    reach_verdict_log.record_verdict("python", "reachable")
+    reach_verdict_log.reset()
+    assert not _isolated_sidecar.exists()
+    assert reach_verdict_log._IN_MEMORY == {}
+
+
+def test_corrupt_sidecar_degrades_gracefully(_isolated_sidecar):
+    # A corrupt JSON file shouldn't crash the flush — the operator
+    # gets a warning, the in-memory state is preserved BUT cleared
+    # (flush always drains; the corrupt file gets replaced with a
+    # fresh one containing the in-memory increments only).
+    _isolated_sidecar.write_text("{ not json")
+    reach_verdict_log.record_verdict("python", "reachable")
+    reach_verdict_log.flush()
+    # Recovery: new file is valid + contains our increment.
+    data = json.loads(_isolated_sidecar.read_text())
+    assert data["languages"]["python"]["verdicts"]["reachable"] == 1
+
+
+def test_schema_version_mismatch_refuses_write(_isolated_sidecar, caplog):
+    # Future-schema file present → flush MUST refuse to write, surfacing
+    # the issue. Better to fail than silently downgrade.
+    _isolated_sidecar.write_text(json.dumps({
+        "version": 999,
+        "languages": {"python": {"verdicts": {"reachable": 99}}},
+    }))
+    reach_verdict_log.record_verdict("python", "reachable")
+    reach_verdict_log.flush()
+    # Flush wraps exceptions in a warning log — sidecar unchanged.
+    data = json.loads(_isolated_sidecar.read_text())
+    assert data["version"] == 999
+    assert data["languages"]["python"]["verdicts"]["reachable"] == 99
+
+
+def test_schema_refusal_preserves_in_memory_for_recovery(_isolated_sidecar):
+    """P0 regression guard: when flush() refuses to write (schema
+    mismatch, EIO, etc.) the drained increments MUST be re-deposited
+    into the in-memory accumulator. Pre-fix, they were silently lost
+    every flush — meaning a single future-schema file on disk would
+    discard every verdict the process records.
+    """
+    # Future-schema file blocks the write.
+    _isolated_sidecar.write_text(json.dumps({
+        "version": 999, "languages": {},
+    }))
+    reach_verdict_log.record_verdict("python", "reachable")
+    reach_verdict_log.record_verdict("python", "reachable")
+    reach_verdict_log.record_verdict("c", "no_path_from_entry")
+    reach_verdict_log.flush()
+    # In-memory state preserved — the operator can recover by fixing
+    # the schema mismatch (e.g. deleting the sidecar) and re-flushing.
+    assert reach_verdict_log._IN_MEMORY == {
+        "python": {"reachable": 2},
+        "c": {"no_path_from_entry": 1},
+    }
+
+
+def test_after_fork_in_child_clears_in_memory(_isolated_sidecar):
+    """P1 regression guard: forked child must NOT inherit and re-flush
+    the parent's accumulator. The os.register_at_fork hook clears the
+    in-memory dict in the child so the child's atexit flush drains an
+    empty accumulator — no double-count.
+    """
+    reach_verdict_log.record_verdict("python", "reachable")
+    reach_verdict_log.record_verdict("python", "reachable")
+    assert reach_verdict_log._IN_MEMORY == {"python": {"reachable": 2}}
+    # Simulate the after-fork-in-child callback directly. Don't actually
+    # fork in a test — fork in a pytest process is fragile (inherits
+    # the test runner's state). The callback IS the contract.
+    reach_verdict_log._clear_after_fork_in_child()
+    assert reach_verdict_log._IN_MEMORY == {}
+
+
+def test_disabled_env_var_short_circuits_record(_isolated_sidecar,
+                                                  monkeypatch):
+    """P2: with RAPTOR_REACH_VERDICT_LOG_DISABLED set, record_verdict
+    is a no-op — the accumulator stays empty even under repeated calls.
+    """
+    monkeypatch.setenv("RAPTOR_REACH_VERDICT_LOG_DISABLED", "1")
+    for _ in range(100):
+        reach_verdict_log.record_verdict("python", "reachable")
+    assert reach_verdict_log._IN_MEMORY == {}
+
+
+def test_chokepoint_records_verdict(_isolated_sidecar):
+    # The chokepoint MUST record every verdict it produces — this is
+    # the wiring the telemetry value depends on. Synthesise the
+    # smallest possible inventory + call classify_reachability.
+    from core.inventory.reach_audit import classify_reachability
+    inv = {
+        "files": [{
+            "path": "m.py", "language": "python",
+            "items": [{"name": "_orphan", "kind": "function",
+                       "line_start": 1}],
+            "call_graph": {"imports": {}, "calls": []},
+        }],
+    }
+    verdict = classify_reachability(inv, "m.py", "_orphan", 1, "m")
+    assert verdict in ("no_path_from_entry", "not_called", "uncertain")
+    # In-memory accumulator picked up the call.
+    assert "python" in reach_verdict_log._IN_MEMORY
+    assert reach_verdict_log._IN_MEMORY["python"].get(verdict) == 1
+
+
+def test_chokepoint_records_language_none_safely(_isolated_sidecar):
+    # File has no recognised language → record_verdict(None, ...) →
+    # no-op in the accumulator, no crash.
+    from core.inventory.reach_audit import classify_reachability
+    inv = {
+        "files": [{
+            "path": "weird_unknown_extension.xyz",
+            "language": None,
+            "items": [{"name": "fn", "kind": "function", "line_start": 1}],
+            "call_graph": {"imports": {}, "calls": []},
+        }],
+    }
+    classify_reachability(inv, "weird_unknown_extension.xyz", "fn", 1, "weird")
+    # No crash, and the None-language path stayed out of the
+    # accumulator (we only record verdicts we can attribute to a lang).
+    assert None not in reach_verdict_log._IN_MEMORY
+
+
+def test_concurrent_record_threadsafe(_isolated_sidecar):
+    # Multiple threads recording at once must not lose increments.
+    # _LOCK serialises the read-modify-write in record_verdict.
+    import threading
+    N_THREADS = 8
+    N_PER_THREAD = 100
+
+    def worker():
+        for _ in range(N_PER_THREAD):
+            reach_verdict_log.record_verdict("python", "reachable")
+
+    threads = [threading.Thread(target=worker) for _ in range(N_THREADS)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert reach_verdict_log._IN_MEMORY["python"]["reachable"] == \
+        N_THREADS * N_PER_THREAD
+
+
+def test_cli_table_output(_isolated_sidecar, capsys, monkeypatch):
+    # Run the CLI's main() with a populated sidecar; verify the
+    # operator-facing table includes language sections + counts.
+    reach_verdict_log.record_verdict("python", "reachable")
+    reach_verdict_log.record_verdict("python", "no_path_from_entry")
+    reach_verdict_log.record_verdict("c", "reachable")
+    reach_verdict_log.flush()
+
+    from core.inventory.reach_verdict_log_cli import main
+    monkeypatch.setattr("sys.argv", ["raptor-reach-verdict-log"])
+    rc = main()
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "python" in out and "c" in out
+    assert "reachable" in out and "no_path_from_entry" in out
+    assert "1" in out  # the c=1 count at least
+
+
+def test_cli_json_output(_isolated_sidecar, capsys, monkeypatch):
+    reach_verdict_log.record_verdict("python", "reachable")
+    reach_verdict_log.flush()
+
+    from core.inventory.reach_verdict_log_cli import main
+    monkeypatch.setattr("sys.argv", ["raptor-reach-verdict-log", "--json"])
+    rc = main()
+    assert rc == 0
+    out = capsys.readouterr().out
+    data = json.loads(out)
+    assert data == {"python": {"reachable": 1}}
+
+
+def test_cli_reset(_isolated_sidecar, capsys, monkeypatch):
+    reach_verdict_log.record_verdict("python", "reachable")
+    reach_verdict_log.flush()
+    assert _isolated_sidecar.exists()
+
+    from core.inventory.reach_verdict_log_cli import main
+    monkeypatch.setattr("sys.argv", ["raptor-reach-verdict-log", "--reset"])
+    rc = main()
+    assert rc == 0
+    assert not _isolated_sidecar.exists()

--- a/core/inventory/tests/test_reach_verdict_log.py
+++ b/core/inventory/tests/test_reach_verdict_log.py
@@ -9,8 +9,6 @@ contaminate the real sidecar — each test isolates via the
 from __future__ import annotations
 
 import json
-from pathlib import Path
-
 import pytest
 
 from core.inventory import reach_verdict_log

--- a/libexec/raptor-reach-verdict-log
+++ b/libexec/raptor-reach-verdict-log
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Inspect / maintain the per-language reachability verdict-frequency log.
+# Substrate: core/inventory/reach_verdict_log.py.
+#
+# Records (language, verdict) → count across every classify_reachability
+# call; sidecar flushes at process exit. Used to spot empirical signal
+# for "which language's framework catalog needs work?" — e.g. lots of
+# not_called on Python = entry detection is missing handlers.
+#
+# Run with --help for usage.
+
+set -e
+
+if [ -z "${CLAUDECODE:-}" ] && [ -z "${_RAPTOR_TRUSTED:-}" ]; then
+    echo "$0: internal dispatch script." >&2
+    echo "  Run via 'bin/raptor' instead." >&2
+    echo "  Tests / power users: set _RAPTOR_TRUSTED=1 to bypass." >&2
+    exit 2
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+cd "$REPO_ROOT"
+exec python3 -m core.inventory.reach_verdict_log_cli "$@"


### PR DESCRIPTION
Every reachability work item beyond "what just shipped" — framework entry-catalog beyond Java, ServiceLoader/setuptools entry_points parsers, JS/Java dead-island, CHA precision — needs an empirical signal to justify the work: "how often does verdict X fire on language Y across real operator runs?" Today we have none. This is the substrate that produces it.

A process-wide accumulator records (language, verdict) from every classify_reachability call, then flushes a counter dict to a JSON sidecar at process exit. Operators read it via raptor-reach-verdict-log (--json / --reset / default table). Privacy: only (language, verdict_string); never source code, finding details, names, or paths. Bounded: schema is num_langs × num_verdicts ≈ 100 entries. Pooled across projects (the cross-project signal is the point — same shape as llm_scorecard).