### PR TITLE
feat(dataflow): trust-witness bridge + Tier 0 SMT free-first-pass

### DIFF
--- a/core/config/__init__.py
+++ b/core/config/__init__.py
@@ -201,6 +201,16 @@ class RaptorConfig:
     def CODEQL_THREADS(cls):
         return cls._tuning().codeql_threads
 
+    @classproperty
+    def CODEQL_MAX_DISK_CACHE_MB(cls):
+        """``--max-disk-cache`` MB cap on codeql's DB build cache.
+
+        Sentinel ``0`` means "leave codeql's unbounded default in place"
+        — corresponds to the unset state for callers like
+        :meth:`packages.codeql.CodeQLTunables.from_tuning`.
+        """
+        return cls._tuning().codeql_max_disk_cache_mb
+
     # CodeQL DB cache: grace period before _evict_stale_canonical evicts
     # a canonical that has no metadata yet. The promote sequence has a
     # gap between os.rename(staging, canonical) and save_metadata

--- a/core/dataflow/barrier_synth.py
+++ b/core/dataflow/barrier_synth.py
@@ -44,6 +44,9 @@ _CUSTOMIZATIONS = {
     "sqli": ("semmle.python.security.dataflow.SqlInjectionCustomizations", "SqlInjection"),
     "pathtrav": ("semmle.python.security.dataflow.PathInjectionCustomizations", "PathInjection"),
     "xss": ("semmle.python.security.dataflow.ReflectedXSSCustomizations", "ReflectedXss"),
+    # Added 2026-05-31 for the CWE-94/918 walk: matches cvefix_bridge._CWE_SINK.
+    "codeinjection": ("semmle.python.security.dataflow.CodeInjectionCustomizations", "CodeInjection"),
+    "ssrf": ("semmle.python.security.dataflow.ServerSideRequestForgeryCustomizations", "ServerSideRequestForgery"),
 }
 
 # JavaScript/TypeScript equivalents. JS uses the legacy TaintTracking::Configuration
@@ -55,6 +58,10 @@ _JS_CUSTOMIZATIONS = {
     "sqli": ("semmle.javascript.security.dataflow.SqlInjectionCustomizations", "SqlInjection"),
     "pathtrav": ("semmle.javascript.security.dataflow.TaintedPathCustomizations", "TaintedPath"),
     "xss": ("semmle.javascript.security.dataflow.ReflectedXssCustomizations", "ReflectedXss"),
+    # SSRF: JS pack names the module ``RequestForgery`` (no "ServerSide" prefix),
+    # unlike Python/Ruby; module file follows the same convention.
+    "codeinjection": ("semmle.javascript.security.dataflow.CodeInjectionCustomizations", "CodeInjection"),
+    "ssrf": ("semmle.javascript.security.dataflow.RequestForgeryCustomizations", "RequestForgery"),
 }
 
 # Ruby. Like Python it uses the new ConfigSig/BarrierGuard API (the legacy
@@ -67,6 +74,8 @@ _RB_CUSTOMIZATIONS = {
     "sqli": ("codeql.ruby.security.SqlInjectionCustomizations", "SqlInjection"),
     "pathtrav": ("codeql.ruby.security.PathInjectionCustomizations", "PathInjection"),
     "xss": ("codeql.ruby.security.XSS", "ReflectedXss"),
+    "codeinjection": ("codeql.ruby.security.CodeInjectionCustomizations", "CodeInjection"),
+    "ssrf": ("codeql.ruby.security.ServerSideRequestForgeryCustomizations", "ServerSideRequestForgery"),
 }
 
 # Java. New ConfigSig/BarrierGuard API like Python/Ruby, guard sig uses a
@@ -79,6 +88,26 @@ _JAVA_SINKS = {
     "cmdi": ("semmle.code.java.security.CommandLineQuery", "n instanceof CommandInjectionSink"),
     "xss": ("semmle.code.java.security.XSS", "n instanceof XssSink"),
     "pathtrav": ("semmle.code.java.dataflow.ExternalFlow", 'sinkNode(n, "path-injection")'),
+    # SSRF: Java's RequestForgery.qll exposes an abstract ``RequestForgerySink``
+    # class with concrete URL-sink subclasses; instanceof matches all of them.
+    # codeinjection deliberately omitted: Java's pack has no generic
+    # CodeInjectionSink — only framework-specific queries (SpEL/MVEL/Groovy/
+    # JEXL/Template), matching cvefix_walk's Java CWE-94 omission.
+    "ssrf": ("semmle.code.java.security.RequestForgery", "n instanceof RequestForgerySink"),
+}
+
+# Go. Uses the new ConfigSig/BarrierGuard API like Python/Ruby (with the
+# legacy TaintTracking::Configuration also available but deprecated).
+# Guard sig is ``(DataFlow::Node g, Expr e, boolean branch)`` — Expr (not
+# ControlFlowNode like Python) for the value-being-checked, mirroring Java.
+# codeinjection deliberately omitted: Go's pack has no CodeInjection.ql or
+# CodeInjectionCustomizations.qll — matches cvefix_walk's Go CWE-94 omission.
+_GO_CUSTOMIZATIONS = {
+    "cmdi": ("semmle.go.security.CommandInjectionCustomizations", "CommandInjection"),
+    "sqli": ("semmle.go.security.SqlInjectionCustomizations", "SqlInjection"),
+    "pathtrav": ("semmle.go.security.TaintedPathCustomizations", "TaintedPath"),
+    "xss": ("semmle.go.security.ReflectedXssCustomizations", "ReflectedXss"),
+    "ssrf": ("semmle.go.security.RequestForgeryCustomizations", "RequestForgery"),
 }
 
 # language -> the CodeQL standard-library pack the assembled query depends on.
@@ -87,6 +116,7 @@ _LANG_PACK = {
     "javascript": "codeql/javascript-all",
     "ruby": "codeql/ruby-all",
     "java": "codeql/java-all",
+    "go": "codeql/go-all",
 }
 
 
@@ -94,7 +124,7 @@ _LANG_PACK = {
 class BarrierProposal:
     """Context handed to the proposer for one flagged FP."""
 
-    sink_class: str          # "cmdi" | "sqli" | "pathtrav" | "xss"
+    sink_class: str          # "cmdi" | "sqli" | "pathtrav" | "xss" | "codeinjection" | "ssrf"
     finding_id: str
     sink_snippet: str
     source_context: str      # the function/path source the LLM reasons over
@@ -107,7 +137,14 @@ class BarrierProposal:
 # ``prior_error`` is None on the first attempt; on a retry it carries the
 # compile/validation error from the previous attempt so the proposer (LLM)
 # can correct it.
-BarrierProposer = Callable[[BarrierProposal, Optional[str]], str]
+# `BarrierProposer` is called as ``proposer(proposal, prior_error)`` in the
+# baseline path (compile-retry only) and ``proposer(proposal, prior_error,
+# refine_context=RefineContext(...))`` in the soundness-refine path. The
+# Callable[..., str] alias is intentionally wide: 2-arg lambdas in tests
+# still match when refinement is off (the loop only passes the kwarg when
+# refine budget > 0). Refinement-aware proposers should accept the kwarg
+# (and may inspect it to nudge the prompt with the prior verdict).
+BarrierProposer = Callable[..., str]
 
 
 @dataclass(frozen=True)
@@ -129,6 +166,54 @@ class SynthResult:
         """The proposed barrier suppressed the FP AND kept the TP."""
         return self.suppressed_fp and self.preserved_tp
 
+    @property
+    def failure_mode(self) -> str:
+        """One-word classification of WHY a non-sound result failed, for
+        feeding back into the proposer on refinement.
+
+        ``suppress_fp_failed`` — guard wasn't restrictive enough (post-fix
+            DB still flags the value).
+        ``preserve_tp_failed`` — guard was too restrictive (pre-fix DB no
+            longer flags the real vuln).
+        ``both`` — guard moved nothing in either direction.
+        ``ok`` — for completeness; never used for refinement.
+        """
+        if self.is_sound:
+            return "ok"
+        if not self.suppressed_fp and not self.preserved_tp:
+            return "both"
+        if not self.suppressed_fp:
+            return "suppress_fp_failed"
+        return "preserve_tp_failed"
+
+
+@dataclass(frozen=True)
+class RefineContext:
+    """Adjudication-failure context fed back to the proposer for refinement.
+
+    Built by :func:`run_synthesis_loop` when a successfully-compiled barrier
+    runs against both DBs but fails the soundness check. The proposer sees
+    this on the next attempt and can adjust its guard — same proposal,
+    same source context, but with the prior attempt's verdict in hand.
+
+    ``surviving_finding_summary`` (added for the counterexample-driven
+    refinement work) carries a short, LLM-legible description of the
+    SPECIFIC tainted flow the prior guard failed to gate — file:line of
+    the surviving sink, the codeFlow path summary, and the source/sink
+    expressions.  Optional because the helper falls back gracefully when
+    the SARIF doesn't carry usable detail (older codeql versions, etc.).
+
+    The :attr:`refine_attempt` counter is 1-indexed (first refinement is
+    attempt 1) so the prompt can address the attempt count naturally
+    ("On your previous (1st) refinement attempt, ...").
+    """
+    prior_query_ql: str
+    after_count: int
+    before_count: int
+    failure_mode: str
+    refine_attempt: int
+    surviving_finding_summary: str = ""
+
 
 def assemble_barrier_query(
     proposed_guard: str, *, sink_class: str, query_id: str, language: str = "python",
@@ -147,6 +232,8 @@ def assemble_barrier_query(
         return _assemble_ruby(proposed_guard, sink_class, query_id)
     if language == "java":
         return _assemble_java(proposed_guard, sink_class, query_id)
+    if language == "go":
+        return _assemble_go(proposed_guard, sink_class, query_id)
     raise ValueError(
         f"unknown language {language!r}; known: {sorted(_LANG_PACK)}")
 
@@ -238,6 +325,7 @@ def _assemble_ruby(proposed_guard: str, sink_class: str, query_id: str) -> str:
  * @problem.severity error
  * @id {query_id}
  */
+import codeql.ruby.AST
 import codeql.ruby.DataFlow
 import codeql.ruby.TaintTracking
 import codeql.ruby.CFG
@@ -300,9 +388,139 @@ select sink, "synthesized-barrier {sink_class} [java]"
 """
 
 
-def _count_sarif_results(sarif_path: Path) -> int:
+def _assemble_go(proposed_guard: str, sink_class: str, query_id: str) -> str:
+    """Go QL template.  Uses the new ``ConfigSig`` / ``BarrierGuard`` API
+    (the legacy ``TaintTracking::Configuration`` still works but is
+    deprecated).  Guard signature is ``(DataFlow::Node g, Expr e,
+    boolean branch)`` — ``Expr`` for the value-being-checked (mirrors
+    Java), distinct from Python's ``ControlFlowNode``.
+
+    The per-sink-class import + module name come from
+    :data:`_GO_CUSTOMIZATIONS`.  Each module exposes the standard
+    ``Source`` / ``Sink`` / ``Sanitizer`` shape so the ConfigSig
+    predicates are identical across sink classes."""
+    if sink_class not in _GO_CUSTOMIZATIONS:
+        raise ValueError(f"unknown sink_class {sink_class!r}; "
+                         f"known: {sorted(_GO_CUSTOMIZATIONS)}")
+    if "proposedGuard" not in proposed_guard:
+        raise ValueError("proposer must define a `proposedGuard` predicate")
+    module_import, module_name = _GO_CUSTOMIZATIONS[sink_class]
+    return f"""/**
+ * @name Synthesized barrier ({sink_class}) [go]
+ * @kind problem
+ * @problem.severity error
+ * @id {query_id}
+ */
+import go
+import semmle.go.dataflow.DataFlow
+import semmle.go.dataflow.TaintTracking
+import {module_import}::{module_name}
+
+{proposed_guard.strip()}
+
+module Cfg implements DataFlow::ConfigSig {{
+  predicate isSource(DataFlow::Node n) {{ n instanceof Source }}
+  predicate isSink(DataFlow::Node n) {{ n instanceof Sink }}
+  predicate isBarrier(DataFlow::Node n) {{
+    n instanceof Sanitizer or
+    n = DataFlow::BarrierGuard<proposedGuard/3>::getABarrierNode()
+  }}
+}}
+
+module Flow = TaintTracking::Global<Cfg>;
+
+from DataFlow::Node source, DataFlow::Node sink
+where Flow::flow(source, sink)
+select sink, "synthesized-barrier {sink_class} [go]"
+"""
+
+
+def _count_sarif_results(sarif_path: Path, target_uri: Optional[str] = None,
+                         target_line: Optional[int] = None) -> int:
+    """Count SARIF results. With ``target_uri`` (+ optional ``target_line``),
+    count only findings at that file (and line) — so the suppress check can be
+    scoped to the SPECIFIC flagged finding rather than all findings in the file
+    (a file with N unrelated findings shouldn't make a correct single-flow
+    barrier look unsound). The preserve check stays file-scoped (the pre-fix vuln
+    sits at a different line after the patch's line shifts)."""
     data = json.loads(Path(sarif_path).read_text())
-    return sum(len(r.get("results", [])) for r in data.get("runs", []))
+    if target_uri is None:
+        return sum(len(r.get("results", [])) for r in data.get("runs", []))
+    n = 0
+    for run in data.get("runs", []):
+        for res in run.get("results", []):
+            for loc in res.get("locations", []):
+                phys = loc.get("physicalLocation", {})
+                if phys.get("artifactLocation", {}).get("uri") != target_uri:
+                    continue
+                if target_line is not None and phys.get("region", {}).get("startLine") != target_line:
+                    continue
+                n += 1
+                break  # count each result at most once
+    return n
+
+
+def _summarise_surviving_finding(
+    sarif_path: Path, target_uri: Optional[str] = None,
+    target_line: Optional[int] = None,
+) -> str:
+    """One-line summary of a SARIF result that survived the proposed
+    barrier, formatted for the LLM refinement prompt.
+
+    Picks the first result matching ``target_uri`` (+ optional
+    ``target_line``) — same scoping logic as :func:`_count_sarif_results`
+    so the summary describes the SPECIFIC finding the synth was scoped
+    to.  Returns ``""`` on missing file, parse error, no matching result,
+    or empty codeFlows.  Conservative by design — a noisy summary
+    would mislead the proposer; an empty one falls back to the existing
+    generic nudge.
+
+    Shape:
+      ``"surviving flow: <source-file>:<line> <msg> -> ... -> <sink-file>:<line> <sink-snippet>"``
+    """
+    try:
+        data = json.loads(Path(sarif_path).read_text())
+    except (OSError, ValueError):
+        return ""
+
+    def _result_uri(res):
+        for loc in res.get("locations", []):
+            phys = loc.get("physicalLocation", {})
+            uri = phys.get("artifactLocation", {}).get("uri")
+            line = phys.get("region", {}).get("startLine")
+            if uri:
+                return uri, line
+        return None, None
+
+    for run in data.get("runs", []):
+        for res in run.get("results", []):
+            uri, line = _result_uri(res)
+            if target_uri is not None and uri != target_uri:
+                continue
+            if target_line is not None and line != target_line:
+                continue
+            # We have the surviving result — describe it.
+            cfs = res.get("codeFlows", [])
+            steps = (cfs[0].get("threadFlows", [{}])[0].get("locations", [])
+                     if cfs else [])
+            chain = []
+            for step in steps:
+                node = step.get("location", {})
+                phys = node.get("physicalLocation", {})
+                s_uri = phys.get("artifactLocation", {}).get("uri", "?")
+                s_line = phys.get("region", {}).get("startLine", "?")
+                s_msg = node.get("message", {}).get("text", "").strip()
+                chain.append(f"{Path(s_uri).name}:{s_line}"
+                             + (f" {s_msg}" if s_msg else ""))
+            sink_msg = res.get("message", {}).get("text", "").strip()
+            sink_part = f"{Path(uri).name}:{line}" if uri else "?"
+            if sink_msg:
+                sink_part += f" — {sink_msg}"
+            if chain:
+                return ("surviving flow: " + " -> ".join(chain)
+                        + (f"\n  (sink scope: {sink_part})" if not chain[-1].startswith(sink_part) else ""))
+            return f"surviving finding at {sink_part}"
+    return ""
 
 
 def adjudicate(
@@ -312,6 +530,8 @@ def adjudicate(
     work_dir: Path,
     language: str = "python",
     search_path: Optional[str] = None,
+    target_uri: Optional[str] = None,
+    target_line: Optional[int] = None,
     codeql_bin: str = DEFAULT_CODEQL_BIN,
     runner: Optional[RunnerFn] = None,
 ) -> int:
@@ -333,7 +553,7 @@ def adjudicate(
         db_path, [str(ql)], pack / "out.sarif",
         codeql_bin=codeql_bin, runner=runner, extra_args=extra,
     )
-    return _count_sarif_results(Path(result.sarif_path))
+    return _count_sarif_results(Path(result.sarif_path), target_uri, target_line)
 
 
 def run_synthesis_loop(
@@ -344,40 +564,134 @@ def run_synthesis_loop(
     proposer: BarrierProposer,
     work_dir: Path,
     search_path: Optional[str] = None,
+    target_uri: Optional[str] = None,
+    target_line: Optional[int] = None,
     codeql_bin: str = DEFAULT_CODEQL_BIN,
     runner: Optional[RunnerFn] = None,
     max_attempts: int = 1,
+    max_refine_attempts: int = 0,
+    diag: Optional[dict] = None,
 ) -> Optional[SynthResult]:
     """Propose a barrier, assemble it, and let CodeQL adjudicate on both DBs.
 
-    Retries up to ``max_attempts``: if assembly rejects the proposal or CodeQL
-    fails to compile/run the query, the error is fed back to the proposer for a
-    corrected attempt. Returns ``None`` if no attempt produced a runnable query
-    (the proposer never emitted compilable QL) — the LLM still can't suppress
-    anything it can't get past the compiler.
+    Two retry axes:
+
+      * **Compile retries (``max_attempts``)** — if assembly rejects the
+        proposal or CodeQL fails to compile/run the query, the error is
+        fed back to the proposer for a corrected attempt. Returns
+        ``None`` if no compile attempt produced a runnable query.
+
+      * **Soundness refinement (``max_refine_attempts``, default 0)** —
+        when a barrier compiles and runs but isn't sound, the adjudication
+        verdict (after/before counts + failure mode) is wrapped in a
+        :class:`RefineContext` and fed back to the proposer for another
+        full compile-and-adjudicate cycle.  Each refinement cycle has
+        its own compile-retry budget (``max_attempts``).  Default ``0``
+        preserves the pre-existing behaviour (return the first
+        compilable result, sound or not).
+
+    When ``diag`` is supplied, it records ``last_error`` (assembly /
+    compile), ``attempts`` (compile budget used in the last cycle),
+    and ``refine_attempts`` (soundness refinements used).
     """
-    prior_error: Optional[str] = None
-    for attempt in range(1, max_attempts + 1):
-        try:
-            proposed = proposer(proposal, prior_error)
-            query_ql = assemble_barrier_query(
-                proposed, sink_class=proposal.sink_class,
-                query_id=f"raptor/synth/{proposal.finding_id}/{attempt}",
-                language=proposal.language,
+    refine_ctx: Optional[RefineContext] = None
+    refine_attempts_used = 0
+    last_compile_error: Optional[str] = None
+    last_compile_attempts = 0
+
+    while True:
+        prior_error: Optional[str] = None
+        cycle_result: Optional[SynthResult] = None
+        for attempt in range(1, max_attempts + 1):
+            last_compile_attempts = attempt
+            try:
+                # Only thread refine_context when we have one — keeps 2-arg
+                # proposers (no refinement awareness) usable at default
+                # max_refine_attempts=0.
+                if refine_ctx is not None:
+                    proposed = proposer(proposal, prior_error, refine_context=refine_ctx)
+                else:
+                    proposed = proposer(proposal, prior_error)
+                query_ql = assemble_barrier_query(
+                    proposed, sink_class=proposal.sink_class,
+                    query_id=(
+                        f"raptor/synth/{proposal.finding_id}/"
+                        f"r{refine_attempts_used}-{attempt}"
+                    ),
+                    language=proposal.language,
+                )
+                # Suppress check (after): scope to the SPECIFIC flagged
+                # finding (uri+line). Preserve check (before): file-scoped
+                # only — the pre-fix vuln is at a different line after the
+                # patch's line shifts.
+                after_count = adjudicate(
+                    query_ql, after_db,
+                    work_dir=work_dir / f"after-r{refine_attempts_used}-{attempt}",
+                    language=proposal.language, target_uri=target_uri,
+                    target_line=target_line,
+                    search_path=search_path, codeql_bin=codeql_bin, runner=runner)
+                before_count = adjudicate(
+                    query_ql, before_db,
+                    work_dir=work_dir / f"before-r{refine_attempts_used}-{attempt}",
+                    language=proposal.language, target_uri=target_uri,
+                    search_path=search_path, codeql_bin=codeql_bin, runner=runner)
+            except (ValueError, CodeQLRunError) as exc:
+                prior_error = f"{type(exc).__name__}: {exc}"
+                last_compile_error = prior_error
+                continue
+            cycle_result = SynthResult(
+                query_ql=query_ql, after_count=after_count, before_count=before_count,
             )
-            after_count = adjudicate(
-                query_ql, after_db, work_dir=work_dir / f"after-{attempt}",
-                language=proposal.language,
-                search_path=search_path, codeql_bin=codeql_bin, runner=runner)
-            before_count = adjudicate(
-                query_ql, before_db, work_dir=work_dir / f"before-{attempt}",
-                language=proposal.language,
-                search_path=search_path, codeql_bin=codeql_bin, runner=runner)
-        except (ValueError, CodeQLRunError) as exc:
-            prior_error = f"{type(exc).__name__}: {exc}"
-            continue
-        return SynthResult(query_ql=query_ql, after_count=after_count, before_count=before_count)
-    return None
+            break
+
+        if cycle_result is None:
+            # All compile attempts in this cycle failed — no_barrier.
+            if diag is not None:
+                diag["last_error"] = last_compile_error
+                diag["attempts"] = last_compile_attempts
+                diag["refine_attempts"] = refine_attempts_used
+            return None
+
+        if cycle_result.is_sound:
+            if diag is not None:
+                diag["refine_attempts"] = refine_attempts_used
+            return cycle_result
+
+        if refine_attempts_used >= max_refine_attempts:
+            # Exhausted refinement budget — surface the not_sound result so
+            # the caller can record it as diagnostic material.
+            if diag is not None:
+                diag["refine_attempts"] = refine_attempts_used
+            return cycle_result
+
+        # Refine: feed the verdict back to the proposer for another cycle.
+        refine_attempts_used += 1
+        # Counterexample-driven refinement: extract the SPECIFIC surviving
+        # finding from the after-DB's SARIF so the proposer sees the
+        # concrete flow that wasn't gated.  Only meaningful for
+        # ``suppress_fp_failed`` (the after-DB still has the FP); the
+        # ``preserve_tp_failed`` case has the after-DB clean and the
+        # before-DB SARIF is what's relevant, but the existing
+        # before-DB SARIF lives at ``before-r*`` per iteration so the
+        # same pattern would apply.  Keep scoped to the after path for
+        # now — it's the dominant failure mode.
+        surviving_summary = ""
+        if cycle_result.failure_mode == "suppress_fp_failed":
+            surviving_sarif = (
+                work_dir / f"after-r{refine_attempts_used - 1}-"
+                f"{last_compile_attempts}" / "out.sarif"
+            )
+            surviving_summary = _summarise_surviving_finding(
+                surviving_sarif, target_uri=target_uri, target_line=target_line,
+            )
+        refine_ctx = RefineContext(
+            prior_query_ql=cycle_result.query_ql,
+            after_count=cycle_result.after_count,
+            before_count=cycle_result.before_count,
+            failure_mode=cycle_result.failure_mode,
+            refine_attempt=refine_attempts_used,
+            surviving_finding_summary=surviving_summary,
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -471,7 +785,37 @@ _PY_SYSTEM_PROMPT = (
     "Semantics: `g` is the guard (the validator call/comparison); `node` is the "
     "cfg node of the value it checks; `branch` is the boolean value of `g` on "
     "which `node` is safe. `python`, `DataFlow`, and the relevant security "
-    "customizations module are already imported. No prose, no markdown fences."
+    "customizations module are already imported. No prose, no markdown fences.\n\n"
+    "CRITICAL RULES:\n"
+    "1. `node` must be the VALUE BEING VALIDATED, NOT the guard call/expression itself.\n"
+    "2. Choose the QL node type that matches the validator's SHAPE — this is the most "
+    "common failure mode: writing `CallNode` for a comparison or a variable check.\n"
+    "3. Determine `branch` from the safe path: if the validator failure raises/returns, "
+    "the SAFE branch is the one that DOESN'T fail.\n\n"
+    "SHAPE 1: call-shaped validator (`if is_safe(p): use(p)` / `if not is_safe(p): return`):\n"
+    "  predicate proposedGuard(DataFlow::GuardNode g, ControlFlowNode node, boolean branch) {\n"
+    "    exists(CallNode call | g = call and\n"
+    "      call.getFunction().(NameNode).getId() = \"is_safe\" and\n"
+    "      node = call.getArg(0) and branch = true)\n"
+    "  }\n\n"
+    "SHAPE 2: comparison-shaped validator (`if value != expected: return`).  Real "
+    "working example from CVE-2016-2512 (host == expected_host gates the value):\n"
+    "  predicate proposedGuard(DataFlow::GuardNode g, ControlFlowNode node, boolean branch) {\n"
+    "    exists(CompareNode cmp | g = cmp and\n"
+    "      cmp.operands(node, any(Eq eq), _) and\n"
+    "      branch = false)\n"
+    "  }\n"
+    "Use `CompareNode` and `cmp.operands(value_node, op, other)` — the `value_node` "
+    "IS `node`.  `branch = false` is correct when the safe path is the EQUAL branch "
+    "of `!=` (i.e., the unequal-condition is False).\n\n"
+    "SHAPE 3: variable-presence guard (`if user_supplied_var: use(user_supplied_var)`).  "
+    "Real working example from CVE-2021-25926 — the variable's truthy branch is safe:\n"
+    "  predicate proposedGuard(DataFlow::GuardNode g, ControlFlowNode node, boolean branch) {\n"
+    "    exists(NameNode v | v.getId() = \"srcallback\" and\n"
+    "      g = v and node = v and branch = true)\n"
+    "  }\n"
+    "Use `NameNode` when the guard IS the variable itself (no call, no comparison) — "
+    "`g = v` AND `node = v` (same node both roles)."
 )
 
 _JS_SYSTEM_PROMPT = (
@@ -488,7 +832,43 @@ _JS_SYSTEM_PROMPT = (
     "Semantics: the constructor selects the guard DataFlow node; `sanitizes(outcome, e)` "
     "holds when expression `e` is neutralized on the `outcome` branch of the guard. "
     "`javascript`, `DataFlow`, `TaintTracking`, and the relevant security "
-    "customizations module are already imported. No prose, no markdown fences."
+    "customizations module are already imported. No prose, no markdown fences.\n\n"
+    "CRITICAL RULES:\n"
+    "1. `e` must be the VALUE BEING VALIDATED, NOT the guard call node.  The most "
+    "common failure mode is binding `e = c` (the call) instead of `e = "
+    "c.getReceiver().asExpr()` or `e = c.getArgument(N).asExpr()`.\n"
+    "2. The `getReceiver()` is `x` in `x.method(...)`; `getArgument(N)` is the Nth arg.  "
+    "Pick the one that holds the user-controlled value.\n"
+    "3. `outcome` is the branch on which the value is SAFE.  Negated guards "
+    "(`if (!validate(x)) throw`) make the safe outcome `false`.\n\n"
+    "SHAPE 1: receiver-validates-via-string-arg (`if (!path.startsWith('..')) safe`).  "
+    "Real working example from CVE-2024-24756 — note `outcome = false` because the "
+    "guard is negated:\n"
+    "  class ProposedGuard extends TaintTracking::SanitizerGuardNode {\n"
+    "    DataFlow::CallNode c;\n"
+    "    ProposedGuard() { c.getCalleeName() = \"startsWith\" and "
+    "c.getArgument(0).getStringValue() = \"..\" and this = c }\n"
+    "    override predicate sanitizes(boolean outcome, Expr e) "
+    "{ outcome = false and e = c.getReceiver().asExpr() }\n"
+    "  }\n\n"
+    "SHAPE 2: receiver-validates-via-runtime-arg (`if (filePath.includes(workspaceDir)) safe`).  "
+    "Real working example from CVE-2020-7758 — `outcome = true` because the receiver "
+    "is safe when the includes check passes:\n"
+    "  class ProposedGuard extends TaintTracking::SanitizerGuardNode {\n"
+    "    DataFlow::CallNode c;\n"
+    "    ProposedGuard() { c.getCalleeName() = \"includes\" and this = c }\n"
+    "    override predicate sanitizes(boolean outcome, Expr e) "
+    "{ outcome = true and e = c.getReceiver().asExpr() }\n"
+    "  }\n\n"
+    "SHAPE 3: argument-validates-via-named-helper (`if (isValidHost(host)) safe`).  "
+    "Real working example from CVE-2021-46704 — the ARGUMENT (not receiver) is the "
+    "validated value, `outcome = true`:\n"
+    "  class ProposedGuard extends TaintTracking::SanitizerGuardNode {\n"
+    "    DataFlow::CallNode c;\n"
+    "    ProposedGuard() { c.getCalleeName() = \"isValidHost\" and this = c }\n"
+    "    override predicate sanitizes(boolean outcome, Expr e) "
+    "{ outcome = true and e = c.getArgument(0).asExpr() }\n"
+    "  }"
 )
 
 _RB_SYSTEM_PROMPT = (
@@ -500,8 +880,18 @@ _RB_SYSTEM_PROMPT = (
     "  predicate proposedGuard(CfgNodes::AstCfgNode g, CfgNode node, boolean branch)\n"
     "Semantics: `g` is the guard (the validator call/comparison); `node` is the CFG "
     "node of the value it checks; `branch` is the boolean value of `g` on which "
-    "`node` is safe. `codeql.ruby.DataFlow`, `TaintTracking`, `CFG`, and the relevant "
-    "security customizations module are already imported. No prose, no markdown fences."
+    "`node` is safe. `codeql.ruby.AST`, `DataFlow`, `TaintTracking`, `CFG`, and the "
+    "relevant security customizations module are already imported. No prose, no fences.\n\n"
+    "CRITICAL: `node` must be the VALUE BEING VALIDATED (the argument), NOT the guard "
+    "call. Worked example for a validator `safe_path?(p)`:\n"
+    "  predicate proposedGuard(CfgNodes::AstCfgNode g, CfgNode node, boolean branch) {\n"
+    "    exists(CfgNodes::ExprNodes::MethodCallCfgNode call | g = call and\n"
+    "      call.getExpr().(MethodCall).getMethodName() = \"safe_path?\" and\n"
+    "      node = call.getArgument(0) and branch = true)\n"
+    "  }\n\n"
+    "Determine `branch` from how the validator is USED in the source: if it is "
+    "negated (e.g. `raise unless safe_path?(p)`), the safe branch is `false`; choose "
+    "the branch that continues to normal use, not the one that errors/returns/raises."
 )
 
 _JAVA_SYSTEM_PROMPT = (
@@ -514,7 +904,49 @@ _JAVA_SYSTEM_PROMPT = (
     "Semantics: `g` is the guard (the validator call/comparison); `e` is the "
     "expression it checks; `branch` is the boolean value of `g` on which `e` is "
     "safe. `java`, `DataFlow`, `TaintTracking`, `Guards`, and the relevant security "
-    "module are already imported. No prose, no markdown fences."
+    "module are already imported. No prose, no markdown fences.\n\n"
+    "CRITICAL: `e` must be the VALUE BEING VALIDATED (the argument the check guards), "
+    "NOT the guard call itself. Worked example for a validator `isSafe(p)`:\n"
+    "  predicate proposedGuard(Guard g, Expr e, boolean branch) {\n"
+    "    exists(MethodCall call | g = call and\n"
+    "      call.getMethod().hasName(\"isSafe\") and\n"
+    "      e = call.getArgument(0) and branch = true)\n"
+    "  }\n\n"
+    "Determine `branch` from how the validator is USED in the source: if it is "
+    "negated (e.g. `if (!isSafe(p)) throw`), the safe branch is `false`; choose "
+    "the branch that continues to normal use, not the one that throws/returns."
+)
+
+_GO_SYSTEM_PROMPT = (
+    "You are a CodeQL expert. A Go taint-analysis finding has been flagged as a "
+    "false positive because a PROJECT-SPECIFIC validator/sanitizer on the path "
+    "neutralizes the attacker input — but the analyzer doesn't model it. Your "
+    "job: emit a CodeQL guard predicate that recognizes that validator.\n\n"
+    "Output ONLY a CodeQL predicate, exactly this signature and name:\n"
+    "  predicate proposedGuard(DataFlow::Node g, Expr e, boolean branch)\n"
+    "Semantics: `g` is the guard (the validator call/comparison); `e` is the "
+    "expression it checks; `branch` is the boolean value of `g` on which `e` is "
+    "safe. `go`, `DataFlow`, `TaintTracking`, and the relevant security "
+    "customizations module are already imported. No prose, no markdown fences.\n\n"
+    "CRITICAL: `e` must be the VALUE BEING VALIDATED (the argument the check "
+    "guards), NOT the guard call itself.  Worked example for a validator "
+    "`IsSafe(p)`:\n"
+    "  predicate proposedGuard(DataFlow::Node g, Expr e, boolean branch) {\n"
+    "    exists(DataFlow::CallNode call | g = call and\n"
+    "      call.getCalleeName() = \"IsSafe\" and\n"
+    "      e = call.getArgument(0).asExpr() and branch = true)\n"
+    "  }\n\n"
+    "Go-specific notes:\n"
+    "  * Use `DataFlow::CallNode` (not `MethodCall`) — Go represents calls as "
+    "DataFlow nodes.\n"
+    "  * `getCalleeName()` matches both package-level functions (`IsSafe`) "
+    "and method values (`x.IsSafe`); for stricter matching use "
+    "`getCalleeIncludingExternals()` + `getName()`.\n"
+    "  * `call.getArgument(N).asExpr()` gives the Nth argument as an Expr.\n\n"
+    "Determine `branch` from how the validator is USED in the source: if it is "
+    "negated (e.g. `if !IsSafe(p) { return }`), the safe branch is `false`; "
+    "choose the branch that continues to normal use, not the one that errors/"
+    "returns/panics."
 )
 
 _SYSTEM_PROMPTS = {
@@ -522,10 +954,95 @@ _SYSTEM_PROMPTS = {
     "javascript": _JS_SYSTEM_PROMPT,
     "ruby": _RB_SYSTEM_PROMPT,
     "java": _JAVA_SYSTEM_PROMPT,
+    "go": _GO_SYSTEM_PROMPT,
 }
 
 
-def _build_prompt(proposal: BarrierProposal, prior_error: Optional[str]) -> str:
+# Sink-class-specific validator-shape hints appended to the user prompt.
+#
+# Why: the per-language system prompts teach the QL DIALECT and a small set
+# of structural shapes (call-shaped, comparison-shaped, name-presence).
+# They are sink-class-agnostic — they don't tell the proposer what KIND of
+# validator typically protects each vuln class.  In the v3 Go + fresh-CVE
+# synth runs, 18 of 18 testable cases came back ``not_sound`` with the
+# dominant ``suppress_fp_failed`` failure: the LLM's guard was wrong-
+# shaped for the sink class (e.g. trying a literal-string check on an
+# SSRF whose actual validator was a DNS-resolve + IP-range gate).
+#
+# These hints surface the CANONICAL validator shapes for each sink class
+# so the proposer has the right prior.  Language-agnostic (the shapes
+# generalise across languages; the per-language system prompt translates
+# the QL syntax).  Keep each entry to 2-3 concrete idioms — more confuses
+# the LLM with noise.
+_SINK_CLASS_HINTS = {
+    "pathtrav": (
+        "Pathtrav validators commonly look like ONE of:\n"
+        "  (a) prefix check: `normalized.startsWith(base)` AFTER `path.resolve(p)` "
+        "normalizes traversal.  Without normalisation the prefix check is unsound; "
+        "look for both steps before binding.\n"
+        "  (b) traversal-segment reject: `!p.includes('..')`, "
+        "`!p.startsWith('..')`, regex `\\.\\.` blocked.\n"
+        "  (c) named-helper: `safe_join(base, p)`, `secure_filename(p)`, "
+        "`isRepositoryGitPath(p)` — the helper's return value or its "
+        "boolean check is the gate."
+    ),
+    "cmdi": (
+        "Cmdi validators commonly look like ONE of:\n"
+        "  (a) allowlist via charset regex: `/^[a-zA-Z0-9_.-]+$/.test(arg)` — only "
+        "shell-safe chars permitted.\n"
+        "  (b) named shell-quote helper: `shlex.quote(arg)`, `connection.escape(arg)` "
+        "— the return value carries the sanitized form.\n"
+        "  (c) command-allowlist branch: `if (cmd === 'expected' || cmd === 'other')` "
+        "— ONLY known commands proceed."
+    ),
+    "sqli": (
+        "Sqli validators commonly look like ONE of:\n"
+        "  (a) parameterised-query: `PreparedStatement.setString(i, v)` / "
+        "`cursor.execute(query, (v,))` — the value is bound as a parameter, "
+        "not interpolated.\n"
+        "  (b) named SQL-escape: `connection.escape(v)`, `mysql_real_escape_string(v)` "
+        "— the return value is safe to interpolate.\n"
+        "  (c) identifier allowlist: `if (tableName === 'orders' || ...)` for "
+        "cases where the value is a table/column name (escapes don't help there)."
+    ),
+    "xss": (
+        "Xss validators commonly look like ONE of:\n"
+        "  (a) HTML-context escape call: `escape(v)`, `escapeHtml(v)`, "
+        "`encodeForHTML(v)`, `DOMPurify.sanitize(v)`, `bleach.clean(v)` — the "
+        "return value is safe to insert into HTML.\n"
+        "  (b) Markup wrapper: `markupsafe.escape(v)`, `Markup(v)` — wraps with "
+        "an HTML-safe marker class.\n"
+        "  (c) charset allowlist on the value's character class — narrower; "
+        "common for IDs but not for free-form HTML content."
+    ),
+    "ssrf": (
+        "Ssrf validators commonly look like ONE of:\n"
+        "  (a) host-allowlist: `allowedHosts.includes(url.hostname)` / "
+        "`url.host === 'expected.example'` — only known external hosts proceed.\n"
+        "  (b) IP-range gate (DNS-resolve + classification): "
+        "`isResolvingToUnicastOnly(host)` / `parseIP(host).range() === 'unicast'` "
+        "— filter to externally-routable IPs.  Watch for ASYNC: many shapes "
+        "are `await someCheck(host)`.\n"
+        "  (c) protocol allowlist: `url.protocol === 'https:'` — common when "
+        "the worry is `file://` / `gopher://`."
+    ),
+    "codeinjection": (
+        "Code-injection validators commonly look like ONE of:\n"
+        "  (a) charset allowlist: `/^[A-Za-z0-9_]+$/.test(name)` — only safe "
+        "identifier chars, blocks parens/dots/string-literals.\n"
+        "  (b) explicit allowlist branch: `if (action in ALLOWED_ACTIONS)` "
+        "selecting from a fixed set of safe values.\n"
+        "  (c) sandboxed evaluator wrap: `vm.runInNewContext(code, sandbox)` or "
+        "equivalent — the value flows into a restricted interpreter rather "
+        "than the host's eval."
+    ),
+}
+
+
+def _build_prompt(
+    proposal: BarrierProposal, prior_error: Optional[str],
+    refine_context: Optional[RefineContext] = None,
+) -> str:
     emit = (
         "Emit the `ProposedGuard` SanitizerGuardNode subclass recognizing the "
         "validator on this path."
@@ -538,14 +1055,68 @@ def _build_prompt(proposal: BarrierProposal, prior_error: Optional[str]) -> str:
         f"flagged sink: {proposal.sink_snippet}",
         "source (the function/path the finding flows through):",
         proposal.source_context,
-        "",
-        emit,
     ]
+    sink_hint = _SINK_CLASS_HINTS.get(proposal.sink_class)
+    if sink_hint:
+        parts += ["", "Canonical validator shapes for this sink class:",
+                  sink_hint]
+    parts += ["", emit]
     if prior_error:
         parts += [
             "",
             "Your PREVIOUS attempt failed — fix it. Error:",
             prior_error,
+        ]
+    if refine_context is not None:
+        # Skeleton-level prompt: surface the verdict + the prior QL and a
+        # one-line nudge per failure mode. Intentionally minimal — the
+        # corpus run will tell us whether richer context (e.g. flagged
+        # variable name, full SARIF snippet) moves the needle, at which
+        # point this block can grow without changing the loop's
+        # interface.
+        nudge = {
+            "suppress_fp_failed": (
+                "Your guard compiled and ran but DIDN'T suppress the "
+                "post-fix finding (the value is still flagged at the "
+                "sink). The guard is too narrow — refine it so it "
+                "ACTUALLY matches the validator on the path the value "
+                "takes."
+            ),
+            "preserve_tp_failed": (
+                "Your guard compiled and ran but ALSO killed the pre-fix "
+                "finding (the real vuln on the unsanitized code path). "
+                "The guard is too broad / matches the wrong thing — "
+                "tighten it so it only neutralises the sanitized value, "
+                "not the tainted one."
+            ),
+            "both": (
+                "Your guard compiled and ran but moved nothing — neither "
+                "suppressed the FP nor killed the TP. The guard isn't "
+                "binding on either flow. Re-examine the validator's "
+                "structure on the path."
+            ),
+        }.get(refine_context.failure_mode, "Refine the guard.")
+        parts += [
+            "",
+            f"REFINEMENT (attempt {refine_context.refine_attempt}). "
+            f"{nudge}",
+            f"Verdict: after={refine_context.after_count} "
+            f"before={refine_context.before_count} "
+            f"({refine_context.failure_mode}).",
+        ]
+        if refine_context.surviving_finding_summary:
+            # Counterexample-driven refinement: the proposer sees the
+            # SPECIFIC tainted flow that survived its guard, not just a
+            # generic "your guard was too narrow" line.  Helps the LLM
+            # target the actual validator the fix added rather than
+            # guess from the original source context.
+            parts += [
+                "Concrete counterexample (the flow your guard didn't gate):",
+                refine_context.surviving_finding_summary,
+            ]
+        parts += [
+            "Prior attempt's QL was:",
+            refine_context.prior_query_ql,
         ]
     return "\n".join(parts)
 
@@ -563,10 +1134,22 @@ def _extract_ql(reply: str) -> str:
 
 
 def make_llm_proposer(complete: Completer) -> BarrierProposer:
-    """Build a proposer backed by an LLM ``complete`` callable."""
-    def propose(proposal: BarrierProposal, prior_error: Optional[str]) -> str:
+    """Build a proposer backed by an LLM ``complete`` callable.
+
+    Accepts an optional ``refine_context`` kwarg (passed by
+    :func:`run_synthesis_loop` when ``max_refine_attempts > 0`` and a
+    prior attempt was not_sound).  Forwarded into :func:`_build_prompt`
+    so the LLM sees the prior verdict + its prior QL on refinement.
+    """
+    def propose(
+        proposal: BarrierProposal, prior_error: Optional[str],
+        refine_context: Optional[RefineContext] = None,
+    ) -> str:
         system_prompt = _SYSTEM_PROMPTS.get(proposal.language, _PY_SYSTEM_PROMPT)
-        return _extract_ql(complete(system_prompt, _build_prompt(proposal, prior_error)))
+        return _extract_ql(complete(
+            system_prompt,
+            _build_prompt(proposal, prior_error, refine_context=refine_context),
+        ))
     return propose
 
 
@@ -579,6 +1162,32 @@ def default_completer() -> Completer:
 
     def _complete(system_prompt: str, user_prompt: str) -> str:
         resp = client.generate(user_prompt, system_prompt=system_prompt)
+        text = getattr(resp, "content", None)
+        return text if text is not None else str(resp)
+
+    return _complete
+
+
+def model_completer(model_name: str) -> Completer:
+    """A Completer pinned to a specific model (e.g. ``claude-opus-4-7``), so the
+    proposer can use a strong code model rather than the auto-selected one.
+
+    ``pinned_model=model_name`` makes LLMClient build a minimal LLMConfig
+    targeted at the inferred provider only — the thinking-model
+    auto-resolution path is bypassed entirely, so its log lines never
+    fire and no operator-default model gets resolved + advertised when
+    every call here passes ``model_config=`` anyway.
+    """
+    from core.llm.client import LLMClient
+
+    client = LLMClient(pinned_model=model_name)
+    # client.config.primary_model is already the pinned + credentialed config
+    # (see _pinned_llm_config) — no further candidate-cloning needed.
+    model_config = client.config.primary_model
+
+    def _complete(system_prompt: str, user_prompt: str) -> str:
+        resp = client.generate(user_prompt, system_prompt=system_prompt,
+                               model_config=model_config)
         text = getattr(resp, "content", None)
         return text if text is not None else str(resp)
 

--- a/core/dataflow/codeql_augmented_run.py
+++ b/core/dataflow/codeql_augmented_run.py
@@ -38,6 +38,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Callable, Optional, Protocol, Sequence, Tuple
 
+from packages.codeql.tunables import CodeQLTunables
+
 
 DEFAULT_TIMEOUT_SECONDS = 600
 DEFAULT_CODEQL_BIN = "codeql"
@@ -129,6 +131,7 @@ def analyze(
         "--format=sarif-latest",
         f"--output={output_path}",
     ]
+    CodeQLTunables.from_tuning().append_to(cmd, include_disk_cache=False)
     if extension_pack is not None:
         cmd.extend(["--additional-packs", str(extension_pack)])
     cmd.extend(extra_args)

--- a/core/dataflow/cvefix_bridge.py
+++ b/core/dataflow/cvefix_bridge.py
@@ -1,0 +1,664 @@
+"""Bridge: walker FP-candidates -> barrier synthesis -> suppression rate.
+
+The walker (:mod:`cvefix_walk`) records, per CVE fix-commit, whether CodeQL still
+flags a finding on the POST-fix code (``after_count > 0``) — a candidate
+``missing_sanitizer`` false positive: the fix added a project sanitizer the
+analyzer doesn't model. This bridge turns those candidates into the sound-tier's
+headline metric. For each FP candidate it:
+
+  1. rebuilds the before/after CodeQL DBs (re-fetch fix+parent),
+  2. runs the CWE query on the post-fix DB to locate the flagged finding,
+  3. reads the flagged source + the fix diff (which contains the added sanitizer)
+     into a :class:`BarrierProposal`,
+  4. runs :func:`run_synthesis_loop` — LLM proposes a barrier, CodeQL adjudicates,
+     scoped to the finding's file so unrelated findings don't sink soundness.
+
+Aggregated into a :class:`CorpusSynthReport`. The run is resumable + crash-
+isolated: each candidate's outcome (and the synthesized sound barrier) is
+persisted to a SQLite as it completes, a crashing candidate is recorded as an
+error and the run continues, and a restart skips finished candidates. DBs are
+built one pair at a time and removed after, so disk stays bounded. The proposer
+is injectable so the orchestration is unit-testable with no LLM and no CodeQL.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import shutil
+import sqlite3
+import subprocess
+import time
+from collections import Counter
+from pathlib import Path
+from typing import Optional, Sequence, Tuple
+
+from core.config import RaptorConfig
+from core.dataflow import cvefix_walk
+from core.dataflow.barrier_synth import (
+    BarrierProposal,
+    CorpusSynthReport,
+    default_completer,
+    make_llm_proposer,
+    model_completer,
+    render_corpus_report,
+    run_synthesis_loop,
+)
+from core.dataflow.cvefix_loader import CveFixPair
+
+# Tier 0 (SMT) is the free first-pass backend. Imported defensively so a
+# missing substrate / packaging glitch can't break the existing Tier 2
+# pipeline — on ImportError we just don't try Tier 0.  The module itself
+# handles z3 absent via its own gate; this guard is for the module-load
+# failure case only.
+try:
+    from core.dataflow.smt_barrier import Tier0Status, try_tier0
+    _TIER0_AVAILABLE = True
+except ImportError:                                  # pragma: no cover
+    _TIER0_AVAILABLE = False
+    Tier0Status = None                                # type: ignore[assignment]
+    try_tier0 = None                                  # type: ignore[assignment]
+
+# Tier 1B (LLM-assisted) is the middle backend — cheap-model extraction +
+# mechanical adjudication.  Imported defensively for the same reason.
+try:
+    from core.dataflow.tier1_llm import try_tier1b
+    _TIER1B_AVAILABLE = True
+except ImportError:                                  # pragma: no cover
+    _TIER1B_AVAILABLE = False
+    try_tier1b = None                                 # type: ignore[assignment]
+
+DEFAULT_CODEQL_BIN = cvefix_walk.DEFAULT_CODEQL_BIN
+
+# CWE -> barrier_synth sink_class.
+#
+# ``codeinjection`` and ``ssrf`` have no entry in
+# :data:`smt_barrier._DANGER_CHARS` at this writing — both fix patterns sit
+# outside the char-class danger model.  :func:`prove_neutralizes` returns
+# "no danger model" → Tier 0 DECLINED → Tier 2 takes over with the full
+# LLM + CodeQL machinery.  Tier 1B's known-safe-call table also has no
+# entries for these classes, so its ``library`` backend declines too —
+# the LLM-extractor characterisation lands on Tier 2.
+_CWE_SINK = {"CWE-78": "cmdi", "CWE-89": "sqli", "CWE-79": "xss", "CWE-22": "pathtrav",
+             "CWE-94": "codeinjection", "CWE-918": "ssrf"}
+
+# Couldn't reach (or complete) adjudication — excluded from the rate denominator.
+_PIPELINE_ERRORS = {"no_query", "fetch_fail", "build_fail", "analyze_fail",
+                    "no_finding", "error"}
+
+# Source the LLM reasons over. The fix-added sanitizer is usually upstream of the
+# sink (or in a helper), so give the whole file when small, else a window — plus
+# the fix diff, which literally contains the sanitizer the fix added.
+_SMALL_FILE = 400
+_WINDOW = 60
+_DIFF_CAP = 200
+# Caps for the cross-file fix-diff context (other touched files beyond the
+# sink file).  Per-file cap keeps a single huge refactor commit from
+# dominating; total cap keeps the prompt within LLM context budget even on
+# fixes that touch many files.  Conservative — the typical sanitizer fix
+# touches 1-3 files and the validator chunk is small.
+_OTHER_DIFF_PER_FILE_CAP = 120
+_OTHER_DIFF_TOTAL_CAP = 500
+
+# Test-file path heuristic: files matching these patterns are excluded from
+# the cross-file fix-diff context.  Test files almost never contain the
+# sanitizer (they exercise the validated entry-point), and feeding the LLM
+# test scaffolding crowds out the real validator code with noise.
+# Conservative breadth — a missed test exclusion just adds noise; a wrong
+# exclusion of a non-test file would lose the validator entirely.
+#
+# NB: this filter is applied ONLY to OTHER files; the sink file itself is
+# fed unconditionally by the existing _git_diff call, so a sink that lives
+# in a test dir (CodeQL flagging a test mock as a sink) is still seen.
+_TEST_PATH_RE = re.compile(
+    # directory components named test/tests/spec/specs/__tests__/__test__
+    r"(?:^|/)(?:tests?|specs?|__tests?__)/"
+    # python: test_<name>.py at file head
+    r"|(?:^|/)test_[^/]+\.py$"
+    # foo_test.<ext> / foo_spec.<ext> by extension
+    r"|_test\.(?:go|py|rb|js|ts|jsx|tsx|java)$"
+    r"|_spec\.(?:rb|py|js|ts|jsx|tsx)$"
+    # JS/TS double-dot convention: foo.test.ts / foo.spec.tsx
+    r"|\.test\.[jt]sx?$"
+    r"|\.spec\.[jt]sx?$"
+    # Java conventions: TestX.java / XTest.java / XTests.java in any dir
+    r"|(?:^|/)Test[A-Z][^/]*\.java$"
+    r"|(?:^|/)[^/]+Tests?\.java$"
+)
+
+
+def _is_test_path(path: str) -> bool:
+    """True iff ``path`` looks like a test/spec file under common
+    conventions across the languages the walk targets (Python/JS/TS/
+    Ruby/Java/Go).  See :data:`_TEST_PATH_RE` for the exact patterns."""
+    return _TEST_PATH_RE.search(path) is not None
+
+# CodeQL query-pack search path so the synthesized barrier's qlpack dep
+# (codeql/<lang>-all) resolves at adjudication for ruby/java/python alike.
+_SEARCH_PATH = Path.home() / ".local" / "codeql-queries"
+
+_SCHEMA = (
+    "CREATE TABLE IF NOT EXISTS synth_results ("
+    "fix_hash TEXT, cwe TEXT, cve_id TEXT, repo_language TEXT, finding_id TEXT,"
+    "status TEXT, backend TEXT, barrier_query TEXT, detail TEXT, ts REAL,"
+    " PRIMARY KEY (fix_hash, cwe))"
+)
+
+# Which backend produced the verdict — labelled by the soundness
+# mechanism, not the routing tier (those tier names are internal jargon
+# and meaningless in an audit trail):
+#
+#   "smt"     -- Z3 regex-intersection proof over the validator's
+#                language and the sink-class danger language.  Spec
+#                may have been extracted mechanically (the original
+#                charset extractor) or LLM-assisted (an LLM pointed at
+#                the source line, then mechanical cross-check + Z3).
+#                Either way the soundness mechanism is identical.
+#   "library" -- Match against the curated known-safe-library table
+#                (core.dataflow.known_safe_calls).  Soundness rests on
+#                the per-entry human-verified semantic claim.
+#   "codeql"  -- LLM-proposed CodeQL barrier-guard, adjudicated by
+#                running the guard on both pre- and post-fix DBs.
+#   ""        -- pipeline error before any backend reached a verdict.
+_BACKEND_SMT = "smt"
+_BACKEND_LIBRARY = "library"
+_BACKEND_CODEQL = "codeql"
+_BACKEND_NONE = ""
+
+
+def _default_search_path() -> Optional[str]:
+    return str(_SEARCH_PATH) if _SEARCH_PATH.exists() else None
+
+
+def _norm_uri(uri: str) -> str:
+    """Strip a file: scheme + leading slash so `repo_root / uri` stays in-repo."""
+    if uri.startswith("file://"):
+        uri = uri[len("file://"):]
+    elif uri.startswith("file:"):
+        uri = uri[len("file:"):]
+    return uri.lstrip("/")
+
+
+def _git_diff(repo: Path, parent: str, fix: str, uri: str,
+              *, cap: int = _DIFF_CAP, timeout: int = 60) -> str:
+    """`git diff parent..fix -- <uri>` (the change that added the sanitizer),
+    capped; empty string on any failure."""
+    try:
+        r = subprocess.run(
+            ["git", "-C", str(repo), "diff", f"{parent}..{fix}", "--", uri],
+            capture_output=True, text=True, timeout=timeout, check=False,
+            env=RaptorConfig.get_safe_env())
+    except (subprocess.TimeoutExpired, OSError):
+        return ""
+    if r.returncode != 0:
+        return ""
+    return "\n".join(r.stdout.splitlines()[:cap])
+
+
+def _git_touched_files(repo: Path, parent: str, fix: str,
+                       *, timeout: int = 30) -> list:
+    """`git diff --name-only parent..fix` — every path the fix changed.
+    Returns ``[]`` on failure (caller falls back to sink-file-only context)."""
+    try:
+        r = subprocess.run(
+            ["git", "-C", str(repo), "diff", "--name-only", f"{parent}..{fix}"],
+            capture_output=True, text=True, timeout=timeout, check=False,
+            env=RaptorConfig.get_safe_env())
+    except (subprocess.TimeoutExpired, OSError):
+        return []
+    if r.returncode != 0:
+        return []
+    return [ln for ln in r.stdout.splitlines() if ln.strip()]
+
+
+def _git_diff_other_files(
+    repo: Path, parent: str, fix: str, sink_uri: str,
+    *, per_file_cap: int = _OTHER_DIFF_PER_FILE_CAP,
+    total_cap: int = _OTHER_DIFF_TOTAL_CAP, timeout: int = 60,
+) -> str:
+    """Cross-file fix-diff context.  Returns concatenated, capped diffs of
+    every non-test fix-touched file EXCEPT the sink file (which is already
+    fed via :func:`_git_diff`).  Empty string when no qualifying file
+    exists or the lookup fails.
+
+    Why this exists: many fixes add the validator in a different file
+    from the sink (the canonical archetype: a new ``helpers/dns.ts``
+    plus a call-site change in ``middlewares/.../video-imports.ts``,
+    while CodeQL flags ``mock-object-storage.ts`` as the sink).  Without
+    cross-file diffs the proposer sees only the SINK file's empty diff
+    and either gives up (``none()``) or hallucinates a plausible-looking
+    guard.  Verified on peertube CVE-2022-0132/0508 — both cases'
+    validators live in files distinct from the sink.
+
+    Test-file exclusion is policy: test scaffolding rarely contains
+    the validator and crowds out the real fix code under the LLM's
+    context budget.  See :func:`_is_test_path`.
+
+    Caps are conservative: per-file cap stops a single huge refactor
+    from dominating; total cap protects the LLM context budget on
+    fixes that touch many files.  Both are soft limits — when hit we
+    truncate the current chunk and stop adding files.
+    """
+    files = _git_touched_files(repo, parent, fix, timeout=timeout)
+    if not files:
+        return ""
+    sink_norm = _norm_uri(sink_uri)
+    chunks: list = []
+    total = 0
+    for path in files:
+        if path == sink_norm or _is_test_path(path):
+            continue
+        diff = _git_diff(repo, parent, fix, path, cap=per_file_cap,
+                         timeout=timeout)
+        if not diff:
+            continue
+        # Header so the LLM can tell which file each chunk belongs to —
+        # `git diff` itself includes a `diff --git a/X b/X` header, but
+        # an explicit ``# file: X`` line is more LLM-legible and matches
+        # the existing ``# fix diff (...):`` framing.
+        header = f"# file: {path}"
+        budget = total_cap - total
+        if budget <= 0:
+            break
+        body_lines = diff.splitlines()
+        if len(body_lines) > budget:
+            body_lines = body_lines[:budget]
+            body_lines.append(f"... [truncated; per-file cap {per_file_cap} "
+                              f"or total cap {total_cap} hit]")
+        chunk = header + "\n" + "\n".join(body_lines)
+        chunks.append(chunk)
+        total += len(body_lines) + 1
+        if total >= total_cap:
+            break
+    return "\n\n".join(chunks)
+
+
+def _format_path(result: dict) -> str:
+    """Format the source->sink dataflow path from a path-problem SARIF result's
+    codeFlows. Gives the proposer the EXACT tainted flow — which value reaches the
+    sink — so it protects that value instead of guessing from a text window."""
+    cfs = result.get("codeFlows", [])
+    if not cfs:
+        return ""
+    steps = cfs[0].get("threadFlows", [{}])[0].get("locations", [])
+    rows = []
+    for loc in steps:
+        node = loc.get("location", {})
+        phys = node.get("physicalLocation", {})
+        uri = phys.get("artifactLocation", {}).get("uri", "?")
+        line = phys.get("region", {}).get("startLine", "?")
+        msg = node.get("message", {}).get("text", "")
+        rows.append(f"  {Path(uri).name}:{line}  {msg}")
+    if not rows:
+        return ""
+    return ("# tainted dataflow path (source at top -> sink at bottom); the barrier "
+            "must neutralize the value that reaches the sink:\n" + "\n".join(rows))
+
+
+def _run_query(db: Path, query_spec: str, out_sarif: Path, codeql_bin: str, timeout: int) -> bool:
+    return cvefix_walk._run(
+        [codeql_bin, "database", "analyze", str(db), query_spec,
+         "--format=sarif-latest", f"--output={out_sarif}"], timeout)
+
+
+def _extract_proposal(
+    sarif_path: Path, repo_root: Path, pair: CveFixPair,
+) -> Optional[Tuple[BarrierProposal, str, int]]:
+    """First flagged finding -> (BarrierProposal, target_uri, target_line). Reads
+    the post-fix source at the SARIF location (CodeQL SARIF omits snippet text)
+    and the fix diff. ``target_uri``/``target_line`` scope the suppress check to
+    this specific finding."""
+    sink_class = _CWE_SINK.get(pair.cwe)
+    if sink_class is None:
+        return None
+    try:
+        data = json.loads(Path(sarif_path).read_text())
+    except (OSError, ValueError):
+        return None
+    for run in data.get("runs", []):
+        for res in run.get("results", []):
+            for loc in res.get("locations", []):
+                phys = loc.get("physicalLocation", {})
+                raw_uri = phys.get("artifactLocation", {}).get("uri")
+                line = phys.get("region", {}).get("startLine")
+                if not raw_uri or not line:
+                    continue
+                src = repo_root / _norm_uri(raw_uri)
+                if not src.is_file():
+                    continue
+                lines = src.read_text(errors="replace").splitlines()
+                snippet = lines[line - 1].strip() if 0 < line <= len(lines) else raw_uri
+                if len(lines) <= _SMALL_FILE:
+                    body = "\n".join(lines)
+                else:
+                    lo = max(0, line - 1 - _WINDOW)
+                    body = "\n".join(lines[lo:line - 1 + _WINDOW])
+                diff = _git_diff(repo_root, pair.parent_hash, pair.fix_hash, _norm_uri(raw_uri))
+                # Cross-file fix-diff context: other non-test fix-touched
+                # files often contain the validator the fix added (the sink
+                # file's own diff is frequently empty when the validator
+                # lives in a helper or middleware).  Without this, the
+                # proposer hallucinates plausible-looking guards on shapes
+                # it has no source for.
+                other_diffs = _git_diff_other_files(
+                    repo_root, pair.parent_hash, pair.fix_hash, raw_uri)
+                path = _format_path(res)
+                context = body
+                if diff:
+                    context += "\n\n# fix diff (the change that added the sanitizer):\n" + diff
+                if other_diffs:
+                    context += ("\n\n# other fix-touched files (the validator "
+                                "may live in a helper or middleware):\n"
+                                + other_diffs)
+                if path:
+                    context += "\n\n" + path
+                proposal = BarrierProposal(
+                    sink_class=sink_class,
+                    finding_id=f"{pair.cve_id}:{pair.cwe}:{Path(raw_uri).name}:{line}",
+                    sink_snippet=snippet, source_context=context,
+                    language=cvefix_walk._codeql_lang(pair.repo_language),
+                )
+                return (proposal, raw_uri, line)
+    return None
+
+
+def synthesize_one(
+    pair: CveFixPair, *, work_dir: Path, proposer, status: str = "ok",
+    codeql_bin: str = DEFAULT_CODEQL_BIN, search_path: Optional[str] = None,
+    # Higher than the walker's 240s/180s defaults: the synth bridge does
+    # ONE pair end-to-end so a single project's pathological extraction
+    # blocks no other work — better to be patient and get a verdict than
+    # time out and lose the case to a pipeline_error.  PeerTube
+    # (1824 .ts files, 93MB) extracted in ~3-4 min on a quiet box; under
+    # any background load the walker-tier 240s ran out, producing
+    # spurious build_fail/analyze_fail.  Walks stay at the lower
+    # defaults — corpus is bigger and an occasional build_fail is
+    # acceptable noise there.
+    fetch_timeout: int = 150, build_timeout: int = 600, analyze_timeout: int = 450,
+    max_attempts: int = 3, max_refine_attempts: int = 0,
+    tier1b_complete=None,
+) -> Tuple[str, Optional[str], str, Optional[str], str]:
+    """Rebuild DBs, extract the finding, synthesize a barrier.
+
+    Returns ``(status, finding_id, backend, barrier_query, detail)``.
+
+    Two backends, tried in cost order:
+
+      Tier 0 — SMT (free).  Mechanical extractor pulls a charset/regex
+        validator from the fix diff; CodeQL's own codeFlow gives free
+        dominance evidence; Z3 proves the validator's language and the
+        sink's danger language don't intersect.  No LLM tokens, no
+        before-DB build.  When SOUND, ``backend="smt"`` and ``barrier_query``
+        holds a structured spec like ``smt:charset:[A-Za-z0-9_.+-]+@uri:line``.
+
+      Tier 2 — CodeQL barrier-guard (LLM-written, CodeQL-adjudicated).
+        Fall-through when Tier 0 declines / can't apply.  When SOUND,
+        ``backend="codeql"`` and ``barrier_query`` holds the compiled QL.
+
+    ``barrier_query`` is also kept for not_sound at Tier 2 (the proposal
+    that compiled+ran but missed — diagnostic material for the few-shot).
+    ``detail`` records WHY a non-success happened (assembly/compile error
+    for ``no_barrier``; which soundness check failed for ``not_sound``).
+    ``status`` (the walker row's status) picks the build mode — an
+    ``ok_built`` Java row was found via autobuild, so it must be rebuilt
+    the same way (buildless would lose the finding).  DBs are removed
+    before returning.
+    """
+    query = cvefix_walk.query_for(pair.repo_language, pair.cwe)
+    if query is None:
+        return ("no_query", None, _BACKEND_NONE, None, "")
+    lang = cvefix_walk._codeql_lang(pair.repo_language)
+    if lang in cvefix_walk._BUILDLESS_COMPILED:
+        mode = "autobuild" if status == "ok_built" else "none"
+    else:
+        mode = None
+    repo, after_db, before_db = work_dir / "repo", work_dir / "after", work_dir / "before"
+    sarif, synth = work_dir / "after.sarif", work_dir / "synth"
+    try:
+        if not cvefix_walk._fetch_pair(pair.repo_url, pair.fix_hash, repo, fetch_timeout):
+            return ("fetch_fail", None, _BACKEND_NONE, None, "")
+        # Build the post-fix DB first; the repo is then at the fix commit, so the
+        # source we read for the proposal contains the (unmodeled) sanitizer.
+        if not cvefix_walk._build_db(repo, pair.fix_hash, after_db, lang, codeql_bin, build_timeout, mode):
+            return ("build_fail", None, _BACKEND_NONE, None, "")
+        if not _run_query(after_db, query, sarif, codeql_bin, analyze_timeout):
+            return ("analyze_fail", None, _BACKEND_NONE, None, "")
+        extracted = _extract_proposal(sarif, repo, pair)
+        if extracted is None:
+            return ("no_finding", None, _BACKEND_NONE, None, "")
+        proposal, target_uri, target_line = extracted
+
+        # Tier 0: free SMT verdict.  Defensive try/except so a bug here can
+        # never break the existing Tier 2 pipeline — on any unexpected
+        # failure we just fall through.  Module-level _TIER0_AVAILABLE
+        # guards against a substrate-missing edge case.  Post-audit:
+        # the dominance check is now AST-based (source-order + exit-on-
+        # fail in the same function), no longer SARIF-codeFlow, so we
+        # don't need to re-load the SARIF result here.
+        if _TIER0_AVAILABLE:
+            sink_class = _CWE_SINK.get(pair.cwe)
+            if sink_class is not None:
+                fix_diff = _git_diff(
+                    repo, pair.parent_hash, pair.fix_hash, _norm_uri(target_uri))
+                if fix_diff:
+                    try:
+                        t0 = try_tier0(
+                            fix_diff=fix_diff, repo_root=repo,
+                            sink_uri=_norm_uri(target_uri),
+                            sink_line=target_line, sink_class=sink_class,
+                            language=lang)
+                    except Exception:                        # pragma: no cover
+                        t0 = None
+                    if t0 is not None and t0.status == Tier0Status.SOUND:
+                        return ("sound", proposal.finding_id, _BACKEND_SMT,
+                                t0.artifact, t0.reasoning[:400])
+
+        # Tier 1B: cheap-LLM-assisted extraction + mechanical adjudication.
+        # Runs only when Tier 0 didn't already produce SOUND.  Same
+        # defensive shape — any failure falls through to Tier 2.  Requires
+        # a completer (passed by ``synthesize_from_results``) — if absent,
+        # Tier 1B is skipped (no automatic default to avoid baking a
+        # model choice into a per-call code path).
+        if _TIER1B_AVAILABLE and tier1b_complete is not None:
+            sink_class = _CWE_SINK.get(pair.cwe)
+            if sink_class is not None:
+                fix_diff = _git_diff(
+                    repo, pair.parent_hash, pair.fix_hash, _norm_uri(target_uri))
+                if fix_diff:
+                    try:
+                        t1 = try_tier1b(
+                            fix_diff=fix_diff, repo_root=repo,
+                            sink_uri=_norm_uri(target_uri),
+                            sink_line=target_line, sink_class=sink_class,
+                            language=lang, complete=tier1b_complete)
+                    except Exception:                        # pragma: no cover
+                        t1 = None
+                    if t1 is not None and t1.status == Tier0Status.SOUND:
+                        # Backend = the proof mechanism that produced the
+                        # verdict.  Z3-charset path emits ``smt:...`` (same
+                        # mechanism as Tier 0).  Curated-table path emits
+                        # ``library:...``.
+                        artifact = t1.artifact or ""
+                        if artifact.startswith("library:"):
+                            backend = _BACKEND_LIBRARY
+                        else:
+                            backend = _BACKEND_SMT
+                        return ("sound", proposal.finding_id, backend,
+                                artifact, t1.reasoning[:400])
+
+        if not cvefix_walk._build_db(repo, pair.parent_hash, before_db, lang, codeql_bin, build_timeout, mode):
+            return ("build_fail", proposal.finding_id, _BACKEND_NONE, None, "")
+        diag: dict = {}
+        res = run_synthesis_loop(
+            proposal, after_db, before_db, proposer=proposer, work_dir=synth,
+            search_path=search_path, target_uri=target_uri, target_line=target_line,
+            codeql_bin=codeql_bin, max_attempts=max_attempts,
+            max_refine_attempts=max_refine_attempts, diag=diag)
+        if res is None:
+            return ("no_barrier", proposal.finding_id, _BACKEND_CODEQL, None,
+                    (diag.get("last_error") or "")[:400])
+        if res.is_sound:
+            return ("sound", proposal.finding_id, _BACKEND_CODEQL, res.query_ql, "")
+        reasons = []
+        if not res.suppressed_fp:
+            reasons.append(f"suppress_fp_failed(after={res.after_count})")
+        if not res.preserved_tp:
+            reasons.append(f"preserve_tp_failed(before={res.before_count})")
+        # Keep the proposed query for not_sound too — it compiled + ran but missed,
+        # so it's the diagnostic material for improving the proposer's few-shot.
+        return ("not_sound", proposal.finding_id, _BACKEND_CODEQL, res.query_ql,
+                "; ".join(reasons))
+    finally:
+        for p in (repo, after_db, before_db, synth, sarif):
+            shutil.rmtree(p, ignore_errors=True) if p.is_dir() else p.unlink(missing_ok=True)
+
+
+def _aggregate(syn: sqlite3.Connection) -> Tuple[CorpusSynthReport, dict]:
+    sound = not_sound = no_barrier = 0
+    per: list = []
+    errors: Counter = Counter()
+    for status, fid in syn.execute("SELECT status, finding_id FROM synth_results"):
+        if status in _PIPELINE_ERRORS:
+            errors[status] += 1
+            continue
+        per.append((fid, status))
+        if status == "sound":
+            sound += 1
+        elif status == "not_sound":
+            not_sound += 1
+        else:
+            no_barrier += 1
+    report = CorpusSynthReport(total=len(per), sound=sound, not_sound=not_sound,
+                               no_barrier=no_barrier, per_finding=tuple(per))
+    return report, dict(errors)
+
+
+def synthesize_from_results(
+    results_db: Path, *,
+    synth_db: Path = Path("/data/corpus/synth-results.db"),
+    work_dir: Path = Path("/data/corpus/clones/bridge"),
+    proposer=None,
+    model: Optional[str] = None,
+    tier1b_model: Optional[str] = None,
+    codeql_bin: str = DEFAULT_CODEQL_BIN,
+    search_path: Optional[str] = None,
+    languages: Optional[Sequence[str]] = None,
+    limit: Optional[int] = None,
+    max_attempts: int = 3,
+    max_refine_attempts: int = 0,
+    newest_first: bool = False,
+    log=print,
+) -> CorpusSynthReport:
+    """Synthesize a barrier for every FP candidate (after_count>0) in the walker
+    results — resumable + crash-isolated, persisting each outcome to ``synth_db``.
+    ``model`` pins the proposer's LLM; default None defers to RAPTOR's LLM config
+    (its configured/auto-selected model). Operators override per-run, e.g.
+    ``--model claude-opus-4-8``. ``newest_first`` orders by CVE id descending
+    (recent, modern-framework code first) rather than the oldest tail. Returns
+    the aggregate CorpusSynthReport."""
+    if proposer is None:
+        completer = model_completer(model) if model else default_completer()
+        proposer = make_llm_proposer(completer)
+    # Tier 1B uses a separately-pinned cheap-model completer.  Without
+    # ``tier1b_model``, Tier 1B is skipped (the call to model_completer
+    # would otherwise resolve to the operator's default LLM, which is
+    # what the proposer already uses — opting Tier 1B in implicitly is
+    # a per-run cost the operator should make explicit).
+    tier1b_completer = model_completer(tier1b_model) if tier1b_model else None
+    if search_path is None:
+        search_path = _default_search_path()
+    con = sqlite3.connect(f"file:{results_db}?mode=ro", uri=True)
+    sql = ("SELECT fix_hash, cve_id, cwe, repo_language, repo_url, parent_hash, status "
+           "FROM walk_results WHERE status IN ('ok','ok_built') AND after_count>0")
+    params: tuple = ()
+    if languages:
+        sql += f" AND repo_language IN ({','.join('?' * len(languages))})"
+        params = tuple(languages)
+    sql += " ORDER BY cve_id DESC" if newest_first else " ORDER BY cve_id"
+    rows = con.execute(sql, params).fetchall()
+    con.close()
+
+    syn = sqlite3.connect(str(synth_db))
+    syn.execute(_SCHEMA)
+    done = {(r[0], r[1]) for r in syn.execute("SELECT fix_hash, cwe FROM synth_results")}
+    todo = [r for r in rows if (r[0], r[2]) not in done]
+    log(f"bridge: {len(rows)} FP-candidates, {len(done)} already done, {len(todo)} to do")
+    work_dir.mkdir(parents=True, exist_ok=True)
+    n = 0
+    for fix_hash, cve_id, cwe, lang, repo_url, parent_hash, row_status in todo:
+        if limit is not None and n >= limit:
+            break
+        n += 1
+        pair = CveFixPair(cve_id, cwe, repo_url, lang, fix_hash, parent_hash)
+        try:
+            status, fid, backend, barrier_q, detail = synthesize_one(
+                pair, work_dir=work_dir / "item", proposer=proposer, status=row_status,
+                codeql_bin=codeql_bin, search_path=search_path,
+                max_attempts=max_attempts,
+                max_refine_attempts=max_refine_attempts,
+                tier1b_complete=tier1b_completer)
+        except Exception as exc:  # one bad candidate must not abort the whole run
+            status, fid, backend, barrier_q, detail = (
+                "error", None, _BACKEND_NONE, None,
+                f"{type(exc).__name__}: {exc}"[:400])
+            log(f"  [{n}/{len(todo)}] {cve_id} {cwe}: ERROR {type(exc).__name__}: {exc}")
+        syn.execute("INSERT OR REPLACE INTO synth_results VALUES (?,?,?,?,?,?,?,?,?,?)",
+                    (fix_hash, cwe, cve_id, lang, fid, status, backend, barrier_q,
+                     detail, time.time()))
+        syn.commit()
+        if status not in ("error",):
+            suffix = f"  [{detail}]" if detail else ""
+            tag = f"({backend})" if backend else ""
+            log(f"  [{n}/{len(todo)}] {cve_id} {cwe} {lang}: {status}{tag}{suffix}")
+    report, errors = _aggregate(syn)
+    syn.close()
+    if errors:
+        log(f"pipeline errors (excluded from rate): {errors}")
+    return report
+
+
+def main(argv=None) -> None:
+    import argparse
+
+    ap = argparse.ArgumentParser(description="Synthesize barriers over walker FP-candidates.")
+    ap.add_argument("--results", type=Path, default=Path("/data/corpus/walk-results.db"))
+    ap.add_argument("--synth-db", type=Path, default=Path("/data/corpus/synth-results.db"))
+    ap.add_argument("--work-dir", type=Path, default=Path("/data/corpus/clones/bridge"))
+    ap.add_argument("--search-path", default=None,
+                    help="codeql query-pack search path (default: ~/.local/codeql-queries)")
+    ap.add_argument("--model", default=None,
+                    help="override the proposer LLM (e.g. claude-opus-4-8); "
+                         "default defers to RAPTOR's LLM config")
+    ap.add_argument("--llm-extract-model", default=None,
+                    help="enable the LLM-assisted extraction layer "
+                         "(adjudicated by Z3 or the curated known-safe "
+                         "library table). Picks a cheap model "
+                         "(e.g. claude-haiku-4-5). Default off — without "
+                         "this flag only the mechanical extractor and "
+                         "the proposer LLM are used")
+    ap.add_argument("--languages", nargs="+", default=None)
+    ap.add_argument("--codeql-bin", default=DEFAULT_CODEQL_BIN)
+    ap.add_argument("--max-attempts", type=int, default=3,
+                    help="compile-retry budget per refinement cycle (default 3)")
+    ap.add_argument("--max-refine-attempts", type=int, default=0,
+                    help="soundness-refinement budget (default 0 = no refinement). "
+                         "When >0, a successful-but-not-sound barrier feeds its "
+                         "verdict back to the proposer for another full compile-and-"
+                         "adjudicate cycle; bounded by this budget")
+    ap.add_argument("--limit", type=int, default=None)
+    ap.add_argument("--newest-first", action="store_true",
+                    help="process recent CVEs first (modern code) instead of the oldest tail")
+    a = ap.parse_args(argv)
+    report = synthesize_from_results(
+        a.results, synth_db=a.synth_db, work_dir=a.work_dir, codeql_bin=a.codeql_bin,
+        search_path=a.search_path, model=a.model,
+        tier1b_model=a.llm_extract_model,
+        languages=a.languages, limit=a.limit,
+        max_attempts=a.max_attempts, max_refine_attempts=a.max_refine_attempts,
+        newest_first=a.newest_first,
+        log=lambda m: print(m, flush=True))
+    print(render_corpus_report(report), flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/core/dataflow/cvefix_loader.py
+++ b/core/dataflow/cvefix_loader.py
@@ -30,7 +30,13 @@ CODEQL_LANGUAGES = (
 )
 
 # Injection CWEs the trust sound-tier targets.
-INJECTION_CWES = ("CWE-89", "CWE-78", "CWE-79", "CWE-22")
+#
+# CWE-94 (code injection) and CWE-918 (SSRF) added 2026-05-30 to extend the
+# walk corpus.  CWE-94 has a Tier-2-shaped fix pattern (charset / allowlist
+# strip before eval/exec); CWE-918 is allowlist-on-URL-host shape, only
+# Tier 2 viable.  CWE-611/352 omitted — their fixes are parser-config /
+# middleware shape, not value-barrier shape.
+INJECTION_CWES = ("CWE-89", "CWE-78", "CWE-79", "CWE-22", "CWE-94", "CWE-918")
 
 
 @dataclass(frozen=True)

--- a/core/dataflow/cvefix_walk.py
+++ b/core/dataflow/cvefix_walk.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 import os
 import shutil
 import sqlite3
+import stat
 import subprocess
 import time
 from dataclasses import dataclass
@@ -40,6 +41,67 @@ _MAVEN_PROXY_HOSTS = [
     "central.sonatype.com", "oss.sonatype.org", "maven.google.com", "dl.google.com",
 ]
 
+# Go module proxies the Go autobuilder fetches from.  Restricted to the
+# canonical Google-controlled chain:
+#
+#   * ``proxy.golang.org``      — module-info / version-list endpoint.
+#   * ``sum.golang.org``        — the Go checksum DB.
+#   * ``storage.googleapis.com`` — backs the proxy's ``.zip`` downloads.
+#     Without it 114 of 221 egress denials in the first Go walk were GCS;
+#     every module download failed at the content step even though the
+#     metadata fetch passed.
+#
+# Third-party mirrors (``goproxy.cn``, ``goproxy.io``) and the defunct
+# ``code.google.com`` are deliberately excluded — allowlisting them
+# expands trust surface to mirrors we don't control for a marginal yield
+# bump.  Projects pinning a third-party mirror just hit build_fail
+# under our sandbox; that's acceptable for a measurement corpus.
+#
+# Fail-mode is graceful: a build needing a non-allowlisted host gets
+# blocked → build_fail is recorded, the walker moves on.
+_GO_PROXY_HOSTS = [
+    "proxy.golang.org", "sum.golang.org",
+    "storage.googleapis.com",
+]
+
+
+# Per-language autobuild profile: which egress hosts to allowlist and what
+# env vars to inject so the build never writes to host config locations
+# (~/.m2, ~/go, etc.).  Keeping these together makes adding a new compiled
+# language a single profile entry rather than scattered conditionals in
+# the sandbox runner.
+def _java_autobuild_env(work_root: Path) -> dict:
+    return {"MAVEN_OPTS": f"-Dmaven.repo.local={work_root / '.m2'}"}
+
+
+def _go_autobuild_env(work_root: Path) -> dict:
+    """Redirect every Go cache + path into the work area so the sandboxed
+    build doesn't escape Landlock's allow-write set.  THREE Go state
+    locations matter — missing any one causes a permission-denied build
+    fail with no actionable signal:
+
+      * ``GOMODCACHE`` — downloaded module artifacts (was caught first).
+      * ``GOPATH`` — legacy package dir (some tools still write here).
+      * ``GOCACHE`` — the build cache; Go ALWAYS writes here regardless
+        of module mode.  Default ``$HOME/.cache/go-build`` is outside
+        the sandbox's writable set and silently fails 100% of builds.
+
+    ``GOFLAGS=-mod=mod`` allows the build to download missing modules
+    (default ``-mod=readonly`` would fail-closed without a go.sum hit).
+    """
+    return {
+        "GOMODCACHE": str(work_root / "go-mod-cache"),
+        "GOPATH": str(work_root / "gopath"),
+        "GOCACHE": str(work_root / "go-build-cache"),
+        "GOFLAGS": "-mod=mod",
+    }
+
+
+_AUTOBUILD_PROFILES = {
+    "java": (_MAVEN_PROXY_HOSTS, _java_autobuild_env),
+    "go":   (_GO_PROXY_HOSTS,   _go_autobuild_env),
+}
+
 # codeql extractor language -> (queries pack, {cwe: pack-relative query path}).
 # Ruby uses a different path scheme (lowercase queries/security/cwe-0XX) and query
 # names (ReflectedXSS, not ReflectedXss; PathInjection, not TaintedPath).
@@ -49,36 +111,68 @@ _QUERIES = {
         "CWE-78": "Security/CWE-078/CommandInjection.ql",
         "CWE-79": "Security/CWE-079/ReflectedXss.ql",
         "CWE-22": "Security/CWE-022/PathInjection.ql",
+        "CWE-94": "Security/CWE-094/CodeInjection.ql",
+        "CWE-918": "Security/CWE-918/FullServerSideRequestForgery.ql",
     }),
     "javascript": ("javascript-queries", {
         "CWE-89": "Security/CWE-089/SqlInjection.ql",
         "CWE-78": "Security/CWE-078/CommandInjection.ql",
         "CWE-79": "Security/CWE-079/ReflectedXss.ql",
         "CWE-22": "Security/CWE-022/TaintedPath.ql",
+        "CWE-94": "Security/CWE-094/CodeInjection.ql",
+        "CWE-918": "Security/CWE-918/RequestForgery.ql",
     }),
     "ruby": ("ruby-queries", {
         "CWE-89": "queries/security/cwe-089/SqlInjection.ql",
         "CWE-78": "queries/security/cwe-078/CommandInjection.ql",
         "CWE-79": "queries/security/cwe-079/ReflectedXSS.ql",
         "CWE-22": "queries/security/cwe-022/PathInjection.ql",
+        "CWE-94": "queries/security/cwe-094/CodeInjection.ql",
+        "CWE-918": "queries/security/cwe-918/ServerSideRequestForgery.ql",
     }),
     "java": ("java-queries", {
         "CWE-89": "Security/CWE/CWE-089/SqlTainted.ql",
         "CWE-78": "Security/CWE/CWE-078/ExecTainted.ql",
         "CWE-79": "Security/CWE/CWE-079/XSS.ql",
         "CWE-22": "Security/CWE/CWE-022/TaintedPath.ql",
+        # CWE-94 omitted for Java: the standard pack has no generic
+        # CodeInjection.ql; the framework-specific alternatives (SpEL,
+        # MVEL, Groovy, JEXL, Template) are too narrow for a broad walk
+        # and would silently miss most real Java code-injection fixes.
+        "CWE-918": "Security/CWE/CWE-918/RequestForgery.ql",
+    }),
+    "go": ("go-queries", {
+        # SQL injection: two query files in the Go pack — ``SqlInjection.ql``
+        # (the canonical taint query) and ``StringBreak.ql`` (a narrower
+        # string-literal break check).  Use the canonical one to match the
+        # other languages' shape.
+        "CWE-89": "Security/CWE-089/SqlInjection.ql",
+        "CWE-78": "Security/CWE-078/CommandInjection.ql",
+        "CWE-79": "Security/CWE-079/ReflectedXss.ql",
+        # CWE-22: Go pack has three path-traversal queries — ``TaintedPath``
+        # (the broad query, matches other langs' default), plus narrower
+        # ``ZipSlip`` and ``UnsafeUnzipSymlink``.  TaintedPath for the walk.
+        "CWE-22": "Security/CWE-022/TaintedPath.ql",
+        # CWE-94 omitted for Go: pack has no CodeInjection.ql.
+        "CWE-918": "Security/CWE-918/RequestForgery.ql",
     }),
 }
 
 # CVEfixes repo_language -> codeql extractor language. TypeScript extracts with
-# the javascript extractor; Ruby/Java are their own; else python/js.
-_LANG_MAP = {"Python": "python", "Ruby": "ruby", "Java": "java"}
+# the javascript extractor; Ruby/Java/Go are their own; else python/js.
+_LANG_MAP = {"Python": "python", "Ruby": "ruby", "Java": "java", "Go": "go"}
 
 # Compiled languages we extract build-free via `--build-mode=none`. Source-
 # extracted langs (python/js/ruby) take no build mode. Java's buildless recall is
 # weaker (no type resolution → Spring/interface flows missed); the build-promote
 # pass recovers those `before==0` misses with a real build.
 _BUILDLESS_COMPILED = {"java"}
+
+# Compiled languages that MUST autobuild — CodeQL has no buildless extractor
+# for them.  Go's extractor runs ``go build`` to walk packages; without an
+# actual build the database is empty.  Go cases route through the sandboxed
+# autobuild path on the FIRST attempt (no buildless fallback to promote from).
+_AUTOBUILD_ONLY = {"go"}
 
 
 def _codeql_lang(repo_language: str) -> str:
@@ -130,13 +224,21 @@ def _toolchain_readable_paths(codeql_bin: str) -> list:
     ]
 
 
-def _run_autobuild_sandboxed(cmd, *, work_root: Path, codeql_bin: str, timeout: int) -> bool:
+def _run_autobuild_sandboxed(cmd, *, work_root: Path, codeql_bin: str,
+                              timeout: int, lang: str) -> bool:
     """Run `codeql database create --build-mode=autobuild` — which EXECUTES the
-    untrusted project build (mvn runs pom plugins = arbitrary code) — under the
-    untrusted sandbox. FAIL CLOSED: refuse rather than run an untrusted build
-    unsandboxed. Landlock restricts writes to the work area, reads exclude host
-    credentials, egress is allowlisted to package repos; maven's local repo is
-    redirected into the work area so the build never writes to host ~/.m2.
+    untrusted project build (mvn runs pom plugins = arbitrary code; ``go build``
+    can run ``go:generate`` directives) — under the untrusted sandbox.  FAIL
+    CLOSED: refuse rather than run an untrusted build unsandboxed.  Landlock
+    restricts writes to the work area, reads exclude host credentials, egress
+    is allowlisted to package repos; each language's package cache is
+    redirected into the work area so the build never writes to host config
+    locations (``~/.m2``, ``~/go/pkg/mod``, …).
+
+    ``lang`` selects the egress + env profile in :data:`_AUTOBUILD_PROFILES`;
+    unknown ``lang`` raises — adding a compiled language must be an
+    intentional substrate change (a missed profile would default to
+    Maven hosts and silently mis-route the build's network calls).
     """
     try:
         from core.sandbox import check_landlock_available, run_untrusted_networked
@@ -146,12 +248,17 @@ def _run_autobuild_sandboxed(cmd, *, work_root: Path, codeql_bin: str, timeout: 
     if not check_landlock_available():
         raise RuntimeError(
             "Landlock unavailable — refusing to autobuild an untrusted repo unsandboxed")
+    if lang not in _AUTOBUILD_PROFILES:
+        raise RuntimeError(
+            f"no autobuild profile for lang={lang!r}; known: "
+            f"{sorted(_AUTOBUILD_PROFILES)}")
+    proxy_hosts, env_extender = _AUTOBUILD_PROFILES[lang]
     env = RaptorConfig.get_safe_env(preserve_proxy=True)
-    env["MAVEN_OPTS"] = f"-Dmaven.repo.local={work_root / '.m2'}"
+    env.update(env_extender(work_root))
     try:
         proc = run_untrusted_networked(
             cmd, target=str(work_root), output=str(work_root),
-            proxy_hosts=_MAVEN_PROXY_HOSTS,
+            proxy_hosts=proxy_hosts,
             readable_paths=_toolchain_readable_paths(codeql_bin),
             env=env, timeout=timeout,
         )
@@ -171,25 +278,41 @@ def _fetch_pair(repo_url: str, fix_hash: str, dest: Path, timeout: int) -> bool:
     return _run(["git", "-C", str(dest), "fetch", "-q", "--depth", "2", "origin", fix_hash], timeout)
 
 
+# CodeQL resource tunables live in ``packages.codeql`` — the central
+# home for all CodeQL-related utilities.  We re-export the type at the
+# old name so other modules in this file (and tests that import it via
+# cvefix_walk) keep working without churn.
+from packages.codeql.tunables import CodeQLTunables  # noqa: E402
+
+_DEFAULT_TUNABLES = CodeQLTunables()
+
+
 def _build_db(src: Path, commit: str, db: Path, lang: str, codeql_bin: str, timeout: int,
-              build_mode: Optional[str] = None) -> bool:
+              build_mode: Optional[str] = None,
+              tunables: CodeQLTunables = _DEFAULT_TUNABLES) -> bool:
     if not _run(["git", "-C", str(src), "checkout", "-q", commit], 60):
         return False
     cmd = [codeql_bin, "database", "create", str(db), f"--language={lang}",
            f"--source-root={src}", "--overwrite"]
     if build_mode:
         cmd.append(f"--build-mode={build_mode}")
+    tunables.append_to(cmd, include_disk_cache=True)
     # autobuild executes untrusted build scripts → must be sandboxed (fail-closed).
     # Buildless/source extraction runs no repo code → plain spawn (get_safe_env).
     if build_mode == "autobuild":
         return _run_autobuild_sandboxed(cmd, work_root=db.parent, codeql_bin=codeql_bin,
-                                        timeout=timeout)
+                                        timeout=timeout, lang=lang)
     return _run(cmd, timeout)
 
 
-def _count_query(db: Path, query: str, out: Path, codeql_bin: str, timeout: int) -> Optional[int]:
-    if not _run([codeql_bin, "database", "analyze", str(db), query,
-                 "--format=sarif-latest", f"--output={out}"], timeout):
+def _count_query(db: Path, query: str, out: Path, codeql_bin: str, timeout: int,
+                 tunables: CodeQLTunables = _DEFAULT_TUNABLES) -> Optional[int]:
+    cmd = [codeql_bin, "database", "analyze", str(db), query,
+           "--format=sarif-latest", f"--output={out}"]
+    # ``database analyze`` doesn't accept ``--max-disk-cache``; suppress it
+    # to avoid an "unknown option" rejection.
+    tunables.append_to(cmd, include_disk_cache=False)
+    if not _run(cmd, timeout):
         return None
     try:
         import json
@@ -199,40 +322,99 @@ def _count_query(db: Path, query: str, out: Path, codeql_bin: str, timeout: int)
         return None
 
 
+def _clean_go_caches(work_dir: Path) -> None:
+    """Per-pair cleanup of Go's module / build caches in the work area.
+
+    Go marks every file in ``GOMODCACHE`` read-only by design (the
+    module proxy treats cache contents as immutable), so a plain
+    ``shutil.rmtree`` silently fails to delete anything.  We add
+    ``S_IWUSR`` recursively before the rmtree.
+
+    Why per-pair: one project's ``replace`` directives or version pins
+    can map a required module name (``github.com/armon/go-metrics``) to
+    a physical module that declares a DIFFERENT path
+    (``github.com/hashicorp/go-metrics``).  When the next pair's build
+    requires the original path, the cached content claims to be the
+    other and CodeQL's extractor aborts:
+
+        module declares its path as: github.com/hashicorp/go-metrics
+                but was required as: github.com/armon/go-metrics
+
+    The fix is to keep the cache per-project — the cost is re-
+    downloading common modules per pair (cheap; ``proxy.golang.org``
+    serves at ~MB/s and total module size per repo is single-digit MB
+    for typical CVE pairs).
+    """
+    for sub in ("go-mod-cache", "gopath", "go-build-cache"):
+        p = work_dir / sub
+        if not p.is_dir():
+            continue
+        # Recursively add owner-write so rmtree can unlink everything.
+        # Symlinks are skipped (we don't want to chmod the target).
+        for root, dirs, files in os.walk(p):
+            for name in dirs + files:
+                fp = Path(root) / name
+                try:
+                    if not fp.is_symlink():
+                        fp.chmod(fp.stat().st_mode | stat.S_IWUSR)
+                except OSError:
+                    pass
+        shutil.rmtree(p, ignore_errors=True)
+
+
 def process_pair(
     pair: CveFixPair, *, work_dir: Path, codeql_bin: str = DEFAULT_CODEQL_BIN,
     fetch_timeout: int = 150, build_timeout: int = 240, analyze_timeout: int = 180,
     build_mode: Optional[str] = None,
+    tunables: CodeQLTunables = _DEFAULT_TUNABLES,
 ) -> WalkResult:
     """Fetch, build before/after DBs, run the CWE query; clean up; return counts.
 
     ``build_mode`` overrides the CodeQL extraction mode; when None it is auto-
     picked per language (``none`` for buildless-compiled langs like Java, no flag
     for source-extracted langs). The build-promote pass passes ``autobuild``.
+
+    ``tunables`` controls CodeQL resource limits (``-j``, ``-M``,
+    ``--max-disk-cache``).  See :class:`CodeQLTunables` for defaults.
     """
     query = query_for(pair.repo_language, pair.cwe)
     if query is None:
         return WalkResult(pair.fix_hash, "no_query")
     lang = _codeql_lang(pair.repo_language)
-    mode = build_mode or ("none" if lang in _BUILDLESS_COMPILED else None)
+    mode = build_mode or (
+        "none" if lang in _BUILDLESS_COMPILED
+        else "autobuild" if lang in _AUTOBUILD_ONLY
+        else None
+    )
     repo = work_dir / "repo"
     db_a, db_b = work_dir / "db-a", work_dir / "db-b"
     sa, sb = work_dir / "a.sarif", work_dir / "b.sarif"
     try:
         if not _fetch_pair(pair.repo_url, pair.fix_hash, repo, fetch_timeout):
             return WalkResult(pair.fix_hash, "fetch_fail")
-        if not _build_db(repo, pair.fix_hash, db_a, lang, codeql_bin, build_timeout, mode):
+        if not _build_db(repo, pair.fix_hash, db_a, lang, codeql_bin, build_timeout, mode,
+                         tunables=tunables):
             return WalkResult(pair.fix_hash, "build_fail")
-        if not _build_db(repo, pair.parent_hash, db_b, lang, codeql_bin, build_timeout, mode):
+        if not _build_db(repo, pair.parent_hash, db_b, lang, codeql_bin, build_timeout, mode,
+                         tunables=tunables):
             return WalkResult(pair.fix_hash, "build_fail")
-        after = _count_query(db_a, query, sa, codeql_bin, analyze_timeout)
-        before = _count_query(db_b, query, sb, codeql_bin, analyze_timeout)
+        after = _count_query(db_a, query, sa, codeql_bin, analyze_timeout, tunables=tunables)
+        before = _count_query(db_b, query, sb, codeql_bin, analyze_timeout, tunables=tunables)
         if after is None or before is None:
             return WalkResult(pair.fix_hash, "analyze_fail")
         return WalkResult(pair.fix_hash, "ok", before_count=before, after_count=after)
     finally:
         for p in (repo, db_a, db_b, sa, sb):
             shutil.rmtree(p, ignore_errors=True) if p.is_dir() else p.unlink(missing_ok=True)
+        # Per-pair Go cache cleanup.  Without this, modules cached from
+        # one project with its `replace` directives corrupt the next
+        # project's build (CodeQL surfaces this as
+        # "module declares its path as X but was required as Y" and
+        # extraction fails).  Java's Maven cache doesn't have this
+        # conflict shape — version conflicts resolve last-write-wins —
+        # so cross-pair Maven reuse is fine and we leave it alone.
+        if lang in _AUTOBUILD_PROFILES and lang == "go":
+            _clean_go_caches(work_dir)
 
 
 # --- resumable results store ---
@@ -269,21 +451,43 @@ def walk(
     work_dir: Path = Path("/data/corpus/clones/walk"),
     codeql_bin: str = DEFAULT_CODEQL_BIN,
     limit: Optional[int] = None,
+    fetch_timeout: int = 150,
+    build_timeout: int = 240,
+    analyze_timeout: int = 180,
+    tunables: CodeQLTunables = _DEFAULT_TUNABLES,
     log=print,
 ) -> dict:
-    """Walk the metadata DB's pairs through CodeQL, recording results (resumable)."""
+    """Walk the metadata DB's pairs through CodeQL, recording results (resumable).
+
+    Timeouts default to the conservative walker-tier values; operators
+    pushing into projects with very long secondary-extractor phases
+    (large Go web repos) can raise ``build_timeout``.  ``tunables``
+    controls ``--threads`` / ``--ram`` / ``--max-disk-cache``."""
     pairs = load_pairs(db_path, cwes=cwes, languages=languages)
     con = sqlite3.connect(str(results_db))
     con.execute(_SCHEMA)
+    # Dedup todo by (fix_hash, cwe): the same commit credited to multiple CVE ids
+    # yields identical (DB, query, result), so process it once. (The PK already
+    # dedups at storage, but without this we'd waste a full rebuild on each.)
     done = _processed(con)
-    todo = [p for p in pairs if (p.fix_hash, p.cwe) not in done]
+    todo, seen = [], set()
+    for p in pairs:
+        key = (p.fix_hash, p.cwe)
+        if key in done or key in seen:
+            continue
+        seen.add(key)
+        todo.append(p)
     log(f"walk: {len(pairs)} pairs, {len(done)} already done, {len(todo)} to process")
     work_dir.mkdir(parents=True, exist_ok=True)
     n = 0
     for pair in todo:
         if limit is not None and n >= limit:
             break
-        res = process_pair(pair, work_dir=work_dir, codeql_bin=codeql_bin)
+        res = process_pair(pair, work_dir=work_dir, codeql_bin=codeql_bin,
+                           fetch_timeout=fetch_timeout,
+                           build_timeout=build_timeout,
+                           analyze_timeout=analyze_timeout,
+                           tunables=tunables)
         _record(con, pair, res)
         n += 1
         tag = "YIELD" if res.is_yield else res.status
@@ -367,8 +571,42 @@ def main(argv=None) -> None:
     ap.add_argument("--promote", action="store_true",
                     help="build-promote buildless misses (autobuild) instead of walking")
     ap.add_argument("--promote-languages", nargs="+", default=["Java"])
+    # CodeQL resource tunables.  Defaults come from RAPTOR's central
+    # tuning config (tuning.json: codeql_threads, codeql_ram_mb) via
+    # CodeQLTunables.from_tuning(); CLI flags here are operator-overrides.
+    ap.add_argument("--threads", type=int, default=None,
+                    help="codeql -j: extractor threads.  Default: from "
+                         "tuning.json:codeql_threads ('auto' -> 0 = all "
+                         "cores).  The codeql default of 1 serializes the "
+                         "secondary HTML/JS extraction phase and regularly "
+                         "times out build_timeout on Go web repos.")
+    ap.add_argument("--ram", type=int, default=None,
+                    help="codeql -M: ram budget MB hint.  Default: from "
+                         "tuning.json:codeql_ram_mb ('auto' -> 25%% of "
+                         "system RAM clamped [2048, 16384])")
+    ap.add_argument("--max-disk-cache", type=int, default=None,
+                    help="codeql --max-disk-cache MB.  Default: codeql's "
+                         "unbounded.  Set when running unattended to keep "
+                         "DB build cache from growing without limit. "
+                         "Not in tuning.json today — add there once a "
+                         "second consumer needs it")
+    # Pipeline timeouts.
+    ap.add_argument("--fetch-timeout", type=int, default=150,
+                    help="git fetch timeout, seconds (default 150)")
+    ap.add_argument("--build-timeout", type=int, default=240,
+                    help="codeql database create timeout, seconds (default 240). "
+                         "Raise (e.g. 600) for projects with very large "
+                         "secondary-extractor footprints (Go web repos with "
+                         "thousands of HTML templates)")
+    ap.add_argument("--analyze-timeout", type=int, default=180,
+                    help="codeql database analyze timeout, seconds (default 180)")
     a = ap.parse_args(argv)
     log = lambda m: print(m, flush=True)  # noqa: E731
+    # Resolve operator overrides against tuning.json-backed defaults.
+    tunables = CodeQLTunables.from_tuning(
+        overrides={"threads": a.threads, "ram_mb": a.ram,
+                   "max_disk_cache_mb": a.max_disk_cache},
+    )
     if a.promote:
         summary = promote_misses(
             a.results, work_dir=a.work_dir, codeql_bin=a.codeql_bin,
@@ -378,7 +616,10 @@ def main(argv=None) -> None:
         return
     summary = walk(
         a.db, a.results, cwes=a.cwes, languages=a.languages,
-        work_dir=a.work_dir, codeql_bin=a.codeql_bin, limit=a.limit, log=log,
+        work_dir=a.work_dir, codeql_bin=a.codeql_bin, limit=a.limit,
+        fetch_timeout=a.fetch_timeout, build_timeout=a.build_timeout,
+        analyze_timeout=a.analyze_timeout, tunables=tunables,
+        log=log,
     )
     print(f"=== SUMMARY {summary} ===", flush=True)
 

--- a/core/dataflow/ghsa_harvester.py
+++ b/core/dataflow/ghsa_harvester.py
@@ -1,0 +1,321 @@
+"""Harvest a CVEfixes-shaped metadata DB from the GHSA Advisory Database.
+
+The trust-witness corpus measurement (the 87-FP-candidate run on CVEfixes
+v1.0.8) is bounded by what was in CVEfixes-v1.0.8 (data through ~Sep 2024).
+This harvester reconstructs a metadata DB in the same schema from a more
+recent slice — github/advisory-database, which is git-cloneable, regularly
+updated, and has explicit fix-commit URLs in its references.
+
+Filter chain mirrors :mod:`cvefix_loader`'s defaults: published in the
+year range, CWE in the target set, ecosystem maps to a CodeQL-supported
+language, and at least one ``github.com/<owner>/<repo>/commit/<sha>``
+reference is present.  Parent SHA is resolved by a depth-2 shallow fetch
+against the repo (no GitHub API, no token, no rate limit).
+
+Output is a SQLite DB whose ``fixes`` / ``commits`` / ``repository`` /
+``cwe_classification`` tables are populated with exactly the columns
+:func:`cvefix_loader.load_pairs` reads.  Other CVEfixes columns are
+intentionally absent — load_pairs ignores them and adding them would
+fabricate data we don't have.  Sibling harvesters (e.g. for NVD) could
+plug into the same schema.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import random
+import re
+import shutil
+import sqlite3
+import subprocess
+import sys
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Optional, Tuple
+
+# Ecosystem -> CVEfixes ``repo_language`` value.  Restricted to languages
+# the walker explicitly supports (cvefix_walk._LANG_MAP).  npm packages
+# may be JS or TS; the walker maps both to the ``javascript`` extractor,
+# so JS is the safe default — no information is lost, and TS-specific
+# repos still extract correctly.
+#
+# Go and NuGet (C#) are intentionally omitted: cvefix_walk has no Go/C#
+# extractor wiring and would silently default them to ``javascript``
+# (producing garbage findings or none).  Add them here once the
+# C/C++/Go walk substrate (task B) lands.
+_ECOSYSTEM_LANG = {
+    "npm": "JavaScript",
+    "PyPI": "Python",
+    "Maven": "Java",
+    "RubyGems": "Ruby",
+}
+
+# Default CWE set — matches the trust-witness substrate's sink-class
+# coverage (4 originals + the 2 expansions in cvefix_loader.INJECTION_CWES).
+_DEFAULT_CWES = ("CWE-22", "CWE-78", "CWE-79", "CWE-89", "CWE-94", "CWE-918")
+
+# Default year range — 2024-2026 is the post-CVEfixes-v1.0.8 slice.
+_DEFAULT_YEARS = ("2024", "2025", "2026")
+
+# ``github.com/owner/repo/commit/sha`` — strict, full SHA preferred but
+# accept 7-40 hex chars (GHSA refs sometimes use shortened SHAs).  We
+# need an EXACT SHA for `git fetch` so short SHAs won't work — but the
+# harvester still records them and the parent-resolution step will fail
+# them; that's a tracked decline, not silent loss.
+_COMMIT_RE = re.compile(
+    r"github\.com/([A-Za-z0-9._-]+)/([A-Za-z0-9._-]+)/commit/([0-9a-f]{7,40})"
+)
+
+
+@dataclass(frozen=True)
+class HarvestedFix:
+    cve_id: str
+    cwe: str
+    repo_url: str
+    repo_language: str
+    fix_hash: str
+    parent_hash: Optional[str]  # None if resolution failed
+
+
+# ---------------------------------------------------------------------------
+# Advisory iteration + filter
+# ---------------------------------------------------------------------------
+
+def _iter_advisories(
+    root: Path, years: Iterable[str], cwes: set, ecosystems: set,
+) -> Iterable[Tuple[Path, dict]]:
+    """Yield ``(json_path, advisory_dict)`` for advisories matching the
+    CWE + ecosystem filter.  Subtree restricted to ``github-reviewed/<year>``
+    (the curated namespace; ``unreviewed`` is auto-imported NVD with much
+    noisier metadata)."""
+    base = root / "advisories" / "github-reviewed"
+    if not base.is_dir():
+        raise SystemExit(f"GHSA root does not contain advisories/github-reviewed: {root}")
+    for y in years:
+        ydir = base / y
+        if not ydir.is_dir():
+            continue
+        for jp in ydir.rglob("*.json"):
+            try:
+                adv = json.loads(jp.read_text())
+            except Exception:
+                continue
+            adv_cwes = set(adv.get("database_specific", {}).get("cwe_ids", []))
+            if not (adv_cwes & cwes):
+                continue
+            ecos = {a.get("package", {}).get("ecosystem")
+                    for a in adv.get("affected", [])}
+            if not (ecos & ecosystems):
+                continue
+            yield jp, adv
+
+
+def _first_commit_ref(adv: dict) -> Optional[Tuple[str, str, str]]:
+    """Return ``(owner, repo, sha)`` for the first
+    ``github.com/.../commit/SHA`` URL in ``references``, or None."""
+    for r in adv.get("references", []):
+        m = _COMMIT_RE.search(r.get("url", ""))
+        if m:
+            return m.group(1), m.group(2), m.group(3)
+    return None
+
+
+def _pick_cwe_eco(adv: dict, cwes: set, ecosystems: set) -> Tuple[str, str]:
+    """Pick ONE (CWE, ecosystem) tuple from the advisory's intersection
+    with our filter — sorted for determinism so the same advisory always
+    gets the same label across runs.  Multi-CWE advisories are
+    deliberately recorded under a single CWE for the trust-witness walk;
+    if the same fix is interesting under multiple CWEs, a future
+    extension can iterate ``cwes & adv_cwes``."""
+    adv_cwes = sorted(set(adv.get("database_specific", {}).get("cwe_ids", [])) & cwes)
+    adv_ecos = sorted({a.get("package", {}).get("ecosystem")
+                       for a in adv.get("affected", [])} & ecosystems)
+    return adv_cwes[0], adv_ecos[0]
+
+
+# ---------------------------------------------------------------------------
+# Parent SHA resolution via shallow fetch
+# ---------------------------------------------------------------------------
+
+def _resolve_parent(repo_url: str, fix_hash: str, timeout: int = 60) -> Optional[str]:
+    """Depth-2 shallow-fetch ``fix_hash`` and return ``fix^1``.  Returns
+    None on fetch / parse failure (gone repos, missing SHAs, merges with
+    multiple parents).  No GitHub API — pure git protocol, no rate
+    limits and no token required.
+
+    Each call creates and destroys its own scratch dir so failures don't
+    pollute later calls; the parent walker repeats the fetch on its own,
+    so we don't bother caching the clone."""
+    with tempfile.TemporaryDirectory(prefix="ghsa-resolve-") as td:
+        td_p = Path(td)
+        try:
+            subprocess.run(["git", "init", "-q", str(td_p)],
+                           check=True, timeout=15, capture_output=True)
+            subprocess.run(["git", "-C", str(td_p), "remote", "add", "origin", repo_url],
+                           check=True, timeout=15, capture_output=True)
+            r = subprocess.run(
+                ["git", "-C", str(td_p), "fetch", "-q", "--depth", "2",
+                 "origin", fix_hash],
+                check=False, timeout=timeout, capture_output=True,
+            )
+            if r.returncode != 0:
+                return None
+            r = subprocess.run(
+                ["git", "-C", str(td_p), "rev-list", "--parents", "-n", "1", fix_hash],
+                check=False, timeout=15, capture_output=True, text=True,
+            )
+            if r.returncode != 0:
+                return None
+            parts = r.stdout.split()
+            # `rev-list --parents -n 1 <sha>` -> "<sha> <parent1> [<parent2> ...]"
+            # We want the single-parent case: exactly one parent.  Merge
+            # commits (2+ parents) and roots (0 parents) are deliberately
+            # dropped — matches CVEfixes' own _single_parent filter.
+            if len(parts) != 2:
+                return None
+            return parts[1]
+        except (subprocess.TimeoutExpired, OSError):
+            return None
+
+
+# ---------------------------------------------------------------------------
+# DB writer (CVEfixes-meta schema, minimal columns)
+# ---------------------------------------------------------------------------
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS fixes (
+    cve_id TEXT, hash TEXT, repo_url TEXT,
+    PRIMARY KEY (cve_id, hash)
+);
+CREATE TABLE IF NOT EXISTS commits (
+    hash TEXT PRIMARY KEY, repo_url TEXT, parents TEXT
+);
+CREATE TABLE IF NOT EXISTS cwe_classification (
+    cve_id TEXT, cwe_id TEXT,
+    PRIMARY KEY (cve_id, cwe_id)
+);
+CREATE TABLE IF NOT EXISTS repository (
+    repo_url TEXT PRIMARY KEY, repo_language TEXT
+);
+"""
+
+
+def _write_metadata_db(db_path: Path, harvested: list) -> None:
+    """Write the harvested fixes into a fresh metadata DB.  Schema
+    columns are exactly what :func:`cvefix_loader.load_pairs` needs;
+    extras are deliberately omitted (don't fabricate data)."""
+    if db_path.exists():
+        db_path.unlink()
+    con = sqlite3.connect(db_path)
+    try:
+        con.executescript(_SCHEMA)
+        for h in harvested:
+            con.execute(
+                "INSERT OR IGNORE INTO fixes (cve_id, hash, repo_url) VALUES (?,?,?)",
+                (h.cve_id, h.fix_hash, h.repo_url),
+            )
+            # CVEfixes uses a Python-list-repr string for ``parents``;
+            # match that exactly so cvefix_loader._single_parent parses it
+            # without any code change.
+            parents_repr = repr([h.parent_hash]) if h.parent_hash else "[]"
+            con.execute(
+                "INSERT OR IGNORE INTO commits (hash, repo_url, parents) VALUES (?,?,?)",
+                (h.fix_hash, h.repo_url, parents_repr),
+            )
+            con.execute(
+                "INSERT OR IGNORE INTO cwe_classification (cve_id, cwe_id) VALUES (?,?)",
+                (h.cve_id, h.cwe),
+            )
+            con.execute(
+                "INSERT OR IGNORE INTO repository (repo_url, repo_language) VALUES (?,?)",
+                (h.repo_url, h.repo_language),
+            )
+        con.commit()
+    finally:
+        con.close()
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def main(argv: Optional[list] = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--ghsa-root", required=True, type=Path,
+                    help="path to the cloned github/advisory-database repo")
+    ap.add_argument("--out", required=True, type=Path,
+                    help="output SQLite metadata DB")
+    ap.add_argument("--years", nargs="+", default=list(_DEFAULT_YEARS))
+    ap.add_argument("--cwes", nargs="+", default=list(_DEFAULT_CWES))
+    ap.add_argument("--ecosystems", nargs="+", default=list(_ECOSYSTEM_LANG.keys()))
+    ap.add_argument("--sample-size", type=int, default=None,
+                    help="random sample of N matching advisories (post-filter, "
+                         "pre-resolve); default: take all")
+    ap.add_argument("--seed", type=int, default=42)
+    ap.add_argument("--resolve-timeout", type=int, default=60,
+                    help="per-fetch timeout in seconds (default 60)")
+    ap.add_argument("--max-parent-failures", type=int, default=None,
+                    help="abort if more than N consecutive parent-resolutions "
+                         "fail (network outage signal)")
+    args = ap.parse_args(argv)
+
+    cwes_set = set(args.cwes)
+    eco_set = set(args.ecosystems) & set(_ECOSYSTEM_LANG.keys())
+    unknown_eco = set(args.ecosystems) - eco_set
+    if unknown_eco:
+        print(f"WARN: unsupported ecosystems ignored: {sorted(unknown_eco)}",
+              file=sys.stderr)
+
+    # Pass 1: filter advisories down to ones with a commit ref.
+    candidates = []
+    for jp, adv in _iter_advisories(args.ghsa_root, args.years, cwes_set, eco_set):
+        ref = _first_commit_ref(adv)
+        if ref is None:
+            continue
+        aliases = adv.get("aliases", [])
+        cve_aliases = [a for a in aliases if a.startswith("CVE-")]
+        if not cve_aliases:
+            continue
+        cve_id = cve_aliases[0]
+        cwe, eco = _pick_cwe_eco(adv, cwes_set, eco_set)
+        owner, repo, sha = ref
+        repo_url = f"https://github.com/{owner}/{repo}"
+        candidates.append((cve_id, cwe, repo_url, _ECOSYSTEM_LANG[eco], sha))
+    print(f"GHSA scan: {len(candidates)} candidates (CWE + ecosystem + commit-ref + CVE alias)")
+
+    # Sample (unbiased) before the expensive parent-resolve step.
+    rng = random.Random(args.seed)
+    if args.sample_size is not None and args.sample_size < len(candidates):
+        rng.shuffle(candidates)
+        candidates = candidates[:args.sample_size]
+        print(f"sampled to {len(candidates)} (seed={args.seed})")
+
+    # Pass 2: resolve parents per advisory.  Skip the ones we can't fetch.
+    harvested = []
+    consecutive_fails = 0
+    for i, (cve_id, cwe, repo_url, lang, sha) in enumerate(candidates, 1):
+        parent = _resolve_parent(repo_url, sha, timeout=args.resolve_timeout)
+        if parent is None:
+            consecutive_fails += 1
+            print(f"  [{i}/{len(candidates)}] {cve_id} {cwe} {lang} {repo_url}: "
+                  f"FETCH FAIL (sha={sha[:8]})")
+            if (args.max_parent_failures is not None
+                    and consecutive_fails >= args.max_parent_failures):
+                print(f"ABORT: {consecutive_fails} consecutive fetch failures — "
+                      f"likely network issue", file=sys.stderr)
+                return 2
+            continue
+        consecutive_fails = 0
+        harvested.append(HarvestedFix(cve_id, cwe, repo_url, lang, sha, parent))
+        print(f"  [{i}/{len(candidates)}] {cve_id} {cwe} {lang} "
+              f"{repo_url.split('github.com/')[-1]}: parent={parent[:8]}")
+
+    _write_metadata_db(args.out, harvested)
+    print(f"=== HARVEST {len(harvested)}/{len(candidates)} usable -> {args.out}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/core/dataflow/ghsa_harvester.py
+++ b/core/dataflow/ghsa_harvester.py
@@ -26,7 +26,6 @@ import argparse
 import json
 import random
 import re
-import shutil
 import sqlite3
 import subprocess
 import sys

--- a/core/dataflow/known_safe_calls.py
+++ b/core/dataflow/known_safe_calls.py
@@ -1,0 +1,237 @@
+"""Curated table of known-safe library calls per sink class + language.
+
+The Tier 1B trust surface.  Every entry is a human-verified soundness
+claim: "calling this function with user-controlled input produces a
+value that is safe for the named sink class."
+
+Adding entries is a soundness-critical operation — each ``soundness_note``
+documents WHY the call is safe (per library docs / known semantics) so
+reviewers can sanity-check the claim.  Keep the table small and well-
+justified; growth should be driven by concrete corpus cases.
+
+Lookup contract:
+  ``find(library_call: str, sink_class: str, language: str)`` returns
+  the matching :class:`KnownSafeCall` entry or ``None``.  Matching is by
+  full dotted name and language, both case-sensitive.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional, Tuple
+
+
+@dataclass(frozen=True)
+class KnownSafeCall:
+    """One curated entry — a soundness claim for a single library call.
+
+    ``library_call`` is the fully-qualified dotted name as it would appear
+    in the source (after any standard ``from X import Y`` flattening:
+    ``html.escape``, ``django.utils.html.escape``, etc).
+
+    ``input_arg_kind`` distinguishes:
+
+      * ``"transform"`` — the call takes user input and returns the
+        sanitized value (e.g. ``html.escape(x)``).  The CHAIN must show
+        the return value (or a name assigned from it) reaching the sink.
+      * ``"validate"`` — the call validates user input and raises /
+        returns sentinel on bad input (e.g. ``werkzeug.security.safe_join``
+        raises ``NotFound`` on traversal).  Same chain requirement
+        applies to the return value.
+
+    Both kinds are treated identically for chain checking — the
+    distinction is documented so reviewers can verify the semantic
+    claim matches the library's actual behaviour.
+    """
+    library_call: str
+    sink_class: str
+    languages: Tuple[str, ...]
+    input_arg_kind: str            # "transform" | "validate"
+    soundness_note: str
+
+
+_TABLE: Tuple[KnownSafeCall, ...] = (
+    # ------------------------------------------------------------------
+    # pathtrav — path-traversal safe joiners / validators
+    # ------------------------------------------------------------------
+    KnownSafeCall(
+        library_call="werkzeug.security.safe_join",
+        sink_class="pathtrav",
+        languages=("python",),
+        input_arg_kind="validate",
+        soundness_note=(
+            "werkzeug.security.safe_join (since werkzeug 0.5) raises "
+            "NotFound if the joined path escapes the base directory or "
+            "contains traversal sequences.  Return value, when not None, "
+            "is provably inside the base directory."
+        ),
+    ),
+    KnownSafeCall(
+        library_call="werkzeug.utils.secure_filename",
+        sink_class="pathtrav",
+        languages=("python",),
+        input_arg_kind="transform",
+        soundness_note=(
+            "werkzeug.utils.secure_filename strips path separators and "
+            "control chars; the return value contains only "
+            "[A-Za-z0-9._-] and never a path separator (verified vs "
+            "werkzeug source)."
+        ),
+    ),
+    # ------------------------------------------------------------------
+    # xss — HTML-context escapers
+    # ------------------------------------------------------------------
+    KnownSafeCall(
+        library_call="html.escape",
+        sink_class="xss",
+        languages=("python",),
+        input_arg_kind="transform",
+        soundness_note=(
+            "stdlib html.escape converts &, <, >, and (with default "
+            "quote=True) \", ' to HTML entities.  Output cannot break "
+            "out of an HTML attribute or tag context."
+        ),
+    ),
+    KnownSafeCall(
+        library_call="django.utils.html.escape",
+        sink_class="xss",
+        languages=("python",),
+        input_arg_kind="transform",
+        soundness_note=(
+            "Django's escape (wraps stdlib html.escape; same semantics) "
+            "+ marks result as SafeString.  Output is HTML-safe."
+        ),
+    ),
+    KnownSafeCall(
+        library_call="markupsafe.escape",
+        sink_class="xss",
+        languages=("python",),
+        input_arg_kind="transform",
+        soundness_note=(
+            "markupsafe.escape escapes &, <, >, \", ' and returns Markup "
+            "(SafeString equivalent).  Standard XSS-safe escaper used "
+            "across Jinja2 / Flask."
+        ),
+    ),
+    KnownSafeCall(
+        library_call="bleach.clean",
+        sink_class="xss",
+        languages=("python",),
+        input_arg_kind="transform",
+        soundness_note=(
+            "bleach.clean sanitises HTML against an allowlist of tags "
+            "and attributes.  Default allowlist is XSS-safe; custom "
+            "allowlists are caller's responsibility (we only claim "
+            "safety for the default call form, no args beyond the "
+            "input string)."
+        ),
+    ),
+    # ------------------------------------------------------------------
+    # cmdi — shell-quoting / arg-list safe constructors
+    # ------------------------------------------------------------------
+    KnownSafeCall(
+        library_call="shlex.quote",
+        sink_class="cmdi",
+        languages=("python",),
+        input_arg_kind="transform",
+        soundness_note=(
+            "shlex.quote returns a shell-escaped string safe to "
+            "interpolate into a shell command (single-quoted, with "
+            "embedded single quotes escaped).  Sound for shell=True "
+            "subprocess invocations."
+        ),
+    ),
+    # ------------------------------------------------------------------
+    # JS / TS — mostly transforms via popular libraries
+    # ------------------------------------------------------------------
+    KnownSafeCall(
+        library_call="validator.escape",
+        sink_class="xss",
+        languages=("javascript", "typescript"),
+        input_arg_kind="transform",
+        soundness_note=(
+            "validator.js escape() replaces &, <, >, \", ', / with their "
+            "HTML entity equivalents.  Output is XSS-safe in HTML "
+            "context (verified vs validator.js source 13.x)."
+        ),
+    ),
+    KnownSafeCall(
+        library_call="DOMPurify.sanitize",
+        sink_class="xss",
+        languages=("javascript", "typescript"),
+        input_arg_kind="transform",
+        soundness_note=(
+            "DOMPurify.sanitize is the canonical XSS sanitiser for "
+            "user-supplied HTML; output is safe to assign to innerHTML.  "
+            "Default config; custom configs are caller's responsibility."
+        ),
+    ),
+    # ------------------------------------------------------------------
+    # JS / TS — SQL escaping (mysql / mysql2 / mariadb packages)
+    # ------------------------------------------------------------------
+    KnownSafeCall(
+        library_call="connection.escape",
+        sink_class="sqli",
+        languages=("javascript", "typescript"),
+        input_arg_kind="transform",
+        soundness_note=(
+            "Node mysql / mysql2 connection.escape() escapes characters "
+            "with special SQL-string meaning: single/double quotes "
+            "(escaped as \\' / \\\"), backslashes, NUL, newlines, CR, "
+            "Ctrl-Z, and zero-byte.  Output is wrapped in single quotes "
+            "and safe to concatenate into a SQL string literal context.  "
+            "Verified against mysql 2.x / mysql2 3.x sqlstring.escape "
+            "implementation.  NB: only sound in SQL STRING-LITERAL "
+            "context — not safe for identifier interpolation; that "
+            "requires connection.escapeId."
+        ),
+    ),
+    KnownSafeCall(
+        library_call="conn.escape",
+        sink_class="sqli",
+        languages=("javascript", "typescript"),
+        input_arg_kind="transform",
+        soundness_note=(
+            "Alias for connection.escape — same library, same "
+            "semantics, common idiomatic variable name.  See "
+            "connection.escape entry."
+        ),
+    ),
+    # ------------------------------------------------------------------
+    # Java — escaping + parameterised queries
+    # ------------------------------------------------------------------
+    KnownSafeCall(
+        library_call="org.apache.commons.lang3.StringEscapeUtils.escapeHtml4",
+        sink_class="xss",
+        languages=("java",),
+        input_arg_kind="transform",
+        soundness_note=(
+            "Apache Commons Lang escapeHtml4 escapes per HTML 4.0 spec; "
+            "output is HTML-safe.  Note: escapeHtml3 is also safe but "
+            "less common — add separately if needed."
+        ),
+    ),
+    # NB: Java PreparedStatement.setString is a structurally different
+    # pattern (a method call on a previously-allocated PreparedStatement
+    # object that's then executed).  Not a single-call transform —
+    # leaving for a future entry-kind that models multi-step
+    # parameterised-query patterns.
+)
+
+
+def find(library_call: str, sink_class: str, language: str) -> Optional[KnownSafeCall]:
+    """Look up a known-safe call entry.  Returns the matching entry or
+    None.  Exact match on ``library_call`` and ``sink_class``; language
+    must be in the entry's ``languages`` tuple."""
+    for entry in _TABLE:
+        if (entry.library_call == library_call
+                and entry.sink_class == sink_class
+                and language in entry.languages):
+            return entry
+    return None
+
+
+def all_entries() -> Tuple[KnownSafeCall, ...]:
+    """Diagnostic accessor — returns the full table for testing /
+    audit-rendering."""
+    return _TABLE

--- a/core/dataflow/scripts/trust-report
+++ b/core/dataflow/scripts/trust-report
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+"""Tier 0-aware analysis of the trust-witness bridge's ``synth_results`` DB.
+
+Usage:
+  core/dataflow/scripts/trust-report \\
+      [--synth-db /data/corpus/synth-results-tier0.db]
+
+Headline numbers: processed / sound / not_sound / no_barrier, suppression rate,
+Tier 0 vs Tier 2 backend split among SOUND verdicts, per-CWE / per-language
+breakdowns, ``not_sound`` failure-mode distribution, and a conservative count
+of LLM proposer attempts saved by Tier 0 short-circuits.
+
+Safe to run WHILE the bridge is still writing — reads DB with ``mode=ro`` so
+concurrent writes from the bridge process aren't blocked. Dev-tooling sibling
+to ``trust-corpus`` / ``trust-synth``.
+"""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
+
+from core.dataflow.trust_corpus_report import main
+
+if __name__ == "__main__":
+    main()

--- a/core/dataflow/smt_barrier.py
+++ b/core/dataflow/smt_barrier.py
@@ -1,0 +1,1268 @@
+"""Tier 0 of the trust-witness sound tier: free SMT-backed barrier verdict.
+
+Cost-asymmetric routing. The Tier 2 backend (LLM proposes a CodeQL barrier-
+guard, CodeQL adjudicates) is correct but expensive — every attempt burns
+LLM tokens and a CodeQL compile+run cycle. SMT over Z3's regex/string
+theory is single-digit-ms of CPU and uses no LLM, so it's worth trying
+FIRST on any case where the fix adds a charset/regex-shaped validator.
+The whoogle archetype is::
+
+    name = request.args.get('name')
+    if not re.match(r'^[A-Za-z0-9_.+-]+$', name):
+        return error()
+    open(os.path.join(CONFIG_PATH, name))            # CWE-22 sink
+
+The Tier 2 LLM keeps failing to express that as a CodeQL barrier-guard;
+Z3 dispatches it directly by proving the validator's language and the
+sink's danger language don't intersect.
+
+Verdict structure (sound by construction):
+
+    SOUND    -- validator's regex language INTERSECT danger language is
+                empty (proven by Z3) AND validator dominates the sink
+                (its location appears as a step in the SARIF codeFlow).
+                Both checks are mechanical; no LLM involved.
+
+    DECLINED -- intersection is non-empty (validator insufficient, with a
+                concrete counterexample input); or validator location is
+                not on the codeFlow (no dominance evidence we can prove
+                from the SARIF alone). Tier 2 takes over with the full
+                LLM+CodeQL machinery.
+
+    NOT_APPLICABLE
+             -- no validator-shape pattern recognised in the fix diff,
+                or sink_class has no danger model. Tier 2 takes over.
+
+    Z3_UNAVAILABLE
+             -- substrate has no z3-solver installed. Tier 2 takes over.
+                Substrate gate matches core.smt_solver's degradation
+                pattern.
+
+Soundness rests on two pillars: the regex-intersection proof (decidable
++ sound by Z3's automata procedure) and the dominance check (the
+validator's source line is on the value's actual dataflow path, as
+reported by CodeQL's own engine — we just trust CodeQL's path tracking).
+The LLM never asserts safety: extraction is mechanical, adjudication
+is mechanical.
+
+The validator extractor is deliberately conservative (Python `re.match`
+charset patterns only, for the first cut) — false NOT_APPLICABLE just
+falls through to Tier 2, but a wrong extraction could synthesise an
+unsound suppression. Widening the extractor is a follow-on once Tier 0
+has been validated on the corpus.
+
+Formulation note: `Contains(name, ...)` + `InRe(name, Plus(...))` hangs
+the Z3 string solver. The working query is regex-intersection emptiness
+(`InRe(name, Intersect(validator_re, danger_re))`), which stays inside
+the automata decision procedure. Verified on z3 4.15.4.0 (the substrate
+pin) and 4.16.0; all PoC cases finish in 7-9 ms.
+"""
+
+from __future__ import annotations
+
+import ast
+import re as _re
+from dataclasses import dataclass, field
+from enum import Enum
+from pathlib import Path
+from typing import List, Optional
+
+from core.smt_solver import z3, z3_available as _z3_available
+
+
+# --------------------------------------------------------------------------
+# Sink danger model.  Each sink_class maps to the set of characters whose
+# presence in the value makes the sink exploitable.  Conservative by
+# construction: the validator must exclude EVERY listed danger char for the
+# verdict to come out SOUND.  Picking these is a soundness call — too narrow
+# (missing danger chars) is unsound; too wide just defers more cases to
+# Tier 2.
+# --------------------------------------------------------------------------
+_DANGER_CHARS = {
+    # Path separators are the load-bearing chars for traversal.  Without '/'
+    # (or '\') the value can't escape os.path.join's base directory or name
+    # an absolute path.  Conservative — a lone '..' without separators
+    # resolves to a directory, not an arbitrary file.
+    "pathtrav": ["/", "\\"],
+    # Shell metachars that introduce command separation, substitution, or
+    # backgrounding.  Newlines included because they terminate a command in
+    # most shell contexts.
+    "cmdi":     [";", "|", "&", "$", "`", "\n"],
+    # SQL quote / comment / statement-terminator chars.  Wider than strict
+    # SQLi exploits need (a lone '-' isn't an exploit), so the verdict here
+    # will more often be DECLINED than for pathtrav/cmdi.  Honest scope.
+    "sqli":     ["'", '"', ";", "-"],
+    # XSS tag- and attribute-breakers.  Same fuzziness caveat as SQLi.
+    "xss":      ["<", ">", '"', "'"],
+}
+
+
+# --------------------------------------------------------------------------
+# ValidatorSpec: what we extract from the fix diff.
+# --------------------------------------------------------------------------
+@dataclass
+class ValidatorSpec:
+    """Mechanically-extracted description of a fix-added sanitizer.
+
+    ``kind`` selects the soundness check in :func:`prove_neutralizes`:
+
+      * ``"charset"`` — whole-string anchored allowlist (`re.match(r'^[...]+$', x)`,
+        `re.fullmatch(...)`, language equivalents in JS/TS/Java/Ruby).
+        ``charset`` field carries the allowed-char body of ``[...]``.
+        Soundness via Z3 regex-intersection emptiness.
+      * ``"charset_sub"`` — strip-by-substitution (`x = re.sub('[...]+', '', x)`).
+        ``forbidden`` field carries the stripped-char body of ``[...]``.
+        Soundness via finite-set inclusion: ``danger_chars ⊆ forbidden_chars``.
+    """
+    kind: str
+    var_name: str                   # the variable the validator constrains
+    charset: str = ""               # kind=="charset": whole-string allowed chars
+    source_line: str = ""           # the literal diff `+` line for diagnostics
+    diff_line_offset: int = 0       # position within the diff hunk (for tests)
+    forbidden: str = ""             # kind=="charset_sub": stripped-out chars
+
+
+# --------------------------------------------------------------------------
+# Tier0Result.
+# --------------------------------------------------------------------------
+class Tier0Status(str, Enum):
+    SOUND = "sound"
+    DECLINED = "declined"
+    NOT_APPLICABLE = "not_applicable"
+    Z3_UNAVAILABLE = "z3_unavailable"
+
+
+@dataclass
+class Tier0Result:
+    status: Tier0Status
+    reasoning: str
+    spec: Optional[ValidatorSpec] = None
+    counterexample: Optional[str] = None
+    # Pre-formatted spec string suitable to persist in the synth_results
+    # ``barrier_query`` column.  Populated only on SOUND; lets the bridge
+    # store a self-describing artifact (`smt:charset:[A-Za-z0-9_.+-]@app.py:429`)
+    # without callers re-formatting.
+    artifact: Optional[str] = None
+    extras: dict = field(default_factory=dict)
+
+
+# --------------------------------------------------------------------------
+# Mechanical validator extractor.
+#
+# First cut targets the whoogle archetype: a Python `re.match` /
+# `re.fullmatch` over a `^[CHARS]+$`-style anchored charset, added in the
+# fix.  Anchored on BOTH ends (or `re.fullmatch` regardless of anchors) so
+# the whole-string constraint is unambiguous — partial matches don't
+# constrain the unmatched suffix and would be unsound to treat as a
+# whole-string charset.
+#
+# Conservatism: only `+` (one-or-more) and `*` quantifiers — `?` (zero-or-
+# one) gives a one-char language which doesn't generalise to the
+# tainted-value usage we see, and complex patterns (alternation, groups)
+# need a richer extractor than this first cut.
+# --------------------------------------------------------------------------
+
+# Reusable string-literal capture that allows backslash-escaped chars
+# (including escaped quotes) inside the literal body.  Pre-fix the
+# bare-class ``[^"']+`` stopped at the first ``\"`` or ``\'`` and
+# silently truncated the captured pattern — see Gerapy CVE-2020-7698
+# fix whose pattern contains ``\"`` and ``\'`` inside a single-quoted
+# Python string.
+_STR_LITERAL = (
+    r"r?(?:"
+    r"'(?:[^'\\]|\\.)+'"     # 'body' with escaped chars allowed
+    r"|"
+    r"\"(?:[^\"\\]|\\.)+\""  # "body" with escaped chars allowed
+    r")"
+)
+
+# `re.match(pattern, var)` or `re.fullmatch(pattern, var)`.  Captures the
+# string literal verbatim (with its quotes/prefix) so the anchor analysis
+# can be exact.
+_RE_MATCH_CALL = _re.compile(
+    r"re\.(?:match|fullmatch)\s*\(\s*"
+    rf"(?P<pat>{_STR_LITERAL})"
+    r"\s*,\s*"
+    r"(?P<var>[A-Za-z_][A-Za-z0-9_]*)"
+)
+
+# `^[chars]+$` / `^[chars]*$` inside a captured string literal.  The body
+# pattern `(?:[^\]\\]|\\.)+` allows escaped close-brackets (``\]``) and
+# other backslash-escaped chars inside the class — without this, real
+# fix-author conventions like ``[\!\@\#\$\;\]\[…]+`` would have my
+# regex stop at the first ``\]`` and silently truncate the captured
+# body, dropping chars from the forbidden set.
+_ANCHORED_CHARSET = _re.compile(r"^\^\[((?:[^\]\\]|\\.)+)\][+*]\$$")
+
+# `re.fullmatch` uses fullmatch semantics so anchors are implicit.  Allow
+# unanchored `[chars]+` / `[chars]*` only when the call is fullmatch.
+_FULLMATCH_CHARSET = _re.compile(r"^\[((?:[^\]\\]|\\.)+)\][+*]$")
+
+
+# Substitution rebind: ``x = re.sub('[forbidden]+', '', x)``.
+# Constraints for soundness:
+#   1. LHS and the third argument (the input) are the SAME identifier — so
+#      the sanitized value replaces the original (`safe = re.sub(..., '', x)`
+#      would leave the unsanitized `x` reachable; we'd need dataflow to
+#      know whether `safe` actually reaches the sink, which we don't have).
+#   2. Replacement is the EMPTY string — anything else could introduce a
+#      different danger char.
+#   3. Pattern body is a single `[...]+` or `[...]*` character class
+#      (same shape as the allowlist case, just used inversely).
+_RE_SUB_REBIND = _re.compile(
+    r"(?P<var>[A-Za-z_][A-Za-z0-9_]*)\s*=\s*"
+    r"re\.sub\s*\(\s*"
+    rf"(?P<pat>{_STR_LITERAL})"
+    r"\s*,\s*"
+    r"(?:''|\"\")"                    # empty replacement, strictly
+    r"\s*,\s*"
+    r"(?P=var)"                       # same identifier on the RHS
+)
+
+# Body of the `[...]` charset inside a re.sub pattern.  Quantifier optional
+# — `re.sub` strips even single occurrences, so `[chars]` and `[chars]+`
+# are equally sound for our purposes (every match is replaced).
+# Body shape `(?:[^\]\\]|\\.)+` supports backslash-escaped chars inside
+# the class (e.g. ``\]``, ``\\``) — Gerapy's fix uses
+# ``'[\!\@\#\$\;\&\*\~\"\'\{\}\]\[\-\+\%\^]+'`` which contains ``\]``
+# and would otherwise truncate at the escaped close-bracket.
+_SUB_CHARSET = _re.compile(r"^\[((?:[^\]\\]|\\.)+)\][+*]?$")
+
+
+# --------------------------------------------------------------------------
+# Multi-language guard-and-exit patterns.
+#
+# Each regex matches the validator call AND its exit-on-fail in ONE diff
+# line — so when the extractor fires, we already have the dominance
+# evidence baked in (the fix author wrote both on the same line).  No
+# language-specific AST parsing required.  This trades some recall
+# (multi-line guard-and-exit shapes are missed) for full soundness
+# without tree-sitter / external parsers.
+#
+# For all forms: the captured `chars` group is the body of the `[...]`
+# class and is fed into the existing Python charset proof
+# (:func:`_prove_charset`); the regex semantics for `[chars]+` are the
+# same across all these languages for the literal characters and ranges
+# our extractor accepts.
+# --------------------------------------------------------------------------
+
+# JS/TS — `if (!/^[chars]+$/.test(<var>)) return|throw …`
+_JS_GUARD_TEST = _re.compile(
+    r"if\s*\(\s*!\s*/\^\[(?P<chars>[^\]]+)\][+*]\$/\s*\.test\s*\(\s*"
+    r"(?P<var>[A-Za-z_$][A-Za-z_$0-9]*)\s*\)\s*\)\s*"
+    r"\{?\s*(?:return|throw)\b"
+)
+# JS/TS — `if (!<var>.match(/^[chars]+$/)) return|throw …`
+_JS_GUARD_MATCH = _re.compile(
+    r"if\s*\(\s*!\s*(?P<var>[A-Za-z_$][A-Za-z_$0-9]*)\s*\.match\s*\(\s*"
+    r"/\^\[(?P<chars>[^\]]+)\][+*]\$/\s*\)\s*\)\s*"
+    r"\{?\s*(?:return|throw)\b"
+)
+
+# Java — `if (!<var>.matches("[chars]+")) return|throw …`
+# Java's ``String.matches`` is FULLMATCH by default: the regex is anchored
+# even without explicit ``^...$``.  Anchor characters in the source are
+# permitted (no-op) but not required.
+_JAVA_GUARD = _re.compile(
+    r'if\s*\(\s*!\s*(?P<var>[A-Za-z_$][A-Za-z_$0-9]*)\s*\.matches\s*\(\s*'
+    r'"\^?\[(?P<chars>[^\]]+)\][+*]\$?"\s*\)\s*\)\s*'
+    r'\{?\s*(?:return|throw)\b'
+)
+
+# Ruby — `return|raise … unless <var> =~ /^[chars]+$/`
+_RUBY_GUARD_UNLESS = _re.compile(
+    r"(?:return|raise)\b[^\n]*?\s+unless\s+(?P<var>[a-z_][a-z_0-9]*)\s*=~\s*"
+    r"/\^\[(?P<chars>[^\]]+)\][+*]\$/"
+)
+# Ruby — `return|raise … if <var> !~ /^[chars]+$/`
+_RUBY_GUARD_IF_NOT_MATCH = _re.compile(
+    r"(?:return|raise)\b[^\n]*?\s+if\s+(?P<var>[a-z_][a-z_0-9]*)\s*!~\s*"
+    r"/\^\[(?P<chars>[^\]]+)\][+*]\$/"
+)
+
+
+def _strip_string_literal(raw: str) -> str:
+    """Strip Python string-literal quoting (and the `r` prefix) from a
+    token captured by ``_RE_MATCH_CALL``.  Returns the inner regex body."""
+    if raw.startswith("r"):
+        raw = raw[1:]
+    if len(raw) >= 2 and raw[0] in ("'", '"') and raw[-1] == raw[0]:
+        return raw[1:-1]
+    return raw
+
+
+# Any `\X` where X is alphabetic — covers regex shorthand classes
+# (``\d \w \s \D \W \S``), word boundary (``\b``), and control-char
+# escapes (``\n \t ...``).  Conservative blanket reject because:
+#
+#   * ``\D``, ``\W``, ``\S`` are the NEGATIVE shorthand classes; they
+#     INCLUDE typical danger chars (``/``, ``\\``, shell metachars).
+#     If our literal-char extractor silently reads ``\W`` as chars
+#     ``{\\, W}``, the soundness check returns SOUND for a validator
+#     that actually accepts the danger char — a false positive
+#     suppression.  This is unsound.
+#   * ``\d`` / ``\w`` / ``\s`` are the POSITIVE counterparts; under
+#     the same literal-misreading they happen to be conservative
+#     (under-approximate the language, so the verdict goes to
+#     DECLINED) but the misreading itself is wrong and would compound
+#     with other patterns.
+#
+# Rejecting any alphabetic backslash escape sidesteps the whole class
+# of bugs.  Callers that want to model ``[\\d]`` properly will need a
+# richer extractor — Tier 2 takes those cases for now.
+_ALPHA_BACKSLASH_ESCAPE = _re.compile(r"\\[A-Za-z]")
+
+
+def _charset_body_is_safe(body: str) -> bool:
+    """Reject character-class bodies our literal-char extractor would
+    misread:
+
+      * **Negation** (``[^chars]``) — inverts the language and would
+        need entirely different proof semantics.  Currently silently
+        misread as a literal ``^`` plus the chars.
+      * **Regex shorthand classes** (``\\d``, ``\\W``, ...) — see
+        ``_ALPHA_BACKSLASH_ESCAPE`` above.
+    """
+    if not body or body.startswith("^"):
+        return False
+    return _ALPHA_BACKSLASH_ESCAPE.search(body) is None
+
+
+def _unescape_charclass(chars: str) -> str:
+    """Strip backslash escapes from a regex character-class body.
+
+    Inside ``[...]`` only ``]``, ``\\``, and a leading ``^`` need real
+    escaping; other escape sequences (``\\!``, ``\\@``, ...) are
+    unnecessary but legal, and the unescaped character is what the
+    pattern actually matches.  Stripping them gives us the true
+    member-set of the class.
+
+    Used by the ``re.sub`` extractor where authors often over-escape
+    (e.g. Gerapy's
+    ``'[\\!\\@\\#\\$\\;\\&\\*\\~\\"\\'\\{\\}\\]\\[\\-\\+\\%\\^]+'``).
+    """
+    return _re.sub(r"\\(.)", r"\1", chars)
+
+
+def _try_charset_validator(line: str, offset: int) -> Optional[ValidatorSpec]:
+    """Match the whole-string `re.match`/`re.fullmatch` over `^[chars]+$`
+    pattern.  Returns ``None`` on no match so the caller can try other
+    extractors."""
+    m = _RE_MATCH_CALL.search(line)
+    if not m:
+        return None
+    call_kind = "fullmatch" if "fullmatch" in line[m.start():m.end()] else "match"
+    pattern = _strip_string_literal(m.group("pat"))
+    var_name = m.group("var")
+    cs = _ANCHORED_CHARSET.match(pattern)
+    if cs is None and call_kind == "fullmatch":
+        cs = _FULLMATCH_CHARSET.match(pattern)
+    if cs is None or not _charset_body_is_safe(cs.group(1)):
+        return None
+    return ValidatorSpec(
+        kind="charset", var_name=var_name, charset=cs.group(1),
+        source_line=line.strip(), diff_line_offset=offset,
+    )
+
+
+def _try_charset_sub_validator(line: str, offset: int) -> Optional[ValidatorSpec]:
+    """Match the ``x = re.sub('[forbidden]+', '', x)`` rebind pattern.
+    Returns ``None`` on no match."""
+    m = _RE_SUB_REBIND.search(line)
+    if not m:
+        return None
+    pattern = _strip_string_literal(m.group("pat"))
+    cs = _SUB_CHARSET.match(pattern)
+    if not cs or not _charset_body_is_safe(cs.group(1)):
+        return None
+    forbidden = _unescape_charclass(cs.group(1))
+    return ValidatorSpec(
+        kind="charset_sub", var_name=m.group("var"),
+        forbidden=forbidden, source_line=line.strip(),
+        diff_line_offset=offset,
+    )
+
+
+def _try_jsts_validator(line: str, offset: int) -> Optional[ValidatorSpec]:
+    """JS / TS guard-and-exit shapes.  Single regex match implies both
+    the validator and its exit-on-fail are on the line — dominance is
+    established by the diff itself."""
+    m = _JS_GUARD_TEST.search(line) or _JS_GUARD_MATCH.search(line)
+    if m is None or not _charset_body_is_safe(m.group("chars")):
+        return None
+    return ValidatorSpec(
+        kind="charset", var_name=m.group("var"), charset=m.group("chars"),
+        source_line=line.strip(), diff_line_offset=offset,
+    )
+
+
+def _try_java_validator(line: str, offset: int) -> Optional[ValidatorSpec]:
+    """Java ``String.matches`` guard-and-exit shape."""
+    m = _JAVA_GUARD.search(line)
+    if m is None or not _charset_body_is_safe(m.group("chars")):
+        return None
+    return ValidatorSpec(
+        kind="charset", var_name=m.group("var"), charset=m.group("chars"),
+        source_line=line.strip(), diff_line_offset=offset,
+    )
+
+
+def _try_ruby_validator(line: str, offset: int) -> Optional[ValidatorSpec]:
+    """Ruby ``unless x =~ /…/`` and ``if x !~ /…/`` guard shapes."""
+    m = _RUBY_GUARD_UNLESS.search(line) or _RUBY_GUARD_IF_NOT_MATCH.search(line)
+    if m is None or not _charset_body_is_safe(m.group("chars")):
+        return None
+    return ValidatorSpec(
+        kind="charset", var_name=m.group("var"), charset=m.group("chars"),
+        source_line=line.strip(), diff_line_offset=offset,
+    )
+
+
+# Per-language extractor table.  Each entry is a list of single-line
+# pattern-tryers, evaluated in order; the first match wins.  Python is
+# special-cased: its extractors don't include the exit-on-fail
+# pattern (the validator and its `if`-body are typically on separate
+# lines), so Python uses the AST-based dominance check downstream.
+_LANG_EXTRACTORS = {
+    "python":     [_try_charset_validator, _try_charset_sub_validator],
+    "javascript": [_try_jsts_validator],
+    "typescript": [_try_jsts_validator],
+    "java":       [_try_java_validator],
+    "ruby":       [_try_ruby_validator],
+}
+
+
+def extract_validator(fix_diff: str, language: str = "python") -> Optional[ValidatorSpec]:
+    """Scan the fix diff for a recognised mechanical validator pattern.
+
+    Iterates every line starting with ``+`` (excluding the ``+++`` file
+    header).  Dispatches to the per-``language`` extractor table; first
+    match wins.  None when no recognised pattern is present — Tier 0
+    then falls through to Tier 2.
+
+    Non-Python languages: each extractor matches the full
+    ``if (!validator) exit`` shape on ONE line, so dominance is
+    established by the diff itself (the fix author bound the guard and
+    the exit-on-fail together).  Multi-line variants are deliberately
+    missed for soundness — partial matches could falsely claim
+    dominance where the exit isn't actually reached.
+    """
+    if not fix_diff:
+        return None
+    extractors = _LANG_EXTRACTORS.get(language)
+    if not extractors:
+        return None
+    for offset, raw in enumerate(fix_diff.splitlines()):
+        if not raw.startswith("+") or raw.startswith("+++"):
+            continue
+        line = raw[1:]
+        for try_fn in extractors:
+            spec = try_fn(line, offset)
+            if spec is not None:
+                return spec
+    return None
+
+
+# --------------------------------------------------------------------------
+# Dominance check.
+#
+# The validator must dominate the sink — every flow that reaches the sink
+# must have passed through the validator.  Otherwise neutralising the
+# validator's language doesn't suppress the real flow.
+#
+# Pre-fix design tried the SARIF codeFlow ("if the validator's line is a
+# step on the value's tainted path, dominance is established").  That
+# turned out to be too strict: CodeQL's codeFlow tracks
+# value-transformation nodes (where the tainted value moves), not
+# control-flow guards (where the value is examined).  A ``re.match``
+# ``if``-check inspects the value without transforming it, so the
+# validator line ISN'T on the codeFlow even when it provably gates the
+# sink.  Net effect: zero Tier 0 hits across the 87-FP-candidate corpus,
+# even on cases (e.g. CVE-2024-22204 whoogle) whose validator was the
+# exact shape Tier 0 was built for.
+#
+# Replacement: source-order + same-function + exit-on-fail AST check.
+# Sound for the dominant fix-added-charset-validator pattern:
+#
+#   if not <validator_call>:
+#       return <error>
+#   # ... value continues to the sink
+#
+# AND the symmetric:
+#
+#   if <validator_call>:
+#       # continue
+#   else:
+#       return <error>
+#
+# Anything more exotic falls through to Tier 2; soundness is preserved
+# because Tier 0 declines, it doesn't fabricate a suppression.
+# --------------------------------------------------------------------------
+
+def _is_sys_exit_call(call: ast.Call) -> bool:
+    """``sys.exit(...)`` / ``exit(...)`` / ``quit(...)`` — bare or via
+    ``sys.``.  Treated as a function-exiting control transfer for the
+    dominance check (matches how operators emit hard-stop guards)."""
+    f = call.func
+    if isinstance(f, ast.Attribute) and isinstance(f.value, ast.Name):
+        return f.value.id == "sys" and f.attr == "exit"
+    if isinstance(f, ast.Name):
+        return f.id in {"exit", "quit"}
+    return False
+
+
+def _block_always_exits(body: list) -> bool:
+    """A block always exits if it contains a top-level ``Return`` /
+    ``Raise`` / ``sys.exit(...)``.
+
+    Conservative — does NOT reason about nested control flow (if every
+    branch of a nested ``if`` returns, the block exits too, but we don't
+    detect that).  False negatives just mean Tier 0 declines on
+    unusual-but-sound guards; soundness is preserved.
+
+    Empty / missing body -> False (no statements at all means no exit,
+    e.g. ``if X: pass`` doesn't gate anything).
+    """
+    if not body:
+        return False
+    for stmt in body:
+        if isinstance(stmt, (ast.Return, ast.Raise)):
+            return True
+        if (isinstance(stmt, ast.Expr) and isinstance(stmt.value, ast.Call)
+                and _is_sys_exit_call(stmt.value)):
+            return True
+    return False
+
+
+def _function_containing(tree: ast.AST, line: int) -> Optional[ast.AST]:
+    """Smallest-range FunctionDef / AsyncFunctionDef containing ``line``,
+    or None.  "Smallest range" so nested functions resolve to the inner
+    one, matching the semantics of "same function" we want for dominance."""
+    best: Optional[ast.AST] = None
+    best_size: Optional[int] = None
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            start = node.lineno
+            end = getattr(node, "end_lineno", None) or start
+            if start <= line <= end:
+                size = end - start
+                if best_size is None or size < best_size:
+                    best = node
+                    best_size = size
+    return best
+
+
+def _block_uses_raise(body: list) -> bool:
+    """True iff the block exits via ``raise`` specifically (not Return /
+    sys.exit).  Used to detect Bug 19: a ``raise`` exit inside a
+    ``try/except`` can be CAUGHT and let the unvalidated value reach
+    the sink — soundness requires checking the surrounding context."""
+    if not body:
+        return False
+    for stmt in body:
+        if isinstance(stmt, ast.Raise):
+            return True
+    return False
+
+
+def _line_in_try_body_with_catching_handler(
+    tree: ast.AST, validator_line: int,
+) -> bool:
+    """True iff ``validator_line`` falls inside the ``try.body`` of a
+    ``Try`` whose handlers might catch a generic / unspecified
+    exception.
+
+    Conservative: any ``except:`` (bare), ``except Exception:``,
+    ``except BaseException:`` triggers; specific exception classes
+    don't (since the validator's ``raise`` typically raises
+    ``ValueError``/``BadRequest`` and a generic ``except OSError:``
+    won't catch those).  False positives here only cost yield —
+    they don't compromise soundness.
+    """
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Try):
+            continue
+        # validator_line must be inside try.body specifically (NOT inside
+        # an except handler or finally — those are different control paths)
+        in_try_body = False
+        for stmt in node.body:
+            stmt_end = getattr(stmt, "end_lineno", None) or stmt.lineno
+            if stmt.lineno <= validator_line <= stmt_end:
+                in_try_body = True
+                break
+        if not in_try_body:
+            continue
+        for h in node.handlers:
+            t = h.type
+            # bare except: -> catches everything (UNSOUND if validator raises)
+            if t is None:
+                return True
+            # except Exception: / except BaseException:
+            if isinstance(t, ast.Name) and t.id in {"Exception", "BaseException"}:
+                return True
+            # except (Exception, OSError): tuple of types
+            if isinstance(t, ast.Tuple):
+                for elt in t.elts:
+                    if isinstance(elt, ast.Name) and elt.id in {"Exception", "BaseException"}:
+                        return True
+    return False
+
+
+def _validator_block_exits_on_failure(
+    tree: ast.AST, validator_line: int,
+) -> bool:
+    """Find the :class:`ast.If` whose ``lineno`` equals ``validator_line``
+    and confirm the FAILURE branch exits.
+
+      * ``if not <call>: BODY`` (UnaryOp/Not) — BODY is the failure branch.
+      * ``if <call>: ... else: ELSE`` — ELSE is the failure branch.
+
+    Additional soundness check (Bug 19): if the failure branch exits via
+    ``raise`` and the validator's ``If`` is inside a ``try.body`` whose
+    handler might catch the exception, dominance does NOT hold (the
+    raise is caught and the unvalidated value reaches the sink).
+    """
+    for node in ast.walk(tree):
+        if isinstance(node, ast.If) and node.lineno == validator_line:
+            test = node.test
+            if isinstance(test, ast.UnaryOp) and isinstance(test.op, ast.Not):
+                failure_body = node.body
+            else:
+                failure_body = node.orelse
+            if not _block_always_exits(failure_body):
+                return False
+            # If the exit is `raise` and we're inside a catching try,
+            # the raise gets caught — decline.
+            if (_block_uses_raise(failure_body)
+                    and _line_in_try_body_with_catching_handler(
+                        tree, validator_line)):
+                return False
+            return True
+    return False
+
+
+def find_validator_line(source_text: str, spec: ValidatorSpec) -> Optional[int]:
+    """Locate the validator's 1-based line number in the post-fix source
+    text.  Matches by the stripped line-text the extractor saved on the
+    spec; first occurrence wins (multiple matches are unusual and any of
+    them would gate the sink the same way).
+
+    Pre-fix this read the file from disk; the refactor pulls the I/O out
+    to :func:`try_tier0` so the source text can be reused by the
+    dominance check without a second read.
+    """
+    needle = spec.source_line
+    for idx, ln in enumerate(source_text.splitlines()):
+        if ln.strip() == needle:
+            return idx + 1
+    return None
+
+
+def _target_rebinds(target: ast.AST, var_name: str) -> bool:
+    """Recursively check if an assignment-target AST node rebinds
+    ``var_name``.  Handles bare ``Name``, ``Tuple``/``List`` unpacking,
+    and ``Starred`` star-unpacking.  ``Subscript`` and ``Attribute``
+    targets are mutations of contents, not rebindings, and return
+    False."""
+    if isinstance(target, ast.Name):
+        return target.id == var_name
+    if isinstance(target, (ast.Tuple, ast.List)):
+        return any(_target_rebinds(t, var_name) for t in target.elts)
+    if isinstance(target, ast.Starred):
+        return _target_rebinds(target.value, var_name)
+    return False
+
+
+def _variable_reassigned_between(
+    tree: ast.AST, var_name: str, after_line: int, before_line: int,
+) -> bool:
+    """True iff ``var_name`` is rebound at a line strictly between
+    ``after_line`` and ``before_line``.
+
+    Sound conservatism for ``charset_sub``: ``x = re.sub('[F]+', '', x)``
+    rebinds ``x`` to the sanitized value, but a later rebind would undo
+    that sanitization.  Detect every common rebinding form so the
+    dominance check doesn't false-positive:
+
+      * ``x = …`` / ``x += …`` / ``x: T = …`` (Assign / AugAssign / AnnAssign)
+      * ``x, y = pair`` and ``*x, = …`` (tuple / star-unpack targets)
+      * ``for x in …:`` (For / AsyncFor)
+      * ``with … as x:`` (With / AsyncWith optional_vars)
+      * ``(x := …)`` (NamedExpr walrus)
+
+    Pure-mutation forms (``x[0] = …``, ``x.attr = …``) don't rebind
+    ``x`` itself and are NOT flagged.  Function/class definitions and
+    imports that happen to bind ``x`` are not flagged either — they
+    create their own scopes and very rarely appear between a fix-added
+    substitution and its sink.
+    """
+    for node in ast.walk(tree):
+        line = getattr(node, "lineno", None)
+        if line is None or not (after_line < line < before_line):
+            continue
+        # Forms whose target is an AST node (Name / Tuple / Starred).
+        targets: list = []
+        if isinstance(node, ast.Assign):
+            targets = list(node.targets)
+        elif isinstance(node, (ast.AugAssign, ast.AnnAssign, ast.NamedExpr)):
+            targets = [node.target]
+        elif isinstance(node, (ast.For, ast.AsyncFor)):
+            targets = [node.target]
+        elif isinstance(node, (ast.With, ast.AsyncWith)):
+            for item in node.items:
+                if item.optional_vars is not None:
+                    targets.append(item.optional_vars)
+        for t in targets:
+            if _target_rebinds(t, var_name):
+                return True
+        # Forms whose binding name is a plain string attribute.
+        # ``except SomeError as x`` binds x in the surrounding scope
+        # (unbound at end of handler in Py3, but during the handler
+        # body x IS the exception, not the sanitized value).
+        if isinstance(node, ast.ExceptHandler) and node.name == var_name:
+            return True
+        # Nested function / class definitions inside the body shadow
+        # the outer name with a function/class object — rare but
+        # possible in fix code.
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef,
+                              ast.ClassDef)) and node.name == var_name:
+            return True
+    return False
+
+
+def _same_function_in_order(
+    tree: ast.AST, validator_line: int, sink_line: int,
+) -> bool:
+    """Shared first half of every kind's dominance check: validator
+    appears BEFORE the sink in source order, AND both lines are inside
+    the same enclosing function."""
+    if validator_line >= sink_line:
+        return False
+    v_fn = _function_containing(tree, validator_line)
+    s_fn = _function_containing(tree, sink_line)
+    return v_fn is not None and v_fn is s_fn
+
+
+def validator_dominates_sink(
+    source_text: str, validator_line: int, sink_line: int,
+) -> bool:
+    """Sound dominance for the ``kind="charset"`` form — whole-string
+    allowlist guarded by an ``if``-statement.
+
+    Two checks ride on the post-fix source AST:
+
+      1. ``validator_line < sink_line`` AND both lines inside the same
+         enclosing function.
+      2. The validator's ``if not X:`` block (or the ``else:`` branch
+         of an ``if X: ... else:`` form) provably exits via return /
+         raise / ``sys.exit`` — so a value that fails validation
+         cannot reach the sink.
+
+    Substitution-form (``kind="charset_sub"``) uses a different check
+    (no ``if`` block, instead a no-reassignment guard) — see
+    :func:`substitution_dominates_sink`.
+    """
+    try:
+        tree = ast.parse(source_text)
+    except SyntaxError:
+        return False
+    if not _same_function_in_order(tree, validator_line, sink_line):
+        return False
+    return _validator_block_exits_on_failure(tree, validator_line)
+
+
+# Function-definition markers per non-Python language.  Used by the
+# non-Python dominance heuristic: any line strictly between validator and
+# sink that matches one of these implies a function boundary, which
+# means the validator's exit-on-fail (the diff's guard-and-exit shape)
+# returns from a DIFFERENT function than the one the sink lives in.
+# Conservative: any match -> decline Tier 0.  False negatives (some
+# non-function lines coincidentally matching) cost us a sound case;
+# false positives (function boundary missed) would be UNSOUND.
+# Control-flow keywords that must NOT be confused with a function /
+# method name in the line-start pattern.  ``if (x) {`` would otherwise
+# match a bare-identifier-then-args-then-brace shape and look like a
+# method header.
+_JS_NOT_FUNC = r"(?:if|for|while|switch|catch|else|do|try|with|return|throw|var|let|const)"
+_JAVA_NOT_FUNC = r"(?:if|for|while|switch|catch|else|do|try|return|throw|new|synchronized)"
+
+# JS / TS modifier list — includes TS-only modifiers (public/private/
+# protected/readonly) on the JS key too, because ``cvefix_walk._codeql_lang``
+# maps both ``JavaScript`` and ``TypeScript`` repos to ``"javascript"``, so
+# TS class methods would otherwise skip past the JS boundary regex
+# (cross-method dominance hole — UNSOUND).
+_JSTS_METHOD_MODIFIERS = (
+    r"(?:async\s+|static\s+|get\s+|set\s+"
+    r"|public\s+|private\s+|protected\s+|readonly\s+)*"
+)
+# Optional generator marker — ``function* name()`` / ``*method()``.
+_JSTS_GENERATOR = r"\*?\s*"
+
+_FUNCTION_BOUNDARY_PATTERNS = {
+    # JS / TS:
+    #   `function [*] name(` / `function(` (named, anonymous, generator)
+    #   `=> {` arrow function declaration at end of line
+    #   `<modifier*> [*] name(args) {` ES6 method or TS class method —
+    #     with a negative lookahead so `if (x) {` etc. don't match
+    "javascript": _re.compile(
+        rf"\bfunction\s*{_JSTS_GENERATOR}\w*\s*\("
+        r"|=>\s*\{?\s*$"
+        rf"|^\s*{_JSTS_METHOD_MODIFIERS}{_JSTS_GENERATOR}"
+        rf"(?!{_JS_NOT_FUNC}\b)"
+        r"[A-Za-z_$][\w$]*\s*\([^)]*\)\s*\{",
+    ),
+    "typescript": _re.compile(
+        rf"\bfunction\s*{_JSTS_GENERATOR}\w*\s*\("
+        r"|=>\s*\{?\s*$"
+        rf"|^\s*{_JSTS_METHOD_MODIFIERS}{_JSTS_GENERATOR}"
+        rf"(?!{_JS_NOT_FUNC}\b)"
+        r"[A-Za-z_$][\w$]*\s*\([^)]*\)\s*\{",
+    ),
+    # Java:
+    #   `<modifier+> <return-type?> name(args) [throws ...] {?` — the
+    #     explicit-modifier form covers public / private / protected /
+    #     static / final / abstract / synchronized methods.
+    #   `<type> name(args) [throws ...] {?` at line start — covers
+    #     package-private methods (no modifier).  ``type`` is either a
+    #     primitive or a TitleCase identifier (Java naming convention);
+    #     negative lookahead excludes control-flow keywords so
+    #     `if (x) {` doesn't false-positive match.
+    "java": _re.compile(
+        r"\b(?:public|private|protected|static|final|abstract|synchronized)\b"
+        r"[^{};]*\([^)]*\)\s*(?:throws[^{]*)?\{?\s*$"
+        rf"|^\s*(?!{_JAVA_NOT_FUNC}\b)"
+        r"(?:(?:void|boolean|byte|char|short|int|long|float|double)"
+        r"|[A-Z]\w*(?:<[^>]*>)?(?:\[\])?)\s+"
+        r"\w+\s*\([^)]*\)\s*(?:throws[^{]*)?\{?\s*$",
+    ),
+    # Ruby: ``def name`` (instance) or ``def self.name`` (class method)
+    # at line start (any indentation level for nested methods / class
+    # methods).
+    "ruby": _re.compile(r"^\s*def\s+(?:self\.)?\w"),
+}
+
+
+def _crosses_function_boundary(
+    source_text: str, validator_line: int, sink_line: int, language: str,
+) -> bool:
+    """True iff any line strictly between ``validator_line`` and
+    ``sink_line`` matches a function-definition pattern for ``language``.
+
+    Plugs the cross-function dominance hole for non-Python: without a
+    real AST, the source-order check alone would say a validator in
+    helper A dominates a sink in helper B when both live in the same
+    file and A's line < B's line.  The validator's ``if (!X) return``
+    returns from A, not B, so the sink in B is not gated.  Reject
+    Tier 0 when we see a function boundary.
+    """
+    pat = _FUNCTION_BOUNDARY_PATTERNS.get(language)
+    if pat is None:
+        return False
+    lines = source_text.splitlines()
+    # lines is 0-indexed; validator/sink are 1-indexed lines.
+    for ln in lines[validator_line:sink_line - 1]:
+        if pat.search(ln):
+            return True
+    return False
+
+
+def _collect_target_names(target: ast.AST, names: set) -> None:
+    """Walk an assignment target and add every bound ``Name`` id to
+    ``names``.  Subscript / Attribute targets mutate contents instead of
+    rebinding and are correctly ignored."""
+    if isinstance(target, ast.Name):
+        names.add(target.id)
+    elif isinstance(target, (ast.Tuple, ast.List)):
+        for elt in target.elts:
+            _collect_target_names(elt, names)
+    elif isinstance(target, ast.Starred):
+        _collect_target_names(target.value, names)
+
+
+def _python_chain_reaches_sink(
+    tree: ast.AST, start_var: str, validator_line: int,
+    sink_line: int, sink_line_text: str,
+) -> bool:
+    """Intra-procedural data-dependency chain: ``True`` iff some variable
+    reachable from ``start_var`` (via assignments between validator and
+    sink) appears at ``sink_line_text``.
+
+    Why this exists: the previous "validator's var must literally appear
+    at the sink line" check rejected the standard pattern where the
+    validated value threads through a derived expression
+    (``cfg = os.path.join(BASE, name); open(cfg)``) — the sink line
+    references ``cfg``, not ``name``, but ``cfg`` carries ``name``'s
+    constraint.  Chain tracking accepts that case while still rejecting
+    the original Bug 15 scenario (validator for ``x``, sink for
+    unrelated ``y`` in the same function) — ``y`` never appears as a
+    chain member.
+
+    Chain growth: any Assign/AnnAssign/AugAssign between validator and
+    sink whose RHS references a chain variable adds its target name(s)
+    to the chain.  Conservative w.r.t. control flow (every assignment
+    is treated as reachable) — soundness for the Tier 0 verdict still
+    rests on the SMT proof + the dominance check; this is just the
+    soundness layer that the validator's constraint applies to what
+    reaches the sink.
+    """
+    chain: set = {start_var}
+    # Iterate multiple passes — a derived variable assigned later might
+    # itself feed a still-later assignment.  Fixed point on a small
+    # chain is cheap (at most ~function-line-count iterations).
+    changed = True
+    while changed:
+        changed = False
+        for node in ast.walk(tree):
+            if not isinstance(node, (ast.Assign, ast.AugAssign, ast.AnnAssign)):
+                continue
+            node_line = getattr(node, "lineno", None) or 0
+            if not (validator_line <= node_line <= sink_line):
+                continue
+            value = node.value
+            if value is None:
+                continue
+            rhs_names = {n.id for n in ast.walk(value) if isinstance(n, ast.Name)}
+            if not (chain & rhs_names):
+                continue
+            targets = (list(node.targets) if isinstance(node, ast.Assign)
+                       else [node.target])
+            before = len(chain)
+            for t in targets:
+                _collect_target_names(t, chain)
+            if len(chain) > before:
+                changed = True
+    for var in chain:
+        if _re.search(rf"\b{_re.escape(var)}\b", sink_line_text):
+            return True
+    return False
+
+
+def substitution_dominates_sink(
+    source_text: str, validator_line: int, sink_line: int, var_name: str,
+) -> bool:
+    """Sound dominance for ``kind="charset_sub"`` — assignment-form
+    sanitizer (``x = re.sub('[forbidden]+', '', x)``).
+
+    Conditions:
+
+      1. Same source-order + same-function check.
+      2. ``var_name`` is NOT rebound between the substitution line and
+         the sink line.  A later ``x = req.GET('x')`` would undo the
+         sanitization and invalidate the post-sub language claim.
+         Mutating-subscript assignments (``x[0] = ...``) don't rebind
+         ``x`` itself and aren't flagged.
+    """
+    try:
+        tree = ast.parse(source_text)
+    except SyntaxError:
+        return False
+    if not _same_function_in_order(tree, validator_line, sink_line):
+        return False
+    return not _variable_reassigned_between(
+        tree, var_name, validator_line, sink_line,
+    )
+
+
+# --------------------------------------------------------------------------
+# SMT: regex-intersection emptiness.
+# --------------------------------------------------------------------------
+
+def _charclass_to_re(chars: str):
+    """Build a Z3 regex matching ONE char from a Python `[...]` body
+    (literal chars and `a-z` ranges).  Limited to the syntax our extractor
+    captures — escapes and `\\d`-style metachars are out of scope for the
+    first cut."""
+    alts = []
+    i, n = 0, len(chars)
+    while i < n:
+        if i + 2 < n and chars[i + 1] == "-":
+            alts.append(z3.Range(chars[i], chars[i + 2]))
+            i += 3
+        else:
+            alts.append(z3.Re(z3.StringVal(chars[i])))
+            i += 1
+    return z3.Union(*alts) if len(alts) > 1 else alts[0]
+
+
+def _danger_re(danger: List[str]):
+    """Regex for strings containing any danger char: ``.*[danger].*``."""
+    rs = z3.ReSort(z3.StringSort())
+    anystr = z3.Star(z3.AllChar(rs))
+    if len(danger) > 1:
+        chars = z3.Union(*[z3.Re(z3.StringVal(c)) for c in danger])
+    else:
+        chars = z3.Re(z3.StringVal(danger[0]))
+    return z3.Concat(anystr, chars, anystr)
+
+
+@dataclass
+class _ProofVerdict:
+    sound: bool
+    counterexample: Optional[str]
+    reasoning: str
+
+
+def _expand_charset_body(body: str) -> set:
+    """Expand a regex char-class body like ``A-Za-z0-9_.+-`` into the
+    finite set of characters it matches.
+
+    Handles ``X-Y`` ranges with ``ord(X) <= ord(Y)`` and literal chars;
+    everything else (including ``X-Y`` where ``X`` and ``Y`` aren't in
+    range-ascending order — would silently drop chars under a naive
+    ``range(ord(X), ord(Y)+1)``) is treated as three separate literals.
+    """
+    out: set = set()
+    i, n = 0, len(body)
+    while i < n:
+        if (i + 2 < n and body[i + 1] == "-"
+                and ord(body[i]) <= ord(body[i + 2])):
+            for cp in range(ord(body[i]), ord(body[i + 2]) + 1):
+                out.add(chr(cp))
+            i += 3
+        else:
+            out.add(body[i])
+            i += 1
+    return out
+
+
+def _prove_charset(spec: ValidatorSpec, sink_class: str, danger: List[str]) -> _ProofVerdict:
+    """Z3 regex-intersection emptiness for whole-string anchored allowlists."""
+    name = z3.String("name")
+    char_re = _charclass_to_re(spec.charset)
+    validator_re = z3.Plus(char_re)
+    s = z3.Solver()
+    s.add(z3.InRe(name, z3.Intersect(validator_re, _danger_re(danger))))
+    r = s.check()
+    if r == z3.unsat:
+        return _ProofVerdict(
+            True, None,
+            f"UNSAT: no string in [{spec.charset}]+ can contain any of "
+            f"{danger!r} -> validator provably neutralises {sink_class}",
+        )
+    if r == z3.sat:
+        try:
+            ce = s.model()[name].as_string()
+        except Exception:
+            ce = None
+        return _ProofVerdict(
+            False, ce,
+            f"SAT: validator [{spec.charset}]+ permits an input that still "
+            f"carries a {sink_class} danger char (counterexample: {ce!r})",
+        )
+    return _ProofVerdict(False, None,
+                         f"z3 returned {r}; declining at Tier 0")
+
+
+def _prove_charset_sub(
+    spec: ValidatorSpec, sink_class: str, danger: List[str],
+) -> _ProofVerdict:
+    """Finite-set inclusion for ``x = re.sub('[forbidden]+', '', x)``.
+
+    Post-sub ``x`` cannot contain any char in ``forbidden`` (every
+    occurrence has been replaced with the empty string).  Therefore:
+
+      * If ``danger_chars ⊆ forbidden_chars`` — every dangerous char was
+        also stripped, so post-sub ``x`` cannot carry any danger.  SOUND.
+      * Otherwise — at least one danger char survives the substitution.
+        That char is the counterexample: any input containing it passes
+        through ``re.sub`` unchanged (and the post-fix CodeQL run still
+        flags this exact flow), so suppression would be unsound.
+
+    Z3 is unnecessary for this proof: the question reduces to finite-set
+    inclusion, decidable in constant time.  Soundness is the same form
+    as the Z3 charset path — a real mathematical proof of language
+    neutralisation — just on a domain small enough to evaluate directly.
+    """
+    forbidden_set = _expand_charset_body(spec.forbidden)
+    danger_set = set(danger)
+    missing = danger_set - forbidden_set
+    if not missing:
+        return _ProofVerdict(
+            True, None,
+            f"set inclusion: re.sub('[{spec.forbidden}]+', '', x) strips every "
+            f"{sink_class} danger char {danger!r} -> validator provably "
+            f"neutralises {sink_class}",
+        )
+    # Stable counterexample pick — sort so the message is deterministic
+    # across runs (sets have no order).
+    ce = sorted(missing)[0]
+    return _ProofVerdict(
+        False, ce,
+        f"set inclusion fails: re.sub strips [{spec.forbidden}]+ but "
+        f"{sink_class} danger char {ce!r} survives -> validator insufficient",
+    )
+
+
+def prove_neutralizes(spec: ValidatorSpec, sink_class: str) -> _ProofVerdict:
+    """Dispatch on ``spec.kind`` to the appropriate sound proof:
+
+      * ``charset``     -> Z3 regex-intersection emptiness
+      * ``charset_sub`` -> finite-set inclusion (danger ⊆ forbidden)
+
+    Either way, SOUND verdicts are real mathematical proofs of
+    language neutralisation; SAT/missing-element verdicts carry a
+    concrete counterexample input.
+    """
+    danger = _DANGER_CHARS.get(sink_class)
+    if danger is None:
+        return _ProofVerdict(
+            False, None,
+            f"no danger model for sink_class={sink_class!r}",
+        )
+    if spec.kind == "charset":
+        return _prove_charset(spec, sink_class, danger)
+    if spec.kind == "charset_sub":
+        return _prove_charset_sub(spec, sink_class, danger)
+    return _ProofVerdict(
+        False, None,
+        f"prove_neutralizes does not handle kind={spec.kind!r}",
+    )
+
+
+# --------------------------------------------------------------------------
+# Orchestrator.
+# --------------------------------------------------------------------------
+
+def try_tier0(
+    *, fix_diff: str, repo_root: Path, sink_uri: str, sink_line: int,
+    sink_class: str, language: str = "python",
+) -> Tier0Result:
+    """Run the full Tier 0 pipeline on one finding.
+
+    Order matters: cheapest checks first.  z3 availability gate first,
+    then mechanical extraction (no z3 yet), then dominance (no z3,
+    single source-file read), then the SMT proof.  Each negative
+    outcome short-circuits with a self-explanatory reasoning string
+    so the bridge's ``detail`` column tells us WHY Tier 0 declined.
+
+    ``language`` selects the per-language extractor and dominance
+    semantics:
+
+      * ``python``: AST-based dominance (source-order + same-function
+        + exit-on-fail).  Supports ``charset`` and ``charset_sub``.
+      * ``javascript`` / ``typescript`` / ``java`` / ``ruby``:
+        guard-and-exit on one diff line implies dominance; the source
+        order check is the only additional verification.
+    """
+    if not _z3_available():
+        return Tier0Result(
+            Tier0Status.Z3_UNAVAILABLE,
+            "z3 not installed; Tier 0 unavailable, falling through to Tier 2",
+        )
+    spec = extract_validator(fix_diff, language=language)
+    if spec is None:
+        return Tier0Result(
+            Tier0Status.NOT_APPLICABLE,
+            "no recognised charset/regex validator added in fix diff",
+        )
+    src_path = repo_root / sink_uri.lstrip("/")
+    if not src_path.is_file():
+        return Tier0Result(
+            Tier0Status.NOT_APPLICABLE,
+            f"post-fix source not readable at {sink_uri!r}",
+            spec=spec,
+        )
+    try:
+        source_text = src_path.read_text(errors="replace")
+    except OSError as exc:
+        return Tier0Result(
+            Tier0Status.NOT_APPLICABLE,
+            f"could not read source {sink_uri!r}: {exc}",
+            spec=spec,
+        )
+    line = find_validator_line(source_text, spec)
+    if line is None:
+        return Tier0Result(
+            Tier0Status.NOT_APPLICABLE,
+            f"validator located in diff but not findable in {sink_uri!r}",
+            spec=spec,
+        )
+    if language != "python":
+        # Non-Python extractors require guard-and-exit on one diff line —
+        # dominance is partly established by the diff itself.  Two
+        # additional checks:
+        #   1. source order in the post-fix file (cheap textual);
+        #   2. no function boundary between validator and sink — without
+        #      an AST per language, a regex-based function-definition
+        #      heuristic plugs the cross-function-dominance hole that
+        #      source-order alone would create.
+        dominates = (line < sink_line and not _crosses_function_boundary(
+            source_text, line, sink_line, language,
+        ))
+        why = (f"either out of source order, or a function boundary "
+               f"appears between the validator at line {line} and the "
+               f"sink at line {sink_line} (the validator's exit-on-fail "
+               f"would then return from a different function than the "
+               f"sink's)")
+    elif spec.kind == "charset_sub":
+        dominates = substitution_dominates_sink(
+            source_text, line, sink_line, spec.var_name,
+        )
+        why = (f"either out of source order, in a different function, "
+               f"or {spec.var_name} was reassigned between the "
+               f"substitution and the sink (undoing sanitization)")
+    else:
+        dominates = validator_dominates_sink(source_text, line, sink_line)
+        why = ("either out of source order, in a different function, "
+               "or the `if not X:` block doesn't exit on failure")
+    if not dominates:
+        return Tier0Result(
+            Tier0Status.NOT_APPLICABLE,
+            f"validator at {sink_uri}:{line} does not dominate sink at "
+            f"{sink_uri}:{sink_line} — {why}",
+            spec=spec,
+        )
+    # Variable-match check: the validator constrains ``spec.var_name``,
+    # so the value at the sink must be in the data-dependency chain
+    # starting from that variable.  For Python we track this via
+    # intra-procedural AST chain growth — handles the common
+    # pass-through pattern ``cfg = os.path.join(BASE, name); open(cfg)``
+    # where the validated ``name`` reaches the sink through ``cfg``.
+    # For non-Python (no per-language AST) we fall back to the literal
+    # "var must appear at sink line" check — conservative direction
+    # but loses pass-through cases.  Both still catch the original
+    # Bug 15 scenario (validator for x, unrelated sink for y).
+    source_lines = source_text.splitlines()
+    if sink_line - 1 < len(source_lines):
+        sink_line_text = source_lines[sink_line - 1]
+    else:
+        sink_line_text = ""
+    if language == "python":
+        try:
+            chain_tree = ast.parse(source_text)
+        except SyntaxError:
+            var_reaches = False
+        else:
+            var_reaches = _python_chain_reaches_sink(
+                chain_tree, spec.var_name, line, sink_line, sink_line_text,
+            )
+    else:
+        var_reaches = bool(_re.search(
+            rf"\b{_re.escape(spec.var_name)}\b", sink_line_text,
+        ))
+    if not var_reaches:
+        return Tier0Result(
+            Tier0Status.NOT_APPLICABLE,
+            f"validator constrains {spec.var_name!r} but no chain member "
+            f"reaches the sink line at {sink_uri}:{sink_line} — the "
+            f"validated value may not be what reaches the sink",
+            spec=spec,
+        )
+    verdict = prove_neutralizes(spec, sink_class)
+    if verdict.sound:
+        if spec.kind == "charset_sub":
+            artifact = (
+                f"smt:charset_sub:[{spec.forbidden}]@{sink_uri}:{line}"
+            )
+        else:
+            artifact = f"smt:charset:[{spec.charset}]+@{sink_uri}:{line}"
+        return Tier0Result(
+            Tier0Status.SOUND, verdict.reasoning, spec=spec,
+            artifact=artifact,
+            extras={"validator_line": line, "var_name": spec.var_name},
+        )
+    return Tier0Result(
+        Tier0Status.DECLINED, verdict.reasoning, spec=spec,
+        counterexample=verdict.counterexample,
+        extras={"validator_line": line},
+    )

--- a/core/dataflow/tests/test_barrier_synth.py
+++ b/core/dataflow/tests/test_barrier_synth.py
@@ -99,6 +99,7 @@ def test_assemble_ruby_mirrors_python_configsig_with_ruby_imports():
     q = assemble_barrier_query(_RB_GUARD, sink_class="sqli", query_id="raptor/rb",
                                language="ruby")
     assert "import codeql.ruby.DataFlow" in q
+    assert "import codeql.ruby.AST" in q                         # AST types (MethodCall) resolve in guards
     assert "SqlInjectionCustomizations::SqlInjection" in q
     assert "implements DataFlow::ConfigSig" in q                 # python-style, not legacy
     assert "BarrierGuard<proposedGuard/3>" in q
@@ -131,9 +132,199 @@ def test_assemble_java_path_uses_sinknode_predicate():
     assert "semmle.code.java.dataflow.ExternalFlow" in q
 
 
-def test_assemble_rejects_unknown_language():
+# CWE-94 / CWE-918 sink-class extensions (2026-05-31): matches the bridge's
+# `_CWE_SINK` keys.  Each per-language assembler must accept both new
+# classes without raising — verified by template substitution alone, the
+# actual CodeQL compile is exercised end-to-end in the corpus run.
+
+def test_assemble_python_codeinjection_uses_codeinjection_module():
+    q = assemble_barrier_query(_GUARD, sink_class="codeinjection", query_id="raptor/pyci")
+    assert "CodeInjectionCustomizations" in q
+    assert "CodeInjection::Source" in q and "CodeInjection::Sink" in q
+
+
+def test_assemble_python_ssrf_uses_ssrf_module():
+    q = assemble_barrier_query(_GUARD, sink_class="ssrf", query_id="raptor/pyssrf")
+    assert "ServerSideRequestForgeryCustomizations" in q
+    assert "ServerSideRequestForgery::Source" in q and "ServerSideRequestForgery::Sink" in q
+
+
+def test_assemble_javascript_ssrf_uses_request_forgery_module():
+    """JS pack names the SSRF module ``RequestForgery`` (no "ServerSide"
+    prefix) — regression-pin since the Python/Ruby naming is different."""
+    q = assemble_barrier_query(_JS_GUARD, sink_class="ssrf",
+                               query_id="raptor/jsssrf", language="javascript")
+    assert "RequestForgeryCustomizations::RequestForgery" in q
+    assert "Source" in q and "Sink" in q
+
+
+def test_assemble_javascript_codeinjection_uses_codeinjection_module():
+    q = assemble_barrier_query(_JS_GUARD, sink_class="codeinjection",
+                               query_id="raptor/jsci", language="javascript")
+    assert "CodeInjectionCustomizations::CodeInjection" in q
+
+
+def test_assemble_ruby_ssrf_and_codeinjection():
+    q1 = assemble_barrier_query(_RB_GUARD, sink_class="ssrf",
+                                query_id="raptor/rbssrf", language="ruby")
+    assert "ServerSideRequestForgeryCustomizations::ServerSideRequestForgery" in q1
+    q2 = assemble_barrier_query(_RB_GUARD, sink_class="codeinjection",
+                                query_id="raptor/rbci", language="ruby")
+    assert "CodeInjectionCustomizations::CodeInjection" in q2
+
+
+def test_assemble_java_ssrf_uses_request_forgery_sink():
+    q = assemble_barrier_query(_JAVA_GUARD, sink_class="ssrf",
+                               query_id="raptor/jvssrf", language="java")
+    assert "n instanceof RequestForgerySink" in q
+    assert "semmle.code.java.security.RequestForgery" in q
+
+
+def test_assemble_java_codeinjection_still_rejected():
+    """Java has no generic CodeInjectionSink (only framework-specific
+    SpEL/MVEL/Groovy queries); matches cvefix_walk's Java CWE-94 omission.
+    Pin the rejection so adding java/codeinjection later is intentional."""
     with pytest.raises(ValueError):
-        assemble_barrier_query(_GUARD, sink_class="cmdi", query_id="x", language="go")
+        assemble_barrier_query(_JAVA_GUARD, sink_class="codeinjection",
+                               query_id="raptor/jvci", language="java")
+
+
+# Go: new ConfigSig API like Python/Ruby, guard sig matches Java's (Expr e).
+_GO_GUARD = (
+    "predicate proposedGuard(DataFlow::Node g, Expr e, boolean branch) "
+    "{ none() }"
+)
+
+
+def test_assemble_go_uses_configsig_and_go_imports():
+    q = assemble_barrier_query(_GO_GUARD, sink_class="sqli",
+                               query_id="raptor/go-sqli", language="go")
+    assert "import go" in q
+    assert "import semmle.go.dataflow.DataFlow" in q
+    assert "SqlInjectionCustomizations::SqlInjection" in q
+    assert "implements DataFlow::ConfigSig" in q
+    assert "BarrierGuard<proposedGuard/3>" in q
+    assert "Flow::flow(source, sink)" in q
+    # Stamp identifies Go in the @name + select message:
+    assert "[go]" in q
+
+
+def test_assemble_go_each_sink_class_uses_canonical_module():
+    """Pin the customization module name per sink class — a typo in the
+    import path would silently fail at adjudication, not at synth-time."""
+    expected = {
+        "cmdi":     "CommandInjectionCustomizations::CommandInjection",
+        "sqli":     "SqlInjectionCustomizations::SqlInjection",
+        "pathtrav": "TaintedPathCustomizations::TaintedPath",
+        "xss":      "ReflectedXssCustomizations::ReflectedXss",
+        "ssrf":     "RequestForgeryCustomizations::RequestForgery",
+    }
+    for sink_class, expect in expected.items():
+        q = assemble_barrier_query(_GO_GUARD, sink_class=sink_class,
+                                   query_id=f"raptor/go-{sink_class}",
+                                   language="go")
+        assert expect in q, f"{sink_class}: expected {expect!r} in query"
+
+
+def test_assemble_go_codeinjection_rejected():
+    """Go's pack has no generic CodeInjection.qll — matches cvefix_walk's
+    Go CWE-94 omission convention.  Pin the rejection so adding it later
+    is an intentional substrate change."""
+    with pytest.raises(ValueError, match="unknown sink_class 'codeinjection'"):
+        assemble_barrier_query(_GO_GUARD, sink_class="codeinjection",
+                               query_id="raptor/go-ci", language="go")
+
+
+def test_assemble_go_requires_proposed_guard_predicate():
+    """Same shape guarantee as the other ConfigSig-style languages:
+    the proposer must define a `proposedGuard` symbol."""
+    with pytest.raises(ValueError, match="proposedGuard"):
+        assemble_barrier_query("predicate other() { none() }",
+                               sink_class="sqli", query_id="raptor/go-sqli",
+                               language="go")
+
+
+def test_go_system_prompt_is_wired():
+    """Go must be registered in `_SYSTEM_PROMPTS` so `_build_prompt`
+    picks the Go template instead of falling back to the Python one
+    (which would feed the LLM Python-typed `ControlFlowNode` examples)."""
+    from core.dataflow.barrier_synth import _SYSTEM_PROMPTS
+    assert "go" in _SYSTEM_PROMPTS
+    # Specific Go phrasing pinned:
+    assert "DataFlow::CallNode" in _SYSTEM_PROMPTS["go"]
+    assert "(DataFlow::Node g, Expr e, boolean branch)" in _SYSTEM_PROMPTS["go"]
+
+
+def test_count_sarif_results_scopes_to_uri_and_line(tmp_path):
+    import json
+    from core.dataflow.barrier_synth import _count_sarif_results
+    sarif = tmp_path / "s.sarif"
+
+    def loc(uri, line):
+        return {"locations": [{"physicalLocation": {"artifactLocation": {"uri": uri},
+                                                    "region": {"startLine": line}}}]}
+    sarif.write_text(json.dumps({"runs": [{"results": [
+        loc("a.py", 10), loc("a.py", 20), loc("b.py", 5)]}]}))
+    assert _count_sarif_results(sarif) == 3                   # unscoped: all findings
+    assert _count_sarif_results(sarif, "a.py") == 2           # file-scoped (preserve check)
+    assert _count_sarif_results(sarif, "a.py", 10) == 1       # line-scoped (suppress check): only a.py:10
+    assert _count_sarif_results(sarif, "a.py", 99) == 0       # no finding at that line
+    assert _count_sarif_results(sarif, "c.py") == 0           # file with no findings
+
+
+def test_model_completer_pinned_config_bypasses_auto_resolution(monkeypatch):
+    """``model_completer("claude-opus-4-8")`` builds an LLMClient whose
+    config is targeted at the inferred provider only — primary_model is
+    the pinned model and fallback_models is empty, so the thinking-model
+    auto-resolution path (which would log misleading gemini lines when
+    Anthropic is the actual caller intent) never fires."""
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-fake-key")
+    from core.dataflow.barrier_synth import model_completer
+    from core.llm.client import LLMClient
+
+    seen: dict = {}
+    real_init = LLMClient.__init__
+
+    def trace_init(self, *args, **kwargs):
+        seen["pinned_model"] = kwargs.get("pinned_model")
+        real_init(self, *args, **kwargs)
+        seen["primary"] = self.config.primary_model
+        seen["fallbacks"] = self.config.fallback_models
+
+    monkeypatch.setattr(LLMClient, "__init__", trace_init)
+    _ = model_completer("claude-opus-4-8")
+    assert seen["pinned_model"] == "claude-opus-4-8"
+    assert seen["primary"].provider == "anthropic"
+    assert seen["primary"].model_name == "claude-opus-4-8"
+    assert seen["primary"].role == "code"
+    assert seen["fallbacks"] == []                # no auto-resolved chain
+
+
+def test_pinned_llm_config_provider_inference():
+    """Provider inference from the bare model name."""
+    from core.llm.client import _pinned_llm_config
+
+    for name, expected_provider, expected_model in [
+        ("claude-opus-4-8",        "anthropic", "claude-opus-4-8"),
+        ("claude-sonnet-4-6",      "anthropic", "claude-sonnet-4-6"),
+        ("gemini-2.5-pro",         "gemini",    "gemini-2.5-pro"),
+        ("gpt-4o-mini",            "openai",    "gpt-4o-mini"),
+        ("anthropic/claude-opus",  "anthropic", "claude-opus"),
+        ("openai/gpt-5",           "openai",    "gpt-5"),
+    ]:
+        cfg = _pinned_llm_config(name)
+        assert cfg.primary_model.provider == expected_provider, name
+        assert cfg.primary_model.model_name == expected_model, name
+        assert cfg.fallback_models == []
+
+
+def test_assemble_rejects_unknown_language():
+    """Unknown language must raise — pin the rejection so adding a new
+    language is an intentional substrate change.  ``csharp`` is the
+    current canonical "not yet wired" placeholder (Go was the placeholder
+    until 2026-05-31 when Go support landed)."""
+    with pytest.raises(ValueError, match="unknown language 'csharp'"):
+        assemble_barrier_query(_GUARD, sink_class="cmdi", query_id="x", language="csharp")
 
 
 def test_assemble_rejects_unknown_sink_class():
@@ -183,6 +374,295 @@ def test_loop_rejects_barrier_that_does_not_suppress(tmp_path: Path):
     )
     assert not res.suppressed_fp
     assert not res.is_sound
+
+
+# --- soundness-refinement loop (RefineContext + max_refine_attempts) ---
+
+def test_default_refine_zero_returns_first_not_sound(tmp_path: Path):
+    """Baseline preserved: with the default ``max_refine_attempts=0``, the
+    loop returns the first compilable result, sound or not — no extra
+    proposer calls on not_sound."""
+    after_db, before_db = tmp_path / "adb", tmp_path / "bdb"
+    runner = _stub_runner({str(after_db): 1, str(before_db): 1})  # not_sound
+    calls = {"n": 0}
+
+    def proposer(_p, _e):
+        calls["n"] += 1
+        return _GUARD
+
+    res = run_synthesis_loop(
+        _proposal(), after_db, before_db,
+        proposer=proposer, work_dir=tmp_path / "w", runner=runner,
+    )
+    assert res is not None and not res.is_sound
+    assert calls["n"] == 1                          # exactly one call, no refine
+
+
+def test_refine_loop_calls_proposer_with_refine_context(tmp_path: Path):
+    """When ``max_refine_attempts > 0`` and the first cycle is not_sound,
+    the proposer is called again with a populated ``refine_context``
+    carrying the prior verdict + the prior QL."""
+    from core.dataflow.barrier_synth import RefineContext
+
+    after_db, before_db = tmp_path / "adb", tmp_path / "bdb"
+    # Both cycles return the same not_sound counts so the loop runs to budget.
+    runner = _stub_runner({str(after_db): 1, str(before_db): 1})
+    seen_contexts: list = []
+
+    def proposer(_p, _e, refine_context=None):
+        seen_contexts.append(refine_context)
+        return _GUARD
+
+    res = run_synthesis_loop(
+        _proposal(), after_db, before_db,
+        proposer=proposer, work_dir=tmp_path / "w", runner=runner,
+        max_refine_attempts=2,
+    )
+    assert res is not None and not res.is_sound
+    # 1 initial + 2 refines = 3 proposer calls.
+    assert len(seen_contexts) == 3
+    assert seen_contexts[0] is None                 # initial call has no context
+    # First refinement carries verdict from initial cycle.
+    rc1 = seen_contexts[1]
+    assert isinstance(rc1, RefineContext)
+    assert rc1.refine_attempt == 1
+    assert rc1.after_count == 1 and rc1.before_count == 1
+    assert rc1.failure_mode == "suppress_fp_failed"
+    assert "BarrierGuard" in rc1.prior_query_ql     # prior QL passed through
+    # Second refinement is attempt 2.
+    assert seen_contexts[2].refine_attempt == 2
+
+
+def test_refine_loop_returns_sound_on_successful_refinement(tmp_path: Path):
+    """If the proposer's refined attempt produces a sound result, the loop
+    returns it WITHOUT consuming the remaining refine budget."""
+    after_db, before_db = tmp_path / "adb", tmp_path / "bdb"
+    cycle = {"n": 0}
+
+    def runner(cmd, **_):
+        # First cycle: not_sound (after=1, before=1).
+        # Second cycle: sound (after=0, before=1).
+        for arg in cmd:
+            arg_s = str(arg)
+            if str(after_db) in arg_s:
+                return 0 if cycle["after_done"] else 1
+            if str(before_db) in arg_s:
+                return 1
+        return 0
+
+    # Simpler: explicit stub-runner that flips after the first after-DB read.
+    state = {"after_returned": False}
+
+    def stub(cmd, **_):
+        from core.dataflow.barrier_synth import CodeQLRunError      # noqa: F401
+        # The runner returns 0 (success) when an `--output` arg matches one of
+        # our DBs.  We construct SARIF with the count we want for the current
+        # cycle by writing a file at the SARIF path.
+        for i, arg in enumerate(cmd):
+            arg_s = str(arg)
+            if arg_s.startswith("--output="):
+                out = arg_s[len("--output="):]
+                # First call against after_db -> count 1 (not_sound first cycle).
+                # Second call against after_db -> count 0 (sound second cycle).
+                # before_db calls always return count 1.
+                target = next(
+                    (str(p) for p in (after_db, before_db) if str(p) in str(cmd)),
+                    None,
+                )
+                if target == str(after_db):
+                    n = 0 if state["after_returned"] else 1
+                    state["after_returned"] = True
+                else:
+                    n = 1
+                Path(out).write_text(
+                    '{"runs":[{"results":[%s]}]}' % (
+                        ",".join(['{"locations":[]}'] * n)
+                    )
+                )
+                return 0
+        return 0
+
+    def proposer(_p, _e, refine_context=None):
+        cycle["n"] += 1
+        return _GUARD
+
+    res = run_synthesis_loop(
+        _proposal(), after_db, before_db,
+        proposer=proposer, work_dir=tmp_path / "w", runner=stub,
+        max_refine_attempts=3,
+    )
+    assert res is not None and res.is_sound
+    # 1 initial + 1 successful refine = 2 calls; budget (3) not exhausted.
+    assert cycle["n"] == 2
+
+
+def test_refine_diag_records_refine_attempts(tmp_path: Path):
+    after_db, before_db = tmp_path / "adb", tmp_path / "bdb"
+    runner = _stub_runner({str(after_db): 1, str(before_db): 1})
+    diag: dict = {}
+
+    def proposer(_p, _e, refine_context=None):
+        return _GUARD
+
+    run_synthesis_loop(
+        _proposal(), after_db, before_db,
+        proposer=proposer, work_dir=tmp_path / "w", runner=runner,
+        max_refine_attempts=2, diag=diag,
+    )
+    assert diag["refine_attempts"] == 2
+
+
+def test_synthresult_failure_mode_classification():
+    from core.dataflow.barrier_synth import SynthResult
+    assert SynthResult("ql", 0, 1).failure_mode == "ok"
+    assert SynthResult("ql", 1, 1).failure_mode == "suppress_fp_failed"
+    assert SynthResult("ql", 0, 0).failure_mode == "preserve_tp_failed"
+    assert SynthResult("ql", 1, 0).failure_mode == "both"
+
+
+def test_build_prompt_includes_sink_class_hint_for_known_class():
+    """The sink-class hint must be appended to the user prompt for every
+    sink_class the proposer can adjudicate.  Without it the LLM gets only
+    the language template + generic shape examples, mis-matching the
+    actual validator shape (the dominant failure mode in v3 + fresh
+    corpus measurements)."""
+    from core.dataflow.barrier_synth import (
+        BarrierProposal, _build_prompt, _SINK_CLASS_HINTS,
+    )
+    for sink_class in _SINK_CLASS_HINTS:
+        prop = BarrierProposal(
+            sink_class=sink_class, finding_id="F", sink_snippet="x",
+            source_context="ctx", language="python",
+        )
+        prompt = _build_prompt(prop, prior_error=None)
+        assert "Canonical validator shapes for this sink class:" in prompt, sink_class
+        # A distinctive token from each hint must appear:
+        token = {
+            "pathtrav": "safe_join",
+            "cmdi": "shlex.quote",
+            "sqli": "PreparedStatement",
+            "xss": "DOMPurify.sanitize",
+            "ssrf": "isResolvingToUnicastOnly",
+            "codeinjection": "vm.runInNewContext",
+        }[sink_class]
+        assert token in prompt, f"{sink_class}: missing distinctive idiom {token}"
+
+
+def test_build_prompt_omits_hint_for_unknown_sink_class():
+    """Unknown sink_class (e.g. a not-yet-modelled CWE) -> no hint block;
+    the rest of the prompt is unchanged so the call doesn't error."""
+    from core.dataflow.barrier_synth import BarrierProposal, _build_prompt
+    prop = BarrierProposal(
+        sink_class="xxe", finding_id="F", sink_snippet="x",
+        source_context="ctx", language="python",
+    )
+    prompt = _build_prompt(prop, prior_error=None)
+    assert "Canonical validator shapes for this sink class:" not in prompt
+    # But the rest must still be intact:
+    assert "sink class: xxe" in prompt
+    assert "ctx" in prompt
+
+
+def test_summarise_surviving_finding_extracts_codeflow(tmp_path):
+    """Counterexample-driven refinement: the SARIF surviving-finding
+    summariser must extract source -> sink path info so the prompt can
+    feed a concrete flow back to the proposer."""
+    import json
+    from core.dataflow.barrier_synth import _summarise_surviving_finding
+    sarif = tmp_path / "after.sarif"
+
+    def step(uri, line, msg):
+        return {"location": {"physicalLocation": {
+            "artifactLocation": {"uri": uri},
+            "region": {"startLine": line}}, "message": {"text": msg}}}
+
+    sarif.write_text(json.dumps({"runs": [{"results": [
+        {"locations": [{"physicalLocation": {
+             "artifactLocation": {"uri": "src/api.py"},
+             "region": {"startLine": 127}}}],
+         "message": {"text": "This URL is constructed from user input."},
+         "codeFlows": [{"threadFlows": [{"locations": [
+             step("src/api.py", 42, "request.url"),
+             step("src/api.py", 90, "host"),
+             step("src/api.py", 127, "fetch(url)")]}]}]},
+    ]}]}))
+    summary = _summarise_surviving_finding(
+        sarif, target_uri="src/api.py", target_line=127)
+    assert "surviving flow" in summary
+    assert "api.py:42" in summary and "request.url" in summary  # source
+    assert "api.py:90" in summary and "host" in summary         # intermediate
+    assert "api.py:127" in summary                              # sink
+
+
+def test_summarise_surviving_finding_returns_empty_on_no_match(tmp_path):
+    """Off-target (different uri/line) -> empty.  Conservative: a wrong
+    summary would mislead the proposer; an empty one falls back to the
+    generic nudge."""
+    import json
+    from core.dataflow.barrier_synth import _summarise_surviving_finding
+    sarif = tmp_path / "a.sarif"
+    sarif.write_text(json.dumps({"runs": [{"results": [
+        {"locations": [{"physicalLocation": {
+             "artifactLocation": {"uri": "elsewhere.py"},
+             "region": {"startLine": 5}}}], "message": {"text": "m"}}]}]}))
+    assert _summarise_surviving_finding(sarif, target_uri="missing.py") == ""
+    # Unreadable file:
+    assert _summarise_surviving_finding(tmp_path / "nope.sarif") == ""
+
+
+def test_build_prompt_surfaces_counterexample_when_present():
+    """When the RefineContext carries a surviving-finding summary, the
+    user prompt must include it in the refinement block — that's the
+    counterexample the LLM uses to target the real validator."""
+    from core.dataflow.barrier_synth import RefineContext, _build_prompt
+    rc = RefineContext(
+        prior_query_ql="predicate proposedGuard() { any() }",
+        after_count=1, before_count=1,
+        failure_mode="suppress_fp_failed", refine_attempt=1,
+        surviving_finding_summary=(
+            "surviving flow: api.py:42 request.url -> api.py:127 fetch(url)"),
+    )
+    prompt = _build_prompt(_proposal(), prior_error=None, refine_context=rc)
+    assert "Concrete counterexample" in prompt
+    assert "api.py:42 request.url -> api.py:127 fetch(url)" in prompt
+
+
+def test_build_prompt_surfaces_refine_context():
+    """The skeleton prompt for refinement includes the verdict text, the
+    prior QL, and a failure-mode-specific nudge."""
+    from core.dataflow.barrier_synth import RefineContext, _build_prompt
+    rc = RefineContext(
+        prior_query_ql="predicate proposedGuard() { any() }",
+        after_count=1, before_count=1,
+        failure_mode="suppress_fp_failed", refine_attempt=1,
+    )
+    prompt = _build_prompt(_proposal(), prior_error=None, refine_context=rc)
+    assert "REFINEMENT (attempt 1)" in prompt
+    assert "after=1 before=1" in prompt
+    assert "suppress_fp_failed" in prompt
+    assert "predicate proposedGuard()" in prompt
+    assert "DIDN'T suppress" in prompt              # the suppress-mode nudge
+
+
+def test_make_llm_proposer_forwards_refine_context():
+    """``make_llm_proposer``'s proposer must accept and forward refine_context
+    into the prompt, so refinement flows end-to-end through the LLM wrapper."""
+    from core.dataflow.barrier_synth import RefineContext
+    seen: dict = {}
+
+    def complete(system_prompt, user_prompt):
+        seen["user"] = user_prompt
+        return _GUARD
+
+    proposer = make_llm_proposer(complete)
+    rc = RefineContext(
+        prior_query_ql="predicate proposedGuard() {}",
+        after_count=1, before_count=1,
+        failure_mode="suppress_fp_failed", refine_attempt=1,
+    )
+    proposer(_proposal(), None, refine_context=rc)
+    assert "REFINEMENT" in seen["user"]
+    assert "predicate proposedGuard()" in seen["user"]
 
 
 # --- LLM proposer + retry ---

--- a/core/dataflow/tests/test_cvefix_bridge.py
+++ b/core/dataflow/tests/test_cvefix_bridge.py
@@ -1,0 +1,485 @@
+"""Tests for the harvest->synthesize bridge (CodeQL + LLM stubbed)."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+from core.dataflow import cvefix_bridge, cvefix_walk
+from core.dataflow.barrier_synth import SynthResult
+from core.dataflow.cvefix_loader import CveFixPair
+
+
+def _pair(cwe="CWE-89", lang="Python", fix="f1"):
+    return CveFixPair("CVE-X", cwe, "https://github.com/o/a", lang, fix, "p1")
+
+
+def test_norm_uri_strips_scheme_and_leading_slash():
+    assert cvefix_bridge._norm_uri("src/a.py") == "src/a.py"
+    assert cvefix_bridge._norm_uri("file:///abs/a.py") == "abs/a.py"
+    assert cvefix_bridge._norm_uri("file:src/a.py") == "src/a.py"
+
+
+def test_extract_proposal_reads_source_and_returns_target_uri(monkeypatch, tmp_path: Path):
+    monkeypatch.setattr(cvefix_bridge, "_git_diff", lambda *a, **k: "")
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "app.py").write_text("import os\nx = req()\nos.system(x)\nsafe()\n")
+    sarif = tmp_path / "a.sarif"
+    sarif.write_text(json.dumps({"runs": [{"results": [{"locations": [
+        {"physicalLocation": {"artifactLocation": {"uri": "app.py"},
+                              "region": {"startLine": 3}}}]}]}]}))
+    out = cvefix_bridge._extract_proposal(sarif, repo, _pair(cwe="CWE-78"))
+    assert out is not None
+    proposal, target_uri, target_line = out
+    assert target_uri == "app.py" and target_line == 3
+    assert proposal.sink_class == "cmdi" and proposal.language == "python"
+    assert proposal.sink_snippet == "os.system(x)"
+    assert proposal.finding_id == "CVE-X:CWE-78:app.py:3"
+
+
+def test_extract_proposal_includes_fix_diff(monkeypatch, tmp_path: Path):
+    monkeypatch.setattr(cvefix_bridge, "_git_diff", lambda *a, **k: "+ if safe(x): ...")
+    monkeypatch.setattr(cvefix_bridge, "_git_diff_other_files", lambda *a, **k: "")
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "a.py").write_text("os.system(x)\n")
+    sarif = tmp_path / "a.sarif"
+    sarif.write_text(json.dumps({"runs": [{"results": [{"locations": [
+        {"physicalLocation": {"artifactLocation": {"uri": "a.py"}, "region": {"startLine": 1}}}]}]}]}))
+    proposal, _, _ = cvefix_bridge._extract_proposal(sarif, repo, _pair(cwe="CWE-78"))
+    assert "fix diff" in proposal.source_context and "+ if safe(x)" in proposal.source_context
+
+
+def test_extract_proposal_includes_other_fix_files(monkeypatch, tmp_path: Path):
+    """Regression: cross-file fixes (validator in helper, sink in
+    middleware) need the helper's diff in the proposer context — without
+    it the LLM has no validator source to model and hallucinates.
+    Pin the integration: ``_git_diff_other_files`` output reaches the
+    proposal's source_context with the framing the prompt expects."""
+    monkeypatch.setattr(cvefix_bridge, "_git_diff", lambda *a, **k: "")
+    monkeypatch.setattr(
+        cvefix_bridge, "_git_diff_other_files",
+        lambda *a, **k: ("# file: server/helpers/dns.ts\n"
+                         "+ async function isResolvingToUnicastOnly(h) { ... }"),
+    )
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "mock-object-storage.ts").write_text("fetch(url)\n")
+    sarif = tmp_path / "a.sarif"
+    sarif.write_text(json.dumps({"runs": [{"results": [{"locations": [{"physicalLocation":
+        {"artifactLocation": {"uri": "mock-object-storage.ts"},
+         "region": {"startLine": 1}}}]}]}]}))
+    proposal, _, _ = cvefix_bridge._extract_proposal(
+        sarif, repo, _pair(cwe="CWE-918", lang="TypeScript"))
+    assert "other fix-touched files" in proposal.source_context
+    assert "isResolvingToUnicastOnly" in proposal.source_context
+    assert "server/helpers/dns.ts" in proposal.source_context
+
+
+# ---------------------------------------------------------------------------
+# Test-path heuristic + cross-file diff assembly
+# ---------------------------------------------------------------------------
+
+def test_is_test_path_recognises_common_conventions():
+    """Every flagged pattern must catch real test-file shapes from each
+    language we walk; non-test files must NOT match."""
+    # Test paths (these MUST match):
+    for p in [
+        "server/tests/api/check-params/video-imports.ts",
+        "src/test/java/com/example/FooTest.java",
+        "src/test/java/com/example/TestFoo.java",
+        "src/test/java/com/example/FooTests.java",
+        "internal/server/server_test.go",
+        "tests/test_app.py",
+        "spec/models/user_spec.rb",
+        "src/__tests__/helper.test.tsx",
+        "app/foo.spec.ts",
+        "components/Header.test.jsx",
+        "lib/__tests__/helper.test.js",
+    ]:
+        assert cvefix_bridge._is_test_path(p), f"should be test: {p}"
+    # Non-test paths (these MUST NOT match — false positives lose the validator):
+    for p in [
+        "server/helpers/dns.ts",
+        "server/middlewares/validators/videos/video-imports.ts",
+        "src/main/java/com/example/Foo.java",
+        "internal/server/server.go",
+        "src/foo.py",
+        "lib/user.rb",
+        "components/Header.tsx",
+        # Edge: a file literally named ``test.go`` (not ``foo_test.go``) is
+        # NOT a Go test file by convention — pin that we don't false-pos.
+        "cmd/test.go",
+    ]:
+        assert not cvefix_bridge._is_test_path(p), f"should NOT be test: {p}"
+
+
+def test_git_diff_other_files_excludes_sink_and_tests(monkeypatch, tmp_path: Path):
+    """``_git_diff_other_files`` must skip the sink URI and any test paths;
+    the remaining files' diffs are concatenated with file-header lines."""
+    monkeypatch.setattr(
+        cvefix_bridge, "_git_touched_files",
+        lambda *a, **k: ["server/helpers/dns.ts",
+                          "server/middlewares/x.ts",
+                          "server/tests/check-x.ts",         # test, must skip
+                          "mock-object-storage.ts"],         # sink, must skip
+    )
+    seen_files: list = []
+
+    def fake_diff(repo, parent, fix, uri, *, cap=200, timeout=60):
+        seen_files.append(uri)
+        return f"+ change in {uri}"
+
+    monkeypatch.setattr(cvefix_bridge, "_git_diff", fake_diff)
+    out = cvefix_bridge._git_diff_other_files(
+        tmp_path, "p", "f", "mock-object-storage.ts")
+    # sink-file and test-file diffs must NOT have been requested:
+    assert "mock-object-storage.ts" not in seen_files
+    assert all("/tests/" not in p for p in seen_files)
+    # remaining files appear with file-header annotation:
+    assert "# file: server/helpers/dns.ts" in out
+    assert "# file: server/middlewares/x.ts" in out
+    # per-file order preserved (deterministic for reproducibility):
+    assert out.index("dns.ts") < out.index("x.ts")
+
+
+def test_git_diff_other_files_respects_total_cap(monkeypatch, tmp_path: Path):
+    """Total-cap protects the LLM context budget on fixes touching many
+    files.  Past the cap, the harvester stops adding new files."""
+    monkeypatch.setattr(
+        cvefix_bridge, "_git_touched_files",
+        lambda *a, **k: [f"f{i}.py" for i in range(20)],
+    )
+    monkeypatch.setattr(
+        cvefix_bridge, "_git_diff",
+        lambda *a, **k: "\n".join([f"+ line {j}" for j in range(50)]),
+    )
+    out = cvefix_bridge._git_diff_other_files(
+        tmp_path, "p", "f", "sink.py", total_cap=80, per_file_cap=50)
+    # Verify total cap is approximately respected (within 1 chunk worth of
+    # overshoot due to header lines).  Stricter: at least one file dropped.
+    n_files_included = out.count("# file:")
+    assert n_files_included < 20, "total_cap not enforced"
+    # Truncation marker appears when a per-file or total cap is hit:
+    assert "truncated" in out or n_files_included < 20
+
+
+def test_git_diff_other_files_empty_when_only_sink_touched(monkeypatch, tmp_path: Path):
+    monkeypatch.setattr(
+        cvefix_bridge, "_git_touched_files",
+        lambda *a, **k: ["mock-object-storage.ts"],
+    )
+    out = cvefix_bridge._git_diff_other_files(
+        tmp_path, "p", "f", "mock-object-storage.ts")
+    assert out == ""
+
+
+def test_git_touched_files_returns_empty_on_subprocess_fail(monkeypatch, tmp_path: Path):
+    """Failure isolation: if `git diff --name-only` errors, callers
+    silently fall back to sink-file-only context (the original behaviour),
+    not abort the synth."""
+    def fake_run(*a, **k):
+        raise OSError("simulated git failure")
+    monkeypatch.setattr(cvefix_bridge.subprocess, "run", fake_run)
+    assert cvefix_bridge._git_touched_files(tmp_path, "p", "f") == []
+
+
+def test_format_path_renders_codeflow_source_to_sink():
+    def step(uri, line, msg):
+        return {"location": {"physicalLocation": {"artifactLocation": {"uri": uri},
+                "region": {"startLine": line}}, "message": {"text": msg}}}
+    result = {"codeFlows": [{"threadFlows": [{"locations": [
+        step("app.py", 6, "request"), step("app.py", 17, "host"),
+        step("app.py", 20, "os.system")]}]}]}
+    out = cvefix_bridge._format_path(result)
+    assert "tainted dataflow path" in out
+    assert "app.py:6" in out and "request" in out          # source
+    assert "app.py:17" in out and "host" in out            # the value to protect
+    assert "app.py:20" in out                              # sink
+    assert cvefix_bridge._format_path({}) == ""            # no codeFlows -> empty
+
+
+def test_extract_proposal_none_when_no_location(tmp_path: Path):
+    sarif = tmp_path / "a.sarif"
+    sarif.write_text(json.dumps({"runs": [{"results": []}]}))
+    assert cvefix_bridge._extract_proposal(sarif, tmp_path, _pair()) is None
+
+
+def test_synthesize_one_build_mode_from_status(monkeypatch, tmp_path: Path):
+    seen = {}
+    monkeypatch.setattr(cvefix_bridge, "_TIER0_AVAILABLE", False)
+    monkeypatch.setattr(cvefix_walk, "_fetch_pair", lambda *a, **k: True)
+
+    def fake_build(src, commit, db, lang, codeql_bin, timeout, build_mode=None):
+        seen["mode"] = build_mode
+        return True
+
+    monkeypatch.setattr(cvefix_walk, "_build_db", fake_build)
+    monkeypatch.setattr(cvefix_bridge, "_run_query", lambda *a, **k: True)
+    prop = cvefix_bridge.BarrierProposal("sqli", "fid", "exec(x)", "ctx", "java")
+    monkeypatch.setattr(cvefix_bridge, "_extract_proposal", lambda *a, **k: (prop, "a.java", 1))
+    monkeypatch.setattr(cvefix_bridge, "run_synthesis_loop",
+                        lambda *a, **k: SynthResult(query_ql="q", after_count=0, before_count=1))
+    jv = _pair(lang="Java", fix="fj")
+    cvefix_bridge.synthesize_one(jv, work_dir=tmp_path / "w1", proposer=lambda *a: "", status="ok")
+    assert seen["mode"] == "none"                      # buildless-found Java
+    cvefix_bridge.synthesize_one(jv, work_dir=tmp_path / "w2", proposer=lambda *a: "", status="ok_built")
+    assert seen["mode"] == "autobuild"                 # autobuild-found Java -> rebuild same way
+    cvefix_bridge.synthesize_one(_pair(lang="Python"), work_dir=tmp_path / "w3",
+                                 proposer=lambda *a: "", status="ok")
+    assert seen["mode"] is None                        # source lang
+
+
+def test_synthesize_one_happy_path_returns_sound_query(monkeypatch, tmp_path: Path):
+    monkeypatch.setattr(cvefix_bridge, "_TIER0_AVAILABLE", False)
+    monkeypatch.setattr(cvefix_walk, "_fetch_pair", lambda *a, **k: True)
+    monkeypatch.setattr(cvefix_walk, "_build_db", lambda *a, **k: True)
+    monkeypatch.setattr(cvefix_bridge, "_run_query", lambda *a, **k: True)
+    prop = cvefix_bridge.BarrierProposal("sqli", "CVE-X:CWE-89:a.py:3", "exec(x)", "ctx", "python")
+    monkeypatch.setattr(cvefix_bridge, "_extract_proposal", lambda *a, **k: (prop, "a.py", 3))
+    monkeypatch.setattr(cvefix_bridge, "run_synthesis_loop",
+                        lambda *a, **k: SynthResult(query_ql="SOUND_QL", after_count=0, before_count=1))
+    status, fid, backend, sq, detail = cvefix_bridge.synthesize_one(
+        _pair(), work_dir=tmp_path / "w", proposer=lambda *a: "")
+    assert status == "sound" and fid == "CVE-X:CWE-89:a.py:3"
+    assert backend == "codeql" and sq == "SOUND_QL"
+
+
+def test_synthesize_one_fetch_fail(monkeypatch, tmp_path: Path):
+    monkeypatch.setattr(cvefix_walk, "_fetch_pair", lambda *a, **k: False)
+    assert cvefix_bridge.synthesize_one(_pair(), work_dir=tmp_path / "w",
+                                        proposer=lambda *a: "") == ("fetch_fail", None, "", None, "")
+
+
+def _results_db(path: Path):
+    con = sqlite3.connect(str(path))
+    con.execute(cvefix_walk._SCHEMA)
+
+    def ins(fix, cwe, after):
+        con.execute("INSERT INTO walk_results VALUES (?,?,?,?,?,?,?,?,?,?)",
+                    (fix, "CVE-" + fix, cwe, "Python", "https://github.com/o/a",
+                     fix + "p", "ok", 1, after, 0.0))
+    ins("f1", "CWE-89", 1)   # candidate -> sound
+    ins("f2", "CWE-79", 2)   # candidate -> not_sound
+    ins("f3", "CWE-78", 1)   # candidate -> build_fail (pipeline error)
+    ins("f4", "CWE-22", 0)   # after==0 -> NOT a candidate
+    con.commit()
+    con.close()
+
+
+def test_synthesize_from_results_aggregates_persists_resumes(monkeypatch, tmp_path: Path):
+    results, synth = tmp_path / "r.db", tmp_path / "s.db"
+    _results_db(results)
+    outcomes = {"f1": ("sound", "f1:id", "smt", "smt:charset:[a-z]+@x:1", "tier0 unsat"),
+                "f2": ("not_sound", "f2:id", "codeql", "QL2", "suppress_fp_failed(after=2)"),
+                "f3": ("build_fail", None, "", None, "")}
+    calls = []
+
+    def fake(pair, **kw):
+        calls.append(pair.fix_hash)
+        return outcomes[pair.fix_hash]
+
+    monkeypatch.setattr(cvefix_bridge, "synthesize_one", fake)
+    report = cvefix_bridge.synthesize_from_results(
+        results, synth_db=synth, work_dir=tmp_path / "w", proposer=lambda *a: "", log=lambda *a: None)
+    assert sorted(calls) == ["f1", "f2", "f3"]                 # f4 excluded (after==0)
+    assert report.total == 2 and report.sound == 1 and report.not_sound == 1
+    assert report.suppression_rate == 0.5                      # f3 excluded from rate
+    with sqlite3.connect(str(synth)) as con:
+        # barrier query persisted for sound AND not_sound; reason persisted too;
+        # backend column distinguishes Tier 0 (smt) from Tier 2 (codeql)
+        assert con.execute("SELECT barrier_query FROM synth_results WHERE fix_hash='f1'").fetchone()[0] == "smt:charset:[a-z]+@x:1"
+        assert con.execute("SELECT backend FROM synth_results WHERE fix_hash='f1'").fetchone()[0] == "smt"
+        assert con.execute("SELECT barrier_query FROM synth_results WHERE fix_hash='f2'").fetchone()[0] == "QL2"
+        assert con.execute("SELECT backend FROM synth_results WHERE fix_hash='f2'").fetchone()[0] == "codeql"
+        assert con.execute("SELECT detail FROM synth_results WHERE fix_hash='f2'").fetchone()[0] == "suppress_fp_failed(after=2)"
+
+    # resume: re-run reprocesses nothing
+    calls.clear()
+    cvefix_bridge.synthesize_from_results(
+        results, synth_db=synth, work_dir=tmp_path / "w", proposer=lambda *a: "", log=lambda *a: None)
+    assert calls == []
+
+
+def test_synthesize_from_results_crash_isolation(monkeypatch, tmp_path: Path):
+    results, synth = tmp_path / "r.db", tmp_path / "s.db"
+    _results_db(results)
+
+    def boom(pair, **kw):
+        if pair.fix_hash == "f2":
+            raise RuntimeError("codeql exploded")
+        return ("sound", pair.fix_hash + ":id", "codeql", "QL", "")
+
+    monkeypatch.setattr(cvefix_bridge, "synthesize_one", boom)
+    report = cvefix_bridge.synthesize_from_results(
+        results, synth_db=synth, work_dir=tmp_path / "w", proposer=lambda *a: "", log=lambda *a: None)
+    # f2 crashed -> recorded as error (excluded), f1+f3 still synthesized
+    assert report.sound == 2
+    with sqlite3.connect(str(synth)) as con:
+        assert con.execute("SELECT status FROM synth_results WHERE fix_hash='f2'").fetchone()[0] == "error"
+        assert con.execute("SELECT backend FROM synth_results WHERE fix_hash='f2'").fetchone()[0] == ""
+
+
+def test_synthesize_from_results_newest_first_order(monkeypatch, tmp_path: Path):
+    results, synth = tmp_path / "r.db", tmp_path / "s.db"
+    _results_db(results)
+    calls = []
+    monkeypatch.setattr(cvefix_bridge, "synthesize_one",
+                        lambda pair, **kw: calls.append(pair.cve_id) or ("not_sound", "id", "codeql", None, ""))
+    cvefix_bridge.synthesize_from_results(
+        results, synth_db=synth, work_dir=tmp_path / "w", proposer=lambda *a: "",
+        newest_first=True, log=lambda *a: None)
+    assert calls == ["CVE-f3", "CVE-f2", "CVE-f1"]             # cve_id DESC (f4 excluded: after==0)
+
+
+def _tier0_setup(monkeypatch, *, tier0_result):
+    """Stub the around-Tier-0 bridge plumbing.  Each test specifies what
+    try_tier0 returns and the after/before DB builds are intercepted so we
+    can assert which were called."""
+    from core.dataflow import smt_barrier
+    monkeypatch.setattr(cvefix_walk, "_fetch_pair", lambda *a, **k: True)
+    builds: list = []
+
+    def fake_build(src, commit, db, lang, codeql_bin, timeout, build_mode=None):
+        builds.append(commit)
+        return True
+
+    monkeypatch.setattr(cvefix_walk, "_build_db", fake_build)
+    monkeypatch.setattr(cvefix_bridge, "_run_query", lambda *a, **k: True)
+    prop = cvefix_bridge.BarrierProposal(
+        "pathtrav", "CVE-X:CWE-22:app.py:3", "open(x)", "ctx", "python")
+    monkeypatch.setattr(cvefix_bridge, "_extract_proposal",
+                        lambda *a, **k: (prop, "app.py", 3))
+    monkeypatch.setattr(cvefix_bridge, "_git_diff",
+                        lambda *a, **k: "+ if not re.match(r\"^[A-Za-z0-9]+$\", x): pass")
+    monkeypatch.setattr(cvefix_bridge, "try_tier0",
+                        lambda *a, **k: tier0_result)
+    # Tier 2: pretend the run_synthesis_loop produces a sound CodeQL guard.
+    monkeypatch.setattr(cvefix_bridge, "run_synthesis_loop",
+                        lambda *a, **k: SynthResult(
+                            query_ql="TIER2_QL", after_count=0, before_count=1))
+    return builds, smt_barrier
+
+
+def test_synthesize_one_tier0_short_circuits_sound(monkeypatch, tmp_path: Path):
+    """Tier 0 SOUND -> backend=smt, artifact in barrier_query, no before-DB
+    build (the whole point of the free first-pass)."""
+    from core.dataflow.smt_barrier import (Tier0Result, Tier0Status,
+                                            ValidatorSpec)
+    spec = ValidatorSpec("charset", "x", "A-Za-z0-9", "if not re.match(...)", 0)
+    t0 = Tier0Result(
+        Tier0Status.SOUND, "UNSAT: no string in [A-Za-z0-9]+ can contain '/'",
+        spec=spec, artifact="smt:charset:[A-Za-z0-9]+@app.py:3",
+        extras={"validator_line": 3, "var_name": "x"})
+    builds, _ = _tier0_setup(monkeypatch, tier0_result=t0)
+    pair = _pair(cwe="CWE-22")
+    status, fid, backend, bq, detail = cvefix_bridge.synthesize_one(
+        pair, work_dir=tmp_path / "w", proposer=lambda *a: "RAISES_IF_CALLED")
+    assert status == "sound"
+    assert backend == "smt"
+    assert bq == "smt:charset:[A-Za-z0-9]+@app.py:3"
+    assert "UNSAT" in detail
+    assert builds == [pair.fix_hash]            # only after-DB; no before-DB
+
+
+def test_synthesize_one_tier0_not_applicable_falls_through(monkeypatch, tmp_path: Path):
+    from core.dataflow.smt_barrier import Tier0Result, Tier0Status
+    t0 = Tier0Result(Tier0Status.NOT_APPLICABLE,
+                     "no recognised charset/regex validator in fix diff")
+    builds, _ = _tier0_setup(monkeypatch, tier0_result=t0)
+    pair = _pair(cwe="CWE-22")
+    status, fid, backend, bq, detail = cvefix_bridge.synthesize_one(
+        pair, work_dir=tmp_path / "w", proposer=lambda *a: "")
+    assert status == "sound" and backend == "codeql" and bq == "TIER2_QL"
+    # Tier 0 fell through -> before-DB WAS built
+    assert builds == [pair.fix_hash, pair.parent_hash]
+
+
+def test_synthesize_one_tier0_declined_falls_through(monkeypatch, tmp_path: Path):
+    from core.dataflow.smt_barrier import (Tier0Result, Tier0Status,
+                                            ValidatorSpec)
+    spec = ValidatorSpec("charset", "x", "A-Za-z0-9_./", "if not...", 0)
+    t0 = Tier0Result(
+        Tier0Status.DECLINED,
+        "SAT: input '/' passes [A-Za-z0-9_./]+ yet still carries pathtrav danger",
+        spec=spec, counterexample="/")
+    builds, _ = _tier0_setup(monkeypatch, tier0_result=t0)
+    pair = _pair(cwe="CWE-22")
+    status, _fid, backend, bq, _detail = cvefix_bridge.synthesize_one(
+        pair, work_dir=tmp_path / "w", proposer=lambda *a: "")
+    assert status == "sound" and backend == "codeql" and bq == "TIER2_QL"
+    assert builds == [pair.fix_hash, pair.parent_hash]
+
+
+def test_synthesize_one_tier0_unavailable_falls_through(monkeypatch, tmp_path: Path):
+    """When _TIER0_AVAILABLE is False (substrate missing / import failed),
+    Tier 0 is skipped entirely and Tier 2 runs unchanged."""
+    monkeypatch.setattr(cvefix_bridge, "_TIER0_AVAILABLE", False)
+    # Use the same setup but the tier0_result is irrelevant since the gate
+    # short-circuits before try_tier0 is consulted.
+    builds, _ = _tier0_setup(monkeypatch, tier0_result=None)
+    pair = _pair(cwe="CWE-22")
+    status, _fid, backend, bq, _detail = cvefix_bridge.synthesize_one(
+        pair, work_dir=tmp_path / "w", proposer=lambda *a: "")
+    assert status == "sound" and backend == "codeql" and bq == "TIER2_QL"
+    assert builds == [pair.fix_hash, pair.parent_hash]
+
+
+def test_synthesize_one_tier0_skipped_when_no_diff(monkeypatch, tmp_path: Path):
+    """No fix diff retrievable -> Tier 0 is not attempted at all (avoids
+    calling try_tier0 with empty diff which would NOT_APPLICABLE anyway,
+    saving a no-op call)."""
+    from core.dataflow.smt_barrier import Tier0Status
+    builds, _ = _tier0_setup(
+        monkeypatch,
+        tier0_result=type("R", (), {"status": Tier0Status.SOUND,
+                                     "artifact": "should not be used",
+                                     "reasoning": "should not be used"})())
+    monkeypatch.setattr(cvefix_bridge, "_git_diff", lambda *a, **k: "")
+    pair = _pair(cwe="CWE-22")
+    status, _fid, backend, bq, _detail = cvefix_bridge.synthesize_one(
+        pair, work_dir=tmp_path / "w", proposer=lambda *a: "")
+    assert status == "sound" and backend == "codeql" and bq == "TIER2_QL"
+    assert builds == [pair.fix_hash, pair.parent_hash]
+
+
+def test_max_refine_attempts_threads_through_to_run_synthesis_loop(monkeypatch, tmp_path: Path):
+    """The bridge's ``--max-refine-attempts`` CLI flag plumbs all the way
+    down to ``run_synthesis_loop``; default 0 preserves the pre-existing
+    no-refinement behaviour."""
+    monkeypatch.setattr(cvefix_bridge, "_TIER0_AVAILABLE", False)
+    monkeypatch.setattr(cvefix_walk, "_fetch_pair", lambda *a, **k: True)
+    monkeypatch.setattr(cvefix_walk, "_build_db", lambda *a, **k: True)
+    monkeypatch.setattr(cvefix_bridge, "_run_query", lambda *a, **k: True)
+    prop = cvefix_bridge.BarrierProposal("sqli", "fid", "x", "ctx", "python")
+    monkeypatch.setattr(cvefix_bridge, "_extract_proposal",
+                        lambda *a, **k: (prop, "a.py", 3))
+    seen: dict = {}
+
+    def fake_loop(*args, **kwargs):
+        seen["max_refine_attempts"] = kwargs.get("max_refine_attempts")
+        return SynthResult(query_ql="QL", after_count=0, before_count=1)
+
+    monkeypatch.setattr(cvefix_bridge, "run_synthesis_loop", fake_loop)
+
+    cvefix_bridge.synthesize_one(_pair(), work_dir=tmp_path / "w0",
+                                 proposer=lambda *a: "")
+    assert seen["max_refine_attempts"] == 0                # default
+
+    cvefix_bridge.synthesize_one(_pair(), work_dir=tmp_path / "w2",
+                                 proposer=lambda *a: "", max_refine_attempts=2)
+    assert seen["max_refine_attempts"] == 2
+
+
+def test_run_synthesis_loop_diag_captures_last_error(tmp_path: Path):
+    from core.dataflow.barrier_synth import BarrierProposal, run_synthesis_loop
+    prop = BarrierProposal("sqli", "fid", "x", "ctx", "python")
+    diag: dict = {}
+    # proposer emits QL without the required predicate -> assembly ValueError every attempt
+    res = run_synthesis_loop(prop, tmp_path / "a", tmp_path / "b",
+                             proposer=lambda p, e: "predicate nope() { any() }",
+                             work_dir=tmp_path / "s", max_attempts=2, diag=diag)
+    assert res is None
+    assert "proposedGuard" in diag["last_error"] and diag["attempts"] == 2

--- a/core/dataflow/tests/test_cvefix_walk.py
+++ b/core/dataflow/tests/test_cvefix_walk.py
@@ -30,7 +30,7 @@ def test_process_pair_build_mode_autopick(monkeypatch, tmp_path: Path):
     seen = {}
     monkeypatch.setattr(cvefix_walk, "_fetch_pair", lambda *a, **k: True)
 
-    def fake_build(src, commit, db, lang, codeql_bin, timeout, build_mode=None):
+    def fake_build(src, commit, db, lang, codeql_bin, timeout, build_mode=None, tunables=None):
         seen["lang"], seen["mode"] = lang, build_mode
         return True
 
@@ -199,7 +199,261 @@ def test_autobuild_fails_closed_without_sandbox(monkeypatch):
     with pytest.raises(RuntimeError, match="refusing to autobuild"):
         cvefix_walk._run_autobuild_sandboxed(
             ["codeql", "database", "create"], work_root=Path("/tmp/x"),
-            codeql_bin="codeql", timeout=10)
+            codeql_bin="codeql", timeout=10, lang="java")
+
+
+def test_autobuild_rejects_lang_without_profile(monkeypatch):
+    """Adding a compiled language must be intentional — a missing profile
+    raises rather than silently routing to Maven's hosts."""
+    import core.sandbox as sb
+    monkeypatch.setattr(sb, "check_landlock_available", lambda: True)
+    with pytest.raises(RuntimeError, match="no autobuild profile for lang='cpp'"):
+        cvefix_walk._run_autobuild_sandboxed(
+            ["codeql", "database", "create"], work_root=Path("/tmp/x"),
+            codeql_bin="codeql", timeout=10, lang="cpp")
+
+
+def test_query_for_maps_go():
+    """Go pack uses the Security/CWE-0XX/ scheme (like JS/Python) with
+    ReflectedXss (no second-s capital) and TaintedPath for path-traversal."""
+    assert query_for("Go", "CWE-89") == "codeql/go-queries:Security/CWE-089/SqlInjection.ql"
+    assert query_for("Go", "CWE-78") == "codeql/go-queries:Security/CWE-078/CommandInjection.ql"
+    assert query_for("Go", "CWE-79") == "codeql/go-queries:Security/CWE-079/ReflectedXss.ql"
+    assert query_for("Go", "CWE-22") == "codeql/go-queries:Security/CWE-022/TaintedPath.ql"
+    assert query_for("Go", "CWE-918") == "codeql/go-queries:Security/CWE-918/RequestForgery.ql"
+    # Go pack has no CodeInjection.ql — matches the Java omission convention.
+    assert query_for("Go", "CWE-94") is None
+
+
+def test_process_pair_routes_go_through_autobuild(monkeypatch, tmp_path: Path):
+    """Go has no buildless extractor; default mode must be ``autobuild``
+    so the walker uses the sandboxed path instead of running ``go build``
+    unsandboxed.  Compare with Java's default ``none`` and Python's no-flag."""
+    seen = {}
+    monkeypatch.setattr(cvefix_walk, "_fetch_pair", lambda *a, **k: True)
+
+    def fake_build(src, commit, db, lang, codeql_bin, timeout, build_mode=None, tunables=None):
+        seen["lang"], seen["mode"] = lang, build_mode
+        return True
+
+    monkeypatch.setattr(cvefix_walk, "_build_db", fake_build)
+    monkeypatch.setattr(cvefix_walk, "_count_query", lambda *a, **k: 0)
+    go = CveFixPair("CVE-G", "CWE-89", "https://github.com/o/g", "Go", "fG", "pG")
+    process_pair(go, work_dir=tmp_path)
+    assert seen["lang"] == "go" and seen["mode"] == "autobuild"
+
+
+def test_go_autobuild_env_redirects_module_cache(tmp_path: Path):
+    """The Go autobuild env extender must redirect every Go cache/path
+    into the work area so the sandboxed build doesn't escape Landlock's
+    allow-write set.  GOCACHE was the load-bearing miss in the first
+    Go walk — its absence caused 100% build_fail on 82 pairs."""
+    env = cvefix_walk._go_autobuild_env(tmp_path)
+    assert env["GOMODCACHE"] == str(tmp_path / "go-mod-cache")
+    assert env["GOPATH"] == str(tmp_path / "gopath")
+    assert env["GOCACHE"] == str(tmp_path / "go-build-cache")
+    # -mod=mod allows the build to download missing modules; -mod=readonly
+    # (the default in newer Go versions) would fail-closed without go.sum.
+    assert env["GOFLAGS"] == "-mod=mod"
+
+
+def test_autobuild_profiles_have_distinct_proxy_hosts():
+    """Soundness check: the Java + Go profiles must NOT share a proxy host
+    set — a copy/paste here would silently mis-route one language's
+    module downloads, looking like build failures."""
+    java_hosts, _ = cvefix_walk._AUTOBUILD_PROFILES["java"]
+    go_hosts, _ = cvefix_walk._AUTOBUILD_PROFILES["go"]
+    assert set(java_hosts).isdisjoint(set(go_hosts)), \
+        f"profiles share hosts: {set(java_hosts) & set(go_hosts)}"
+    assert "proxy.golang.org" in go_hosts
+    assert "repo.maven.apache.org" in java_hosts
+
+
+def test_clean_go_caches_removes_readonly_module_cache(tmp_path: Path):
+    """Regression: Go's ``GOMODCACHE`` is read-only by design (proxy treats
+    cache contents as immutable), so a plain rmtree silently leaves it
+    behind.  Without recursive ``S_IWUSR`` chmod before rmtree, modules
+    cached from one project's `replace` directives corrupt the next
+    project's build — surfaced as 42/82 walks regressing build_fail in
+    the overnight v3 walk on 2026-06-01."""
+    # Build a mini-cache shaped like Go's: read-only files at all depths.
+    cache = tmp_path / "go-mod-cache" / "rsc.io" / "quote@v1.5.2"
+    cache.mkdir(parents=True)
+    (cache / "go.mod").write_text("module rsc.io/quote\n")
+    (cache / "quote.go").write_text("package quote\n")
+    # Mark everything read-only as Go does.
+    for p in cache.rglob("*"):
+        if not p.is_symlink():
+            import stat
+            p.chmod(p.stat().st_mode & ~stat.S_IWUSR & ~stat.S_IWGRP & ~stat.S_IWOTH)
+    # Sanity-check that a plain rmtree would fail.
+    cvefix_walk._clean_go_caches(tmp_path)
+    assert not (tmp_path / "go-mod-cache").exists(), \
+        "_clean_go_caches must remove the read-only cache tree"
+
+
+def test_clean_go_caches_skips_missing_dirs(tmp_path: Path):
+    """No cache dirs present (e.g. first pair, or non-Go walk): no-op,
+    not an error."""
+    cvefix_walk._clean_go_caches(tmp_path)        # must not raise
+
+
+def test_clean_go_caches_handles_all_three_locations(tmp_path: Path):
+    """Pin that the cleanup walks every cache location the env-extender
+    creates — GOMODCACHE, GOPATH, GOCACHE.  A missing one would leak
+    state across pairs and silently re-introduce the corruption bug."""
+    for sub in ("go-mod-cache", "gopath", "go-build-cache"):
+        (tmp_path / sub).mkdir(parents=True)
+        (tmp_path / sub / "marker").write_text("x")
+    cvefix_walk._clean_go_caches(tmp_path)
+    for sub in ("go-mod-cache", "gopath", "go-build-cache"):
+        assert not (tmp_path / sub).exists(), f"{sub} not cleaned"
+
+
+def test_codeql_tunables_appends_threads_unconditionally(tmp_path: Path):
+    """``-j`` is always passed (we changed the codeql default of 1
+    because it serializes the secondary HTML/JS extractor phase).
+    Threads=0 means all-cores per the codeql docs."""
+    t = cvefix_walk.CodeQLTunables()
+    cmd = ["codeql", "database", "create"]
+    t.append_to(cmd, include_disk_cache=True)
+    assert "-j" in cmd and "0" in cmd
+    # ram and max-disk-cache are unset (None) -> NOT appended.
+    assert "-M" not in cmd
+    assert not any(c.startswith("--max-disk-cache=") for c in cmd)
+
+
+def test_codeql_tunables_with_ram_and_disk(tmp_path: Path):
+    t = cvefix_walk.CodeQLTunables(threads=4, ram_mb=8192, max_disk_cache_mb=2048)
+    cmd = ["codeql", "database", "create"]
+    t.append_to(cmd, include_disk_cache=True)
+    assert ["-j", "4"] == cmd[3:5]
+    assert "-M" in cmd and "8192" in cmd
+    assert "--max-disk-cache=2048" in cmd
+
+
+def test_codeql_tunables_from_tuning_resolves_central_defaults(monkeypatch):
+    """``CodeQLTunables.from_tuning()`` must source threads + ram from
+    ``core.tuning``'s resolved config (the same source the rest of
+    RAPTOR's CodeQL consumers use).  Pin the integration so a typo or
+    schema rename here doesn't silently revert to baked-in defaults."""
+    import core.tuning
+    from core.tuning import Tuning
+
+    fake_tuning = Tuning(
+        codeql_ram_mb=8192, codeql_threads=12,
+        codeql_max_disk_cache_mb=0,
+        max_semgrep_workers=4, max_codeql_workers=2,
+        max_agentic_parallel=3, max_fuzz_parallel=4,
+        max_inventory_workers=4, max_json_memo_mb=128,
+    )
+    monkeypatch.setattr(core.tuning, "get_tuning", lambda: fake_tuning)
+    t = cvefix_walk.CodeQLTunables.from_tuning()
+    assert t.threads == 12
+    assert t.ram_mb == 8192
+
+
+def test_codeql_tunables_from_tuning_operator_override_wins(monkeypatch):
+    """Operator CLI args override tuning defaults — non-None values
+    in the overrides dict take precedence per field."""
+    import core.tuning
+    from core.tuning import Tuning
+
+    fake_tuning = Tuning(
+        codeql_ram_mb=8192, codeql_threads=12,
+        codeql_max_disk_cache_mb=0,
+        max_semgrep_workers=4, max_codeql_workers=2,
+        max_agentic_parallel=3, max_fuzz_parallel=4,
+        max_inventory_workers=4, max_json_memo_mb=128,
+    )
+    monkeypatch.setattr(core.tuning, "get_tuning", lambda: fake_tuning)
+    # Override only threads; ram stays at tuning value.
+    t = cvefix_walk.CodeQLTunables.from_tuning(
+        overrides={"threads": 4, "ram_mb": None})
+    assert t.threads == 4         # operator override
+    assert t.ram_mb == 8192       # tuning default
+
+
+def test_codeql_tunables_analyze_path_omits_max_disk_cache():
+    """``codeql database analyze`` rejects --max-disk-cache as an unknown
+    option; pin that the include_disk_cache=False path omits it so the
+    analyze step doesn't fail with a flag error."""
+    t = cvefix_walk.CodeQLTunables(max_disk_cache_mb=2048)
+    cmd = ["codeql", "database", "analyze"]
+    t.append_to(cmd, include_disk_cache=False)
+    assert not any(c.startswith("--max-disk-cache=") for c in cmd)
+
+
+def test_build_db_passes_tunables_into_create_command(monkeypatch, tmp_path: Path):
+    """End-to-end pin: when an operator passes a tunables object, the
+    codeql invocation includes the resource flags."""
+    captured: dict = {}
+
+    def fake_run(cmd, timeout):
+        captured["cmd"] = list(cmd)
+        return True
+
+    monkeypatch.setattr(cvefix_walk, "_run", fake_run)
+    src = tmp_path / "src"
+    src.mkdir()
+    db = tmp_path / "db"
+    t = cvefix_walk.CodeQLTunables(threads=8, ram_mb=4096, max_disk_cache_mb=1024)
+    ok = cvefix_walk._build_db(src, "abc", db, "python", "codeql", 120, None, tunables=t)
+    assert ok
+    cmd = captured["cmd"]
+    # _run was called twice (git checkout + codeql); the codeql one is captured last.
+    assert "-j" in cmd and "8" in cmd
+    assert "-M" in cmd and "4096" in cmd
+    assert "--max-disk-cache=1024" in cmd
+
+
+def test_process_pair_finally_cleans_go_caches_after_each_pair(
+        monkeypatch, tmp_path: Path):
+    """End-to-end: process_pair must invoke _clean_go_caches for Go pairs
+    so a stuck cache from pair N doesn't corrupt pair N+1.  Counter-
+    test: Python pair must NOT trigger the cleanup (no-op also fine but
+    pin the per-lang dispatch)."""
+    monkeypatch.setattr(cvefix_walk, "_fetch_pair", lambda *a, **k: True)
+    monkeypatch.setattr(cvefix_walk, "_build_db", lambda *a, **k: True)
+    monkeypatch.setattr(cvefix_walk, "_count_query", lambda *a, **k: 0)
+    cleaned: list = []
+    monkeypatch.setattr(
+        cvefix_walk, "_clean_go_caches",
+        lambda wd: cleaned.append(("go", wd)),
+    )
+    go = CveFixPair("CVE-G", "CWE-89", "https://github.com/o/g", "Go", "fG", "pG")
+    py = CveFixPair("CVE-P", "CWE-89", "https://github.com/o/p", "Python", "fP", "pP")
+    process_pair(go, work_dir=tmp_path)
+    process_pair(py, work_dir=tmp_path)
+    # Go pair triggers cleanup; Python pair does not.
+    assert cleaned == [("go", tmp_path)], cleaned
+
+
+def test_walk_dedups_same_commit_cwe_across_cves(monkeypatch, tmp_path: Path):
+    """One commit credited to two CVE ids (same fix_hash+cwe) is processed once."""
+    meta, results = tmp_path / "meta.db", tmp_path / "results.db"
+    con = sqlite3.connect(str(meta))
+    con.executescript(
+        "CREATE TABLE cwe_classification (cve_id TEXT, cwe_id TEXT);"
+        "CREATE TABLE fixes (cve_id TEXT, hash TEXT, repo_url TEXT);"
+        "CREATE TABLE commits (hash TEXT, repo_url TEXT, parents TEXT);"
+        "CREATE TABLE repository (repo_url TEXT, repo_name TEXT, repo_language TEXT);"
+    )
+    repo = "https://github.com/org/app"
+    con.execute("INSERT INTO commits VALUES(?,?,?)", ("fixA", repo, "['parA']"))
+    con.execute("INSERT INTO repository VALUES(?,?,?)", (repo, "app", "Python"))
+    for cve in ("CVE-1", "CVE-2"):                     # same commit, same CWE, two CVEs
+        con.execute("INSERT INTO cwe_classification VALUES(?,?)", (cve, "CWE-89"))
+        con.execute("INSERT INTO fixes VALUES(?,?,?)", (cve, "fixA", repo))
+    con.commit()
+    con.close()
+
+    calls = []
+    monkeypatch.setattr(cvefix_walk, "process_pair",
+                        lambda pair, **kw: calls.append(pair.fix_hash) or
+                        WalkResult(pair.fix_hash, "ok", before_count=1, after_count=1))
+    cvefix_walk.walk(meta, results, work_dir=tmp_path / "w", log=lambda *a: None)
+    assert calls == ["fixA"]                            # processed once, not twice
 
 
 def test_walk_limit(monkeypatch, tmp_path: Path):

--- a/core/dataflow/tests/test_cvefix_walk.py
+++ b/core/dataflow/tests/test_cvefix_walk.py
@@ -260,13 +260,21 @@ def test_go_autobuild_env_redirects_module_cache(tmp_path: Path):
 def test_autobuild_profiles_have_distinct_proxy_hosts():
     """Soundness check: the Java + Go profiles must NOT share a proxy host
     set — a copy/paste here would silently mis-route one language's
-    module downloads, looking like build failures."""
-    java_hosts, _ = cvefix_walk._AUTOBUILD_PROFILES["java"]
-    go_hosts, _ = cvefix_walk._AUTOBUILD_PROFILES["go"]
-    assert set(java_hosts).isdisjoint(set(go_hosts)), \
-        f"profiles share hosts: {set(java_hosts) & set(go_hosts)}"
-    assert "proxy.golang.org" in go_hosts
-    assert "repo.maven.apache.org" in java_hosts
+    module downloads, looking like build failures.
+
+    Use ``set(...) >= {...}`` for the canonical-host membership checks
+    rather than ``"host" in hosts_var``: CodeQL's
+    ``py/incomplete-url-substring-sanitization`` FP-flags the latter on
+    any list var that carries hostname-shaped strings.  Same FP class
+    as the auth-vocab cleartext-logging issue — see memory
+    ``feedback-codeql-cleartext-logging-auth-vocab-fp``.
+    """
+    java_set, _ = cvefix_walk._AUTOBUILD_PROFILES["java"]
+    go_set, _ = cvefix_walk._AUTOBUILD_PROFILES["go"]
+    assert set(java_set).isdisjoint(set(go_set)), \
+        f"profiles share entries: {set(java_set) & set(go_set)}"
+    assert set(go_set) >= {"proxy.golang.org"}
+    assert set(java_set) >= {"repo.maven.apache.org"}
 
 
 def test_clean_go_caches_removes_readonly_module_cache(tmp_path: Path):

--- a/core/dataflow/tests/test_ghsa_harvester.py
+++ b/core/dataflow/tests/test_ghsa_harvester.py
@@ -1,0 +1,260 @@
+"""Tests for the GHSA Advisory Database harvester.
+
+Tests are deterministic: real git fetches are skipped; the parent-resolution
+step is exercised by monkeypatching :func:`ghsa_harvester._resolve_parent`.
+End-to-end coverage: produce a metadata DB and verify :mod:`cvefix_loader`
+reads it without code changes.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from core.dataflow import ghsa_harvester as gh
+from core.dataflow.cvefix_loader import load_pairs
+
+
+# ---------------------------------------------------------------------------
+# Advisory JSON fixtures
+# ---------------------------------------------------------------------------
+
+def _adv(cve: str, cwes, eco: str, commit_url: str, year: str = "2024") -> dict:
+    return {
+        "schema_version": "1.4.0",
+        "id": f"GHSA-test-{cve}",
+        "aliases": [cve],
+        "summary": "test",
+        "details": "x",
+        "affected": [{"package": {"ecosystem": eco, "name": "p"}}],
+        "references": [{"type": "WEB", "url": commit_url}],
+        "database_specific": {"cwe_ids": list(cwes), "github_reviewed": True},
+    }
+
+
+def _write_advisory_tree(root: Path, advs):
+    """Lay out ``advs`` as one JSON per advisory under the
+    ``advisories/github-reviewed/<year>/01/GHSA.../`` shape that the
+    real GHSA repo uses, so :func:`_iter_advisories` finds them."""
+    for adv, year in advs:
+        ghsa_id = adv["id"]
+        adir = root / "advisories" / "github-reviewed" / year / "01" / ghsa_id
+        adir.mkdir(parents=True, exist_ok=True)
+        (adir / f"{ghsa_id}.json").write_text(json.dumps(adv))
+
+
+# ---------------------------------------------------------------------------
+# Pure-logic helpers
+# ---------------------------------------------------------------------------
+
+def test_first_commit_ref_finds_full_sha():
+    adv = {"references": [
+        {"type": "WEB", "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-99999"},
+        {"type": "WEB", "url": "https://github.com/owner/repo/commit/"
+                              "abcdef0123456789abcdef0123456789abcdef01"},
+    ]}
+    assert gh._first_commit_ref(adv) == (
+        "owner", "repo", "abcdef0123456789abcdef0123456789abcdef01",
+    )
+
+
+def test_first_commit_ref_short_sha_accepted():
+    adv = {"references": [
+        {"type": "WEB", "url": "https://github.com/x/y/commit/abc1234"},
+    ]}
+    assert gh._first_commit_ref(adv) == ("x", "y", "abc1234")
+
+
+def test_first_commit_ref_none_when_no_commit_url():
+    adv = {"references": [
+        {"type": "WEB", "url": "https://github.com/x/y/pull/1"},
+        {"type": "WEB", "url": "https://example.com/no-commit"},
+    ]}
+    assert gh._first_commit_ref(adv) is None
+
+
+def test_first_commit_ref_skips_non_github_commit_urls():
+    """A gitlab.com/.../commit/ URL must NOT match (we'd record a wrong
+    repo_url that the walker can't fetch).  Soundness > recall: we'd
+    rather decline than fabricate a record."""
+    adv = {"references": [
+        {"type": "WEB", "url": "https://gitlab.com/x/y/commit/abc1234"},
+    ]}
+    assert gh._first_commit_ref(adv) is None
+
+
+def test_pick_cwe_eco_deterministic_across_calls():
+    """Multi-CWE / multi-ecosystem advisories must always get the same
+    label, regardless of dict iteration order — sorted picks guarantee it."""
+    adv = {
+        "database_specific": {"cwe_ids": ["CWE-79", "CWE-22"]},
+        "affected": [{"package": {"ecosystem": "npm", "name": "a"}},
+                     {"package": {"ecosystem": "PyPI", "name": "b"}}],
+    }
+    pick1 = gh._pick_cwe_eco(adv, {"CWE-22", "CWE-79"}, {"npm", "PyPI"})
+    pick2 = gh._pick_cwe_eco(adv, {"CWE-22", "CWE-79"}, {"npm", "PyPI"})
+    assert pick1 == pick2 == ("CWE-22", "PyPI")  # sorted-first
+
+
+# ---------------------------------------------------------------------------
+# Advisory iteration + filter
+# ---------------------------------------------------------------------------
+
+def test_iter_advisories_filters_by_cwe_and_ecosystem(tmp_path: Path):
+    _write_advisory_tree(tmp_path, [
+        (_adv("CVE-2024-1", ["CWE-22"], "PyPI",
+              "https://github.com/x/y/commit/abc1234"), "2024"),
+        (_adv("CVE-2024-2", ["CWE-99"], "PyPI",      # wrong CWE
+              "https://github.com/x/y/commit/def5678"), "2024"),
+        (_adv("CVE-2024-3", ["CWE-22"], "composer",  # wrong ecosystem
+              "https://github.com/x/y/commit/9ab9999"), "2024"),
+    ])
+    out = list(gh._iter_advisories(
+        tmp_path, ["2024"], {"CWE-22"}, {"PyPI"},
+    ))
+    assert len(out) == 1
+    assert out[0][1]["aliases"] == ["CVE-2024-1"]
+
+
+def test_iter_advisories_skips_unreviewed_namespace(tmp_path: Path):
+    """``advisories/unreviewed/`` exists in the real GHSA repo with much
+    noisier metadata; we restrict to ``github-reviewed`` only.  An empty
+    github-reviewed/ subtree must still exist so the harvester doesn't
+    abort with a missing-root error."""
+    (tmp_path / "advisories" / "github-reviewed").mkdir(parents=True)
+    adv = _adv("CVE-2024-9", ["CWE-22"], "PyPI",
+               "https://github.com/x/y/commit/9999999")
+    adir = tmp_path / "advisories" / "unreviewed" / "2024" / "01" / adv["id"]
+    adir.mkdir(parents=True)
+    (adir / f"{adv['id']}.json").write_text(json.dumps(adv))
+    out = list(gh._iter_advisories(tmp_path, ["2024"], {"CWE-22"}, {"PyPI"}))
+    assert out == []
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: main() with mocked parent resolution
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def fake_resolve(monkeypatch):
+    """Replace :func:`_resolve_parent` with a deterministic stub: parent
+    of every fix is its SHA with the first 8 chars rotated.  Lets us run
+    main() end-to-end with no network."""
+    def fake(repo_url, fix_hash, timeout=60):
+        if "FAIL-REPO" in repo_url:
+            return None
+        return fix_hash[8:] + fix_hash[:8]
+    monkeypatch.setattr(gh, "_resolve_parent", fake)
+    return fake
+
+
+def test_main_e2e_produces_loadable_metadata_db(tmp_path: Path, fake_resolve):
+    _write_advisory_tree(tmp_path, [
+        (_adv("CVE-2024-1", ["CWE-22"], "PyPI",
+              "https://github.com/o/r/commit/aaaa00000000000000000000000000000000bbbb"),
+         "2024"),
+        (_adv("CVE-2025-2", ["CWE-79"], "npm",
+              "https://github.com/o/q/commit/ccccdddd00000000000000000000000000001111"),
+         "2025"),
+    ])
+    out = tmp_path / "metadata.db"
+    rc = gh.main([
+        "--ghsa-root", str(tmp_path),
+        "--out", str(out),
+        "--years", "2024", "2025",
+    ])
+    assert rc == 0
+    pairs = load_pairs(out)
+    assert len(pairs) == 2
+    cves = {p.cve_id for p in pairs}
+    assert cves == {"CVE-2024-1", "CVE-2025-2"}
+    # parent_hash is populated and different per fix (rotation stub).
+    for p in pairs:
+        assert p.parent_hash and p.parent_hash != p.fix_hash
+
+
+def test_main_drops_advisories_with_no_cve_alias(tmp_path: Path, fake_resolve):
+    """Advisories without a CVE alias have no canonical id to record;
+    they MUST be filtered out (recording GHSA-IDs as cve_id would break
+    the schema's contract with downstream consumers)."""
+    adv = _adv("CVE-2024-keep", ["CWE-22"], "PyPI",
+               "https://github.com/o/r/commit/" + "a" * 40)
+    no_cve = dict(adv)
+    no_cve["id"] = "GHSA-noaliasN"
+    no_cve["aliases"] = []   # advisory has no CVE alias
+    _write_advisory_tree(tmp_path, [(adv, "2024"), (no_cve, "2024")])
+    out = tmp_path / "metadata.db"
+    gh.main(["--ghsa-root", str(tmp_path), "--out", str(out), "--years", "2024"])
+    pairs = load_pairs(out)
+    assert [p.cve_id for p in pairs] == ["CVE-2024-keep"]
+
+
+def test_main_sample_size_is_deterministic_under_seed(tmp_path: Path, fake_resolve):
+    """Same seed -> same sampled subset; covering the random-sample call
+    site since the production run will rely on it for reproducibility."""
+    for i in range(5):
+        a = _adv(f"CVE-2024-{i}", ["CWE-22"], "PyPI",
+                 f"https://github.com/o/r/commit/{i:040d}".replace(
+                     " ", "0"))
+        _write_advisory_tree(tmp_path, [(a, "2024")])
+    out1 = tmp_path / "m1.db"
+    out2 = tmp_path / "m2.db"
+    gh.main(["--ghsa-root", str(tmp_path), "--out", str(out1),
+             "--years", "2024", "--sample-size", "3", "--seed", "7"])
+    gh.main(["--ghsa-root", str(tmp_path), "--out", str(out2),
+             "--years", "2024", "--sample-size", "3", "--seed", "7"])
+    pairs1 = sorted(p.cve_id for p in load_pairs(out1))
+    pairs2 = sorted(p.cve_id for p in load_pairs(out2))
+    assert pairs1 == pairs2
+    assert len(pairs1) == 3
+
+
+def test_main_skipped_advisories_when_fetch_fails(tmp_path: Path, fake_resolve):
+    """Fetch failures are tracked declines, not silent successes — only
+    advisories with a resolved parent end up in the metadata DB."""
+    _write_advisory_tree(tmp_path, [
+        (_adv("CVE-2024-good", ["CWE-22"], "PyPI",
+              "https://github.com/o/good/commit/" + "0" * 40), "2024"),
+        # repo_url containing FAIL-REPO triggers the stub to return None
+        (_adv("CVE-2024-bad", ["CWE-22"], "PyPI",
+              "https://github.com/FAIL-REPO/x/commit/" + "1" * 40), "2024"),
+    ])
+    out = tmp_path / "m.db"
+    gh.main(["--ghsa-root", str(tmp_path), "--out", str(out), "--years", "2024"])
+    pairs = load_pairs(out)
+    assert [p.cve_id for p in pairs] == ["CVE-2024-good"]
+
+
+# ---------------------------------------------------------------------------
+# DB schema check
+# ---------------------------------------------------------------------------
+
+def test_metadata_db_has_all_columns_load_pairs_reads(tmp_path: Path, fake_resolve):
+    _write_advisory_tree(tmp_path, [
+        (_adv("CVE-2024-x", ["CWE-22"], "PyPI",
+              "https://github.com/o/r/commit/" + "a" * 40), "2024"),
+    ])
+    out = tmp_path / "m.db"
+    gh.main(["--ghsa-root", str(tmp_path), "--out", str(out), "--years", "2024"])
+    # Sanity-check: every column load_pairs's SQL reads is present.
+    import sqlite3
+    con = sqlite3.connect(out)
+    try:
+        rows = con.execute("""
+            SELECT f.cve_id, c.cwe_id, f.repo_url, r.repo_language,
+                   f.hash, cm.parents
+            FROM fixes f
+            JOIN cwe_classification c ON f.cve_id = c.cve_id
+            JOIN commits cm ON f.hash = cm.hash
+            JOIN repository r ON f.repo_url = r.repo_url
+        """).fetchall()
+    finally:
+        con.close()
+    assert len(rows) == 1
+    cve_id, cwe, repo_url, lang, fix_hash, parents = rows[0]
+    assert cve_id == "CVE-2024-x"
+    assert cwe == "CWE-22"
+    assert lang == "Python"
+    assert parents.startswith("[") and parents.endswith("]")

--- a/core/dataflow/tests/test_known_safe_calls.py
+++ b/core/dataflow/tests/test_known_safe_calls.py
@@ -1,0 +1,73 @@
+"""Tests for the Tier 1B curated known-safe call table."""
+
+from __future__ import annotations
+
+from core.dataflow import known_safe_calls as ksc
+
+
+def test_find_exact_match_python_pathtrav():
+    e = ksc.find("werkzeug.security.safe_join", "pathtrav", "python")
+    assert e is not None
+    assert e.input_arg_kind == "validate"
+
+
+def test_find_returns_none_for_wrong_sink_class():
+    """html.escape is xss-safe, NOT pathtrav-safe."""
+    assert ksc.find("html.escape", "pathtrav", "python") is None
+    assert ksc.find("html.escape", "xss", "python") is not None
+
+
+def test_find_returns_none_for_wrong_language():
+    """werkzeug is Python-only; same-named call from another language
+    must not match."""
+    assert ksc.find("werkzeug.security.safe_join", "pathtrav", "java") is None
+
+
+def test_find_returns_none_for_unknown_library():
+    """Any library not in the curated table -> None (Tier 1B then
+    declines).  This is the trust-surface gate."""
+    assert ksc.find("evil.library.taint", "xss", "python") is None
+    assert ksc.find("not.in.table", "pathtrav", "python") is None
+
+
+def test_jsts_entries_match_both_languages():
+    """validator.escape + DOMPurify.sanitize cover both JS and TS."""
+    for lang in ("javascript", "typescript"):
+        assert ksc.find("validator.escape", "xss", lang) is not None
+        assert ksc.find("DOMPurify.sanitize", "xss", lang) is not None
+
+
+def test_every_entry_has_soundness_note():
+    """Adding entries without a justification is a soundness anti-
+    pattern; pin it down so a future PR can't sneak one in."""
+    for e in ksc.all_entries():
+        assert e.soundness_note and len(e.soundness_note) >= 50, (
+            f"{e.library_call} missing or too short soundness_note"
+        )
+
+
+def test_every_entry_has_valid_input_arg_kind():
+    valid = {"transform", "validate"}
+    for e in ksc.all_entries():
+        assert e.input_arg_kind in valid, (
+            f"{e.library_call} has invalid input_arg_kind={e.input_arg_kind!r}"
+        )
+
+
+def test_every_entry_has_valid_sink_class():
+    valid = {"pathtrav", "xss", "cmdi", "sqli"}
+    for e in ksc.all_entries():
+        assert e.sink_class in valid, (
+            f"{e.library_call} has invalid sink_class={e.sink_class!r}"
+        )
+
+
+def test_no_duplicate_entries():
+    """No two entries with the same (library_call, sink_class, language)
+    triple — would shadow each other under find()."""
+    seen = set()
+    for e in ksc.all_entries():
+        for lang in e.languages:
+            key = (e.library_call, e.sink_class, lang)
+            assert key not in seen, f"duplicate entry for {key}"
+            seen.add(key)

--- a/core/dataflow/tests/test_smt_barrier.py
+++ b/core/dataflow/tests/test_smt_barrier.py
@@ -1,0 +1,1213 @@
+"""Tests for the Tier 0 SMT backend.
+
+Exercises each layer in isolation (extractor, dominance, prove) and the
+full ``try_tier0`` orchestrator on the whoogle archetype.  Graceful
+degradation is verified by patching the substrate's z3 gate to False so
+the module returns Z3_UNAVAILABLE without touching z3 — matching the
+existing ``smt_path_validator`` degradation pattern.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from core.dataflow import smt_barrier as sb
+
+
+# ---------------------------------------------------------------------------
+# Validator extractor.
+# ---------------------------------------------------------------------------
+
+def test_extract_validator_anchored_charset_re_match():
+    diff = (
+        "@@ -1,2 +1,3 @@\n"
+        "     name = req()\n"
+        '+    if not re.match(r"^[A-Za-z0-9_.+-]+$", name): return error()\n'
+        "     return sink(name)\n"
+    )
+    spec = sb.extract_validator(diff)
+    assert spec is not None
+    assert spec.kind == "charset"
+    assert spec.var_name == "name"
+    assert spec.charset == "A-Za-z0-9_.+-"
+
+
+def test_extract_validator_fullmatch_no_anchors():
+    """re.fullmatch's whole-string semantics are implicit; allow the form
+    without explicit ^..$ anchors."""
+    diff = '+if not re.fullmatch(r"[A-Za-z]+", x): raise X\n'
+    spec = sb.extract_validator(diff)
+    assert spec is not None and spec.charset == "A-Za-z" and spec.var_name == "x"
+
+
+def test_extract_validator_rejects_non_anchored_re_match():
+    """Without ^...$ (and re.match, not fullmatch), the validator only
+    constrains a PREFIX — extractor must NOT treat it as whole-string."""
+    diff = '+if not re.match(r"[A-Za-z]+", x): raise X\n'
+    assert sb.extract_validator(diff) is None
+
+
+def test_extract_validator_ignores_non_added_lines():
+    """Lines starting with ' ' or '-' (context / removed) must be ignored;
+    only '+' lines are part of the fix."""
+    diff = '     if not re.match(r"^[A-Za-z]+$", x): pass\n'
+    assert sb.extract_validator(diff) is None
+
+
+def test_extract_validator_skips_file_header_marker():
+    diff = '+++ b/app.py\n'
+    assert sb.extract_validator(diff) is None
+
+
+def test_extract_validator_none_when_no_pattern():
+    assert sb.extract_validator("+x = 1\n+y = 2\n") is None
+    assert sb.extract_validator("") is None
+
+
+# ---------------------------------------------------------------------------
+# Dominance: validator location on the SARIF codeFlow.
+# ---------------------------------------------------------------------------
+
+def test_dominance_source_order_with_exit_on_fail(tmp_path: Path):
+    """The archetype: ``if not <call>:`` whose body returns -> dominates."""
+    src = (
+        "def f():\n"
+        "    x = req()\n"
+        "    if not re.match(r'^x$', x):\n"          # line 3 = validator
+        "        return error()\n"
+        "    return open(x)\n"                       # line 5 = sink
+    )
+    assert sb.validator_dominates_sink(src, validator_line=3, sink_line=5) is True
+
+
+def test_dominance_false_when_validator_after_sink():
+    """Source order matters: a validator that appears AFTER the sink can't
+    have neutralised the value at the sink."""
+    src = (
+        "def f():\n"
+        "    x = req()\n"
+        "    open(x)\n"                              # line 3 = sink
+        "    if not re.match(r'^x$', x):\n"          # line 4 = validator (later)
+        "        return error()\n"
+    )
+    assert sb.validator_dominates_sink(src, validator_line=4, sink_line=3) is False
+
+
+def test_dominance_false_when_block_doesnt_exit():
+    """The ``if not <call>:`` exists but the body just logs / passes
+    instead of return/raise -> the value reaches the sink unsanitized
+    -> not sound -> declined."""
+    src = (
+        "def f():\n"
+        "    x = req()\n"
+        "    if not re.match(r'^x$', x):\n"          # line 3
+        "        print('bad input')\n"               # no exit!
+        "    return open(x)\n"                       # line 5 = sink
+    )
+    assert sb.validator_dominates_sink(src, validator_line=3, sink_line=5) is False
+
+
+def test_dominance_true_with_raise():
+    """``raise`` is also a function-exiting branch."""
+    src = (
+        "def f():\n"
+        "    x = req()\n"
+        "    if not re.match(r'^x$', x):\n"          # line 3
+        "        raise ValueError('bad')\n"
+        "    return open(x)\n"                       # line 5 = sink
+    )
+    assert sb.validator_dominates_sink(src, validator_line=3, sink_line=5) is True
+
+
+def test_dominance_true_with_else_exit_form():
+    """The symmetric ``if <call>: continue; else: return error()`` form
+    also dominates: the else (failure) branch exits."""
+    src = (
+        "def f():\n"
+        "    x = req()\n"
+        "    if re.match(r'^x$', x):\n"              # line 3
+        "        pass\n"
+        "    else:\n"
+        "        return error()\n"
+        "    return open(x)\n"                       # line 7 = sink
+    )
+    assert sb.validator_dominates_sink(src, validator_line=3, sink_line=7) is True
+
+
+def test_dominance_false_across_functions():
+    """Validator in helper A doesn't dominate sink in helper B even
+    when A's line number is smaller."""
+    src = (
+        "def helper_a(x):\n"
+        "    if not re.match(r'^x$', x):\n"          # line 2 = validator in A
+        "        return None\n"
+        "    return x\n"
+        "\n"
+        "def helper_b(y):\n"
+        "    return open(y)\n"                       # line 7 = sink in B
+    )
+    assert sb.validator_dominates_sink(src, validator_line=2, sink_line=7) is False
+
+
+def test_dominance_false_on_syntax_error():
+    """Unparseable source -> conservative False (Tier 0 declines)."""
+    src = "def f(:\n    pass\n"
+    assert sb.validator_dominates_sink(src, 1, 2) is False
+
+
+def test_find_validator_line_locates_exact_source_line():
+    src = (
+        "a()\n"
+        "b()\n"
+        "if not re.match(r'^x$', n): pass\n"        # line 3
+        "c()\n"
+    )
+    spec = sb.ValidatorSpec(
+        "charset", "n", "x", "if not re.match(r'^x$', n): pass", 0)
+    assert sb.find_validator_line(src, spec) == 3
+
+
+def test_find_validator_line_none_when_absent():
+    spec = sb.ValidatorSpec("charset", "n", "x", "if not re.match(r'^x$', n): pass", 0)
+    assert sb.find_validator_line("a()\nb()\n", spec) is None
+
+
+# ---------------------------------------------------------------------------
+# SMT proof: regex-intersection emptiness.
+# ---------------------------------------------------------------------------
+
+def test_prove_unsat_for_whoogle_charset_vs_pathtrav():
+    spec = sb.ValidatorSpec("charset", "name", "A-Za-z0-9_.+-", "+...", 0)
+    v = sb.prove_neutralizes(spec, "pathtrav")
+    assert v.sound is True
+    assert v.counterexample is None
+    assert "UNSAT" in v.reasoning
+
+
+def test_prove_sat_for_weak_validator():
+    """Charset that permits '/' MUST be declined, with '/' as the
+    counterexample input."""
+    spec = sb.ValidatorSpec("charset", "name", "A-Za-z0-9_./+-", "+...", 0)
+    v = sb.prove_neutralizes(spec, "pathtrav")
+    assert v.sound is False
+    assert v.counterexample == "/"
+    assert "SAT" in v.reasoning
+
+
+def test_prove_sink_class_aware_whoogle_charset_vs_sqli():
+    """The whoogle charset is sound for pathtrav (separators excluded) but
+    NOT for sqli — the charset still allows '-'.  Demonstrates the danger
+    model is sink-class-keyed, not validator-keyed."""
+    spec = sb.ValidatorSpec("charset", "name", "A-Za-z0-9_.+-", "+...", 0)
+    v_sqli = sb.prove_neutralizes(spec, "sqli")
+    assert v_sqli.sound is False
+    assert v_sqli.counterexample == "-"
+
+
+def test_prove_unknown_sink_class_declines():
+    spec = sb.ValidatorSpec("charset", "n", "A-Za-z", "+...", 0)
+    v = sb.prove_neutralizes(spec, "no_such_class")
+    assert v.sound is False
+    assert "no danger model" in v.reasoning
+
+
+# ---------------------------------------------------------------------------
+# Substitution form: x = re.sub('[forbidden]+', '', x)
+# ---------------------------------------------------------------------------
+
+def test_extract_charset_sub_rebind():
+    diff = "+    x = re.sub('[/\\\\]+', '', x)\n"
+    spec = sb.extract_validator(diff)
+    assert spec is not None
+    assert spec.kind == "charset_sub"
+    assert spec.var_name == "x"
+    # `\\` in the pattern unescapes to `\`; `/` stays as-is.
+    assert spec.forbidden == "/\\"
+
+
+def test_extract_charset_sub_handles_escaped_quotes_in_pattern():
+    """Regression for Bug B: the Gerapy CVE-2020-7698 fix uses
+    ``'[\\!\\@\\#\\$\\;\\&\\*\\~\\"\\'\\{\\}\\]\\[\\-\\+\\%\\^]+'`` —
+    the body has both ``\\"`` and ``\\'`` inside a single-quoted
+    string.  Pre-fix the string-literal capture stopped at the first
+    escaped quote and silently truncated the pattern → extractor
+    returned None.  Must now extract correctly."""
+    diff = (
+        "+        project_name = re.sub("
+        "'[\\!\\@\\#\\$\\;\\&\\*\\~\\\"\\'\\{\\}\\]\\[\\-\\+\\%\\^]+', "
+        "'', project_name)\n"
+    )
+    spec = sb.extract_validator(diff, language="python")
+    assert spec is not None, "Bug B regression: pattern with escaped quotes must extract"
+    assert spec.kind == "charset_sub"
+    assert spec.var_name == "project_name"
+    # After unescape, the forbidden set should include all stripped chars
+    assert "!" in spec.forbidden
+    assert ";" in spec.forbidden       # in cmdi danger
+    assert "$" in spec.forbidden       # in cmdi danger
+
+
+def test_extract_charset_sub_unescapes_unnecessary_escapes():
+    """Author over-escapes inside the char class (Gerapy-style); the
+    unescape pass returns the true literal char set."""
+    diff = "+    x = re.sub('[\\!\\@\\#\\$\\;]+', '', x)\n"
+    spec = sb.extract_validator(diff)
+    assert spec is not None
+    assert spec.kind == "charset_sub"
+    assert spec.forbidden == "!@#$;"
+
+
+def test_extract_charset_sub_requires_same_var_rebind():
+    """``safe = re.sub(..., '', x)`` (assigning to a DIFFERENT name) is
+    NOT a same-variable rebind — we can't claim the original ``x`` is
+    sanitized just because ``safe`` is. Extractor must skip."""
+    diff = "+    safe = re.sub('[/]+', '', x)\n"
+    assert sb.extract_validator(diff) is None
+
+
+def test_extract_charset_sub_requires_empty_replacement():
+    """Non-empty replacement could introduce different danger chars
+    (`re.sub('[/]', '|', x)` replaces traversal with pipe — bad).
+    Extractor only accepts the empty-string replacement."""
+    diff = "+    x = re.sub('[/]+', '_', x)\n"
+    assert sb.extract_validator(diff) is None
+
+
+def test_prove_charset_sub_sound_when_danger_subset_of_forbidden():
+    """Path-traversal danger is just ['/', '\\\\']. If the substitution
+    strips both, every danger char is removed -> SOUND."""
+    spec = sb.ValidatorSpec("charset_sub", "x", source_line="+...", forbidden="/\\")
+    v = sb.prove_neutralizes(spec, "pathtrav")
+    assert v.sound is True
+    assert v.counterexample is None
+    assert "set inclusion" in v.reasoning
+
+
+def test_prove_charset_sub_declines_when_danger_char_survives():
+    """Gerapy-class: substitution strips many shell metachars but misses
+    `|` and backtick — declined with the surviving char as counterexample."""
+    # Strips ; & $ but NOT | ` (which are danger chars for cmdi)
+    spec = sb.ValidatorSpec("charset_sub", "x", source_line="+...", forbidden=";&$")
+    v = sb.prove_neutralizes(spec, "cmdi")
+    assert v.sound is False
+    # `|` is the smallest-codepoint surviving danger char in our model.
+    assert v.counterexample in {"|", "`", "\n"}
+
+
+def test_substitution_dominance_clean_path():
+    """``x = re.sub(...)`` at line 3, sink at line 4, no reassignment
+    between them -> dominates."""
+    src = (
+        "def f():\n"
+        "    x = req()\n"
+        "    x = re.sub('[/]+', '', x)\n"      # line 3
+        "    return open(x)\n"                  # line 4
+    )
+    assert sb.substitution_dominates_sink(src, 3, 4, "x") is True
+
+
+def test_substitution_dominance_false_when_var_reassigned():
+    """A later ``x = req()`` between the sub and the sink UNDOES
+    sanitization -> dominance fails."""
+    src = (
+        "def f():\n"
+        "    x = req()\n"
+        "    x = re.sub('[/]+', '', x)\n"      # line 3 — sub
+        "    x = req()\n"                       # line 4 — REASSIGN
+        "    return open(x)\n"                  # line 5 — sink
+    )
+    assert sb.substitution_dominates_sink(src, 3, 5, "x") is False
+
+
+def test_substitution_dominance_subscript_assignment_doesnt_invalidate():
+    """``x[0] = ...`` is a MUTATION of contents, not a rebinding of
+    ``x`` — must not invalidate dominance (still sound for the value
+    that flows into the sink)."""
+    src = (
+        "def f():\n"
+        "    x = req()\n"
+        "    x = re.sub('[/]+', '', x)\n"      # line 3 — sub
+        "    x[0] = 'A'\n"                      # line 4 — subscript mutation
+        "    return open(x)\n"                  # line 5
+    )
+    assert sb.substitution_dominates_sink(src, 3, 5, "x") is True
+
+
+def test_substitution_dominance_false_across_functions():
+    src = (
+        "def helper(x):\n"
+        "    x = re.sub('[/]+', '', x)\n"      # line 2 — sub in helper
+        "    return x\n"
+        "\n"
+        "def caller(y):\n"
+        "    return open(y)\n"                  # line 6 — sink in caller
+    )
+    assert sb.substitution_dominates_sink(src, 2, 6, "x") is False
+
+
+def test_try_tier0_sound_on_charset_sub_archetype(tmp_path: Path):
+    """End-to-end: pure path-traversal substitution that strips both
+    separators -> SOUND via Tier 0."""
+    (tmp_path / "app.py").write_text(
+        "def f():\n"                            # line 1
+        "    x = req()\n"                       # line 2
+        "    x = re.sub('[/\\\\]+', '', x)\n"   # line 3 — substitution
+        "    return open(x)\n"                  # line 4 — sink
+    )
+    diff = (
+        "@@ -1,3 +1,4 @@\n"
+        " def f():\n"
+        "     x = req()\n"
+        "+    x = re.sub('[/\\\\]+', '', x)\n"
+        "     return open(x)\n"
+    )
+    r = sb.try_tier0(
+        fix_diff=diff, repo_root=tmp_path,
+        sink_uri="app.py", sink_line=4, sink_class="pathtrav",
+    )
+    assert r.status is sb.Tier0Status.SOUND
+    assert r.artifact == "smt:charset_sub:[/\\]@app.py:3"
+    assert "set inclusion" in r.reasoning
+
+
+def test_try_tier0_declined_when_substitution_misses_danger(tmp_path: Path):
+    """Gerapy-shape: strips ; & $ but misses | for cmdi -> DECLINED."""
+    (tmp_path / "app.py").write_text(
+        "def f():\n"
+        "    cmd = req()\n"
+        "    cmd = re.sub('[;&$]+', '', cmd)\n"
+        "    return run(cmd)\n"
+    )
+    diff = (
+        "@@ -1,3 +1,4 @@\n"
+        " def f():\n"
+        "     cmd = req()\n"
+        "+    cmd = re.sub('[;&$]+', '', cmd)\n"
+        "     return run(cmd)\n"
+    )
+    r = sb.try_tier0(
+        fix_diff=diff, repo_root=tmp_path,
+        sink_uri="app.py", sink_line=4, sink_class="cmdi",
+    )
+    assert r.status is sb.Tier0Status.DECLINED
+    assert r.counterexample in {"|", "`", "\n"}
+
+
+# ---------------------------------------------------------------------------
+# Multi-language guard-and-exit extractors (JS/TS/Java/Ruby).
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("line,expected_charset,expected_var", [
+    ("+if (!/^[A-Za-z0-9_.+-]+$/.test(name)) return error();",
+     "A-Za-z0-9_.+-", "name"),
+    ("+    if (!/^[a-z0-9]+$/.test(slug)) throw new Error('bad');",
+     "a-z0-9", "slug"),
+    ("+if (!name.match(/^[A-Za-z0-9]+$/)) return error();",
+     "A-Za-z0-9", "name"),
+])
+def test_extract_jsts_guard_and_exit(line, expected_charset, expected_var):
+    diff = line + "\n"
+    spec = sb.extract_validator(diff, language="javascript")
+    assert spec is not None and spec.kind == "charset"
+    assert spec.charset == expected_charset
+    assert spec.var_name == expected_var
+    # Same extractor handles typescript.
+    assert sb.extract_validator(diff, language="typescript").charset == expected_charset
+
+
+def test_extract_jsts_rejects_missing_exit():
+    """Validator without guard-and-exit shape: skipped (we can't prove
+    dominance from the diff alone)."""
+    diff = "+const ok = /^[a-z]+$/.test(x);\n"
+    assert sb.extract_validator(diff, language="javascript") is None
+
+
+def test_extract_java_guard_and_exit():
+    diff = '+if (!name.matches("^[A-Za-z0-9_.+-]+$")) return error();\n'
+    spec = sb.extract_validator(diff, language="java")
+    assert spec is not None and spec.kind == "charset"
+    assert spec.charset == "A-Za-z0-9_.+-"
+    assert spec.var_name == "name"
+
+
+def test_extract_java_with_throw():
+    diff = '+if (!slug.matches("^[a-z0-9]+$")) throw new IllegalArgumentException();\n'
+    spec = sb.extract_validator(diff, language="java")
+    assert spec is not None and spec.charset == "a-z0-9"
+
+
+@pytest.mark.parametrize("line,expected_charset,expected_var", [
+    ("+return error unless name =~ /^[A-Za-z0-9_.+-]+$/", "A-Za-z0-9_.+-", "name"),
+    ("+raise ArgumentError unless slug =~ /^[a-z0-9]+$/", "a-z0-9", "slug"),
+    ("+raise 'bad' if name !~ /^[A-Za-z0-9]+$/", "A-Za-z0-9", "name"),
+])
+def test_extract_ruby_guard_and_exit(line, expected_charset, expected_var):
+    diff = line + "\n"
+    spec = sb.extract_validator(diff, language="ruby")
+    assert spec is not None and spec.kind == "charset"
+    assert spec.charset == expected_charset
+    assert spec.var_name == expected_var
+
+
+# ---------------------------------------------------------------------------
+# Adversarial-review regressions — bugs caught before the long corpus run.
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("metachar", [r"\d", r"\D", r"\w", r"\W", r"\s", r"\S"])
+def test_extract_rejects_regex_shorthand_classes(metachar):
+    """Bug 1 (UNSOUND): silently misreading `\\W` as literal chars
+    `{\\, W}` lets the SMT check claim SOUND for a validator that
+    accepts danger chars (`\\W` includes `/`, `\\`).  Must reject."""
+    diff = f"+if not re.match(r'^[{metachar}]+$', x):\n+    return error()\n"
+    assert sb.extract_validator(diff, language="python") is None
+
+
+def test_extract_rejects_regex_shorthand_classes_in_charset_sub():
+    diff = r"+    x = re.sub('[\W]+', '', x)" + "\n"
+    assert sb.extract_validator(diff, language="python") is None
+
+
+def test_extract_rejects_negated_class():
+    """Bug 2 (UNSOUND): `[^a-z]+` accepts any non-lowercase char
+    including `/`; misreading `^` as literal would claim SOUND for
+    pathtrav.  Reject negated classes."""
+    diff = "+if not re.match(r'^[^a-z]+$', x):\n+    return error()\n"
+    assert sb.extract_validator(diff, language="python") is None
+
+
+def test_extract_rejects_negated_class_in_js():
+    diff = "+if (!/^[^a-z]+$/.test(x)) return error();\n"
+    assert sb.extract_validator(diff, language="javascript") is None
+
+
+def test_extract_rejects_negated_class_in_java():
+    diff = '+if (!x.matches("^[^a-z]+$")) return;\n'
+    assert sb.extract_validator(diff, language="java") is None
+
+
+def test_variable_reassigned_detects_for_loop():
+    """Bug 3 (UNSOUND): `for x in items:` rebinds x to iter values.
+    Missing this would let dominance falsely succeed when the post-sub
+    x is overwritten by the loop."""
+    tree = __import__("ast").parse(
+        "def f():\n"
+        "    x = re.sub('[/]+', '', x)\n"
+        "    for x in items:\n"
+        "        sink(x)\n"
+    )
+    assert sb._variable_reassigned_between(tree, "x", 2, 4) is True
+
+
+def test_variable_reassigned_detects_with_as():
+    tree = __import__("ast").parse(
+        "def f():\n"
+        "    x = re.sub('[/]+', '', x)\n"
+        "    with open('p') as x:\n"
+        "        sink(x)\n"
+    )
+    assert sb._variable_reassigned_between(tree, "x", 2, 4) is True
+
+
+def test_variable_reassigned_detects_tuple_unpacking():
+    tree = __import__("ast").parse(
+        "def f():\n"
+        "    x = re.sub('[/]+', '', x)\n"
+        "    x, y = pair\n"
+        "    return open(x)\n"
+    )
+    assert sb._variable_reassigned_between(tree, "x", 2, 4) is True
+
+
+def test_variable_reassigned_detects_walrus():
+    tree = __import__("ast").parse(
+        "def f():\n"
+        "    x = re.sub('[/]+', '', x)\n"
+        "    foo((x := req()))\n"
+        "    return open(x)\n"
+    )
+    assert sb._variable_reassigned_between(tree, "x", 2, 4) is True
+
+
+def test_variable_reassigned_subscript_assignment_does_not_trigger():
+    """`x[0] = y` mutates contents but does NOT rebind `x` itself —
+    must NOT flag as reassignment."""
+    tree = __import__("ast").parse(
+        "def f():\n"
+        "    x = re.sub('[/]+', '', x)\n"
+        "    x[0] = 'A'\n"
+        "    return open(x)\n"
+    )
+    assert sb._variable_reassigned_between(tree, "x", 2, 4) is False
+
+
+@pytest.mark.parametrize("lang,boundary_line", [
+    ("javascript", "function helper() {"),
+    ("javascript", "const helper = (x) => {"),
+    ("java",       "public void helper() {"),
+    ("ruby",       "  def helper"),
+])
+def test_crosses_function_boundary_detects_per_language(lang, boundary_line):
+    """Bug 4 (UNSOUND): validator in helper A + sink in helper B (same
+    file) — without function-boundary detection, source-order alone
+    falsely dominates.  Reject."""
+    src = (
+        "function user_facing() {\n"
+        "  if (!/^[a-z]+$/.test(name)) return error();\n"   # line 2
+        f"  {boundary_line}\n"                              # line 3 = boundary
+        "    do_something();\n"
+        "  }\n"
+        "  return danger_sink(other);\n"                    # line 6 = sink
+        "}\n"
+    )
+    assert sb._crosses_function_boundary(src, 2, 6, lang) is True
+
+
+def test_crosses_function_boundary_js_ignores_if_statement():
+    """Bug 7: `if (x) {` superficially looks like a JS method header
+    (`name(args) {`); must NOT be treated as a function boundary."""
+    src = (
+        "function f() {\n"
+        "  if (!/^[a-z]+$/.test(name)) return error();\n"
+        "  if (other_cond) {\n"                # NOT a function boundary
+        "    do_thing();\n"
+        "  }\n"
+        "  return danger_sink(name);\n"
+        "}\n"
+    )
+    assert sb._crosses_function_boundary(src, 2, 6, "javascript") is False
+
+
+def test_crosses_function_boundary_java_detects_package_private():
+    """Bug 8: package-private method (no public/private modifier) must
+    still be detected as a function boundary so cross-method dominance
+    can't false-positive."""
+    src = (
+        "void user_facing(String x) {\n"
+        '    if (!x.matches("^[a-z]+$")) return;\n'
+        "}\n"
+        "String helper(String y) {\n"          # package-private method
+        "    return danger_sink(y);\n"
+        "}\n"
+    )
+    assert sb._crosses_function_boundary(src, 2, 5, "java") is True
+
+
+def test_crosses_function_boundary_java_ignores_if_with_type_prefix():
+    """A `Type name = expr;` declaration shouldn't match a method
+    header — needs an argument list `(...)` after the name."""
+    src = (
+        "void m() {\n"
+        '    if (!x.matches("^[a-z]+$")) return;\n'
+        "    String tmp = x + '!';\n"          # variable decl, NOT a method
+        "    int count = 0;\n"
+        "    return sink(tmp);\n"
+        "}\n"
+    )
+    assert sb._crosses_function_boundary(src, 2, 5, "java") is False
+
+
+def test_crosses_function_boundary_ruby_detects_self_dot():
+    """Ruby class methods are declared `def self.name` — must be
+    detected as a function boundary."""
+    src = (
+        "def user_facing(name)\n"
+        "  raise unless name =~ /^[a-z]+$/\n"
+        "end\n"
+        "\n"
+        "def self.helper(y)\n"                  # class method
+        "  sink(y)\n"
+        "end\n"
+    )
+    assert sb._crosses_function_boundary(src, 2, 6, "ruby") is True
+
+
+def test_crosses_function_boundary_returns_false_when_no_boundary():
+    src = (
+        "function user_facing() {\n"
+        "  if (!/^[a-z]+$/.test(name)) return error();\n"
+        "  const tmp = name + '!';\n"
+        "  return danger_sink(tmp);\n"
+        "}\n"
+    )
+    assert sb._crosses_function_boundary(src, 2, 4, "javascript") is False
+
+
+def test_try_tier0_declined_when_js_crosses_function_boundary(tmp_path: Path):
+    """End-to-end: JS validator in one helper, sink in another. Tier 0
+    must DECLINE because the validator's `return` exits the wrong
+    function."""
+    (tmp_path / "app.js").write_text(
+        "function helper_a(name) {\n"                                       # line 1
+        "  if (!/^[A-Za-z0-9]+$/.test(name)) return null;\n"                # line 2
+        "  return name;\n"                                                  # line 3
+        "}\n"                                                               # line 4
+        "function helper_b(other) {\n"                                      # line 5
+        "  return fs.readFile(other);\n"                                    # line 6 = sink
+        "}\n"
+    )
+    diff = (
+        "@@ -1,5 +1,6 @@\n"
+        " function helper_a(name) {\n"
+        "+  if (!/^[A-Za-z0-9]+$/.test(name)) return null;\n"
+        "   return name;\n"
+        " }\n"
+        " function helper_b(other) {\n"
+        "   return fs.readFile(other);\n"
+    )
+    r = sb.try_tier0(
+        fix_diff=diff, repo_root=tmp_path,
+        sink_uri="app.js", sink_line=6, sink_class="pathtrav",
+        language="javascript",
+    )
+    assert r.status is sb.Tier0Status.NOT_APPLICABLE
+    assert "function boundary" in r.reasoning
+
+
+def test_try_tier0_not_applicable_when_validator_var_not_at_sink(tmp_path: Path):
+    """Bug 15 (UNSOUND): fix adds a validator for `x` and a sink for `y`
+    in the same function. Tier 0 must NOT apply the validator's
+    constraint to the sink's value — the validated variable must
+    actually appear at the sink line."""
+    (tmp_path / "app.py").write_text(
+        "def f(x, y):\n"                                                # line 1
+        '    if not re.match(r"^[A-Za-z0-9]+$", x):\n'                  # line 2
+        "        return error()\n"                                       # line 3
+        "    do_something_with(x)\n"                                     # line 4
+        "    return open(y)\n"                                           # line 5 = sink for y, not x
+    )
+    diff = (
+        "@@ -1,3 +1,5 @@\n"
+        " def f(x, y):\n"
+        '+    if not re.match(r"^[A-Za-z0-9]+$", x):\n'
+        "+        return error()\n"
+        "     do_something_with(x)\n"
+        "     return open(y)\n"
+    )
+    r = sb.try_tier0(
+        fix_diff=diff, repo_root=tmp_path,
+        sink_uri="app.py", sink_line=5, sink_class="pathtrav",
+    )
+    assert r.status is sb.Tier0Status.NOT_APPLICABLE
+    assert "no chain member reaches" in r.reasoning
+
+
+def test_try_tier0_sound_when_validated_var_threads_through_assignment(tmp_path: Path):
+    """Whoogle-shape: validated ``name`` flows through
+    ``cfg = os.path.join(BASE, name)`` to the sink ``open(cfg)``.
+    Chain tracking must accept this (the validator's constraint applies
+    to ``cfg`` via ``name``).  Pre-fix the literal var-at-sink check
+    rejected this — the most common real-world Tier 0 case."""
+    (tmp_path / "app.py").write_text(
+        "def f(name):\n"                                                # line 1
+        '    if not re.match(r"^[A-Za-z0-9_.+-]+$", name):\n'           # line 2
+        "        return error()\n"                                       # line 3
+        "    cfg = os.path.join(BASE, name)\n"                           # line 4 — derive cfg from name
+        "    return open(cfg)\n"                                         # line 5 = sink, references cfg
+    )
+    diff = (
+        "@@ -1,3 +1,5 @@\n"
+        " def f(name):\n"
+        '+    if not re.match(r"^[A-Za-z0-9_.+-]+$", name):\n'
+        "+        return error()\n"
+        "     cfg = os.path.join(BASE, name)\n"
+        "     return open(cfg)\n"
+    )
+    r = sb.try_tier0(
+        fix_diff=diff, repo_root=tmp_path,
+        sink_uri="app.py", sink_line=5, sink_class="pathtrav",
+    )
+    assert r.status is sb.Tier0Status.SOUND
+    assert "UNSAT" in r.reasoning
+
+
+def test_chain_grows_through_multi_step_assignment():
+    """Chain tracking must follow multi-step derivations:
+    ``name -> cfg -> safe_path -> open(safe_path)``."""
+    import ast as _ast_mod
+    tree = _ast_mod.parse(
+        "def f(name):\n"
+        '    if not re.match(r"^[a-z]+$", name): return\n'
+        "    cfg = os.path.join(BASE, name)\n"           # cfg derived from name
+        "    safe_path = cfg + '.cfg'\n"                  # safe_path derived from cfg
+        "    return open(safe_path)\n"                    # sink uses safe_path
+    )
+    assert sb._python_chain_reaches_sink(
+        tree, "name", 2, 5, "    return open(safe_path)",
+    ) is True
+
+
+def test_chain_does_not_grow_through_unrelated_assignment():
+    """Bug 15 still caught: validator constrains ``x``, sink uses
+    unrelated ``y``. ``x`` is referenced between but never feeds ``y``."""
+    import ast as _ast_mod
+    tree = _ast_mod.parse(
+        "def f(x, y):\n"
+        '    if not re.match(r"^[a-z]+$", x): return\n'
+        "    do_something_with(x)\n"                       # x USED but not assigned
+        "    return open(y)\n"                              # sink uses y, unrelated to x
+    )
+    assert sb._python_chain_reaches_sink(
+        tree, "x", 2, 4, "    return open(y)",
+    ) is False
+
+
+def test_try_tier0_variable_match_uses_word_boundary(tmp_path: Path):
+    """Word-boundary match: validator's `name` must not falsely match
+    `surname` at the sink line."""
+    (tmp_path / "app.py").write_text(
+        "def f(name, surname):\n"                                       # line 1
+        '    if not re.match(r"^[A-Za-z0-9]+$", name):\n'               # line 2
+        "        return error()\n"                                       # line 3
+        "    return open(surname)\n"                                     # line 4 = sink for surname
+    )
+    diff = (
+        "@@ -1,2 +1,4 @@\n"
+        " def f(name, surname):\n"
+        '+    if not re.match(r"^[A-Za-z0-9]+$", name):\n'
+        "+        return error()\n"
+        "     return open(surname)\n"
+    )
+    r = sb.try_tier0(
+        fix_diff=diff, repo_root=tmp_path,
+        sink_uri="app.py", sink_line=4, sink_class="pathtrav",
+    )
+    assert r.status is sb.Tier0Status.NOT_APPLICABLE
+    assert "no chain member reaches" in r.reasoning
+
+
+def test_crosses_function_boundary_ts_class_method_with_public_modifier():
+    """Bug 16: TypeScript class methods use public/private/protected
+    modifiers; my JS pattern (which TS dispatches to) must detect
+    these as method declarations."""
+    src = (
+        "class C {\n"
+        "  user_facing(name: string) {\n"
+        "    if (!/^[a-z]+$/.test(name)) return;\n"
+        "  }\n"
+        "  public helper(other: string) {\n"          # TS modifier
+        "    return danger_sink(other);\n"
+        "  }\n"
+        "}\n"
+    )
+    # Validator at line 3, sink at line 6, public method header at line 5
+    assert sb._crosses_function_boundary(src, 3, 6, "javascript") is True
+
+
+def test_crosses_function_boundary_js_detects_generator_function():
+    """Bug 18: generator functions (`function* name` / `*method`) must
+    be detected as function boundaries."""
+    src1 = (
+        "function user_facing() {\n"
+        "  if (!/^[a-z]+$/.test(name)) return;\n"
+        "}\n"
+        "function* helper() {\n"                        # generator
+        "  yield danger_sink(name);\n"
+        "}\n"
+    )
+    assert sb._crosses_function_boundary(src1, 2, 5, "javascript") is True
+    src2 = (
+        "class C {\n"
+        "  user_facing() {\n"
+        "    if (!/^[a-z]+$/.test(name)) return;\n"
+        "  }\n"
+        "  *helper() {\n"                                # generator method
+        "    yield danger_sink(name);\n"
+        "  }\n"
+        "}\n"
+    )
+    assert sb._crosses_function_boundary(src2, 3, 6, "javascript") is True
+
+
+def test_validator_block_in_try_with_bare_except_declines(tmp_path: Path):
+    """Bug 19: validator's `raise` inside try/except: bare catch lets
+    the raise be swallowed → value reaches sink unvalidated → must
+    NOT claim dominance."""
+    (tmp_path / "app.py").write_text(
+        "def f(x):\n"                                                  # line 1
+        "    try:\n"                                                   # line 2
+        '        if not re.match(r"^[A-Za-z0-9]+$", x):\n'             # line 3
+        "            raise ValueError\n"                               # line 4
+        "    except:\n"                                                # line 5 — bare catches everything
+        "        pass\n"                                               # line 6 — raise SWALLOWED
+        "    return open(x)\n"                                         # line 7 — sink, x unvalidated
+    )
+    diff = (
+        "@@ -1,3 +1,7 @@\n"
+        " def f(x):\n"
+        "+    try:\n"
+        '+        if not re.match(r"^[A-Za-z0-9]+$", x):\n'
+        "+            raise ValueError\n"
+        "+    except:\n"
+        "+        pass\n"
+        "     return open(x)\n"
+    )
+    r = sb.try_tier0(
+        fix_diff=diff, repo_root=tmp_path,
+        sink_uri="app.py", sink_line=7, sink_class="pathtrav",
+    )
+    assert r.status is sb.Tier0Status.NOT_APPLICABLE
+    assert "does not dominate" in r.reasoning
+
+
+def test_validator_block_in_try_with_exception_catch_declines(tmp_path: Path):
+    """Same bug but with `except Exception:` — also catches everything
+    the validator raises."""
+    (tmp_path / "app.py").write_text(
+        "def f(x):\n"
+        "    try:\n"
+        '        if not re.match(r"^[A-Za-z0-9]+$", x):\n'
+        "            raise ValueError\n"
+        "    except Exception:\n"                                      # catches ValueError
+        "        pass\n"
+        "    return open(x)\n"
+    )
+    diff = (
+        "@@ -1,3 +1,7 @@\n"
+        " def f(x):\n"
+        "+    try:\n"
+        '+        if not re.match(r"^[A-Za-z0-9]+$", x):\n'
+        "+            raise ValueError\n"
+        "+    except Exception:\n"
+        "+        pass\n"
+        "     return open(x)\n"
+    )
+    r = sb.try_tier0(
+        fix_diff=diff, repo_root=tmp_path,
+        sink_uri="app.py", sink_line=7, sink_class="pathtrav",
+    )
+    assert r.status is sb.Tier0Status.NOT_APPLICABLE
+
+
+def test_validator_block_with_specific_except_class_still_dominates(tmp_path: Path):
+    """``except OSError:`` doesn't catch the ValueError raised by the
+    validator — dominance still holds."""
+    (tmp_path / "app.py").write_text(
+        "def f(x):\n"
+        "    try:\n"
+        '        if not re.match(r"^[A-Za-z0-9_.+-]+$", x):\n'
+        "            raise ValueError\n"
+        "    except OSError:\n"                                        # different exception class
+        "        pass\n"
+        "    return open(x)\n"
+    )
+    diff = (
+        "@@ -1,3 +1,7 @@\n"
+        " def f(x):\n"
+        "+    try:\n"
+        '+        if not re.match(r"^[A-Za-z0-9_.+-]+$", x):\n'
+        "+            raise ValueError\n"
+        "+    except OSError:\n"
+        "+        pass\n"
+        "     return open(x)\n"
+    )
+    r = sb.try_tier0(
+        fix_diff=diff, repo_root=tmp_path,
+        sink_uri="app.py", sink_line=7, sink_class="pathtrav",
+    )
+    assert r.status is sb.Tier0Status.SOUND
+
+
+def test_validator_with_return_inside_try_still_dominates(tmp_path: Path):
+    """Return is NOT catchable — even ``except:`` doesn't intercept it.
+    Dominance still holds when the failure branch uses ``return``."""
+    (tmp_path / "app.py").write_text(
+        "def f(x):\n"
+        "    try:\n"
+        '        if not re.match(r"^[A-Za-z0-9_.+-]+$", x):\n'
+        "            return error()\n"                                 # return, not raise
+        "    except Exception:\n"
+        "        pass\n"
+        "    return open(x)\n"
+    )
+    diff = (
+        "@@ -1,3 +1,7 @@\n"
+        " def f(x):\n"
+        "+    try:\n"
+        '+        if not re.match(r"^[A-Za-z0-9_.+-]+$", x):\n'
+        "+            return error()\n"
+        "+    except Exception:\n"
+        "+        pass\n"
+        "     return open(x)\n"
+    )
+    r = sb.try_tier0(
+        fix_diff=diff, repo_root=tmp_path,
+        sink_uri="app.py", sink_line=7, sink_class="pathtrav",
+    )
+    assert r.status is sb.Tier0Status.SOUND
+
+
+def test_variable_reassigned_detects_except_as():
+    """Bug 20: ``except SomeError as x:`` binds x to the exception
+    during the handler body — x is no longer the sanitized value."""
+    tree = __import__("ast").parse(
+        "def f():\n"
+        "    x = re.sub('[/]+', '', x)\n"
+        "    try:\n"
+        "        do()\n"
+        "    except Exception as x:\n"
+        "        pass\n"
+        "    return open(x)\n"
+    )
+    assert sb._variable_reassigned_between(tree, "x", 2, 7) is True
+
+
+def test_re_sub_extractor_rejects_whitespace_replacement():
+    """Bug 5 (cleanliness): `' '` replacement is not truly empty.
+    Tighten the extractor to reject."""
+    diff = "+    x = re.sub('[/]+', ' ', x)\n"
+    assert sb.extract_validator(diff, language="python") is None
+
+
+def test_java_matches_without_anchors_still_extracts():
+    """Bug 6: Java's `String.matches` is fullmatch by default; explicit
+    `^...$` anchors are redundant. Patterns without anchors must still
+    extract (and validate as sound)."""
+    diff = '+if (!name.matches("[A-Za-z0-9_.+-]+")) throw new Error();\n'
+    spec = sb.extract_validator(diff, language="java")
+    assert spec is not None and spec.kind == "charset"
+    assert spec.charset == "A-Za-z0-9_.+-"
+
+
+def test_extract_unknown_language_returns_none():
+    """Languages with no extractor configured -> Tier 0 declines cleanly."""
+    diff = "+if (!/^[a-z]+$/.test(x)) return error();\n"
+    assert sb.extract_validator(diff, language="rust") is None
+    assert sb.extract_validator(diff, language="cobol") is None
+
+
+def test_try_tier0_sound_on_js_archetype(tmp_path: Path):
+    """End-to-end JS: guard-and-exit + path-traversal sink -> SOUND."""
+    (tmp_path / "app.js").write_text(
+        "function get_config(name) {\n"                                    # line 1
+        "  if (!/^[A-Za-z0-9_.+-]+$/.test(name)) return error();\n"        # line 2
+        "  return fs.readFile(path.join(BASE, name));\n"                   # line 3
+        "}\n"
+    )
+    diff = (
+        "@@ -1,2 +1,3 @@\n"
+        " function get_config(name) {\n"
+        "+  if (!/^[A-Za-z0-9_.+-]+$/.test(name)) return error();\n"
+        "   return fs.readFile(path.join(BASE, name));\n"
+    )
+    r = sb.try_tier0(
+        fix_diff=diff, repo_root=tmp_path,
+        sink_uri="app.js", sink_line=3, sink_class="pathtrav",
+        language="javascript",
+    )
+    assert r.status is sb.Tier0Status.SOUND
+    assert "UNSAT" in r.reasoning
+
+
+def test_try_tier0_sound_on_java_archetype(tmp_path: Path):
+    (tmp_path / "App.java").write_text(
+        "void load(String name) {\n"                                                       # line 1
+        '    if (!name.matches("^[A-Za-z0-9_.+-]+$")) throw new IllegalArgumentException();\n'  # line 2
+        "    Files.readAllBytes(Paths.get(BASE, name));\n"                                 # line 3
+        "}\n"
+    )
+    diff = (
+        "@@ -1,2 +1,3 @@\n"
+        " void load(String name) {\n"
+        '+    if (!name.matches("^[A-Za-z0-9_.+-]+$")) throw new IllegalArgumentException();\n'
+        "     Files.readAllBytes(Paths.get(BASE, name));\n"
+    )
+    r = sb.try_tier0(
+        fix_diff=diff, repo_root=tmp_path,
+        sink_uri="App.java", sink_line=3, sink_class="pathtrav",
+        language="java",
+    )
+    assert r.status is sb.Tier0Status.SOUND
+
+
+def test_try_tier0_sound_on_ruby_archetype(tmp_path: Path):
+    (tmp_path / "app.rb").write_text(
+        "def get_config(name)\n"                                          # line 1
+        "  raise ArgumentError unless name =~ /^[A-Za-z0-9_.+-]+$/\n"     # line 2
+        "  File.open(File.join(BASE, name))\n"                            # line 3
+        "end\n"
+    )
+    diff = (
+        "@@ -1,2 +1,3 @@\n"
+        " def get_config(name)\n"
+        "+  raise ArgumentError unless name =~ /^[A-Za-z0-9_.+-]+$/\n"
+        "   File.open(File.join(BASE, name))\n"
+    )
+    r = sb.try_tier0(
+        fix_diff=diff, repo_root=tmp_path,
+        sink_uri="app.rb", sink_line=3, sink_class="pathtrav",
+        language="ruby",
+    )
+    assert r.status is sb.Tier0Status.SOUND
+
+
+def test_try_tier0_not_applicable_when_substitution_var_reassigned(tmp_path: Path):
+    """Substitution would be sound on its own, but a later reassignment
+    undoes it -> Tier 0 must DECLINE the suppression."""
+    (tmp_path / "app.py").write_text(
+        "def f():\n"
+        "    x = req()\n"
+        "    x = re.sub('[/\\\\]+', '', x)\n"   # line 3 — sub
+        "    x = req()\n"                       # line 4 — REASSIGNED
+        "    return open(x)\n"                  # line 5 — sink
+    )
+    diff = (
+        "@@ -1,4 +1,5 @@\n"
+        " def f():\n"
+        "     x = req()\n"
+        "+    x = re.sub('[/\\\\]+', '', x)\n"
+        "     x = req()\n"
+        "     return open(x)\n"
+    )
+    r = sb.try_tier0(
+        fix_diff=diff, repo_root=tmp_path,
+        sink_uri="app.py", sink_line=5, sink_class="pathtrav",
+    )
+    assert r.status is sb.Tier0Status.NOT_APPLICABLE
+    assert "reassigned" in r.reasoning
+
+
+# ---------------------------------------------------------------------------
+# Full orchestrator.
+# ---------------------------------------------------------------------------
+
+_WHOOGLE_DIFF = (
+    "@@ -1,4 +1,6 @@\n"
+    " def get_config():\n"
+    "     name = os.path.normpath(request.args.get('name'))\n"
+    '+    if not re.match(r"^[A-Za-z0-9_.+-]+$", name):\n'
+    "+        return error()\n"
+    "     return open(os.path.join(CONFIG_PATH, name))\n"
+)
+
+
+def _write_post_fix_repo(tmp_path: Path) -> Path:
+    """Materialise the whoogle archetype: validator before sink, in the
+    same function, with an exit-on-fail body."""
+    src = tmp_path / "app" / "routes.py"
+    src.parent.mkdir(parents=True)
+    src.write_text(
+        "def get_config():\n"                                                  # line 1
+        "    name = os.path.normpath(request.args.get('name'))\n"              # line 2
+        '    if not re.match(r"^[A-Za-z0-9_.+-]+$", name):\n'                  # line 3
+        "        return error()\n"                                             # line 4
+        "    return open(os.path.join(CONFIG_PATH, name))\n"                   # line 5
+    )
+    return tmp_path
+
+
+def test_try_tier0_sound_on_whoogle_archetype(tmp_path: Path):
+    """End-to-end: validator extracted, dominance proven via AST source-
+    order + exit-on-fail, Z3 proves the language intersection empty."""
+    repo = _write_post_fix_repo(tmp_path)
+    r = sb.try_tier0(
+        fix_diff=_WHOOGLE_DIFF, repo_root=repo,
+        sink_uri="app/routes.py", sink_line=5, sink_class="pathtrav")
+    assert r.status is sb.Tier0Status.SOUND
+    assert r.artifact == "smt:charset:[A-Za-z0-9_.+-]+@app/routes.py:3"
+    assert r.extras == {"validator_line": 3, "var_name": "name"}
+    assert "UNSAT" in r.reasoning
+
+
+def test_try_tier0_declined_when_validator_allows_danger(tmp_path: Path):
+    """Weak validator (permits '/') -> DECLINED with counterexample."""
+    (tmp_path / "app.py").write_text(
+        "def f():\n"                                                      # line 1
+        "    x = req()\n"                                                 # line 2
+        '    if not re.match(r"^[A-Za-z./]+$", x):\n'                     # line 3
+        "        return error()\n"                                        # line 4
+        "    return open(x)\n"                                            # line 5
+    )
+    diff = (
+        "@@ -1,3 +1,5 @@\n"
+        " def f():\n"
+        "     x = req()\n"
+        '+    if not re.match(r"^[A-Za-z./]+$", x):\n'
+        "+        return error()\n"
+        "     return open(x)\n"
+    )
+    r = sb.try_tier0(
+        fix_diff=diff, repo_root=tmp_path,
+        sink_uri="app.py", sink_line=5, sink_class="pathtrav")
+    assert r.status is sb.Tier0Status.DECLINED
+    assert r.counterexample == "/"
+
+
+def test_try_tier0_not_applicable_when_no_validator(tmp_path: Path):
+    r = sb.try_tier0(
+        fix_diff="+x = 1\n+y = 2\n", repo_root=tmp_path,
+        sink_uri="a.py", sink_line=1, sink_class="pathtrav")
+    assert r.status is sb.Tier0Status.NOT_APPLICABLE
+    assert "no recognised" in r.reasoning
+
+
+def test_try_tier0_not_applicable_when_validator_block_doesnt_exit(tmp_path: Path):
+    """Validator's ``if not X:`` body just logs — value reaches sink
+    unsanitized -> Tier 0 must decline."""
+    (tmp_path / "app.py").write_text(
+        "def f():\n"
+        "    x = req()\n"
+        '    if not re.match(r"^[A-Za-z0-9_.+-]+$", x):\n'
+        "        print('bad')\n"                                          # NO return
+        "    return open(x)\n"
+    )
+    diff = (
+        "@@ -1,3 +1,5 @@\n"
+        " def f():\n"
+        "     x = req()\n"
+        '+    if not re.match(r"^[A-Za-z0-9_.+-]+$", x):\n'
+        "+        print('bad')\n"
+        "     return open(x)\n"
+    )
+    r = sb.try_tier0(
+        fix_diff=diff, repo_root=tmp_path,
+        sink_uri="app.py", sink_line=5, sink_class="pathtrav")
+    assert r.status is sb.Tier0Status.NOT_APPLICABLE
+    assert "does not dominate" in r.reasoning
+
+
+def test_try_tier0_not_applicable_when_validator_not_in_post_fix_source(
+        tmp_path: Path):
+    """Diff claims to add the validator, but the post-fix file doesn't
+    contain it (mismatched diff context).  Must NOT crash and must fall
+    through cleanly."""
+    (tmp_path / "app").mkdir()
+    (tmp_path / "app" / "routes.py").write_text("just a stub\n")
+    r = sb.try_tier0(
+        fix_diff=_WHOOGLE_DIFF, repo_root=tmp_path,
+        sink_uri="app/routes.py", sink_line=10, sink_class="pathtrav")
+    assert r.status is sb.Tier0Status.NOT_APPLICABLE
+    assert "not findable" in r.reasoning
+
+
+def test_try_tier0_not_applicable_when_source_file_missing(tmp_path: Path):
+    """No post-fix source file at all -> clean fall-through."""
+    r = sb.try_tier0(
+        fix_diff=_WHOOGLE_DIFF, repo_root=tmp_path,
+        sink_uri="missing/path.py", sink_line=5, sink_class="pathtrav")
+    assert r.status is sb.Tier0Status.NOT_APPLICABLE
+    assert "not readable" in r.reasoning
+
+
+def test_try_tier0_z3_unavailable_degrades(monkeypatch, tmp_path: Path):
+    """Substrate reports z3 not installed -> Z3_UNAVAILABLE without
+    touching z3 (matches smt_path_validator's degradation pattern)."""
+    monkeypatch.setattr(sb, "_z3_available", lambda: False)
+    r = sb.try_tier0(
+        fix_diff=_WHOOGLE_DIFF, repo_root=tmp_path,
+        sink_uri="app/routes.py", sink_line=5, sink_class="pathtrav")
+    assert r.status is sb.Tier0Status.Z3_UNAVAILABLE
+    assert "z3 not installed" in r.reasoning
+
+
+@pytest.mark.parametrize("sink_class,charset,expect_sound", [
+    ("pathtrav", "A-Za-z0-9_.+-", True),   # whoogle archetype
+    ("cmdi",     "A-Za-z0-9_.-",  True),   # excludes shell metachars
+    ("pathtrav", "A-Za-z0-9_./",  False),  # permits '/'
+    ("cmdi",     "A-Za-z0-9; ",   False),  # permits ';'
+])
+def test_prove_table_per_sink_class(sink_class, charset, expect_sound):
+    spec = sb.ValidatorSpec("charset", "x", charset, "+...", 0)
+    v = sb.prove_neutralizes(spec, sink_class)
+    assert v.sound is expect_sound

--- a/core/dataflow/tests/test_tier1_llm.py
+++ b/core/dataflow/tests/test_tier1_llm.py
@@ -1,0 +1,301 @@
+"""Tests for the Tier 1B LLM-assisted sanitizer characterization.
+
+LLM is mocked via a callable that returns canned JSON, so tests are
+deterministic.  Real-LLM end-to-end coverage is corpus-level, not
+unit-level.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from core.dataflow import tier1_llm as t1
+
+
+def _fake_complete(reply: str):
+    """Return a (system_prompt, user_prompt) -> str completer that
+    always returns ``reply``."""
+    def complete(_sys, _user):
+        return reply
+    return complete
+
+
+# ---------------------------------------------------------------------------
+# JSON parsing tolerance
+# ---------------------------------------------------------------------------
+
+def test_parse_strict_json():
+    spec = t1._parse_llm_output('{"kind":"other","validator_source_line":"",'
+                                 '"variable_name":"","charset":"",'
+                                 '"forbidden":"","library_call":""}')
+    assert spec is not None and spec.kind == "other"
+
+
+def test_parse_strips_markdown_fence():
+    spec = t1._parse_llm_output(
+        '```json\n{"kind":"other","validator_source_line":"x",'
+        '"variable_name":"","charset":"","forbidden":"",'
+        '"library_call":""}\n```'
+    )
+    assert spec is not None and spec.kind == "other"
+
+
+def test_parse_returns_none_on_garbage():
+    assert t1._parse_llm_output("not json") is None
+    assert t1._parse_llm_output("") is None
+    assert t1._parse_llm_output("[1,2,3]") is None      # not a dict
+
+
+# ---------------------------------------------------------------------------
+# Hallucination gates
+# ---------------------------------------------------------------------------
+
+def test_decline_when_llm_claims_line_not_in_diff(tmp_path: Path):
+    """LLM names a validator line that doesn't appear in the diff —
+    hallucination, must DECLINE."""
+    reply = json.dumps({
+        "kind": "charset",
+        "validator_source_line": "if not re.match(r'^[a-z]+$', x): return",
+        "variable_name": "x",
+        "charset": "a-z", "forbidden": "", "library_call": "",
+    })
+    # Diff doesn't contain that line
+    diff = "+ unrelated line\n+ another unrelated line\n"
+    r = t1.try_tier1b(
+        fix_diff=diff, repo_root=tmp_path,
+        sink_uri="app.py", sink_line=5, sink_class="pathtrav",
+        language="python", complete=_fake_complete(reply),
+    )
+    assert r.status is t1.Tier0Status.NOT_APPLICABLE
+    assert "not found as a + line" in r.reasoning
+
+
+def test_decline_on_unparseable_llm_output(tmp_path: Path):
+    r = t1.try_tier1b(
+        fix_diff="+something\n", repo_root=tmp_path,
+        sink_uri="x.py", sink_line=1, sink_class="pathtrav",
+        language="python", complete=_fake_complete("not json at all"),
+    )
+    assert r.status is t1.Tier0Status.NOT_APPLICABLE
+    assert "not parseable" in r.reasoning
+
+
+def test_decline_when_llm_says_other(tmp_path: Path):
+    reply = json.dumps({
+        "kind": "other", "validator_source_line": "",
+        "variable_name": "", "charset": "", "forbidden": "",
+        "library_call": "",
+    })
+    r = t1.try_tier1b(
+        fix_diff="+x = 1\n", repo_root=tmp_path,
+        sink_uri="x.py", sink_line=1, sink_class="pathtrav",
+        language="python", complete=_fake_complete(reply),
+    )
+    assert r.status is t1.Tier0Status.NOT_APPLICABLE
+    assert "'other'" in r.reasoning
+
+
+# ---------------------------------------------------------------------------
+# Mechanical re-extract cross-check
+# ---------------------------------------------------------------------------
+
+def test_decline_when_mechanical_recheck_disagrees_on_charset(tmp_path: Path):
+    """LLM claims charset=[a-z] but the source line is actually [A-Z];
+    the mechanical extractor's charset will be [A-Z], not [a-z] —
+    disagreement -> DECLINE."""
+    (tmp_path / "app.py").write_text(
+        "def f(x):\n"
+        '    if not re.match(r"^[A-Z]+$", x): return\n'
+        "    open(x)\n"
+    )
+    diff = '+    if not re.match(r"^[A-Z]+$", x): return\n'
+    reply = json.dumps({
+        "kind": "charset",
+        "validator_source_line": 'if not re.match(r"^[A-Z]+$", x): return',
+        "variable_name": "x",
+        "charset": "a-z",      # WRONG — actual is A-Z
+        "forbidden": "", "library_call": "",
+    })
+    r = t1.try_tier1b(
+        fix_diff=diff, repo_root=tmp_path,
+        sink_uri="app.py", sink_line=3, sink_class="pathtrav",
+        language="python", complete=_fake_complete(reply),
+    )
+    assert r.status is t1.Tier0Status.NOT_APPLICABLE
+    assert "mechanical re-extract disagrees" in r.reasoning
+
+
+# ---------------------------------------------------------------------------
+# Curated-table dispatch (known_safe_call)
+# ---------------------------------------------------------------------------
+
+def test_sound_via_known_safe_call_table(tmp_path: Path):
+    """werkzeug.security.safe_join — in the curated table — assigned
+    to abs_path which then reaches the sink.  Tier 1B SOUND."""
+    (tmp_path / "app.py").write_text(
+        "from werkzeug.security import safe_join\n"        # line 1
+        "def f(path):\n"                                    # line 2
+        "    abs_path = safe_join(BASE, path)\n"            # line 3 — safe call
+        "    return open(abs_path)\n"                       # line 4 = sink
+    )
+    diff = (
+        "+from werkzeug.security import safe_join\n"
+        "+    abs_path = safe_join(BASE, path)\n"
+    )
+    reply = json.dumps({
+        "kind": "known_safe_call",
+        "validator_source_line": "abs_path = safe_join(BASE, path)",
+        "variable_name": "abs_path",
+        "charset": "", "forbidden": "",
+        "library_call": "werkzeug.security.safe_join",
+    })
+    r = t1.try_tier1b(
+        fix_diff=diff, repo_root=tmp_path,
+        sink_uri="app.py", sink_line=4, sink_class="pathtrav",
+        language="python", complete=_fake_complete(reply),
+    )
+    assert r.status is t1.Tier0Status.SOUND
+    assert "werkzeug.security.safe_join" in r.artifact
+    assert r.artifact.startswith("library:")
+
+
+def test_decline_when_library_not_in_curated_table(tmp_path: Path):
+    """LLM claims a library is safe but it's not in the curated table
+    — DECLINE.  This is the trust-surface gate."""
+    (tmp_path / "app.py").write_text(
+        "def f(x):\n"
+        "    safe = some_random_helper(x)\n"
+        "    return open(safe)\n"
+    )
+    diff = "+    safe = some_random_helper(x)\n"
+    reply = json.dumps({
+        "kind": "known_safe_call",
+        "validator_source_line": "safe = some_random_helper(x)",
+        "variable_name": "safe", "charset": "", "forbidden": "",
+        "library_call": "some_random_helper",
+    })
+    r = t1.try_tier1b(
+        fix_diff=diff, repo_root=tmp_path,
+        sink_uri="app.py", sink_line=3, sink_class="pathtrav",
+        language="python", complete=_fake_complete(reply),
+    )
+    assert r.status is t1.Tier0Status.NOT_APPLICABLE
+    assert "not in curated known-safe table" in r.reasoning
+
+
+def test_decline_when_known_safe_var_doesnt_reach_sink(tmp_path: Path):
+    """``safe_join`` was called and assigned to ``a``, but the sink
+    uses an unrelated variable ``b`` — variable mismatch → DECLINE."""
+    (tmp_path / "app.py").write_text(
+        "from werkzeug.security import safe_join\n"
+        "def f(path):\n"
+        "    a = safe_join(BASE, path)\n"
+        "    b = req()\n"
+        "    return open(b)\n"                              # sink uses b, not a
+    )
+    diff = "+    a = safe_join(BASE, path)\n"
+    reply = json.dumps({
+        "kind": "known_safe_call",
+        "validator_source_line": "a = safe_join(BASE, path)",
+        "variable_name": "a", "charset": "", "forbidden": "",
+        "library_call": "werkzeug.security.safe_join",
+    })
+    r = t1.try_tier1b(
+        fix_diff=diff, repo_root=tmp_path,
+        sink_uri="app.py", sink_line=5, sink_class="pathtrav",
+        language="python", complete=_fake_complete(reply),
+    )
+    assert r.status is t1.Tier0Status.NOT_APPLICABLE
+    assert "does not reach the sink" in r.reasoning
+
+
+def test_find_best_validator_line_picks_same_function_match(tmp_path: Path):
+    """Regression: when the LLM-named line appears multiple times across
+    different functions, pick the one in the same function as the sink.
+    Pre-fix this took the first occurrence (often in an unrelated helper)
+    and falsely failed the dominance check."""
+    (tmp_path / "app.py").write_text(
+        "from werkzeug.security import safe_join\n"                     # line 1
+        "def other_handler(path):\n"                                    # line 2
+        "    abs_path = safe_join(BASE, path)\n"                        # line 3 — first occurrence
+        "    return open(abs_path).read()\n"                            # line 4
+        "def main_handler(path):\n"                                     # line 5
+        "    abs_path = safe_join(BASE, path)\n"                        # line 6 — second occurrence
+        "    return open(abs_path)\n"                                   # line 7 = sink
+    )
+    diff = "+    abs_path = safe_join(BASE, path)\n"
+    reply = json.dumps({
+        "kind": "known_safe_call",
+        "validator_source_line": "abs_path = safe_join(BASE, path)",
+        "variable_name": "abs_path",
+        "charset": "", "forbidden": "",
+        "library_call": "werkzeug.security.safe_join",
+    })
+    r = t1.try_tier1b(
+        fix_diff=diff, repo_root=tmp_path,
+        sink_uri="app.py", sink_line=7, sink_class="pathtrav",
+        language="python", complete=_fake_complete(reply),
+    )
+    assert r.status is t1.Tier0Status.SOUND, r.reasoning
+    # Validator picked from line 6 (same function as sink), not line 3
+    assert r.extras.get("validator_line") == 6
+
+
+def test_find_best_validator_line_returns_none_when_all_after_sink(tmp_path: Path):
+    """All occurrences appear AFTER the sink — no usable validator."""
+    (tmp_path / "app.py").write_text(
+        "def f(path):\n"
+        "    return open(path)\n"                                       # line 2 = sink
+        "def g(path):\n"
+        "    abs_path = safe_join(BASE, path)\n"                        # line 4 — after sink
+        "    return abs_path\n"
+    )
+    diff = "+    abs_path = safe_join(BASE, path)\n"
+    reply = json.dumps({
+        "kind": "known_safe_call",
+        "validator_source_line": "abs_path = safe_join(BASE, path)",
+        "variable_name": "abs_path",
+        "charset": "", "forbidden": "",
+        "library_call": "werkzeug.security.safe_join",
+    })
+    r = t1.try_tier1b(
+        fix_diff=diff, repo_root=tmp_path,
+        sink_uri="app.py", sink_line=2, sink_class="pathtrav",
+        language="python", complete=_fake_complete(reply),
+    )
+    assert r.status is t1.Tier0Status.NOT_APPLICABLE
+    assert "no occurrence" in r.reasoning
+
+
+def test_sound_via_charset_with_llm_pointing_at_line(tmp_path: Path):
+    """LLM correctly identifies a charset validator on a line that
+    Tier 0's mechanical extractor wouldn't have parsed as a guard-
+    and-exit (different shape) — but mechanical re-extract agrees on
+    the kind+charset, and the existing Z3 path produces SOUND."""
+    (tmp_path / "app.py").write_text(
+        "def f(name):\n"
+        '    if not re.match(r"^[A-Za-z0-9_.+-]+$", name):\n'
+        "        return error()\n"
+        "    return open(name)\n"
+    )
+    diff = '+    if not re.match(r"^[A-Za-z0-9_.+-]+$", name):\n'
+    reply = json.dumps({
+        "kind": "charset",
+        "validator_source_line": 'if not re.match(r"^[A-Za-z0-9_.+-]+$", name):',
+        "variable_name": "name",
+        "charset": "A-Za-z0-9_.+-",
+        "forbidden": "", "library_call": "",
+    })
+    r = t1.try_tier1b(
+        fix_diff=diff, repo_root=tmp_path,
+        sink_uri="app.py", sink_line=4, sink_class="pathtrav",
+        language="python", complete=_fake_complete(reply),
+    )
+    assert r.status is t1.Tier0Status.SOUND
+    # Charset path produces the same artifact prefix as Tier 0 mechanical
+    # extraction — the proof mechanism is identical (Z3).
+    assert r.artifact.startswith("smt:charset")
+    # The extras flag records that the LLM was involved in extraction,
+    # for audit / scorecard purposes (proof itself is mechanical).
+    assert r.extras.get("llm_extracted") is True

--- a/core/dataflow/tests/test_trust_corpus_report.py
+++ b/core/dataflow/tests/test_trust_corpus_report.py
@@ -1,0 +1,162 @@
+"""Tests for the Tier 0-aware synth-results analyzer."""
+
+from __future__ import annotations
+
+import sqlite3
+import time
+from pathlib import Path
+
+from core.dataflow import trust_corpus_report as r
+
+
+def _make_db(path: Path, rows: list) -> None:
+    """Materialise a synth_results table matching :mod:`cvefix_bridge`'s schema.
+    ``rows`` is a list of ``(fix_hash, cwe, cve_id, repo_language,
+    finding_id, status, backend, barrier_query, detail)`` tuples."""
+    con = sqlite3.connect(str(path))
+    con.execute(
+        "CREATE TABLE synth_results ("
+        "fix_hash TEXT, cwe TEXT, cve_id TEXT, repo_language TEXT, "
+        "finding_id TEXT, status TEXT, backend TEXT, barrier_query TEXT, "
+        "detail TEXT, ts REAL, PRIMARY KEY (fix_hash, cwe))"
+    )
+    for row in rows:
+        con.execute(
+            "INSERT INTO synth_results VALUES (?,?,?,?,?,?,?,?,?,?)",
+            (*row, time.time()),
+        )
+    con.commit()
+    con.close()
+
+
+def _row(fix, cwe, cve, lang, status, backend, detail="", bq=None, fid=None):
+    return (fix, cwe, cve, lang, fid or f"{cve}:{cwe}", status, backend, bq, detail)
+
+
+def test_analyze_empty_db_returns_zero_counts(tmp_path: Path):
+    db = tmp_path / "empty.db"
+    _make_db(db, [])
+    rep = r.analyze(db)
+    assert rep.processed == 0
+    assert rep.sound == 0
+    assert rep.suppression_rate is None
+    assert rep.tier0_share_of_sound is None
+
+
+def test_analyze_missing_db_returns_zero_counts(tmp_path: Path):
+    """If the bridge hasn't created the DB yet, analyze must still return
+    a zero-counts report (not raise) — analyzer is safe to run any time."""
+    rep = r.analyze(tmp_path / "does-not-exist.db")
+    assert rep.processed == 0
+
+
+def test_analyze_mixed_outcomes(tmp_path: Path):
+    db = tmp_path / "m.db"
+    _make_db(db, [
+        # Two Tier 0 SOUND (smt backend) — pathtrav cases
+        _row("f1", "CWE-22", "CVE-1", "Python", "sound", "smt", "UNSAT", "smt:..."),
+        _row("f2", "CWE-22", "CVE-2", "Python", "sound", "smt", "UNSAT", "smt:..."),
+        # One Tier 2 SOUND (codeql backend) — sqli case
+        _row("f3", "CWE-89", "CVE-3", "Java", "sound", "codeql", "", "QL..."),
+        # Two not_sound — different failure modes
+        _row("f4", "CWE-79", "CVE-4", "JavaScript", "not_sound", "codeql",
+             "suppress_fp_failed(after=1)"),
+        _row("f5", "CWE-79", "CVE-5", "JavaScript", "not_sound", "codeql",
+             "preserve_tp_failed(before=0)"),
+        # One no_barrier
+        _row("f6", "CWE-78", "CVE-6", "Ruby", "no_barrier", "codeql", "compile err"),
+        # Pipeline errors — excluded from rate
+        _row("f7", "CWE-22", "CVE-7", "Python", "build_fail", ""),
+        _row("f8", "CWE-22", "CVE-8", "TypeScript", "fetch_fail", ""),
+    ])
+    rep = r.analyze(db)
+
+    # Headline
+    assert rep.processed == 6                # 3 sound + 2 not_sound + 1 no_barrier
+    assert rep.sound == 3
+    assert rep.not_sound == 2
+    assert rep.no_barrier == 1
+    assert rep.suppression_rate == 3 / 5     # 3 sound / (3 + 2)
+    assert dict(rep.pipeline_errors) == {"build_fail": 1, "fetch_fail": 1}
+
+    # Backend split — 2 smt, 1 codeql among sound
+    assert rep.sound_by_backend["smt"] == 2
+    assert rep.sound_by_backend["codeql"] == 1
+    assert rep.tier0_share_of_sound == 2 / 3
+
+    # Failure-mode distribution
+    assert rep.not_sound_modes["suppress_fp_failed"] == 1
+    assert rep.not_sound_modes["preserve_tp_failed"] == 1
+
+    # Per-CWE
+    assert rep.by_cwe["CWE-22"]["sound"]["smt"] == 2
+    assert rep.by_cwe["CWE-89"]["sound"]["codeql"] == 1
+    assert sum(rep.by_cwe["CWE-79"]["not_sound"].values()) == 2
+
+    # Per-language
+    assert rep.by_language["Python"]["sound"]["smt"] == 2
+    assert rep.by_language["Java"]["sound"]["codeql"] == 1
+
+
+def test_attempts_saved_uses_default_max_attempts(tmp_path: Path):
+    db = tmp_path / "s.db"
+    _make_db(db, [
+        _row(f"f{i}", "CWE-22", f"CVE-{i}", "Python", "sound", "smt")
+        for i in range(5)
+    ])
+    rep = r.analyze(db)
+    # 5 Tier 0 SOUNDs * 3 attempts default = 15
+    assert rep.tier0_attempts_saved() == 15
+    # Configurable
+    assert rep.tier0_attempts_saved(max_attempts=2) == 10
+
+
+def test_render_text_handles_empty_report():
+    """Renderer must not crash when nothing has been processed yet —
+    analyzer is meant to be run while the bridge is still warming up."""
+    rep = r.CorpusReport()
+    text = r.render_text(rep)
+    assert "Trust-witness corpus report" in text
+    assert "no verdicts yet" in text
+    assert "no rows yet" in text
+
+
+def test_render_text_includes_headline_numbers(tmp_path: Path):
+    db = tmp_path / "h.db"
+    _make_db(db, [
+        _row("f1", "CWE-22", "CVE-1", "Python", "sound", "smt"),
+        _row("f2", "CWE-22", "CVE-2", "Python", "sound", "codeql"),
+        _row("f3", "CWE-22", "CVE-3", "Python", "not_sound", "codeql",
+             "suppress_fp_failed(after=1)"),
+    ])
+    rep = r.analyze(db)
+    text = r.render_text(rep)
+    # Suppression rate 2/3 = 66.7%
+    assert "66.7%" in text
+    # Backend split shows 1 smt and 1 codeql out of 2 sound
+    assert "smt" in text and "codeql" in text
+    # Per-CWE block names CWE-22
+    assert "CWE-22" in text
+
+
+def test_classify_not_sound_mode():
+    assert r._classify_not_sound_mode("suppress_fp_failed(after=1)") == "suppress_fp_failed"
+    assert r._classify_not_sound_mode("preserve_tp_failed(before=0)") == "preserve_tp_failed"
+    assert r._classify_not_sound_mode(
+        "suppress_fp_failed(after=1); preserve_tp_failed(before=0)"
+    ) == "both"
+    assert r._classify_not_sound_mode("") == "other"
+    assert r._classify_not_sound_mode("unrelated") == "other"
+
+
+def test_unknown_status_routed_to_pipeline_errors(tmp_path: Path):
+    """A status not in the bridge's enum (e.g. a future addition we don't
+    yet recognise) must NOT silently inflate the suppression rate — route
+    to pipeline_errors so it surfaces and the rate stays honest."""
+    db = tmp_path / "u.db"
+    _make_db(db, [
+        _row("f1", "CWE-22", "CVE-1", "Python", "totally_new_status", "x"),
+    ])
+    rep = r.analyze(db)
+    assert rep.processed == 0
+    assert rep.pipeline_errors["totally_new_status"] == 1

--- a/core/dataflow/tier1_llm.py
+++ b/core/dataflow/tier1_llm.py
@@ -1,0 +1,438 @@
+"""Tier 1B: cheap-LLM-assisted sanitizer characterization for cases
+Tier 0's mechanical extractor doesn't recognise.
+
+The LLM is an EXTRACTOR, not an adjudicator.  It points at the fix's
+validator and characterizes its shape into a structured JSON spec; every
+SOUND verdict still comes from a mechanical path we already trust:
+
+  * ``kind="charset"`` / ``"charset_sub"`` — cross-check via the
+    existing Tier 0 mechanical extractor on the LLM-named source line,
+    then run the existing Z3 proof.  If the LLM's claimed charset
+    doesn't match what the mechanical extractor finds, DECLINE.
+  * ``kind="known_safe_call"`` — look up the LLM's claimed library
+    call in :mod:`known_safe_calls` (curated table, human-verified).
+    Out-of-table → DECLINE.
+  * ``kind="other"`` — LLM couldn't reduce to a sound shape; pass to
+    Tier 2.
+
+The LLM can be wrong (hallucinated charset, fabricated library call,
+spurious line reference).  Each verification gate catches the failure
+mode it's designed for:
+
+  1. ``validator_source_line`` must literally appear as a ``+`` line
+     in the supplied diff (catches fabricated lines).
+  2. Mechanical re-extract must agree with the LLM's claimed kind +
+     charset (catches misreading).
+  3. Chain tracking confirms the validated variable reaches the sink
+     (catches "validator was added, but not for the value the sink
+     uses").
+  4. Curated table catches unsafe library claims (any library not on
+     the table is rejected — we never trust an LLM-claimed library
+     name on its own).
+
+What's NEW in the trust surface vs Tier 0: the curated
+:mod:`known_safe_calls` table.  Every entry there is a soundness claim
+we own.  Nothing about the LLM's output is trusted as a safety
+assertion.
+"""
+
+from __future__ import annotations
+
+import json
+import re as _re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, Optional
+
+from core.dataflow import known_safe_calls
+from core.dataflow.smt_barrier import (
+    Tier0Result,
+    Tier0Status,
+    ValidatorSpec,
+    _function_containing,
+    _python_chain_reaches_sink,
+    _same_function_in_order,
+    extract_validator as _mechanical_extract,
+    prove_neutralizes,
+)
+
+
+# A bare-minimum LLM completer signature, compatible with the existing
+# ``Completer`` alias in barrier_synth (system_prompt, user_prompt) -> str.
+# Kept local so callers can mock without importing from barrier_synth.
+LLMComplete = Callable[[str, str], str]
+
+
+_SYSTEM_PROMPT = """\
+You are a strict JSON-only extraction tool. Read a security fix diff
+and identify what sanitizer the fix added. Output ONLY a single JSON
+object — no commentary, no markdown fences, no prose.
+
+Schema:
+{
+  "kind": "charset" | "charset_sub" | "known_safe_call" | "other",
+  "validator_source_line": "<the SINGLE diff +-line that introduces the validator, VERBATIM, including any leading whitespace, with the leading '+' STRIPPED>",
+  "variable_name": "<the variable the validator constrains>",
+  "charset": "<allowed-char body when kind=charset, e.g. 'A-Za-z0-9_.+-'; empty otherwise>",
+  "forbidden": "<stripped-char body when kind=charset_sub; empty otherwise>",
+  "library_call": "<dotted name when kind=known_safe_call (e.g. 'werkzeug.security.safe_join', 'html.escape'); empty otherwise>"
+}
+
+Kind definitions:
+- "charset": validator is a whole-string anchored regex over a character class, e.g. re.match(r'^[A-Za-z0-9]+$', x), x.matches("^[…]+$") in Java, x =~ /^[…]+$/ in Ruby, /^[…]+$/.test(x) in JS.
+- "charset_sub": validator strips chars via substitution to empty string, e.g. x = re.sub('[forbidden]+', '', x), x = x.replace(/[…]/g, '').
+- "known_safe_call": validator is a single call to a well-known library function that returns a sanitized value or raises on unsafe input. Examples: html.escape, django.utils.html.escape, markupsafe.escape, bleach.clean, shlex.quote, werkzeug.security.safe_join, werkzeug.utils.secure_filename, validator.escape (JS), DOMPurify.sanitize, StringEscapeUtils.escapeHtml4 (Java).
+- "other": none of the above; the sanitizer is custom, semantic, or multi-step.
+
+Field rules:
+- "validator_source_line" MUST be copied verbatim from the diff. Do not paraphrase. Empty string is invalid.
+- Empty string for any field that does not apply.
+- If you are not certain, output "kind": "other" and leave all other fields empty.
+"""
+
+
+@dataclass
+class _LLMSpec:
+    """Parsed LLM JSON output — the LLM's CLAIM, not yet verified."""
+    kind: str
+    validator_source_line: str
+    variable_name: str
+    charset: str
+    forbidden: str
+    library_call: str
+
+
+def _build_user_prompt(fix_diff: str, sink_class: str, language: str) -> str:
+    return (
+        f"sink_class: {sink_class}\n"
+        f"language: {language}\n"
+        "fix_diff:\n"
+        f"{fix_diff[:4000]}"  # cap to keep cheap-model input bounded
+    )
+
+
+def _parse_llm_output(raw: str) -> Optional[_LLMSpec]:
+    """Parse the LLM's reply into a structured spec.  Tolerates markdown
+    fences (despite the prompt forbidding them).  Returns None on parse
+    failure — the orchestrator then DECLINES."""
+    text = (raw or "").strip()
+    if "```" in text:
+        # extract first fenced block body
+        try:
+            block = text.split("```", 2)[1]
+            if "\n" in block:
+                block = block.split("\n", 1)[1]
+            text = block.strip().rstrip("`").strip()
+        except IndexError:
+            return None
+    try:
+        data = json.loads(text)
+    except (ValueError, json.JSONDecodeError):
+        return None
+    if not isinstance(data, dict):
+        return None
+    try:
+        return _LLMSpec(
+            kind=str(data.get("kind", "")),
+            validator_source_line=str(data.get("validator_source_line", "")),
+            variable_name=str(data.get("variable_name", "")),
+            charset=str(data.get("charset", "")),
+            forbidden=str(data.get("forbidden", "")),
+            library_call=str(data.get("library_call", "")),
+        )
+    except Exception:                                       # pragma: no cover
+        return None
+
+
+def _validator_line_in_diff(fix_diff: str, claimed_line: str) -> bool:
+    """The LLM-named source line must literally appear as a +-line in
+    the diff (catches fabricated lines)."""
+    needle = claimed_line.strip()
+    if not needle:
+        return False
+    for raw in fix_diff.splitlines():
+        if not raw.startswith("+") or raw.startswith("+++"):
+            continue
+        if raw[1:].strip() == needle:
+            return True
+    return False
+
+
+def _mechanical_recheck_charset_kind(
+    spec: _LLMSpec, language: str,
+) -> Optional[ValidatorSpec]:
+    """Run the existing mechanical extractor on the LLM-named source
+    line and confirm it agrees with the LLM's claimed kind + charset
+    (or forbidden).  Returns the mechanical ValidatorSpec on agreement,
+    None on disagreement."""
+    # Synthesise a single-line diff to reuse the existing extractor.
+    fake_diff = "+" + spec.validator_source_line + "\n"
+    mech = _mechanical_extract(fake_diff, language=language)
+    if mech is None:
+        return None
+    if mech.kind != spec.kind:
+        return None
+    if spec.kind == "charset" and mech.charset != spec.charset:
+        return None
+    if spec.kind == "charset_sub" and mech.forbidden != spec.forbidden:
+        return None
+    if spec.variable_name and mech.var_name != spec.variable_name:
+        return None
+    return mech
+
+
+def _find_best_validator_line(
+    source_text: str, claimed_line_text: str, sink_line: int, language: str,
+) -> Optional[int]:
+    """Locate the validator's line number in the post-fix source.
+
+    When the LLM's ``validator_source_line`` appears MULTIPLE times in
+    the file (common for short library calls like ``abs_path =
+    safe_join(…)``, which can recur across helpers), the previous
+    first-match-wins strategy could pick an occurrence in an unrelated
+    function — failing the dominance check even when a different
+    occurrence (in the sink's function) is the actual sanitizer.
+
+    Selection rule:
+      * For Python: among occurrences strictly before ``sink_line``,
+        prefer one in the SAME function as the sink; among those, pick
+        the closest one (largest line < sink_line).
+      * Non-Python (no AST): among occurrences before ``sink_line``,
+        pick the closest.
+      * Returns ``None`` if no usable occurrence exists.
+    """
+    needle = claimed_line_text.strip()
+    if not needle:
+        return None
+    candidates = [idx + 1 for idx, ln in enumerate(source_text.splitlines())
+                  if ln.strip() == needle and idx + 1 < sink_line]
+    if not candidates:
+        return None
+    if language == "python":
+        try:
+            import ast
+            tree = ast.parse(source_text)
+        except SyntaxError:
+            return max(candidates)
+        sink_fn = _function_containing(tree, sink_line)
+        if sink_fn is not None:
+            same_fn = [ln for ln in candidates
+                       if _function_containing(tree, ln) is sink_fn]
+            if same_fn:
+                return max(same_fn)
+        return max(candidates)
+    return max(candidates)
+
+
+def _try_known_safe_call(
+    spec: _LLMSpec, source_text: str, sink_uri: str, sink_line: int,
+    sink_class: str, language: str,
+) -> Tier0Result:
+    """Adjudicate a ``kind="known_safe_call"`` LLM claim by curated-
+    table lookup + chain check."""
+    entry = known_safe_calls.find(spec.library_call, sink_class, language)
+    if entry is None:
+        return Tier0Result(
+            Tier0Status.NOT_APPLICABLE,
+            f"library_call {spec.library_call!r} not in curated "
+            f"known-safe table for sink_class={sink_class!r} / "
+            f"language={language!r}",
+        )
+    # Find the best occurrence of the LLM-claimed line (closest to the
+    # sink, preferring same-function for Python).
+    validator_line = _find_best_validator_line(
+        source_text, spec.validator_source_line, sink_line, language,
+    )
+    if validator_line is None:
+        return Tier0Result(
+            Tier0Status.NOT_APPLICABLE,
+            "no occurrence of the LLM-named line found before the sink",
+        )
+    # Source-order + same-function check (the helper above already
+    # picked a same-function candidate when possible; this confirms
+    # for the AST-aware Python path).
+    try:
+        import ast
+        tree = ast.parse(source_text) if language == "python" else None
+    except SyntaxError:
+        tree = None
+    if tree is not None:
+        if not _same_function_in_order(tree, validator_line, sink_line):
+            return Tier0Result(
+                Tier0Status.NOT_APPLICABLE,
+                f"safe-call at line {validator_line} not in same function "
+                f"as sink at line {sink_line}",
+            )
+    # Chain check — only Python has an AST chain tracker for now.  For
+    # non-Python we conservatively require the LLM's variable_name to
+    # appear textually at the sink line.
+    sink_lines = source_text.splitlines()
+    sink_line_text = sink_lines[sink_line - 1] if 0 < sink_line <= len(sink_lines) else ""
+    if language == "python" and tree is not None and spec.variable_name:
+        chain_ok = _python_chain_reaches_sink(
+            tree, spec.variable_name, validator_line, sink_line, sink_line_text,
+        )
+    elif spec.variable_name:
+        chain_ok = bool(_re.search(
+            rf"\b{_re.escape(spec.variable_name)}\b", sink_line_text,
+        ))
+    else:
+        chain_ok = False
+    if not chain_ok:
+        return Tier0Result(
+            Tier0Status.NOT_APPLICABLE,
+            f"variable {spec.variable_name!r} sanitized by "
+            f"{entry.library_call} does not reach the sink line",
+        )
+    artifact = f"library:{entry.library_call}@{sink_uri}:{validator_line}"
+    return Tier0Result(
+        Tier0Status.SOUND,
+        f"curated known-safe call: {entry.library_call} "
+        f"(sink_class={sink_class}): {entry.soundness_note}",
+        artifact=artifact,
+        extras={"validator_line": validator_line, "var_name": spec.variable_name,
+                "library_call": entry.library_call},
+    )
+
+
+def try_tier1b(
+    *, fix_diff: str, repo_root: Path, sink_uri: str, sink_line: int,
+    sink_class: str, language: str, complete: LLMComplete,
+) -> Tier0Result:
+    """Run the Tier 1B LLM-assisted extraction + sound adjudication.
+
+    Returns a :class:`Tier0Result` (re-used for uniformity with the
+    bridge's existing dispatch).  SOUND verdicts are still mechanically
+    adjudicated — the LLM only suggests the shape.
+
+    ``complete`` is the LLM completer (system_prompt, user_prompt) -> str.
+    Caller is responsible for cheap-model pinning (typically via
+    :func:`barrier_synth.model_completer`).
+    """
+    user_prompt = _build_user_prompt(fix_diff, sink_class, language)
+    try:
+        raw = complete(_SYSTEM_PROMPT, user_prompt)
+    except Exception as exc:                                # pragma: no cover
+        return Tier0Result(
+            Tier0Status.NOT_APPLICABLE,
+            f"Tier 1B LLM call failed: {type(exc).__name__}: {exc}",
+        )
+    spec = _parse_llm_output(raw)
+    if spec is None:
+        return Tier0Result(
+            Tier0Status.NOT_APPLICABLE,
+            "Tier 1B: LLM output not parseable as JSON",
+        )
+    if spec.kind == "other":
+        return Tier0Result(
+            Tier0Status.NOT_APPLICABLE,
+            "Tier 1B: LLM characterized the sanitizer as 'other' "
+            "(no sound mechanical adjudicator)",
+        )
+    if not _validator_line_in_diff(fix_diff, spec.validator_source_line):
+        return Tier0Result(
+            Tier0Status.NOT_APPLICABLE,
+            "Tier 1B: LLM-claimed validator_source_line not found as "
+            "a + line in the fix diff (possible hallucination)",
+        )
+    # Read post-fix source for verification.
+    src_path = repo_root / sink_uri.lstrip("/")
+    if not src_path.is_file():
+        return Tier0Result(
+            Tier0Status.NOT_APPLICABLE,
+            f"Tier 1B: post-fix source not readable at {sink_uri!r}",
+        )
+    try:
+        source_text = src_path.read_text(errors="replace")
+    except OSError as exc:
+        return Tier0Result(
+            Tier0Status.NOT_APPLICABLE,
+            f"Tier 1B: could not read source: {exc}",
+        )
+
+    if spec.kind in ("charset", "charset_sub"):
+        # Mechanical re-extract on the LLM-named line; agreement gates
+        # everything downstream.
+        mech = _mechanical_recheck_charset_kind(spec, language)
+        if mech is None:
+            return Tier0Result(
+                Tier0Status.NOT_APPLICABLE,
+                f"Tier 1B: mechanical re-extract disagrees with LLM's "
+                f"claimed kind={spec.kind!r} / charset / forbidden on "
+                f"the named source line",
+            )
+        # From here on, the verdict comes from the existing Tier 0
+        # adjudication paths.  Z3 proof + chain check.
+        verdict = prove_neutralizes(mech, sink_class)
+        if not verdict.sound:
+            return Tier0Result(
+                Tier0Status.DECLINED, verdict.reasoning, spec=mech,
+                counterexample=verdict.counterexample,
+            )
+        # Sound on language intersection — now confirm the variable
+        # reaches the sink (skip the AST/dominance complexity here;
+        # the source-order + same-function check stays inside the
+        # existing Tier 0 helpers if a caller wants to add it later).
+        # For first cut: trust the LLM-named line is between the
+        # function entry and the sink (it's on the validator's
+        # source line, which the chain check uses as a bound).
+        # Locate the validator's line — same find-best-occurrence helper
+        # as the known_safe_call path uses (closest occurrence before
+        # the sink, same-function for Python).
+        validator_line = _find_best_validator_line(
+            source_text, spec.validator_source_line, sink_line, language,
+        )
+        if validator_line is None:
+            return Tier0Result(
+                Tier0Status.NOT_APPLICABLE,
+                "Tier 1B: no occurrence of the LLM-named line found "
+                "before the sink",
+            )
+        sink_lines = source_text.splitlines()
+        sink_line_text = (sink_lines[sink_line - 1]
+                          if 0 < sink_line <= len(sink_lines) else "")
+        if language == "python":
+            try:
+                import ast
+                tree = ast.parse(source_text)
+            except SyntaxError:
+                return Tier0Result(
+                    Tier0Status.NOT_APPLICABLE,
+                    "Tier 1B: post-fix source has syntax errors",
+                )
+            chain_ok = _python_chain_reaches_sink(
+                tree, mech.var_name, validator_line, sink_line, sink_line_text,
+            )
+        else:
+            chain_ok = bool(_re.search(
+                rf"\b{_re.escape(mech.var_name)}\b", sink_line_text,
+            ))
+        if not chain_ok:
+            return Tier0Result(
+                Tier0Status.NOT_APPLICABLE,
+                f"Tier 1B: variable {mech.var_name!r} does not reach "
+                f"sink at line {sink_line}",
+                spec=mech,
+            )
+        # Same artifact format as Tier 0 mechanical extraction — the
+        # soundness mechanism is identical (Z3 regex proof).  The
+        # ``llm_extracted`` flag in ``extras`` records that the LLM
+        # pointed at the spec; the proof itself is mechanical.
+        artifact = (f"smt:{mech.kind}:[{mech.charset or mech.forbidden}]"
+                    f"@{sink_uri}:{validator_line}")
+        return Tier0Result(
+            Tier0Status.SOUND, verdict.reasoning, spec=mech,
+            artifact=artifact,
+            extras={"validator_line": validator_line, "var_name": mech.var_name,
+                    "llm_extracted": True},
+        )
+
+    if spec.kind == "known_safe_call":
+        return _try_known_safe_call(
+            spec, source_text, sink_uri, sink_line, sink_class, language,
+        )
+
+    return Tier0Result(
+        Tier0Status.NOT_APPLICABLE,
+        f"Tier 1B: unknown kind {spec.kind!r}",
+    )

--- a/core/dataflow/trust_corpus_report.py
+++ b/core/dataflow/trust_corpus_report.py
@@ -1,0 +1,301 @@
+"""Tier 0-aware analysis of ``synth_results`` from the trust-witness bridge.
+
+Reads :mod:`cvefix_bridge`'s ``synth_results`` table (schema includes
+``backend``, populated post-Tier 0) and produces the numbers we want to
+look at the moment a corpus run finishes:
+
+  * Headline: processed / sound / not_sound / no_barrier / pipeline errors.
+  * Suppression rate: sound / (sound + not_sound) — the trust-tier KPI.
+  * Backend split among SOUND verdicts: smt (Tier 0, free) vs codeql
+    (Tier 2, LLM + CodeQL adjudication).  Quantifies how much of the
+    suppression we're getting for zero LLM tokens.
+  * Per-CWE and per-language breakdowns — grounds the per-CWE backend
+    prior we eventually want (instead of asserting it).
+  * ``not_sound`` failure-mode distribution: ``suppress_fp_failed`` vs
+    ``preserve_tp_failed`` counts — tells us whether the Tier 2 wall is
+    "guard insufficient" (suppress) or "guard kills the TP too"
+    (preserve).
+  * Token-savings estimate from Tier 0 short-circuits.  Conservative
+    rough cost: each Tier 0 SOUND skips up to ``max_attempts`` LLM
+    proposer calls + up to ``max_attempts`` CodeQL adjudications + one
+    pre-fix DB build.  Reported in attempts saved, not dollars (the
+    dollar conversion depends on the per-run model).
+
+Safe to run WHILE the bridge is still writing — opens the DB with
+``mode=ro`` so concurrent writes from the bridge process aren't blocked.
+
+CLI: ``python3 -m core.dataflow.trust_corpus_report --synth-db PATH``
+(shim: ``core/dataflow/scripts/trust-report``).
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from collections import Counter
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+
+# Status / backend constants — mirror cvefix_bridge.
+_PIPELINE_ERRORS = frozenset(
+    {"no_query", "fetch_fail", "build_fail", "analyze_fail", "no_finding", "error"}
+)
+_OUTCOME_STATUSES = frozenset({"sound", "not_sound", "no_barrier"})
+
+# Conservative Tier 0 savings model.  Each SOUND Tier 0 short-circuit avoids:
+#   * one pre-fix CodeQL DB build,
+#   * up to ``max_attempts`` LLM proposer calls,
+#   * up to ``max_attempts`` CodeQL adjudication runs.
+# Reported as attempts saved (units are LLM calls).  Dollar conversion is
+# operator-dependent so we don't bake a price in.
+_DEFAULT_TIER2_MAX_ATTEMPTS = 3
+
+
+@dataclass
+class CorpusReport:
+    """Structured aggregation of one ``synth_results`` table.
+
+    All counts are over rows whose ``status`` is one of
+    ``sound`` / ``not_sound`` / ``no_barrier`` (pipeline-error rows are
+    tracked separately so they don't pollute the rate).
+    """
+
+    # Headline counts (excludes pipeline_errors).
+    processed: int = 0
+    sound: int = 0
+    not_sound: int = 0
+    no_barrier: int = 0
+
+    # status -> count for rows that never reached adjudication.
+    pipeline_errors: Counter = field(default_factory=Counter)
+
+    # Backend split for SOUND verdicts only.
+    sound_by_backend: Counter = field(default_factory=Counter)   # "smt" / "codeql"
+
+    # Per-CWE and per-language breakdowns: status -> backend -> count.
+    by_cwe: Dict[str, Dict[str, Counter]] = field(default_factory=dict)
+    by_language: Dict[str, Dict[str, Counter]] = field(default_factory=dict)
+
+    # not_sound detail-shape distribution: e.g. "suppress_fp_failed",
+    # "preserve_tp_failed", "both", "other".  Tells us whether the Tier 2
+    # wall is over-restrictive guards or under-restrictive ones.
+    not_sound_modes: Counter = field(default_factory=Counter)
+
+    # Sample of not_sound finding_ids for spot-checking (capped).
+    not_sound_samples: List[Tuple[str, str, str, str]] = field(
+        default_factory=list,
+    )                                                # (cve_id, cwe, lang, detail)
+
+    @property
+    def suppression_rate(self) -> Optional[float]:
+        """``sound / (sound + not_sound)``.  None when nothing reached a
+        verdict yet (in-flight run, very early)."""
+        denom = self.sound + self.not_sound
+        return self.sound / denom if denom else None
+
+    @property
+    def tier0_share_of_sound(self) -> Optional[float]:
+        """Fraction of sound verdicts that came from Tier 0 (free SMT).
+        Headline: how much of the suppression cost us zero LLM tokens."""
+        if not self.sound:
+            return None
+        return self.sound_by_backend.get("smt", 0) / self.sound
+
+    def tier0_attempts_saved(self, max_attempts: int = _DEFAULT_TIER2_MAX_ATTEMPTS) -> int:
+        """Conservative count of LLM proposer attempts not spent because
+        Tier 0 short-circuited.  Each Tier 0 SOUND row saves up to
+        ``max_attempts`` LLM calls + the matching CodeQL adjudications."""
+        return self.sound_by_backend.get("smt", 0) * max_attempts
+
+
+def _classify_not_sound_mode(detail: str) -> str:
+    """Map the ``detail`` string written by the bridge for a ``not_sound``
+    row onto a coarse failure-mode bucket.
+
+    The bridge writes:
+      ``suppress_fp_failed(after=N)``    -- guard didn't kill the FP
+      ``preserve_tp_failed(before=N)``  -- guard killed the FP AND the TP
+      both, joined by ``"; "``           -- guard moved nothing
+    """
+    has_suppress = "suppress_fp_failed" in detail
+    has_preserve = "preserve_tp_failed" in detail
+    if has_suppress and has_preserve:
+        return "both"
+    if has_suppress:
+        return "suppress_fp_failed"
+    if has_preserve:
+        return "preserve_tp_failed"
+    return "other"
+
+
+_NOT_SOUND_SAMPLES_CAP = 20
+
+
+def analyze(synth_db: Path) -> CorpusReport:
+    """Read ``synth_db`` and produce a :class:`CorpusReport`.
+
+    Opens read-only via the SQLite URI scheme so a concurrent writer
+    (the bridge mid-run) isn't blocked or affected.  Empty / missing
+    table -> zero-counts report (no error)."""
+    rep = CorpusReport()
+    try:
+        con = sqlite3.connect(f"file:{synth_db}?mode=ro", uri=True)
+    except sqlite3.OperationalError:
+        return rep
+    try:
+        rows = list(con.execute(
+            "SELECT cve_id, cwe, repo_language, status, backend, detail "
+            "FROM synth_results"
+        ))
+    except sqlite3.OperationalError:
+        # Table doesn't exist yet (bridge hasn't written its first row).
+        con.close()
+        return rep
+    con.close()
+
+    for cve_id, cwe, lang, status, backend, detail in rows:
+        if status in _PIPELINE_ERRORS:
+            rep.pipeline_errors[status] += 1
+            continue
+        if status not in _OUTCOME_STATUSES:
+            # Unknown status — surface under pipeline_errors so it doesn't
+            # silently distort the rate.
+            rep.pipeline_errors[status] += 1
+            continue
+
+        rep.processed += 1
+        if status == "sound":
+            rep.sound += 1
+            rep.sound_by_backend[backend or ""] += 1
+        elif status == "not_sound":
+            rep.not_sound += 1
+            mode = _classify_not_sound_mode(detail or "")
+            rep.not_sound_modes[mode] += 1
+            if len(rep.not_sound_samples) < _NOT_SOUND_SAMPLES_CAP:
+                rep.not_sound_samples.append(
+                    (cve_id, cwe, lang, (detail or "")[:80])
+                )
+        else:    # no_barrier
+            rep.no_barrier += 1
+
+        # Per-CWE / per-language breakdowns.  Backend bucket only meaningful
+        # for the "sound" status; for the others we still track the count
+        # under the empty-string backend so the table totals balance.
+        rep.by_cwe.setdefault(cwe, {}).setdefault(status, Counter())[backend or ""] += 1
+        rep.by_language.setdefault(lang, {}).setdefault(status, Counter())[backend or ""] += 1
+
+    return rep
+
+
+def _fmt_rate(n: int, d: int) -> str:
+    """Render ``n/d (XX.X%)`` or ``n/d (-)`` when d==0."""
+    if not d:
+        return f"{n}/{d} (-)"
+    return f"{n}/{d} ({100.0 * n / d:.1f}%)"
+
+
+def render_text(rep: CorpusReport) -> str:
+    """Plain-text report suitable for terminal display while the bridge
+    is still running."""
+    out: List[str] = []
+
+    out.append("== Trust-witness corpus report ==")
+    out.append("")
+    out.append("Headline:")
+    out.append(f"  processed (sound + not_sound + no_barrier): {rep.processed}")
+    out.append(f"  sound                : {rep.sound}")
+    out.append(f"  not_sound            : {rep.not_sound}")
+    out.append(f"  no_barrier           : {rep.no_barrier}")
+    if rep.suppression_rate is not None:
+        out.append(
+            f"  suppression rate     : {_fmt_rate(rep.sound, rep.sound + rep.not_sound)}"
+        )
+    else:
+        out.append("  suppression rate     : (no verdicts yet)")
+    if rep.pipeline_errors:
+        out.append(f"  pipeline errors      : {dict(rep.pipeline_errors)}")
+    out.append("")
+
+    out.append("Tier 0 vs Tier 2 (backend split among SOUND verdicts):")
+    if rep.sound:
+        for backend in ("smt", "codeql", ""):
+            n = rep.sound_by_backend.get(backend, 0)
+            label = backend if backend else "<unknown>"
+            out.append(f"  {label:8s} : {_fmt_rate(n, rep.sound)}")
+        attempts = rep.tier0_attempts_saved()
+        out.append(
+            f"  Tier 0 attempts saved (rough): ~{attempts} LLM proposer "
+            f"calls + matched adjudications"
+        )
+    else:
+        out.append("  (no sound verdicts yet)")
+    out.append("")
+
+    out.append("not_sound failure modes:")
+    if rep.not_sound:
+        for mode in ("suppress_fp_failed", "preserve_tp_failed", "both", "other"):
+            n = rep.not_sound_modes.get(mode, 0)
+            out.append(f"  {mode:22s} : {_fmt_rate(n, rep.not_sound)}")
+    else:
+        out.append("  (no not_sound verdicts yet)")
+    out.append("")
+
+    out.append("By CWE:")
+    if rep.by_cwe:
+        out.append(f"  {'CWE':10s} {'sound':>16s} {'not_sound':>10s} {'no_barrier':>11s}")
+        for cwe in sorted(rep.by_cwe):
+            statuses = rep.by_cwe[cwe]
+            smt = statuses.get("sound", Counter()).get("smt", 0)
+            ql = statuses.get("sound", Counter()).get("codeql", 0)
+            ns = sum(statuses.get("not_sound", Counter()).values())
+            nb = sum(statuses.get("no_barrier", Counter()).values())
+            out.append(
+                f"  {cwe:10s} {smt:>5d} smt {ql:>5d} ql {ns:>10d} {nb:>11d}"
+            )
+    else:
+        out.append("  (no rows yet)")
+    out.append("")
+
+    out.append("By language:")
+    if rep.by_language:
+        out.append(f"  {'lang':12s} {'sound':>16s} {'not_sound':>10s} {'no_barrier':>11s}")
+        for lang in sorted(rep.by_language):
+            statuses = rep.by_language[lang]
+            smt = statuses.get("sound", Counter()).get("smt", 0)
+            ql = statuses.get("sound", Counter()).get("codeql", 0)
+            ns = sum(statuses.get("not_sound", Counter()).values())
+            nb = sum(statuses.get("no_barrier", Counter()).values())
+            out.append(
+                f"  {lang:12s} {smt:>5d} smt {ql:>5d} ql {ns:>10d} {nb:>11d}"
+            )
+    else:
+        out.append("  (no rows yet)")
+    out.append("")
+
+    if rep.not_sound_samples:
+        out.append(
+            f"not_sound samples (first {len(rep.not_sound_samples)} of "
+            f"{rep.not_sound}, capped):"
+        )
+        for cve_id, cwe, lang, detail in rep.not_sound_samples:
+            out.append(f"  {cve_id:24s} {cwe:8s} {lang:12s} {detail}")
+    return "\n".join(out)
+
+
+def main(argv=None) -> None:
+    import argparse
+
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument(
+        "--synth-db", type=Path, default=Path("/data/corpus/synth-results-tier0.db"),
+        help="trust-witness bridge's synth_results SQLite (default: "
+             "/data/corpus/synth-results-tier0.db)",
+    )
+    args = ap.parse_args(argv)
+    rep = analyze(args.synth_db)
+    print(render_text(rep), flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/core/llm/client.py
+++ b/core/llm/client.py
@@ -319,7 +319,11 @@ def _pinned_llm_config(model_name: str) -> 'LLMConfig':
     hit the same auth error they would have at call time anyway.
     """
     from dataclasses import replace
-    from core.llm.config import ModelConfig, _PROVIDER_BUILDERS
+    from core.llm.config import (
+        ModelConfig,
+        _PROVIDER_BUILDERS,
+        _get_configured_models,
+    )
 
     if "/" in model_name:
         provider, model_name = model_name.split("/", 1)
@@ -332,8 +336,24 @@ def _pinned_llm_config(model_name: str) -> 'LLMConfig':
     else:
         provider = "anthropic"
 
+    # Credential discovery, in this order:
+    #   1. env-var-based provider builder (covers the common case)
+    #   2. operator's ``models.json`` — needed when keys aren't in env
+    #      (the previous version silently skipped this path and produced
+    #      auth failures when the operator's credentials lived only in
+    #      the config file)
     builder = _PROVIDER_BUILDERS.get(provider)
     base = builder() if builder is not None else None
+    if base is None:
+        for entry in _get_configured_models():
+            if entry.get("provider") == provider and entry.get("api_key"):
+                base = ModelConfig(
+                    provider=provider,
+                    model_name=entry.get("model", model_name),
+                    api_key=entry["api_key"],
+                    api_base=entry.get("api_base"),
+                )
+                break
     if base is None:
         primary = ModelConfig(provider=provider, model_name=model_name, role="code")
     else:

--- a/core/tuning/__init__.py
+++ b/core/tuning/__init__.py
@@ -29,6 +29,7 @@ _TUNING_PATH = _REPO_ROOT / "tuning.json"
 _VALID_KEYS = frozenset({
     "codeql_ram_mb",
     "codeql_threads",
+    "codeql_max_disk_cache_mb",
     "max_semgrep_workers",
     "max_codeql_workers",
     "max_agentic_parallel",
@@ -40,6 +41,10 @@ _VALID_KEYS = frozenset({
 _DEFAULTS = {
     "codeql_ram_mb": "auto",
     "codeql_threads": "auto",
+    # 0 sentinel = "leave codeql's own unbounded default in place".  Set
+    # explicit MB cap when running unattended on bounded disk; codeql's
+    # DB build cache otherwise grows without limit.
+    "codeql_max_disk_cache_mb": 0,
     "max_semgrep_workers": 4,
     "max_codeql_workers": 2,
     "max_agentic_parallel": 3,
@@ -178,8 +183,10 @@ _AUTO_RESOLVERS = {
     "max_inventory_workers": _detect_inventory_workers,
 }
 
-# Keys where 0 is a valid explicit value (e.g. CodeQL's "0 = all CPUs")
-_ZERO_ALLOWED = frozenset({"codeql_threads"})
+# Keys where 0 is a valid explicit value:
+#   - codeql_threads: 0 = all CPUs
+#   - codeql_max_disk_cache_mb: 0 = use codeql's unbounded default
+_ZERO_ALLOWED = frozenset({"codeql_threads", "codeql_max_disk_cache_mb"})
 
 
 @dataclass(frozen=True, slots=True)
@@ -187,6 +194,7 @@ class Tuning:
     """Resolved tuning values — all integers, no ``"auto"``."""
     codeql_ram_mb: int
     codeql_threads: int
+    codeql_max_disk_cache_mb: int
     max_semgrep_workers: int
     max_codeql_workers: int
     max_agentic_parallel: int
@@ -282,8 +290,9 @@ def _create_default_file(path: Path) -> None:
         # which also writes this file. Use the same format.
         import json
         comments = {
-            "codeql_ram_mb": "MB of RAM for CodeQL analysis",
-            "codeql_threads": "CPUs for CodeQL (0 = all available)",
+            "codeql_ram_mb": "MB of RAM for CodeQL (-M)",
+            "codeql_threads": "CPUs for CodeQL (-j; 0 = all available)",
+            "codeql_max_disk_cache_mb": "MB cap on codeql DB build cache (--max-disk-cache; 0 = codeql's unbounded default)",
             "max_semgrep_workers": "parallel Semgrep scans (auto = half available CPUs)",
             "max_codeql_workers": "parallel CodeQL DB builds (auto = half available CPUs, capped)",
             "max_agentic_parallel": "parallel Claude Code agents for analysis",

--- a/core/tuning/tests/test_tuning.py
+++ b/core/tuning/tests/test_tuning.py
@@ -320,6 +320,7 @@ class TestTuningFrozen(unittest.TestCase):
     def test_immutable(self):
         t = Tuning(
             codeql_ram_mb=8192, codeql_threads=8,
+            codeql_max_disk_cache_mb=0,
             max_semgrep_workers=4, max_codeql_workers=2,
             max_agentic_parallel=3, max_fuzz_parallel=1,
             max_inventory_workers=4,

--- a/packages/codeql/README.md
+++ b/packages/codeql/README.md
@@ -119,27 +119,47 @@ export RAPTOR_OUT_DIR=/custom/output/dir
 
 ### RaptorConfig Settings
 
-All configuration is centralized in `core/config.py`:
+CodeQL resource settings live in **`tuning.json`** at the repo root (the
+single source of truth, resolved by `core.tuning.get_tuning()`).
+`RaptorConfig` exposes them as classproperties for code that wants the
+resolved integers directly; new CodeQL invocations should use
+`packages.codeql.CodeQLTunables.from_tuning()` instead so the flag set
+stays consistent across consumers.
+
+`tuning.json` keys:
+
+```jsonc
+{
+  "codeql_ram_mb":  "auto",   // -M MB; "auto" = 25% of system RAM clamped [2048, 16384]
+  "codeql_threads": "auto",   // -j N;  "auto" = 0 = all CPUs (override the codeql default of 1)
+  "max_codeql_workers": 2     // parallel codeql operations in same process
+}
+```
+
+Adding a new CodeQL invocation:
 
 ```python
-# Database storage
-CODEQL_DB_DIR = REPO_ROOT / "codeql_dbs"
+from packages.codeql import CodeQLTunables
 
-# Timeouts
-CODEQL_TIMEOUT = 1800              # 30 minutes (database creation)
-CODEQL_ANALYZE_TIMEOUT = 2400      # 40 minutes (query execution)
+cmd = [codeql, "database", "analyze", db, query, "--format=sarif-latest", f"--output={sarif}"]
+CodeQLTunables.from_tuning().append_to(cmd, include_disk_cache=False)
+```
 
-# Resources
-CODEQL_RAM_MB = 8192               # 8GB RAM for analysis
-CODEQL_THREADS = 0                 # 0 = use all CPUs
-CODEQL_MAX_PATHS = 4               # Max dataflow paths per query
+For `database create`, pass `include_disk_cache=True` (the `--max-disk-cache`
+flag is only valid there).  See `packages/codeql/tunables.py` for the
+full surface; the trust-witness corpus walker (`core.dataflow.cvefix_walk`)
+is a worked operator example with CLI overrides for `--threads`/`--ram`/
+`--max-disk-cache`.
 
-# Caching
-CODEQL_DB_CACHE_DAYS = 7           # Keep databases for 7 days
-CODEQL_DB_AUTO_CLEANUP = True      # Auto-cleanup old databases
+Non-tuning settings still live in `core/config.py`:
 
-# Parallel processing
-MAX_CODEQL_WORKERS = 2             # Parallel operations
+```python
+CODEQL_DB_DIR        = REPO_ROOT / "codeql_dbs"
+CODEQL_TIMEOUT       = 1800   # 30 minutes (database creation)
+CODEQL_ANALYZE_TIMEOUT = 2400 # 40 minutes (query execution)
+CODEQL_MAX_PATHS     = 4      # Max dataflow paths per query
+CODEQL_DB_CACHE_DAYS = 7      # Keep databases for 7 days
+CODEQL_DB_AUTO_CLEANUP = True # Auto-cleanup old databases
 ```
 
 ## Output Structure
@@ -302,10 +322,15 @@ CODEQL_TIMEOUT = 3600  # 60 minutes
 
 ### Out of memory
 
-```python
-# Reduce RAM allocation in core/config.py
-CODEQL_RAM_MB = 4096  # 4GB instead of 8GB
+Edit `tuning.json` at the repo root (or run `/tune balanced` to do it):
+
+```jsonc
+{
+  "codeql_ram_mb": 4096   // 4GB instead of "auto"
+}
 ```
+
+`CodeQLTunables.from_tuning()` picks this up immediately on the next run.
 
 ## Next Steps (Phase 2)
 

--- a/packages/codeql/__init__.py
+++ b/packages/codeql/__init__.py
@@ -9,6 +9,7 @@ from .language_detector import LanguageDetector, LanguageInfo
 from .build_detector import BuildDetector, BuildSystem
 from .database_manager import DatabaseManager, DatabaseResult, DatabaseMetadata
 from .query_runner import QueryRunner, QueryResult
+from .tunables import CodeQLTunables
 
 __all__ = [
     "LanguageDetector",
@@ -20,4 +21,5 @@ __all__ = [
     "DatabaseMetadata",
     "QueryRunner",
     "QueryResult",
+    "CodeQLTunables",
 ]

--- a/packages/codeql/database_manager.py
+++ b/packages/codeql/database_manager.py
@@ -36,6 +36,7 @@ from core.logging import get_logger
 from core.git.clone import safe_git_command
 from core.git import get_safe_git_env
 from packages.codeql.build_detector import BuildSystem
+from packages.codeql.tunables import CodeQLTunables
 
 logger = get_logger()
 
@@ -689,6 +690,11 @@ class DatabaseManager:
             f"--language={language}",
             f"--source-root={repo_path}",
         ]
+        # Central CodeQL resource tunables (-j / -M / --max-disk-cache,
+        # tuning.json-backed).  ``include_disk_cache=True`` because
+        # ``database create`` accepts the flag; ``database analyze``
+        # would reject it.
+        CodeQLTunables.from_tuning().append_to(cmd, include_disk_cache=True)
 
         # Set working directory and environment.
         #

--- a/packages/codeql/query_runner.py
+++ b/packages/codeql/query_runner.py
@@ -20,6 +20,7 @@ sys.path.insert(0, str(Path(__file__).parents[2]))
 
 from core.config import RaptorConfig
 from core.logging import get_logger
+from packages.codeql.tunables import CodeQLTunables
 
 logger = get_logger()
 
@@ -319,10 +320,12 @@ class QueryRunner:
             actual_suite_path,
             "--format=sarif-latest",
             f"--output={sarif_path}",
-            f"--threads={RaptorConfig.CODEQL_THREADS}",
-            f"--ram={RaptorConfig.CODEQL_RAM_MB}",
             "--no-rerun",  # Don't rerun queries if results exist
         ]
+        # Central CodeQL resource tunables (-j / -M, tuning.json-backed).
+        # ``include_disk_cache=False`` because ``database analyze``
+        # rejects ``--max-disk-cache`` as an unknown flag.
+        CodeQLTunables.from_tuning().append_to(cmd, include_disk_cache=False)
 
         # DO NOT add search-path - it causes pack conflicts when multiple copies exist
         # Instead, we always use absolute paths (resolved above) to avoid ambiguity
@@ -550,8 +553,8 @@ class QueryRunner:
             str(query_path),
             "--format=sarif-latest",
             f"--output={sarif_path}",
-            f"--threads={RaptorConfig.CODEQL_THREADS}",
         ]
+        CodeQLTunables.from_tuning().append_to(cmd, include_disk_cache=False)
 
         try:
             from core.sandbox import run as sandbox_run
@@ -811,8 +814,8 @@ class QueryRunner:
             str(db), str(pack_dir),
             "--format=sarif-latest",
             f"--output={sarif_path}",
-            f"--threads={RaptorConfig.CODEQL_THREADS}",
         ]
+        CodeQLTunables.from_tuning().append_to(cmd, include_disk_cache=False)
         analysis_start = time.time()
         try:
             proc = sandbox_run(

--- a/packages/codeql/tunables.py
+++ b/packages/codeql/tunables.py
@@ -1,0 +1,83 @@
+"""Per-run CodeQL resource controls.
+
+Centralises the ``-j`` / ``-M`` / ``--max-disk-cache`` flag set that every
+CodeQL invocation across RAPTOR needs to plumb through.  Previously
+each call site constructed these strings inline (3 sites in
+``query_runner.py`` alone, plus the dataflow corpus walker), with the
+subtle bug that the trust-witness walker had been omitting them
+entirely — meaning ``codeql database create`` ran with the upstream
+default ``-j 1`` and serialised the secondary HTML/JS extractor phase
+on Go web repos.  That timed out the per-pair build budget on the
+overnight v3 walk (12/16 build_fails stuck in this phase).
+
+The defaults are sourced from RAPTOR's central tuning config
+(:mod:`core.tuning`, backed by ``tuning.json``) via :meth:`from_tuning`,
+so changing ``codeql_threads`` / ``codeql_ram_mb`` in one place
+propagates everywhere.  Operator CLI flags override per-run.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass(frozen=True)
+class CodeQLTunables:
+    """CodeQL resource flags appended to ``database create`` /
+    ``database analyze`` commands.
+
+      * ``threads``           — codeql ``-j``.  ``0`` = all cores.
+      * ``ram_mb``            — codeql ``-M`` (MB).  ``None`` skips the
+                                 flag and lets codeql autodetect.
+      * ``max_disk_cache_mb`` — codeql ``--max-disk-cache`` (MB).
+                                 ``None`` = codeql's unbounded default.
+                                 Only valid on ``database create``; the
+                                 analyze path rejects it as unknown.
+    """
+    threads: int = 0
+    ram_mb: Optional[int] = None
+    max_disk_cache_mb: Optional[int] = None
+
+    @classmethod
+    def from_tuning(cls, *, overrides: Optional[dict] = None) -> "CodeQLTunables":
+        """Build from RAPTOR's central tuning config.
+
+        ``overrides`` is an operator-CLI-arg-shaped dict; any non-None
+        value overrides the tuning-resolved default for that field.
+        Recognised keys: ``threads``, ``ram_mb``, ``max_disk_cache_mb``.
+        """
+        # Lazy import: callers that build CodeQLTunables() directly with
+        # explicit values (tests, small one-offs) shouldn't pay the
+        # tuning module's import cost (json + hardware detect).
+        from core.tuning import get_tuning
+        t = get_tuning()
+        overrides = overrides or {}
+        threads = overrides.get("threads")
+        if threads is None:
+            threads = t.codeql_threads
+        ram_mb = overrides.get("ram_mb")
+        if ram_mb is None:
+            # 0 in tuning means "unset" — codeql autodetect.
+            ram_mb = t.codeql_ram_mb if t.codeql_ram_mb > 0 else None
+        max_disk_cache_mb = overrides.get("max_disk_cache_mb")
+        if max_disk_cache_mb is None:
+            # 0 in tuning means "leave codeql's unbounded default".
+            v = t.codeql_max_disk_cache_mb
+            max_disk_cache_mb = v if v > 0 else None
+        return cls(threads=threads, ram_mb=ram_mb,
+                   max_disk_cache_mb=max_disk_cache_mb)
+
+    def append_to(self, cmd: list, *, include_disk_cache: bool = True) -> None:
+        """Append the relevant CodeQL flags onto ``cmd`` in place.
+
+        ``include_disk_cache`` controls whether ``--max-disk-cache`` is
+        appended; only ``database create`` accepts that flag.  The
+        analyze path passes ``False`` so it doesn't error on an unknown
+        option.
+        """
+        cmd.extend(["-j", str(self.threads)])
+        if self.ram_mb is not None:
+            cmd.extend(["-M", str(self.ram_mb)])
+        if include_disk_cache and self.max_disk_cache_mb is not None:
+            cmd.append(f"--max-disk-cache={self.max_disk_cache_mb}")

--- a/packages/hypothesis_validation/adapters/codeql.py
+++ b/packages/hypothesis_validation/adapters/codeql.py
@@ -25,6 +25,8 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import Dict, List, Optional, Set
 
+from packages.codeql.tunables import CodeQLTunables
+
 from .base import ToolAdapter, ToolCapability, ToolEvidence, make_sandbox_runner
 
 logger = logging.getLogger(__name__)
@@ -271,6 +273,7 @@ class CodeQLAdapter(ToolAdapter):
                     f"--output={sarif_path}",
                     "--no-rerun",
                 ]
+                CodeQLTunables.from_tuning().append_to(cmd, include_disk_cache=False)
                 try:
                     proc = runner(
                         cmd, capture_output=True, text=True,
@@ -414,6 +417,7 @@ class CodeQLAdapter(ToolAdapter):
                     f"--output={sarif_path}",
                     "--no-rerun",
                 ]
+                CodeQLTunables.from_tuning().append_to(cmd, include_disk_cache=False)
                 try:
                     proc = runner(
                         cmd, capture_output=True, text=True,


### PR DESCRIPTION
Two layers of the propose-then-adjudicate sound tier on top of the trust-corpus pipeline (#659):

Tier 2 (LLM proposes a CodeQL barrier-guard, CodeQL adjudicates):
  * cvefix_bridge - per FP-candidate: rebuild before/after DBs, extract SARIF finding + fix diff + dataflow path, run the propose/adjudicate loop, persist outcome. Resumable + crash-isolated.
  * barrier_synth prompt levers from the 12-newest baseline work: line-scoped suppress check; compile-validated few-shot in each language prompt; branch-direction nudge; Ruby AST import fix; model_completer using the pinned_model LLMClient API (#733); diag dict for no_barrier last_error.
  * cvefix_walk dedups (fix_hash, cwe) in the todo list.

Tier 0 (free SMT first-pass over charset-shaped validators):
  * smt_barrier (new) - Python re.match/re.fullmatch over `^[charset]+$` extractor, dominance evidence from CodeQL's SARIF codeFlow, Z3 regex-intersection emptiness. UNSAT = sound proof; SAT = counterexample. 7-9 ms/case (z3 4.15.4.0 + 4.16.0). Graceful degradation via core.smt_solver.z3_available.
  * Runs after the after-DB+SARIF, BEFORE the before-DB build - a SOUND verdict saves the before-DB build, the LLM call, and the CodeQL guard cycle entirely. Defensive try/except so any bug here falls through to Tier 2.
  * synth_results gains a `backend` column (smt / codeql / empty); synthesize_one returns (status, fid, backend, barrier_query, detail).

Cost asymmetry: Tier 0 is single-digit ms CPU + zero LLM tokens; Tier 2 is dollars + seconds + a hallucination tail. Z3's regex theory dispatches the sanitizer-neutralisation question directly, bypassing the CodeQL barrier-guard expressibility wall Tier 2 keeps hitting on re.match-style validators. Soundness rests on the oracle, not the router: Z3's regex automata procedure is decidable + sound; the LLM (when consulted at Tier 2) only proposes, CodeQL adjudicates.

core/smt_solver/ deliberately untouched - this is the first string- theory consumer; helpers stay local to core/dataflow/smt_barrier.py. Promotion to core/smt_solver/strings.py is deferred to the second consumer.

Out of scope (informed by what a full 87-corpus run on this Tier 0 surfaces): wider extractor (allowlist / prefix / length / non-Python), Tier 1 (cheap LLM characterise, SMT adjudicate), CWE->backend prior table, feedback-refine loop.