### PR TITLE
agentic+scan: consume target-type catalog for per-run defaults

### DIFF
--- a/packages/llm_analysis/agent.py
+++ b/packages/llm_analysis/agent.py
@@ -70,6 +70,60 @@ def apply_prefer_globs(
     return preferred + others
 
 
+def _dir_to_glob(d: str) -> str:
+    """Convert a catalog directory path (``src/http``) to an
+    fnmatch glob that matches files inside it (``src/http/*``).
+    Already-glob entries (``src/device/sysdep_*``) pass through
+    unchanged.
+
+    fnmatch ``*`` is greedy across ``/`` (per Python's
+    ``fnmatch.translate``), so ``src/http/*`` matches both
+    ``src/http/server.c`` AND ``src/http/foo/bar.c`` — no need
+    for ``src/http/**`` or similar.
+    """
+    if "*" in d:
+        return d
+    return d.rstrip("/") + "/*"
+
+
+def resolve_prefer_globs(
+    operator_globs: Optional[List[str]],
+    repo_path: Optional[Path],
+) -> tuple:
+    """Resolve the effective attack-surface prefer-globs for an
+    /agentic run. Operator-supplied globs win unconditionally;
+    when absent, fall back to the target-type catalog's
+    ``attack_surface.high_priority_dirs`` for the matched target
+    type.
+
+    Returns ``(effective_globs, source_label)`` where
+    ``source_label`` is for the operator-facing log line
+    (``--prefer`` or ``catalog '<name>'``); both are None when
+    neither operator nor catalog supplied anything (operator
+    didn't pass --prefer AND no catalog entry matched, or repo_path
+    is missing entirely).
+
+    Module-level (rather than agent-method) so unit tests can
+    drive it without instantiating the full AutonomousSecurityAgentV2
+    (which pulls in LLMConfig, scorecard, sandbox, etc.).
+    """
+    if operator_globs:
+        return list(operator_globs), "--prefer"
+    if not repo_path:
+        return None, None
+    try:
+        from core.run.target_types import load
+        entry = load(Path(repo_path))
+    except Exception:  # noqa: BLE001
+        # Catalog substrate is best-effort; never fail the agent
+        # on a catalog-load issue.
+        return None, None
+    if entry is None or not entry.attack_surface_high:
+        return None, None
+    globs = [_dir_to_glob(d) for d in entry.attack_surface_high]
+    return globs, f"catalog '{entry.name}'"
+
+
 def apply_exclude_dir_globs(
     findings: List[Dict[str, Any]],
     exclude_globs: Optional[List[str]],
@@ -1721,6 +1775,15 @@ class AutonomousSecurityAgentV2:
             logger.debug("annotation emit error", exc_info=True)
             return None
 
+    def _resolve_prefer_globs(
+        self, operator_globs: Optional[List[str]],
+    ) -> tuple:
+        """Instance-method wrapper around module-level
+        ``resolve_prefer_globs`` — passes the agent's
+        ``self.repo_path``. Kept as a method so the call site in
+        ``process_findings`` stays brief."""
+        return resolve_prefer_globs(operator_globs, self.repo_path)
+
     def process_findings(self, sarif_paths: List[str] = None, findings_path: str = None,
                          max_findings: int = 10, checklist: Dict[str, Any] = None,
                          emit_annotations: bool = True,
@@ -1793,21 +1856,34 @@ class AutonomousSecurityAgentV2:
         # Put dataflow findings first, then others
         prioritized_findings = findings_with_dataflow + findings_without_dataflow
 
-        # Operator-controlled attack-surface ordering: --prefer GLOB
-        # sorts matching findings to the front before the cap fires.
-        if prefer_globs:
+        # Attack-surface ordering: prefer-globs from operator
+        # (--prefer GLOB) take precedence; when absent, the
+        # target-type catalog's ``attack_surface.high_priority_dirs``
+        # supplies an implicit default for the matched target type
+        # so a low ``--max-findings`` cap reaches the architectural
+        # attack surface (src/http, src/protocols, ...) instead of
+        # spending budget on platform shims by SARIF order luck.
+        # Operator override always wins; catalog only fires when
+        # the operator didn't supply globs.
+        effective_globs, prefer_source = self._resolve_prefer_globs(
+            prefer_globs,
+        )
+        if effective_globs:
             total_before = len(prioritized_findings)
             prioritized_findings = apply_prefer_globs(
-                prioritized_findings, prefer_globs,
+                prioritized_findings, effective_globs,
             )
             matched = sum(
                 1 for f in prioritized_findings
-                if _file_matches_globs(f.get("file_path", ""), prefer_globs)
+                if _file_matches_globs(
+                    f.get("file_path", ""), effective_globs,
+                )
             )
             if matched and not is_prep_only:
                 logger.info(
-                    f"--prefer reordered: {matched} of {total_before} "
-                    f"findings match {prefer_globs} (sorted to front)"
+                    f"attack-surface ranking ({prefer_source}): "
+                    f"{matched} of {total_before} findings match "
+                    f"{effective_globs} (sorted to front)"
                 )
 
         if not is_prep_only:

--- a/packages/llm_analysis/orchestrator.py
+++ b/packages/llm_analysis/orchestrator.py
@@ -172,6 +172,59 @@ class CostTracker:
             return summary
 
 
+def _finalize_results_for_emit(results: list) -> None:
+    """Strip operator-internal fields + stamp explicit status on
+    each per-finding record before it lands in
+    ``orchestrated_report.json``. Mutates ``results`` in place.
+
+    Two concerns:
+
+    * ``repo_path`` is an absolute filesystem path on the operator's
+      machine (``/home/alice/projects/my-target``,
+      ``/tmp/raptor/foo``); stamping it onto each finding earlier in
+      the pipeline (line ~303) is necessary for SAGE enrichment
+      scoping, but leaking it into the persisted report exposes
+      operator filesystem layout downstream (username, project
+      naming, runner tmp-dir hierarchy). Strip AFTER all internal
+      consumers have used it (judge, consensus, aggregation) and
+      BEFORE save_json hits disk.
+    * ``status`` is the QoL #19 canonical enum
+      (``analysed`` / ``analysis_inconsistent`` / ``error`` /
+      ``skipped_*``). Stamping it here lets on-disk readers
+      (raptor_agentic summary, report renderers, future automation)
+      consume positive status markers instead of detecting via
+      null-fields. Derived from the per-finding shape via
+      ``core.run.finding_status.derive_status`` — no fields
+      invented; consumers that previously inferred from
+      ``is_true_positive is None`` / ``self_contradictory`` /
+      ``error`` keys now read ``status`` instead.
+
+    Skipped variants (``skipped_over_budget``,
+    ``skipped_duplicate``, etc.) are stamped by their respective
+    producers (budget cap, dedup, binary-oracle) at skip time —
+    this finaliser only handles the analysed / inconsistent /
+    error cases that survive to the orchestrator emit.
+
+    Extracted from the inline emit-time loop so it's unit-testable
+    without driving the full orchestrate() dispatch path.
+
+    Producer-stamped status (when a specific skip-reason or
+    error-class producer set ``status`` explicitly upstream) is
+    PRESERVED — derive's generic fallback would lose the
+    specificity (``skipped_over_budget`` would become generic
+    ``skipped``). Only stamp when status is absent or carries an
+    unknown value (defensive against partial-write state from an
+    older codebase variant).
+    """
+    from core.run.finding_status import ALL_STATUSES, derive_status
+    for f in results:
+        if isinstance(f, dict):
+            f.pop("repo_path", None)
+            existing = f.get("status")
+            if existing not in ALL_STATUSES:
+                f["status"] = derive_status(f)
+
+
 def build_llm_config_from_flags(
     *,
     models: Optional[List[str]] = None,
@@ -1276,19 +1329,10 @@ def orchestrate(
     if defense_telemetry.has_warnings:
         merged["orchestration"]["defense_telemetry"] = defense_telemetry.summary()
 
-    # Strip the host-side `repo_path` we stamped onto every
-    # finding for SAGE enrichment scoping (line ~303). It's an
-    # absolute filesystem path on the operator's machine
-    # (`/home/alice/projects/my-target`, `/tmp/raptor/foo`) and
-    # leaking it into the persisted report exposes operator
-    # filesystem layout downstream — anyone the report is
-    # shared with sees username, project naming conventions,
-    # and the runner's tmp-dir hierarchy. Pop AFTER all
-    # internal consumers have used it (judge, consensus,
-    # aggregation) and BEFORE save_json hits disk.
-    for f in merged.get("results", []):
-        if isinstance(f, dict):
-            f.pop("repo_path", None)
+    # Finalize per-result records before save_json: strip
+    # operator-internal fields + stamp explicit status. See
+    # ``_finalize_results_for_emit`` for the rationale.
+    _finalize_results_for_emit(merged.get("results", []))
 
     out_dir.mkdir(parents=True, exist_ok=True)
     from core.json import save_json

--- a/packages/llm_analysis/tests/test_orchestrator_finalize_emit.py
+++ b/packages/llm_analysis/tests/test_orchestrator_finalize_emit.py
@@ -1,0 +1,157 @@
+"""Tests for ``_finalize_results_for_emit`` — the orchestrator's
+emit-side finaliser that strips operator-internal fields + stamps
+the explicit status enum (QoL #10 / #11-11e / #19) on each result
+before save_json hits disk."""
+
+from __future__ import annotations
+
+from packages.llm_analysis.orchestrator import _finalize_results_for_emit
+
+
+class TestRepoPathStripping:
+    """Operator-internal ``repo_path`` was carried per-finding for
+    SAGE enrichment scoping (orchestrate ~line 303); must be gone
+    from the on-disk record so filesystem layout doesn't leak to
+    anyone the report is shared with."""
+
+    def test_repo_path_removed(self):
+        results = [{
+            "finding_id": "F1",
+            "repo_path": "/home/alice/projects/secret-target",
+            "is_true_positive": True,
+            "is_exploitable": True,
+        }]
+        _finalize_results_for_emit(results)
+        assert "repo_path" not in results[0]
+
+    def test_missing_repo_path_is_noop(self):
+        results = [{"finding_id": "F1", "is_true_positive": True}]
+        # Findings that never had repo_path stamped (e.g. CC-prep
+        # path) don't crash.
+        _finalize_results_for_emit(results)
+        assert "repo_path" not in results[0]
+
+
+class TestStatusStamping:
+    """Explicit status field per the QoL #19 enum lands on every
+    result so downstream readers (raptor_agentic summary, report
+    renderers, automation) skip null-field detection."""
+
+    def test_analysed_finding_gets_analysed_status(self):
+        results = [{
+            "finding_id": "F1",
+            "is_true_positive": True,
+            "is_exploitable": True,
+        }]
+        _finalize_results_for_emit(results)
+        assert results[0]["status"] == "analysed"
+
+    def test_self_contradictory_gets_analysis_inconsistent_status(self):
+        results = [{
+            "finding_id": "F1",
+            "is_true_positive": True,
+            "is_exploitable": True,
+            "self_contradictory": True,
+        }]
+        _finalize_results_for_emit(results)
+        assert results[0]["status"] == "analysis_inconsistent"
+
+    def test_judge_resolved_contradiction_lands_in_analysed(self):
+        # Composes with the QoL #11-11d judge-resolution shipped in
+        # the previous batch: a finding that WAS self_contradictory
+        # but the judge resolved it lands in ``analysed`` (not
+        # ``analysis_inconsistent``), so the headline counts drop
+        # the false-positive review load.
+        results = [{
+            "finding_id": "F1",
+            "is_true_positive": True,
+            "is_exploitable": True,
+            "self_contradictory": False,
+            "contradiction_resolved_by_judge": True,
+        }]
+        _finalize_results_for_emit(results)
+        assert results[0]["status"] == "analysed"
+
+    def test_error_finding_gets_error_status(self):
+        results = [{
+            "finding_id": "F1",
+            "error": "timeout after 600s",
+        }]
+        _finalize_results_for_emit(results)
+        assert results[0]["status"] == "error"
+
+    def test_missing_verdict_gets_skipped_status(self):
+        # No is_true_positive key → derived as generic skipped.
+        # Producers that know the specific reason (budget cap,
+        # dedup, binary-oracle) stamp ``skipped_*`` explicitly;
+        # this fallback covers the case where SOMETHING decided
+        # to drop the finding without recording the reason.
+        results = [{"finding_id": "F1", "file_path": "x.c"}]
+        _finalize_results_for_emit(results)
+        assert results[0]["status"] == "skipped"
+
+
+class TestExplicitStatusPreserved:
+    """When a producer already stamped an explicit ``status`` value
+    (skipped_over_budget, skipped_duplicate, skipped_dead_code),
+    the finaliser MUST NOT clobber it — those values carry more
+    information than the generic ``skipped`` derivation."""
+
+    def test_explicit_skipped_over_budget_preserved(self):
+        # Producer (budget cap) stamped specific reason; finaliser
+        # leaves it alone.
+        results = [{
+            "finding_id": "F1",
+            "status": "skipped_over_budget",
+            "skip_reason": "cap reached after 8 findings",
+        }]
+        _finalize_results_for_emit(results)
+        assert results[0]["status"] == "skipped_over_budget"
+        assert results[0]["skip_reason"] == "cap reached after 8 findings"
+
+    def test_explicit_skipped_dead_code_preserved(self):
+        # binary-oracle stamped status; preserved.
+        results = [{
+            "finding_id": "F1",
+            "status": "skipped_dead_code",
+            "is_true_positive": True,  # would normally derive to analysed
+            "is_exploitable": True,
+        }]
+        _finalize_results_for_emit(results)
+        assert results[0]["status"] == "skipped_dead_code"
+
+    def test_unknown_explicit_status_overwritten_by_derive(self):
+        # Defensive: a malformed status string (typo, older
+        # codebase variant) falls back to derive so the on-disk
+        # value is always one of ALL_STATUSES.
+        results = [{
+            "finding_id": "F1",
+            "status": "made_up_value",
+            "is_true_positive": True,
+        }]
+        _finalize_results_for_emit(results)
+        assert results[0]["status"] == "analysed"
+
+
+class TestNonDictResultsTolerated:
+    """Defensive: the loop must not crash on malformed records
+    (None, list, string) that shouldn't be there but might creep
+    in via test fixtures / corrupted JSON / sub-task dispatch
+    errors writing the wrong shape."""
+
+    def test_none_entry_skipped(self):
+        results = [None, {"finding_id": "F1", "is_true_positive": True}]
+        _finalize_results_for_emit(results)
+        # The dict entry got its status; the None was left alone.
+        assert results[0] is None
+        assert results[1]["status"] == "analysed"
+
+    def test_list_entry_skipped(self):
+        results = [[], {"finding_id": "F1", "is_true_positive": True}]
+        _finalize_results_for_emit(results)
+        assert results[1]["status"] == "analysed"
+
+    def test_empty_results_is_noop(self):
+        results: list = []
+        _finalize_results_for_emit(results)  # no crash
+        assert results == []

--- a/packages/llm_analysis/tests/test_resolve_prefer_globs.py
+++ b/packages/llm_analysis/tests/test_resolve_prefer_globs.py
@@ -1,0 +1,124 @@
+"""Tests for ``resolve_prefer_globs`` — the operator/catalog
+attack-surface ranking arbitrator (QoL #9 L2)."""
+
+from __future__ import annotations
+
+from packages.llm_analysis.agent import (
+    _dir_to_glob,
+    resolve_prefer_globs,
+)
+
+
+class TestDirToGlob:
+    def test_plain_dir_gets_trailing_star(self):
+        assert _dir_to_glob("src/http") == "src/http/*"
+
+    def test_trailing_slash_normalised(self):
+        assert _dir_to_glob("src/http/") == "src/http/*"
+
+    def test_already_globbed_passes_through(self):
+        # Catalog entries like ``src/device/sysdep_*`` already
+        # carry the wildcard — must not double-glob.
+        assert _dir_to_glob("src/device/sysdep_*") == "src/device/sysdep_*"
+
+    def test_wildcard_anywhere_passes_through(self):
+        # Defensive: any ``*`` in the input means the catalog
+        # author intended it as a glob; respect that.
+        assert _dir_to_glob("**/handlers") == "**/handlers"
+
+
+class TestOperatorOverridesCatalog:
+    """When --prefer is supplied, the operator's globs win
+    unconditionally — catalog defaults don't even get consulted
+    (the catalog lookup is the slow path; skip it when not needed)."""
+
+    def test_operator_globs_returned_as_is(self, tmp_path):
+        # tmp_path is empty so catalog detection would return
+        # ``generic`` (no attack_surface_high), but the operator
+        # globs short-circuit before we get there.
+        operator = ["src/auth/*", "src/api/*"]
+        globs, source = resolve_prefer_globs(operator, tmp_path)
+        assert globs == operator
+        assert source == "--prefer"
+
+    def test_operator_empty_list_falls_through_to_catalog(self, tmp_path):
+        # Empty list = ''no operator preference''. Same as None;
+        # fall through to catalog detection.
+        (tmp_path / "configure.ac").write_text("")
+        (tmp_path / "src" / "main.c").parent.mkdir(parents=True)
+        (tmp_path / "src" / "main.c").write_text("")
+        globs, source = resolve_prefer_globs([], tmp_path)
+        # Catalog matches c.userspace-daemon → attack_surface_high
+        # populated → globs returned with ``catalog 'X'`` source.
+        assert globs is not None
+        assert source.startswith("catalog ")
+
+
+class TestCatalogFallback:
+    """When --prefer isn't supplied, the catalog's
+    ``attack_surface.high_priority_dirs`` for the matched target
+    type becomes the implicit prefer-globs."""
+
+    def test_c_userspace_daemon_target_uses_catalog_defaults(self, tmp_path):
+        # Build a tree matching c.userspace-daemon detection
+        # (autotools + .c files).
+        (tmp_path / "configure.ac").write_text("")
+        (tmp_path / "Makefile.am").write_text("")
+        (tmp_path / "src").mkdir()
+        (tmp_path / "src" / "main.c").write_text("")
+        globs, source = resolve_prefer_globs(None, tmp_path)
+        assert globs is not None
+        assert source == "catalog 'c.userspace-daemon'"
+        # Catalog stores dirs like ``src/http`` — converted to
+        # ``src/http/*`` for fnmatch.
+        assert "src/http/*" in globs
+        assert "src/api/*" in globs
+
+    def test_python_web_app_target_uses_catalog_defaults(self, tmp_path):
+        (tmp_path / "manage.py").write_text("")
+        (tmp_path / "settings.py").write_text("")
+        (tmp_path / "urls.py").write_text("")
+        globs, source = resolve_prefer_globs(None, tmp_path)
+        assert source == "catalog 'python.web-app'"
+        # python.web-app catalog has globbed entries like
+        # ``**/views`` already — should pass through.
+        assert globs is not None
+        assert any("views" in g for g in globs)
+
+    def test_unmatched_target_returns_none(self, tmp_path):
+        # Empty tree → catalog falls back to ``generic``, which
+        # has empty attack_surface_high → returns None (no globs
+        # to apply). Caller skips the prefer-sort step entirely.
+        globs, source = resolve_prefer_globs(None, tmp_path)
+        assert globs is None
+        assert source is None
+
+    def test_missing_repo_path_returns_none(self):
+        globs, source = resolve_prefer_globs(None, None)
+        assert globs is None
+        assert source is None
+
+    def test_nonexistent_repo_path_returns_none(self, tmp_path):
+        # Path doesn't exist on disk → catalog detection walks
+        # nothing → falls back to generic → no high_priority_dirs.
+        globs, source = resolve_prefer_globs(
+            None, tmp_path / "does-not-exist",
+        )
+        assert globs is None
+
+
+class TestCatalogLoadFailureToleratedSilently:
+    """Catalog substrate is best-effort. Any exception from
+    ``load()`` must not break the agent — return (None, None) and
+    let the run proceed with no prefer-sort."""
+
+    def test_catalog_exception_returns_none(self, monkeypatch, tmp_path):
+        # Inject a catalog.load that raises — agent must shrug
+        # and continue.
+        import core.run.target_types as tt
+        def _boom(_path):
+            raise RuntimeError("catalog corrupted")
+        monkeypatch.setattr(tt, "load", _boom)
+        globs, source = resolve_prefer_globs(None, tmp_path)
+        assert globs is None
+        assert source is None

--- a/packages/static-analysis/scanner.py
+++ b/packages/static-analysis/scanner.py
@@ -85,6 +85,69 @@ def filter_sarif_by_exclude_globs(
     return out, dropped
 
 
+def _pack_tuple_for_id(pack_id: str) -> Tuple[str, str]:
+    """Resolve a pack-id-suffix (``"security-audit"``,
+    ``"command-injection"``) to the full
+    ``(display_name, full_pack_id)`` tuple ``BASELINE_SEMGREP_PACKS``
+    uses. The display names aren't a clean derivation from the
+    pack-id (``command-injection`` → ``semgrep_injection``,
+    ``owasp-top-ten`` → ``semgrep_owasp_top_10`` — both reflect
+    historical naming conventions in
+    ``RaptorConfig.POLICY_GROUP_TO_SEMGREP_PACK``), so consult
+    those mappings first; fall back to a synthesised name for
+    unknown ids.
+
+    Used by ``_resolve_baseline_packs`` to convert the
+    target-type catalog's ``semgrep_packs.default`` (a list of
+    pack-id suffixes) to the tuple shape scanner internals expect.
+    """
+    full_id = f"p/{pack_id}"
+    # Baseline packs are listed by full tuple already.
+    for name, fid in RaptorConfig.BASELINE_SEMGREP_PACKS:
+        if fid == full_id:
+            return (name, fid)
+    # POLICY_GROUP_TO_SEMGREP_PACK values cover the rest of the
+    # canonical (name, pack-id) pairs.
+    for name, fid in RaptorConfig.POLICY_GROUP_TO_SEMGREP_PACK.values():
+        if fid == full_id:
+            return (name, fid)
+    # Unknown pack-id (catalog author added something we don't
+    # have a name convention for) — synthesise a safe name.
+    safe = pack_id.replace("-", "_").replace("/", "_")
+    return (f"semgrep_{safe}", full_id)
+
+
+def _resolve_baseline_packs(
+    repo_path: Optional[Path],
+) -> List[Tuple[str, str]]:
+    """Resolve the baseline semgrep pack set for ``repo_path``.
+
+    When the target-type catalog matches and ships
+    ``semgrep_packs.default``, use the catalog's list — that's
+    the per-target-type tuning #7-7b ships. When no catalog match
+    (or the matched entry has no default packs, like the
+    ``generic`` fallback), use the hardcoded
+    ``RaptorConfig.BASELINE_SEMGREP_PACKS``.
+
+    Operator override via ``--policy-groups`` happens elsewhere
+    (in main's rules_dirs construction) and remains authoritative
+    — this resolver only governs the baseline (what runs when
+    the operator hasn't narrowed the rule set explicitly).
+    """
+    if repo_path is None:
+        return list(RaptorConfig.BASELINE_SEMGREP_PACKS)
+    try:
+        from core.run.target_types import load as load_target_type
+        entry = load_target_type(Path(repo_path))
+    except Exception:  # noqa: BLE001
+        # Catalog substrate is best-effort; never break the scan
+        # on a catalog load issue.
+        return list(RaptorConfig.BASELINE_SEMGREP_PACKS)
+    if entry is None or not entry.semgrep_packs_default:
+        return list(RaptorConfig.BASELINE_SEMGREP_PACKS)
+    return [_pack_tuple_for_id(pid) for pid in entry.semgrep_packs_default]
+
+
 def _sanitize_pack_name(name: str) -> str:
     """Strict allowlist: alphanumeric + dash + underscore + dot.
 
@@ -426,7 +489,8 @@ def semgrep_scan_parallel(
     rules_dirs: List[str],
     out_dir: Path,
     timeout: int = RaptorConfig.SEMGREP_TIMEOUT,
-    progress_callback: Optional[Callable] = None
+    progress_callback: Optional[Callable] = None,
+    baseline_packs: Optional[List[Tuple[str, str]]] = None,
 ) -> Tuple[List[str], List[str]]:
     """
     Run Semgrep scans in parallel for improved performance.
@@ -437,6 +501,13 @@ def semgrep_scan_parallel(
         out_dir: Output directory for results
         timeout: Timeout per scan
         progress_callback: Optional callback for progress updates
+        baseline_packs: Override for the always-run baseline pack
+            set (``[(display_name, pack_id), ...]``). When None,
+            falls back to ``RaptorConfig.BASELINE_SEMGREP_PACKS`` —
+            preserves pre-#17 behaviour for callers that don't
+            consult the target-type catalog. Callers integrated
+            with the catalog (scanner.py main) resolve via
+            ``_resolve_baseline_packs`` and pass the result.
 
     Returns:
         (sarif_paths, failed_pack_names). Callers MUST surface the
@@ -449,6 +520,8 @@ def semgrep_scan_parallel(
         caller renders the summary line and writes it into the
         coverage record.
     """
+    if baseline_packs is None:
+        baseline_packs = list(RaptorConfig.BASELINE_SEMGREP_PACKS)
     out_dir.mkdir(parents=True, exist_ok=True)
 
     # Build config list with BOTH local rules AND standard packs for each category
@@ -475,8 +548,10 @@ def semgrep_scan_parallel(
         else:
             logger.warning(f"Rule directory not found: {rd_path}")
 
-    # Add baseline packs (unless already added)
-    for pack_name, pack_identifier in RaptorConfig.BASELINE_SEMGREP_PACKS:
+    # Add baseline packs (unless already added). ``baseline_packs``
+    # was resolved by the caller (target-type catalog → tuned
+    # default per #7-7b; otherwise hardcoded BASELINE).
+    for pack_name, pack_identifier in baseline_packs:
         if pack_identifier not in added_packs:
             configs.append((pack_name, RaptorConfig.get_semgrep_config(pack_identifier)))
             added_packs.add(pack_identifier)
@@ -558,7 +633,8 @@ def semgrep_scan_sequential(
     repo_path: Path,
     rules_dirs: List[str],
     out_dir: Path,
-    timeout: int = RaptorConfig.SEMGREP_TIMEOUT
+    timeout: int = RaptorConfig.SEMGREP_TIMEOUT,
+    baseline_packs: Optional[List[Tuple[str, str]]] = None,
 ) -> Tuple[List[str], List[str]]:
     """Sequential scanning fallback for debugging.
 
@@ -568,7 +644,13 @@ def semgrep_scan_sequential(
     the silent-drop class but the worker can still claim success
     while no SARIF lands (filesystem error, sandbox teardown), so
     the same cross-check + reporting apply.
+
+    ``baseline_packs``: same contract as the parallel sibling —
+    override for the always-run baseline pack set; None falls back
+    to ``RaptorConfig.BASELINE_SEMGREP_PACKS``.
     """
+    if baseline_packs is None:
+        baseline_packs = list(RaptorConfig.BASELINE_SEMGREP_PACKS)
     out_dir.mkdir(parents=True, exist_ok=True)
     sarif_paths: List[str] = []
     failed_scans: List[str] = []
@@ -594,8 +676,9 @@ def semgrep_scan_sequential(
                     configs.append((pack_name, resolved))
                     added_packs.add(pack_id)
 
-    # Add baseline packs (unless already added)
-    for pack_name, pack_identifier in RaptorConfig.BASELINE_SEMGREP_PACKS:
+    # Add baseline packs (unless already added) — see parallel sibling
+    # for the catalog-aware resolution rationale.
+    for pack_name, pack_identifier in baseline_packs:
         if pack_identifier not in added_packs:
             configs.append((pack_name, RaptorConfig.get_semgrep_config(pack_identifier)))
             added_packs.add(pack_identifier)
@@ -1280,17 +1363,38 @@ def main():
         }
         save_json(out_dir / "scan-manifest.json", manifest)
 
-        # Semgrep stage - Use parallel scanning by default
+        # Semgrep stage - Use parallel scanning by default. Resolve
+        # the baseline pack set via the target-type catalog (QoL
+        # #7-7b: per-target tuning) — catalog entry for the matched
+        # target type provides ``semgrep_packs.default``; falls back
+        # to the hardcoded RaptorConfig.BASELINE_SEMGREP_PACKS when
+        # no catalog match. Surface the resolved set + source so the
+        # operator sees WHY a particular pack list ran.
+        resolved_baseline = _resolve_baseline_packs(repo_path)
+        if list(resolved_baseline) != list(RaptorConfig.BASELINE_SEMGREP_PACKS):
+            try:
+                from core.run.target_types import load as _load_tt
+                _tt = _load_tt(repo_path)
+                _tt_name = _tt.name if _tt else "unknown"
+            except Exception:  # noqa: BLE001
+                _tt_name = "unknown"
+            _names = [n for n, _ in resolved_baseline]
+            logger.info(
+                f"Semgrep baseline packs from target-type catalog "
+                f"'{_tt_name}': {_names}"
+            )
         logger.info("Starting Semgrep scans...")
         if args.sequential:
             # Fallback to sequential for debugging
             logger.warning("Sequential scanning enabled (slower)")
             semgrep_sarifs, semgrep_failed = semgrep_scan_sequential(
                 repo_path, rules_dirs, out_dir,
+                baseline_packs=resolved_baseline,
             )
         else:
             semgrep_sarifs, semgrep_failed = semgrep_scan_parallel(
                 repo_path, rules_dirs, out_dir,
+                baseline_packs=resolved_baseline,
             )
 
         # Surface failed-pack count on stderr — at scan-level so the

--- a/packages/static-analysis/tests/test_resolve_baseline_packs.py
+++ b/packages/static-analysis/tests/test_resolve_baseline_packs.py
@@ -1,0 +1,137 @@
+"""Tests for ``_resolve_baseline_packs`` + ``_pack_tuple_for_id`` —
+the QoL #7-7b catalog-driven baseline-pack resolution."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+from core.config import RaptorConfig
+
+# packages/static-analysis isn't an importable package (the dir
+# name contains a hyphen). Load the module directly via spec so
+# the helpers are reachable in tests — same pattern other
+# static-analysis tests in this dir use (see e.g.
+# test_scanner_semgrep_parallel.py).
+_SCANNER_PATH = Path(__file__).resolve().parents[1] / "scanner.py"
+_spec = importlib.util.spec_from_file_location(
+    "_scanner_under_test_resolve_baseline", _SCANNER_PATH,
+)
+_scanner = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_scanner)
+
+_pack_tuple_for_id = _scanner._pack_tuple_for_id
+_resolve_baseline_packs = _scanner._resolve_baseline_packs
+
+
+class TestPackTupleForId:
+    """Resolve catalog pack-id-suffix → (display_name, full_pack_id)."""
+
+    def test_baseline_pack_id_resolves_to_canonical_tuple(self):
+        # ``security-audit`` is in BASELINE_SEMGREP_PACKS; should
+        # return the canonical tuple (display name aligns with the
+        # baseline registration).
+        name, fid = _pack_tuple_for_id("security-audit")
+        assert fid == "p/security-audit"
+        # Display name matches what BASELINE_SEMGREP_PACKS uses.
+        baseline_pair = next(
+            (n, f) for n, f in RaptorConfig.BASELINE_SEMGREP_PACKS
+            if f == "p/security-audit"
+        )
+        assert name == baseline_pair[0]
+
+    def test_policy_group_pack_id_resolves_via_mapping(self):
+        # ``command-injection`` lives in POLICY_GROUP_TO_SEMGREP_PACK
+        # (under the ''injection'' key), not BASELINE. Resolver
+        # checks both places.
+        name, fid = _pack_tuple_for_id("command-injection")
+        assert fid == "p/command-injection"
+        # POLICY_GROUP_TO_SEMGREP_PACK has ('semgrep_injection',
+        # 'p/command-injection') under 'injection' — verify the
+        # name matches.
+        policy_pair = next(
+            (n, f) for n, f
+            in RaptorConfig.POLICY_GROUP_TO_SEMGREP_PACK.values()
+            if f == "p/command-injection"
+        )
+        assert name == policy_pair[0]
+
+    def test_unknown_pack_id_synthesises_name(self):
+        # Catalog author shipped a pack the codebase doesn't have
+        # a name convention for — synthesise a safe display name
+        # rather than crashing.
+        name, fid = _pack_tuple_for_id("future-rule-pack")
+        assert fid == "p/future-rule-pack"
+        # Synthesised name: hyphens → underscores, ``semgrep_``
+        # prefix.
+        assert name == "semgrep_future_rule_pack"
+
+
+class TestResolveBaselinePacks:
+    """Catalog-aware baseline selection. Operator-explicit
+    ``--policy-groups`` happens elsewhere in main; this resolver
+    only governs the baseline (what runs when not narrowed)."""
+
+    def test_no_repo_path_returns_hardcoded_baseline(self):
+        # No path → can't consult catalog → fall back to hardcoded
+        # BASELINE_SEMGREP_PACKS.
+        result = _resolve_baseline_packs(None)
+        assert list(result) == list(RaptorConfig.BASELINE_SEMGREP_PACKS)
+
+    def test_empty_target_falls_back_to_generic_and_hardcoded(self, tmp_path):
+        # Empty target → catalog matches ``generic`` → generic has
+        # no semgrep_packs_default → resolver falls back to
+        # hardcoded baseline. (``generic`` IS shipped with default
+        # packs in the seed YAML, so this test actually exercises
+        # the catalog path — but the catalog's packs are
+        # ``security-audit + owasp-top-ten`` which differs from
+        # the hardcoded baseline's three-pack set. Assert the
+        # returned list at least exists and is non-empty; specific
+        # equality with hardcoded would conflate test intent.)
+        result = _resolve_baseline_packs(tmp_path)
+        # generic.yml ships ``security-audit`` + ``owasp-top-ten``
+        # in default. Verify resolver picked it up (catalog-aware
+        # path fires).
+        assert len(result) >= 1
+        assert any(fid == "p/security-audit" for _, fid in result)
+
+    def test_c_userspace_daemon_target_uses_catalog_default(self, tmp_path):
+        # Build a tree matching c.userspace-daemon detection.
+        (tmp_path / "configure.ac").write_text("")
+        (tmp_path / "Makefile.am").write_text("")
+        (tmp_path / "src").mkdir()
+        (tmp_path / "src" / "main.c").write_text("")
+        result = _resolve_baseline_packs(tmp_path)
+        # c.userspace-daemon.yml ships:
+        #   default: [security-audit, command-injection, owasp-top-ten]
+        # Verify all three are in the result (in the canonical
+        # tuple shape).
+        pack_ids = {fid for _, fid in result}
+        assert "p/security-audit" in pack_ids
+        assert "p/command-injection" in pack_ids
+        assert "p/owasp-top-ten" in pack_ids
+
+    def test_python_web_app_target_uses_catalog_default(self, tmp_path):
+        (tmp_path / "manage.py").write_text("")
+        (tmp_path / "settings.py").write_text("")
+        (tmp_path / "urls.py").write_text("")
+        result = _resolve_baseline_packs(tmp_path)
+        # python.web-app.yml ships a broader set including
+        # ``python-django`` / ``python-flask`` packs — verify
+        # security-audit + owasp-top-ten at minimum are in.
+        pack_ids = {fid for _, fid in result}
+        assert "p/security-audit" in pack_ids
+        assert "p/owasp-top-ten" in pack_ids
+
+
+class TestCatalogLoadFailureTolerated:
+    """Best-effort: catalog substrate failures must not break the
+    scan. Resolver falls back to hardcoded baseline silently."""
+
+    def test_catalog_exception_falls_back_to_hardcoded(self, monkeypatch, tmp_path):
+        import core.run.target_types as tt
+        def _boom(_path):
+            raise RuntimeError("catalog corrupted")
+        monkeypatch.setattr(tt, "load", _boom)
+        result = _resolve_baseline_packs(tmp_path)
+        assert list(result) == list(RaptorConfig.BASELINE_SEMGREP_PACKS)


### PR DESCRIPTION
Three consumer surfaces now consult the target-type catalog (``core/run/target_types/``) for their per-run defaults, replacing the previous one-size-fits-all constants. All three are backward- compatible — catalog absent / broken / unmatched → prior hardcoded behaviour. All three preserve operator-explicit overrides as authoritative.

**agentic orchestrator: explicit status on every result**

``_finalize_results_for_emit`` strips operator-internal ``repo_path`` and stamps the canonical ``status`` enum (``analysed`` / ``analysis_inconsistent`` / ``skipped_*`` / ``error``) on each per- finding record before ``orchestrated_report.json`` lands on disk. Producer-stamped specificity (``skipped_over_budget``, ``skipped_duplicate``, ``skipped_dead_code``) is preserved — the finaliser only fills in absent or unknown values. Downstream readers (summary printers, report renderers, automation) no longer need null-field guessing.

**agentic agent: catalog-driven attack-surface ranking**

When ``--prefer`` isn't supplied, the agent now consults the matched target-type catalog's ``attack_surface.high_priority_dirs`` and ranks those dirs the same way operator globs would have. Operator ``--prefer`` still wins unconditionally; an empty operator list falls through to the catalog; catalog-load exceptions are tolerated silently (return ``(None, None)`` → no prefer-sort).

**scan scanner: catalog-driven baseline pack selection**

The always-run baseline semgrep pack set now derives from the matched catalog entry's ``semgrep_packs.default`` rather than the hardcoded ``RaptorConfig.BASELINE_SEMGREP_PACKS``. C / userspace-daemon trees pick up ``security-audit + command-injection + owasp-top-ten``; Python web-app trees pick up ``security-audit + python-django + python-flask + owasp-top-ten``. ``--policy-groups`` still narrows authoritatively. The scanner logs the resolved set + source target type whenever it differs from the hardcoded baseline so operators see why a particular pack list ran.