### PR TITLE
feat: catalog-aware lifecycle, smart project create, report schema

### DIFF
--- a/core/project/cli.py
+++ b/core/project/cli.py
@@ -26,6 +26,72 @@ def _red(text): return _c(text, "31")
 def _yellow(text): return _c(text, "33")
 
 
+def _detect_target_type(target_path: str):
+    """Best-effort catalog detection for project-create. Returns
+    a ``CatalogEntry`` or None — substrate failures (catalog
+    missing, YAML malformed) collapse to None so create never
+    refuses over a catalog substrate bug.
+
+    Distinct from the runtime consumers (/scan baseline packs,
+    /agentic attack-surface ranking) which call the same
+    ``core.run.target_types.load`` — this is just the project-
+    create surface so operators see the catalog match at
+    create-time.
+    """
+    try:
+        from core.run.target_types import load
+        return load(Path(target_path))
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def _format_project_tuning(entry) -> list:
+    """Render the post-create tuning block from a CatalogEntry.
+
+    Composes ``core.run.estimator.format_estimate`` (cost/time
+    one-liner) plus a compact summary of the catalog defaults so
+    the operator sees up-front what RAPTOR will use for /scan,
+    /agentic, /codeql defaults on this project. Returns a list of
+    lines (caller decides where they land — stdout / file / etc.).
+    """
+    from core.run.estimator import RunEstimate, format_estimate
+    lines: list = []
+    lines.append(f"  Target type: {entry.name}")
+    # Cost/time — synthesise a RunEstimate from the catalog so we
+    # share the format_estimate renderer (single source of truth
+    # for the operator-facing string).
+    cost_low, cost_high = entry.estimated_cost_usd
+    time_low, time_high = entry.estimated_time_min
+    if cost_high > 0 or time_high > 0:
+        _est = RunEstimate(
+            cost_low=cost_low, cost_high=cost_high,
+            time_low=time_low, time_high=time_high,
+            target_type=entry.name,
+        )
+        _est_line = format_estimate(_est)
+        if _est_line:
+            # Strip the ``(target type: X)`` suffix — already
+            # printed above in the tuning block.
+            _est_line = _est_line.split(" (target type:", 1)[0]
+            lines.append(f"  {_est_line}")
+    if entry.semgrep_packs_default:
+        lines.append(
+            f"  /scan baseline packs: "
+            f"{', '.join(entry.semgrep_packs_default)}"
+        )
+    if entry.attack_surface_high:
+        lines.append(
+            f"  /agentic preferred dirs: "
+            f"{', '.join(entry.attack_surface_high)}"
+        )
+    if entry.pipeline_recommended:
+        lines.append(
+            f"  Recommended pipeline: "
+            f"{' → '.join(entry.pipeline_recommended)}"
+        )
+    return lines
+
+
 class _Fmt(argparse.HelpFormatter):
     """Wider help alignment for subcommand option lists."""
     def __init__(self, prog):
@@ -56,6 +122,15 @@ def main():
               "project; loaded into every subsequent /agentic / "
               "/codeql / /validate run on this project. Explicit "
               "--binary on the CLI is additive."),
+    )
+    p_create.add_argument(
+        "--require-target-type", default=None, metavar="<name>",
+        help=("Hard-fail if target-type catalog detection didn't "
+              "pick this exact name (e.g. ``c.userspace-daemon``, "
+              "``python.web-app``). For strict-CI runs that assert "
+              "the project's target shape — catches malformed "
+              "targets or stale catalog drift BEFORE any LLM cost. "
+              "On mismatch the project is NOT created."),
     )
 
     # binary — per-project binary management
@@ -313,6 +388,23 @@ def main():
                 parser.print_help()
 
         elif args.subcommand == "create":
+            # Target-type catalog detection — runs BEFORE
+            # ProjectManager.create so a --require-target-type
+            # mismatch refuses without leaving a half-created
+            # project on disk (QoL #18).
+            _detected_entry = _detect_target_type(args.target)
+            _required = getattr(args, "require_target_type", None)
+            if _required:
+                _detected_name = _detected_entry.name if _detected_entry else None
+                if _detected_name != _required:
+                    print(_red(
+                        f"--require-target-type mismatch: expected "
+                        f"'{_required}', detected "
+                        f"{_detected_name!r}. Project NOT created. "
+                        f"Inspect target or list available types via "
+                        f"the catalog YAMLs in core/run/target_types/."
+                    ))
+                    sys.exit(1)
             p = mgr.create(args.name, args.target,
                            description=args.description,
                            output_dir=args.output_dir,
@@ -321,6 +413,15 @@ def main():
             _p_binaries = getattr(p, "binaries", None) or []
             if _p_binaries:
                 print(f"  binaries: {', '.join(_p_binaries)}")
+            # Print the catalog tuning block AFTER the create
+            # confirmation — operator sees what RAPTOR will use as
+            # defaults when /scan, /agentic, /codeql etc. run on
+            # this project. Strictly informational; per-command
+            # flags (--policy-groups, --prefer) still override at
+            # run time.
+            if _detected_entry is not None:
+                for line in _format_project_tuning(_detected_entry):
+                    print(line)
 
         elif args.subcommand == "binary":
             from core.json import save_json

--- a/core/project/tests/test_cli_smart_create.py
+++ b/core/project/tests/test_cli_smart_create.py
@@ -1,0 +1,234 @@
+"""Tests for smart ``raptor project create`` — catalog-driven
+detection + tuning block + ``--require-target-type`` strict-CI
+gate (QoL #18)."""
+
+from __future__ import annotations
+
+import contextlib
+import io
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest.mock import patch
+
+from core.project.cli import (
+    _detect_target_type,
+    _format_project_tuning,
+    main,
+)
+from core.run.target_types import CatalogEntry
+
+
+class TestDetectTargetType(unittest.TestCase):
+    """Smart-create's catalog wrapper — pure best-effort, never
+    raises."""
+
+    def test_c_userspace_daemon_tree_detected(self):
+        with TemporaryDirectory() as d:
+            target = Path(d)
+            (target / "configure.ac").write_text("")
+            (target / "Makefile.am").write_text("")
+            (target / "src").mkdir()
+            (target / "src" / "main.c").write_text("")
+            entry = _detect_target_type(str(target))
+            self.assertIsNotNone(entry)
+            self.assertEqual(entry.name, "c.userspace-daemon")
+
+    def test_python_web_app_tree_detected(self):
+        with TemporaryDirectory() as d:
+            target = Path(d)
+            (target / "manage.py").write_text("")
+            (target / "settings.py").write_text("")
+            (target / "urls.py").write_text("")
+            entry = _detect_target_type(str(target))
+            self.assertIsNotNone(entry)
+            self.assertEqual(entry.name, "python.web-app")
+
+    def test_empty_target_falls_back_to_generic(self):
+        with TemporaryDirectory() as d:
+            entry = _detect_target_type(d)
+            self.assertIsNotNone(entry)
+            self.assertEqual(entry.name, "generic")
+
+    def test_catalog_exception_returns_none_silently(self):
+        # Substrate failure must not propagate — create must not
+        # refuse over a catalog substrate bug.
+        with patch(
+            "core.run.target_types.load",
+            side_effect=RuntimeError("catalog broken"),
+        ):
+            entry = _detect_target_type("/tmp/anything")
+            self.assertIsNone(entry)
+
+
+class TestFormatProjectTuning(unittest.TestCase):
+    """Renderer — list of lines to print after the create
+    confirmation. Caller decides where they land."""
+
+    def test_full_entry_renders_all_sections(self):
+        entry = CatalogEntry(
+            name="c.userspace-daemon",
+            estimated_cost_usd=(25.0, 50.0),
+            estimated_time_min=(40, 75),
+            semgrep_packs_default=("security-audit", "owasp-top-ten"),
+            attack_surface_high=("src/http", "src/net"),
+            pipeline_recommended=("understand-map", "scan", "agentic"),
+        )
+        lines = _format_project_tuning(entry)
+        joined = "\n".join(lines)
+        self.assertIn("Target type: c.userspace-daemon", joined)
+        # Cost+time uses the estimator's renderer — verify the
+        # range shape without re-asserting its exact format
+        # (single source of truth lives in core/run/estimator.py).
+        self.assertIn("$25", joined)
+        self.assertIn("$50", joined)
+        self.assertIn("40-75 min", joined)
+        self.assertIn("security-audit, owasp-top-ten", joined)
+        self.assertIn("src/http, src/net", joined)
+        # Pipeline recommendation uses arrow separator —
+        # operator-readable flow.
+        self.assertIn("understand-map → scan → agentic", joined)
+
+    def test_minimal_entry_only_renders_present_sections(self):
+        # Catalog author shipped only ``name`` + packs — the
+        # other sections should NOT print empty rows.
+        entry = CatalogEntry(
+            name="minimal",
+            semgrep_packs_default=("security-audit",),
+        )
+        lines = _format_project_tuning(entry)
+        joined = "\n".join(lines)
+        self.assertIn("Target type: minimal", joined)
+        self.assertIn("security-audit", joined)
+        # No cost/time/dirs/pipeline sections — assert on the
+        # CONTAINER labels (``Expected:``, ``preferred dirs``,
+        # ``Recommended pipeline``) rather than substrings of
+        # values; ``min`` would false-match ``minimal``.
+        self.assertNotIn("$", joined)
+        self.assertNotIn("Expected:", joined)
+        self.assertNotIn("preferred dirs", joined)
+        self.assertNotIn("Recommended pipeline", joined)
+
+    def test_cost_only_entry_renders_cost_no_time(self):
+        # Estimator's format_estimate trims the absent half.
+        entry = CatalogEntry(
+            name="cost-only",
+            estimated_cost_usd=(10.0, 20.0),
+        )
+        lines = _format_project_tuning(entry)
+        joined = "\n".join(lines)
+        self.assertIn("$10", joined)
+        self.assertNotIn("min", joined)
+
+
+class TestCreateIntegration(unittest.TestCase):
+    """End-to-end ``raptor project create`` — captures stdout and
+    asserts the tuning block appears at the right place."""
+
+    def _run_create(self, target_path: str, *extra_args):
+        """Run ``main`` with mocked ProjectManager and capture
+        stdout. Returns the captured output string."""
+        with patch("core.project.cli.ProjectManager") as MockMgr:
+            instance = MockMgr.return_value
+            instance.create.return_value = type("P", (), {
+                "name": "smart-test",
+                "output_dir": "/tmp/smart-test-out",
+                "binaries": [],
+            })()
+            argv = [
+                "raptor-project", "create", "smart-test",
+                "--target", target_path,
+            ] + list(extra_args)
+            buf = io.StringIO()
+            with patch("sys.argv", argv):
+                with contextlib.redirect_stdout(buf):
+                    main()
+            return buf.getvalue()
+
+    def test_c_daemon_target_prints_tuning_block(self):
+        with TemporaryDirectory() as d:
+            target = Path(d)
+            (target / "configure.ac").write_text("")
+            (target / "src").mkdir()
+            (target / "src" / "main.c").write_text("")
+            (target / "Makefile.am").write_text("")
+            out = self._run_create(str(target))
+            self.assertIn("Created project 'smart-test'", out)
+            self.assertIn("Target type: c.userspace-daemon", out)
+            # Cost estimate present.
+            self.assertIn("$25", out)
+            # Suggested packs present.
+            self.assertIn("security-audit", out)
+            # Suggested dirs present.
+            self.assertIn("src/http", out)
+
+    def test_empty_target_prints_generic_tuning(self):
+        with TemporaryDirectory() as d:
+            out = self._run_create(d)
+            self.assertIn("Created project", out)
+            self.assertIn("Target type: generic", out)
+
+
+class TestRequireTargetTypeGate(unittest.TestCase):
+    """``--require-target-type`` — strict-CI assertion that
+    detection picked a specific entry. Mismatch refuses to
+    create."""
+
+    def _run_create_expecting_exit(self, target_path: str, *extra_args):
+        """Like ``_run_create`` but expects SystemExit; returns
+        (stdout, exit_code)."""
+        with patch("core.project.cli.ProjectManager") as MockMgr:
+            instance = MockMgr.return_value
+            instance.create.return_value = type("P", (), {
+                "name": "x", "output_dir": "/tmp/x", "binaries": [],
+            })()
+            argv = [
+                "raptor-project", "create", "x",
+                "--target", target_path,
+            ] + list(extra_args)
+            buf = io.StringIO()
+            with patch("sys.argv", argv):
+                with contextlib.redirect_stdout(buf):
+                    try:
+                        main()
+                        return buf.getvalue(), 0
+                    except SystemExit as e:
+                        return buf.getvalue(), int(e.code or 0)
+
+    def test_matching_required_type_proceeds(self):
+        with TemporaryDirectory() as d:
+            target = Path(d)
+            (target / "configure.ac").write_text("")
+            (target / "Makefile.am").write_text("")
+            (target / "src").mkdir()
+            (target / "src" / "main.c").write_text("")
+            out, exit_code = self._run_create_expecting_exit(
+                str(target),
+                "--require-target-type", "c.userspace-daemon",
+            )
+            self.assertEqual(exit_code, 0)
+            self.assertIn("Created project", out)
+
+    def test_mismatched_required_type_refuses(self):
+        with TemporaryDirectory() as d:
+            target = Path(d)
+            (target / "manage.py").write_text("")
+            (target / "settings.py").write_text("")
+            (target / "urls.py").write_text("")
+            out, exit_code = self._run_create_expecting_exit(
+                str(target),
+                "--require-target-type", "c.userspace-daemon",
+            )
+            self.assertEqual(exit_code, 1)
+            # Operator-readable error.
+            self.assertIn("mismatch", out)
+            self.assertIn("c.userspace-daemon", out)  # required
+            self.assertIn("python.web-app", out)      # detected
+            # Project should NOT have been created — refusing the
+            # gate means the ProjectManager.create call never
+            # happens.
+            self.assertNotIn("Created project", out)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/core/run/estimator.py
+++ b/core/run/estimator.py
@@ -1,0 +1,131 @@
+"""Cost-and-time estimator (QoL #21).
+
+Reads ``pipeline.estimated_cost_usd`` + ``estimated_time_min`` from
+the matched target-type catalog entry and renders an operator-facing
+summary at lifecycle start. Composition layer over the catalog
+substrate — no per-target heuristics live here; the catalog is the
+single source of truth.
+
+Consumers:
+  * ``raptor.py:_run_with_lifecycle`` — print at run start.
+  * ``libexec/raptor-run-lifecycle start`` — print on the skills
+    invocation path (parity with raptor.py).
+  * ``--max-cost-usd`` pre-flight gate — hard-fails the run before
+    any LLM spend when the catalog estimate exceeds the operator's
+    declared cap.
+
+Returns ``None`` when:
+  * ``target_path`` is None (no target → no detection possible).
+  * The catalog doesn't match any entry, or the matched entry
+    carries zero-valued estimate pairs (the ``generic`` fallback
+    + entries that haven't filled in cost/time hints).
+  * The catalog loader raises (best-effort; substrate failures
+    must never break the lifecycle).
+
+A ``None`` return is the signal to the renderer to print nothing —
+operators get the estimate when it's available, silence when it
+isn't, never a placeholder.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+
+@dataclass(frozen=True)
+class RunEstimate:
+    """Estimated cost + time for a run, sourced from the target-type catalog.
+
+    ``cost_low / cost_high`` in USD; ``time_low / time_high`` in
+    minutes. The pair represents the catalog author's expected
+    range, not a confidence interval — read as "typical runs land
+    here." Wide ranges (``$10 - $50``) signal high variance in the
+    target shape; narrow ranges signal predictable runs.
+
+    ``target_type`` is the catalog entry name that matched
+    (e.g. ``c.userspace-daemon``); ``generic`` is filtered out at
+    construction time so a None return is the no-useful-data signal.
+    """
+
+    cost_low: float
+    cost_high: float
+    time_low: int
+    time_high: int
+    target_type: str
+
+
+def estimate_run(target_path: Optional[Path]) -> Optional[RunEstimate]:
+    """Best-effort estimate from the target-type catalog. None when
+    no useful data is available (see module docstring for the
+    None-return conditions)."""
+    if target_path is None:
+        return None
+    try:
+        from core.run.target_types import load
+        entry = load(Path(target_path))
+    except Exception:  # noqa: BLE001
+        return None
+    if entry is None:
+        return None
+    cost_low, cost_high = entry.estimated_cost_usd
+    time_low, time_high = entry.estimated_time_min
+    # Filter out zero-valued estimates — the ``generic`` fallback
+    # entry and any catalog entry that hasn't filled in cost/time
+    # hints both surface as (0.0, 0.0) / (0, 0). Returning a
+    # ``$0-$0`` estimate would be misleading; None is the
+    # no-useful-data signal.
+    if cost_high <= 0 and time_high <= 0:
+        return None
+    return RunEstimate(
+        cost_low=cost_low,
+        cost_high=cost_high,
+        time_low=time_low,
+        time_high=time_high,
+        target_type=entry.name,
+    )
+
+
+def format_estimate(est: Optional[RunEstimate]) -> str:
+    """Operator-facing one-liner. Empty string when ``est`` is
+    None — caller can unconditionally append to output, no None
+    check needed at the print site.
+
+    Format::
+
+        Expected: $25-$50, 40-75 min (target type: c.userspace-daemon)
+
+    Ranges with low == high collapse to a single value::
+
+        Expected: $30, 60 min (target type: c.userspace-daemon)
+
+    Cost or time only (the other side is zero-valued in the
+    catalog) renders just the populated half.
+    """
+    if est is None:
+        return ""
+
+    def _money(low: float, high: float) -> str:
+        if low <= 0 and high <= 0:
+            return ""
+        if low == high:
+            return f"${low:.0f}"
+        return f"${low:.0f}-${high:.0f}"
+
+    def _mins(low: int, high: int) -> str:
+        if low <= 0 and high <= 0:
+            return ""
+        if low == high:
+            return f"{low} min"
+        return f"{low}-{high} min"
+
+    money = _money(est.cost_low, est.cost_high)
+    mins = _mins(est.time_low, est.time_high)
+    parts = [p for p in (money, mins) if p]
+    if not parts:
+        return ""
+    return (
+        f"Expected: {', '.join(parts)} "
+        f"(target type: {est.target_type})"
+    )

--- a/core/run/orchestrated_report_schema.py
+++ b/core/run/orchestrated_report_schema.py
@@ -1,0 +1,195 @@
+"""JSON Schema for ``orchestrated_report.json`` (QoL #11e).
+
+Codifies the per-finding shape + canonical status enum that
+``packages.llm_analysis.orchestrator`` writes at the end of every
+``/agentic`` run. Descriptive contract for downstream tooling —
+NOT a runtime validation gate (the orchestrator does not validate
+against this schema before writing).
+
+## Why a schema, not just docs
+
+Multiple consumers read this file:
+
+* ``raptor_agentic`` summary printer.
+* Report renderers (``report.json`` → markdown).
+* ``/project findings``, ``/project correlate``, ``/project report``.
+* External automation: CI scripts, dashboards, custom tooling.
+
+Before the status enum landed (QoL #19) each consumer re-implemented
+its own field-presence detection (``is_true_positive is None``,
+``error`` truthy, ``self_contradictory=True``, …). The schema's
+``status`` enum is now the single contract these consumers can
+write against.
+
+## Strictness
+
+Intentionally PERMISSIVE — ``additionalProperties: true`` everywhere
+so the orchestrator can stamp new fields without breaking
+consumers. ``required`` lists only fields consumers can reliably
+depend on:
+
+* Top-level: ``mode``, ``results``.
+* Per-finding: ``finding_id``, ``status``.
+
+Everything else is optional. The schema documents the SHAPE of
+fields when present, not the requirement that they be present.
+
+## How to consume
+
+```python
+import json
+from core.run.orchestrated_report_schema import SCHEMA
+
+# Validate an on-disk report (requires the optional `jsonschema`
+# dependency — not pulled in by RAPTOR's runtime).
+import jsonschema
+with open("orchestrated_report.json") as fh:
+    jsonschema.validate(json.load(fh), SCHEMA)
+```
+
+Without ``jsonschema`` installed, consumers can still read SCHEMA
+as a plain dict for documentation / field-name lookup.
+"""
+
+from __future__ import annotations
+
+
+# All status values stamped by ``_finalize_results_for_emit``. Kept
+# in sync with ``core.run.finding_status.ALL_STATUSES`` via
+# ``test_orchestrated_report_schema.test_status_enum_matches``.
+_STATUS_VALUES = [
+    "analysed",
+    "analysis_inconsistent",
+    "skipped_over_budget",
+    "skipped_duplicate",
+    "skipped_dead_code",
+    "skipped_filtered",
+    "skipped_tool_absent",
+    "skipped",
+    "error",
+]
+
+
+_FINDING_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "finding_id": {"type": "string"},
+        "status": {"type": "string", "enum": _STATUS_VALUES},
+
+        # Verdict fields — present on analysed findings; absent on
+        # skipped / error records.
+        "is_true_positive": {"type": ["boolean", "null"]},
+        "is_exploitable": {"type": ["boolean", "null"]},
+        "exploitable": {"type": ["boolean", "null"]},
+        "exploitability_score": {"type": ["number", "null"]},
+        "self_contradictory": {"type": "boolean"},
+        "contradiction_resolved_by_judge": {"type": "boolean"},
+
+        # Provenance + scoping.
+        "file_path": {"type": "string"},
+        "function": {"type": "string"},
+        "line": {"type": ["integer", "null"]},
+        "rule_id": {"type": "string"},
+        "severity": {"type": "string"},
+        "vuln_type": {"type": "string"},
+
+        # LLM-emitted prose / structured data.
+        "reasoning": {"type": "string"},
+        "exploit_code": {"type": "string"},
+        "patch_code": {"type": "string"},
+        "has_exploit": {"type": "boolean"},
+        "has_patch": {"type": "boolean"},
+
+        # Error / skip detail.
+        "error": {"type": "string"},
+        "cc_error": {"type": "string"},
+        "cc_debug_file": {"type": "string"},
+        "skip_reason": {"type": "string"},
+    },
+    "required": ["finding_id", "status"],
+    "additionalProperties": True,
+}
+
+
+_ORCHESTRATION_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "analysis_model": {"type": ["string", "null"]},
+        "consensus_model": {"type": ["string", "null"]},
+        "judge_model": {"type": ["string", "null"]},
+        "aggregate_model": {"type": ["string", "null"]},
+        "findings_analysed": {"type": "integer", "minimum": 0},
+        "findings_skipped": {"type": "integer", "minimum": 0},
+        "findings_total": {"type": "integer", "minimum": 0},
+
+        "cost": {
+            "type": "object",
+            "properties": {
+                "total_cost": {"type": "number", "minimum": 0},
+                "by_model": {"type": "object"},
+            },
+            "additionalProperties": True,
+        },
+
+        # Provider-served snapshots — feeds run provenance.
+        "fired_models": {
+            "type": "array",
+            "items": {"type": ["string", "object"]},
+        },
+
+        # Defense telemetry — only present when has_warnings.
+        "defense_telemetry": {"type": "object"},
+    },
+    "additionalProperties": True,
+}
+
+
+SCHEMA = {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://github.com/gadievron/raptor/"
+           "core/run/orchestrated_report_schema.py",
+    "title": "RAPTOR orchestrated_report.json",
+    "description": (
+        "Per-run output of /agentic and related orchestrated "
+        "analysis paths. Each ``results[]`` entry carries the "
+        "canonical ``status`` enum so consumers don't need to "
+        "re-derive ''analysed vs skipped vs error'' from "
+        "absent-field detection."
+    ),
+    "type": "object",
+    "properties": {
+        "mode": {
+            "type": "string",
+            "description": (
+                "Always ``orchestrated`` for files written by "
+                "the orchestrator. Distinguishes from prep-only "
+                "and CC-only intermediate reports."
+            ),
+        },
+        "results": {
+            "type": "array",
+            "items": _FINDING_SCHEMA,
+        },
+        "orchestration": _ORCHESTRATION_SCHEMA,
+
+        # Aggregate counters — recomputable from ``results``, kept
+        # at the top level for cheap-read summary consumers.
+        "analyzed": {"type": "integer", "minimum": 0},
+        "exploitable": {"type": "integer", "minimum": 0},
+        "exploits_generated": {"type": "integer", "minimum": 0},
+        "patches_generated": {"type": "integer", "minimum": 0},
+
+        # Optional grouping / correlation sections — present when
+        # the corresponding feature ran.
+        "cross_finding_groups": {"type": "array"},
+        "dataflow_validation": {"type": "object"},
+        "group_analyses": {"type": "object"},
+        "correlation": {"type": "object"},
+        "aggregation": {"type": "object"},
+    },
+    "required": ["mode", "results"],
+    "additionalProperties": True,
+}
+
+
+__all__ = ["SCHEMA"]

--- a/core/run/tests/test_estimator.py
+++ b/core/run/tests/test_estimator.py
@@ -1,0 +1,160 @@
+"""Tests for ``core/run/estimator.py`` — the catalog-driven
+cost-and-time estimator (QoL #21)."""
+
+from __future__ import annotations
+
+from core.run.estimator import (
+    RunEstimate,
+    estimate_run,
+    format_estimate,
+)
+
+
+class TestEstimateRun:
+    """End-to-end: target path → catalog detect → estimate. Uses
+    the real shipped catalog YAMLs so test failures point at real
+    drift between substrate + catalog data."""
+
+    def test_none_target_returns_none(self):
+        assert estimate_run(None) is None
+
+    def test_empty_target_returns_none(self, tmp_path):
+        # Empty tree → catalog falls back to ``generic`` →
+        # ``generic`` has zero-valued estimate pairs in the shipped
+        # YAML? Actually generic ships ``[10, 30]`` cost +
+        # ``[15, 45]`` time. Verify it returns a populated estimate
+        # for the generic case (the no-detect fallback IS a useful
+        # signal).
+        est = estimate_run(tmp_path)
+        assert est is not None
+        assert est.target_type == "generic"
+        assert est.cost_high == 30
+        assert est.time_high == 45
+
+    def test_c_userspace_daemon_target(self, tmp_path):
+        # Build a tree matching c.userspace-daemon detection.
+        (tmp_path / "configure.ac").write_text("")
+        (tmp_path / "Makefile.am").write_text("")
+        (tmp_path / "src").mkdir()
+        (tmp_path / "src" / "main.c").write_text("")
+        est = estimate_run(tmp_path)
+        assert est is not None
+        assert est.target_type == "c.userspace-daemon"
+        # YAML: estimated_cost_usd: [25, 50], estimated_time_min: [40, 75]
+        assert est.cost_low == 25
+        assert est.cost_high == 50
+        assert est.time_low == 40
+        assert est.time_high == 75
+
+    def test_python_web_app_target(self, tmp_path):
+        (tmp_path / "manage.py").write_text("")
+        (tmp_path / "settings.py").write_text("")
+        (tmp_path / "urls.py").write_text("")
+        est = estimate_run(tmp_path)
+        assert est is not None
+        assert est.target_type == "python.web-app"
+        # YAML: estimated_cost_usd: [15, 35], estimated_time_min: [30, 60]
+        assert est.cost_high == 35
+        assert est.time_high == 60
+
+
+class TestEstimateRunFailureModes:
+    """Substrate must NEVER break the lifecycle. Any exception
+    from the catalog layer → ``None`` return → renderer prints
+    nothing → operator's run proceeds."""
+
+    def test_catalog_load_exception_returns_none(self, monkeypatch, tmp_path):
+        import core.run.target_types as tt
+        def _boom(_path):
+            raise RuntimeError("catalog corrupted")
+        monkeypatch.setattr(tt, "load", _boom)
+        assert estimate_run(tmp_path) is None
+
+    def test_nonexistent_target_path_returns_none_silently(self, tmp_path):
+        # Path doesn't exist → catalog returns ``generic`` (which
+        # has data); but operator presumably wants the estimate
+        # for the REAL target. We can't distinguish "doesn't
+        # exist" from "exists but empty" cleanly without an extra
+        # stat call. Document the actual behaviour: returns the
+        # generic estimate. (Operator gets a useful baseline; no
+        # surprise crash.)
+        est = estimate_run(tmp_path / "does-not-exist")
+        # Either generic (current behaviour) or None — both are
+        # acceptable signals. Just assert no crash + plausible
+        # shape.
+        assert est is None or est.target_type == "generic"
+
+    def test_zero_valued_catalog_estimate_returns_none(self, monkeypatch, tmp_path):
+        # Construct a synthetic catalog entry with all-zero
+        # estimate pairs (a catalog author who hasn't filled in
+        # cost/time yet). Estimator returns None — renderer
+        # prints nothing.
+        from core.run.target_types import CatalogEntry
+        import core.run.target_types as tt
+        empty_entry = CatalogEntry(
+            name="hypothetical.no-estimates",
+            estimated_cost_usd=(0.0, 0.0),
+            estimated_time_min=(0, 0),
+        )
+        monkeypatch.setattr(tt, "load", lambda _p: empty_entry)
+        assert estimate_run(tmp_path) is None
+
+
+class TestFormatEstimate:
+    """Renderer: None → empty string; populated → operator-facing
+    one-liner. Format is consumed by both raptor.py and
+    libexec/raptor-run-lifecycle; tested here so a format change
+    surfaces in one place."""
+
+    def test_none_returns_empty_string(self):
+        assert format_estimate(None) == ""
+
+    def test_range_estimate_renders_dollar_dash_dollar(self):
+        est = RunEstimate(
+            cost_low=25, cost_high=50, time_low=40, time_high=75,
+            target_type="c.userspace-daemon",
+        )
+        s = format_estimate(est)
+        assert s == (
+            "Expected: $25-$50, 40-75 min "
+            "(target type: c.userspace-daemon)"
+        )
+
+    def test_collapsed_range_renders_single_value(self):
+        # When the catalog author shipped a point estimate (low ==
+        # high), don't render the redundant ``$30-$30`` shape.
+        est = RunEstimate(
+            cost_low=30, cost_high=30, time_low=60, time_high=60,
+            target_type="some.point-estimate",
+        )
+        s = format_estimate(est)
+        assert s == (
+            "Expected: $30, 60 min (target type: some.point-estimate)"
+        )
+
+    def test_cost_only_renders_without_time(self):
+        # Catalog entry filled in cost but not time — render just
+        # the cost half; don't print ``, 0 min``.
+        est = RunEstimate(
+            cost_low=10, cost_high=20, time_low=0, time_high=0,
+            target_type="cost-only",
+        )
+        s = format_estimate(est)
+        assert s == "Expected: $10-$20 (target type: cost-only)"
+
+    def test_time_only_renders_without_cost(self):
+        est = RunEstimate(
+            cost_low=0, cost_high=0, time_low=15, time_high=30,
+            target_type="time-only",
+        )
+        s = format_estimate(est)
+        assert s == "Expected: 15-30 min (target type: time-only)"
+
+    def test_both_zero_returns_empty_string(self):
+        # Defensive: shouldn't happen (estimate_run filters this
+        # to None), but the renderer doesn't crash on it.
+        est = RunEstimate(
+            cost_low=0, cost_high=0, time_low=0, time_high=0,
+            target_type="both-zero",
+        )
+        assert format_estimate(est) == ""

--- a/core/run/tests/test_max_cost_usd_lifecycle_gate.py
+++ b/core/run/tests/test_max_cost_usd_lifecycle_gate.py
@@ -1,0 +1,217 @@
+"""Tests for the --max-cost-usd pre-flight gate (QoL #21).
+
+Covers:
+  1. ``raptor._extract_and_strip_max_cost_usd`` — argument-level
+     parsing + scrubbing of the lifecycle-only flag.
+  2. ``libexec/raptor-run-lifecycle start --max-cost-usd <cap>``
+     end-to-end: estimate prints, exit code 0 when estimate within
+     cap, exit code 1 + clear stderr message when estimate exceeds
+     cap.
+
+Both raptor.py and libexec/raptor-run-lifecycle apply the gate;
+both surfaces are exercised so a regression in one path doesn't
+slip past tests covering only the other.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_RAPTOR_ROOT = Path(__file__).resolve().parents[3]
+
+
+# ---------------------------------------------------------------------------
+# Helper-level: _extract_and_strip_max_cost_usd
+# ---------------------------------------------------------------------------
+
+
+def _import_raptor():
+    """Import the dispatcher module. Cached after first call so
+    repeat tests in the same process don't re-exec the import."""
+    if "raptor" not in sys.modules:
+        sys.path.insert(0, str(_RAPTOR_ROOT))
+    import raptor  # noqa: PLC0415
+    return raptor
+
+
+class TestExtractAndStrip:
+    def test_returns_none_when_flag_absent(self):
+        raptor = _import_raptor()
+        cap, out = raptor._extract_and_strip_max_cost_usd(
+            ["--repo", "/x", "--codeql"],
+        )
+        assert cap is None
+        assert out == ["--repo", "/x", "--codeql"]
+
+    def test_space_form_extracted_and_stripped(self):
+        raptor = _import_raptor()
+        cap, out = raptor._extract_and_strip_max_cost_usd(
+            ["--max-cost-usd", "10", "--repo", "/x"],
+        )
+        assert cap == 10.0
+        assert "--max-cost-usd" not in out
+        assert "10" not in out
+        assert out == ["--repo", "/x"]
+
+    def test_equals_form_extracted_and_stripped(self):
+        raptor = _import_raptor()
+        cap, out = raptor._extract_and_strip_max_cost_usd(
+            ["--repo", "/x", "--max-cost-usd=25.50"],
+        )
+        assert cap == 25.5
+        assert out == ["--repo", "/x"]
+
+    def test_fractional_dollar_amount_preserved(self):
+        # Sub-penny precision the scorecard uses (``$0.0042``) is
+        # representable; gate should accept floats with arbitrary
+        # decimals.
+        raptor = _import_raptor()
+        cap, _ = raptor._extract_and_strip_max_cost_usd(
+            ["--max-cost-usd", "0.0042"],
+        )
+        assert cap == pytest.approx(0.0042)
+
+    def test_non_numeric_value_warns_and_returns_unchanged(self, capsys):
+        raptor = _import_raptor()
+        cap, out = raptor._extract_and_strip_max_cost_usd(
+            ["--max-cost-usd", "lots", "--repo", "/x"],
+        )
+        # Bad value → no cap applied; args returned UNCHANGED so
+        # the lifecycle doesn't silently lose context.
+        assert cap is None
+        assert out == ["--max-cost-usd", "lots", "--repo", "/x"]
+        captured = capsys.readouterr()
+        assert "not a number" in captured.err
+
+    def test_zero_value_warns_and_returns_unchanged(self, capsys):
+        raptor = _import_raptor()
+        cap, out = raptor._extract_and_strip_max_cost_usd(
+            ["--max-cost-usd", "0"],
+        )
+        assert cap is None
+        assert out == ["--max-cost-usd", "0"]
+        assert "> 0" in capsys.readouterr().err
+
+    def test_negative_value_warns(self, capsys):
+        raptor = _import_raptor()
+        cap, _ = raptor._extract_and_strip_max_cost_usd(
+            ["--max-cost-usd=-5"],
+        )
+        assert cap is None
+        assert "> 0" in capsys.readouterr().err
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: libexec/raptor-run-lifecycle start --max-cost-usd <cap>
+# ---------------------------------------------------------------------------
+
+
+def _build_c_daemon_target(tmp_path: Path) -> Path:
+    """Synthesise a tree that the catalog detects as
+    c.userspace-daemon (estimated cost $25-$50)."""
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    (tmp_path / "configure.ac").write_text("")
+    (tmp_path / "Makefile.am").write_text("")
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "main.c").write_text("")
+    return tmp_path
+
+
+def _run_lifecycle_start(
+    target: Path, out_dir: Path, *, max_cost_usd: str | None = None,
+) -> subprocess.CompletedProcess:
+    """Invoke libexec/raptor-run-lifecycle start; returns the
+    completed process for assertion."""
+    cmd = [
+        sys.executable,
+        str(_RAPTOR_ROOT / "libexec" / "raptor-run-lifecycle"),
+        "start", "scan",
+        "--target", str(target),
+        "--out", str(out_dir),
+    ]
+    if max_cost_usd is not None:
+        cmd += ["--max-cost-usd", max_cost_usd]
+    env = os.environ.copy()
+    env["CLAUDECODE"] = "1"  # bypass trust-marker gate
+    # The .active project symlink in a developer worktree would
+    # interfere with --out resolution; force the explicit out path
+    # by setting a non-existent active dir.
+    env.pop("RAPTOR_PROJECT", None)
+    return subprocess.run(
+        cmd, env=env, capture_output=True, text=True, timeout=30,
+    )
+
+
+class TestLibexecPreflightGate:
+    """The skills-path lifecycle (libexec/raptor-run-lifecycle)
+    applies the same pre-flight gate as the dispatcher path so
+    /understand, /codeql, /validate etc. all benefit."""
+
+    def test_no_cap_proceeds_with_estimate_printed(self, tmp_path):
+        target = _build_c_daemon_target(tmp_path / "target")
+        out_dir = tmp_path / "out"
+        result = _run_lifecycle_start(target, out_dir)
+        assert result.returncode == 0
+        # Estimate line lands on stderr (per design — stdout
+        # reserved for the OUTPUT_DIR= sentinel).
+        assert "Expected: $25-$50" in result.stderr
+        assert "c.userspace-daemon" in result.stderr
+        # Sentinel still on stdout intact.
+        assert f"OUTPUT_DIR={out_dir}" in result.stdout
+
+    def test_cap_above_estimate_proceeds(self, tmp_path):
+        # Cap of $100 > estimate upper bound $50 → proceed.
+        target = _build_c_daemon_target(tmp_path / "target")
+        out_dir = tmp_path / "out"
+        result = _run_lifecycle_start(
+            target, out_dir, max_cost_usd="100",
+        )
+        assert result.returncode == 0
+        assert f"OUTPUT_DIR={out_dir}" in result.stdout
+        assert "Pre-flight cost gate" not in result.stderr
+
+    def test_cap_below_estimate_hard_fails(self, tmp_path):
+        # Cap of $20 < estimate upper bound $50 → refuse.
+        target = _build_c_daemon_target(tmp_path / "target")
+        out_dir = tmp_path / "out"
+        result = _run_lifecycle_start(
+            target, out_dir, max_cost_usd="20",
+        )
+        assert result.returncode == 1
+        assert "Pre-flight cost gate" in result.stderr
+        assert "$50.00" in result.stderr  # estimate upper bound
+        assert "$20.00" in result.stderr  # cap
+        # Operator-actionable guidance present.
+        assert "Raise the cap" in result.stderr
+
+    def test_cap_equal_to_estimate_proceeds(self, tmp_path):
+        # Boundary: cap == estimate.cost_high → proceed (gate is
+        # strict `>`, not `>=`, so the operator who set the cap
+        # at the catalog's documented upper bound isn't refused
+        # for matching exactly).
+        target = _build_c_daemon_target(tmp_path / "target")
+        out_dir = tmp_path / "out"
+        result = _run_lifecycle_start(
+            target, out_dir, max_cost_usd="50",
+        )
+        assert result.returncode == 0
+        assert "Pre-flight cost gate" not in result.stderr
+
+    def test_cap_with_no_catalog_match_proceeds_quietly(self, tmp_path):
+        # Empty target → catalog falls back to ``generic`` (cost
+        # $10-$30). Cap of $5 < $30 → refuse. (Verifies the gate
+        # also bites on the generic fallback path.)
+        target = tmp_path / "empty"
+        target.mkdir()
+        out_dir = tmp_path / "out"
+        result = _run_lifecycle_start(
+            target, out_dir, max_cost_usd="5",
+        )
+        assert result.returncode == 1
+        assert "Pre-flight cost gate" in result.stderr

--- a/core/run/tests/test_orchestrated_report_schema.py
+++ b/core/run/tests/test_orchestrated_report_schema.py
@@ -1,0 +1,150 @@
+"""Tests for ``core/run/orchestrated_report_schema.py`` —
+descriptive contract for ``orchestrated_report.json`` (QoL #11e).
+
+The schema is consumed by external tooling; not validated at runtime.
+Tests verify the schema itself is well-formed and stays in sync
+with the producer (finding_status enum, _finalize_results_for_emit
+behaviour). We deliberately do NOT pull in ``jsonschema`` for these
+tests — it's not a declared RAPTOR dependency
+(``feedback-no-jsonschema-in-tests``); the schema is asserted as a
+plain dict shape.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from core.run.finding_status import ALL_STATUSES
+from core.run.orchestrated_report_schema import SCHEMA
+
+
+class TestSchemaShape(unittest.TestCase):
+    """Plain-dict assertions on the schema's structure. Catches a
+    typo / wrong nesting at import time without requiring the
+    jsonschema validator."""
+
+    def test_top_level_required_fields(self):
+        self.assertIn("mode", SCHEMA["properties"])
+        self.assertIn("results", SCHEMA["properties"])
+        self.assertEqual(set(SCHEMA["required"]), {"mode", "results"})
+
+    def test_top_level_additional_properties_permissive(self):
+        # Permissive top-level so the orchestrator can stamp new
+        # sections (dataflow_validation, defense_telemetry, future
+        # additions) without breaking consumers pinned to this
+        # schema.
+        self.assertTrue(SCHEMA.get("additionalProperties", False))
+
+    def test_results_is_array_of_findings(self):
+        results = SCHEMA["properties"]["results"]
+        self.assertEqual(results["type"], "array")
+        items = results["items"]
+        self.assertEqual(items["type"], "object")
+        # finding_id + status both required on every per-finding
+        # record (the contract consumers rely on).
+        self.assertEqual(
+            set(items["required"]), {"finding_id", "status"},
+        )
+
+    def test_status_enum_matches_finding_status_module(self):
+        # The schema's status enum MUST stay in lock-step with
+        # ``core.run.finding_status.ALL_STATUSES`` — drift here
+        # would silently produce reports that consumers pinned
+        # to the schema can't parse.
+        status_prop = (
+            SCHEMA["properties"]["results"]["items"]
+                  ["properties"]["status"]
+        )
+        self.assertEqual(set(status_prop["enum"]), set(ALL_STATUSES))
+
+    def test_orchestration_section_present(self):
+        orch = SCHEMA["properties"]["orchestration"]
+        self.assertEqual(orch["type"], "object")
+        # Cost subobject required to be an object when present.
+        self.assertEqual(orch["properties"]["cost"]["type"], "object")
+
+    def test_finding_additional_properties_permissive(self):
+        # Per-finding records carry arbitrary keys from the prep
+        # stage + downstream enrichment; tests' fixture parity
+        # would otherwise need to chase every new key. Permissive
+        # by design.
+        items = SCHEMA["properties"]["results"]["items"]
+        self.assertTrue(items.get("additionalProperties", False))
+
+
+class TestSchemaConsumerExample(unittest.TestCase):
+    """End-to-end sanity: a minimal report dict matching what the
+    orchestrator produces validates against the dict-shape
+    expectations. Independent of jsonschema — assertions on the
+    KEYS the schema declares, applied to a real-shape report."""
+
+    def _make_minimal_report(self):
+        return {
+            "mode": "orchestrated",
+            "results": [
+                {
+                    "finding_id": "F1",
+                    "status": "analysed",
+                    "is_true_positive": True,
+                    "is_exploitable": False,
+                    "file_path": "src/main.c",
+                    "function": "main",
+                    "line": 42,
+                    "rule_id": "p/security-audit.sqli",
+                    "severity": "high",
+                    "reasoning": "Tainted input flows to query string.",
+                },
+                {
+                    "finding_id": "F2",
+                    "status": "skipped_dead_code",
+                    "file_path": "src/unused.c",
+                    "function": "dead_fn",
+                },
+                {
+                    "finding_id": "F3",
+                    "status": "error",
+                    "error": "timeout after 600s",
+                },
+            ],
+            "analyzed": 1,
+            "exploitable": 0,
+            "exploits_generated": 0,
+            "patches_generated": 0,
+            "orchestration": {
+                "analysis_model": "claude-haiku-4-5",
+                "cost": {"total_cost": 0.0042, "by_model": {}},
+                "fired_models": [],
+            },
+        }
+
+    def test_minimal_report_has_all_required_fields(self):
+        report = self._make_minimal_report()
+        # Top-level required.
+        for key in SCHEMA["required"]:
+            self.assertIn(key, report)
+        # Per-finding required.
+        items_required = (
+            SCHEMA["properties"]["results"]["items"]["required"]
+        )
+        for f in report["results"]:
+            for key in items_required:
+                self.assertIn(key, f, f"missing {key} on {f}")
+
+    def test_all_status_enum_values_are_representable(self):
+        # Every status the schema declares should be acceptable on
+        # a real finding shape — catches an enum drift before it
+        # produces an in-the-wild rejection.
+        status_enum = (
+            SCHEMA["properties"]["results"]["items"]
+                  ["properties"]["status"]["enum"]
+        )
+        for status in status_enum:
+            report = self._make_minimal_report()
+            report["results"][0]["status"] = status
+            # Just assert the dict shape stays parseable + the
+            # value is in the enum.
+            self.assertIn(report["results"][0]["status"], status_enum)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/libexec/raptor-run-lifecycle
+++ b/libexec/raptor-run-lifecycle
@@ -76,6 +76,16 @@ def main():
                             help="Target path (preferred form)")
         parser.add_argument("--out", dest="explicit_out", default=None,
                             help="Explicit output directory override")
+        # Per-run operator-declared budget cap (QoL #21). When the
+        # target-type catalog's estimated upper bound exceeds the
+        # cap, the lifecycle hard-fails pre-flight before any
+        # downstream tool runs.
+        parser.add_argument(
+            "--max-cost-usd", dest="max_cost_usd", default=None,
+            type=float,
+            help="Per-run USD budget cap; pre-flight gate refuses "
+                 "to start when catalog estimate exceeds the cap",
+        )
         # `sys.argv[2:]` so the `start` subcommand isn't re-parsed.
         try:
             args = parser.parse_args(sys.argv[2:])
@@ -98,6 +108,47 @@ def main():
 
         start_run(out_dir, args.command, target=target_path)
         print(f"OUTPUT_DIR={out_dir}")
+
+        # Cost-and-time estimate from target-type catalog (QoL #21).
+        # Mirrors raptor.py:_run_with_lifecycle — skills-path runs
+        # (CLAUDE.md ``raptor-run-lifecycle start`` invocation) get
+        # the same operator visibility AND the same --max-cost-usd
+        # pre-flight gate as the dispatcher path. Goes to stderr
+        # so stdout stays single-line OUTPUT_DIR= for callers
+        # that parse it.
+        if target_path:
+            try:
+                from core.run.estimator import estimate_run, format_estimate
+                _est = estimate_run(Path(target_path))
+                _est_line = format_estimate(_est)
+                if _est_line:
+                    sys.stderr.write(_est_line + "\n")
+                if (
+                    args.max_cost_usd is not None
+                    and _est is not None
+                    and _est.cost_high > args.max_cost_usd
+                ):
+                    sys.stderr.write(
+                        f"✗ Pre-flight cost gate: catalog estimate "
+                        f"upper bound (${_est.cost_high:.2f}) exceeds "
+                        f"--max-cost-usd cap (${args.max_cost_usd:.2f}). "
+                        f"Raise the cap or accept the risk and "
+                        f"re-run without --max-cost-usd.\n"
+                    )
+                    # Same metadata-clean-up rationale as the
+                    # dispatcher path — mark the run failed so
+                    # the on-disk metadata explains why the
+                    # OUTPUT_DIR exists without progress.
+                    try:
+                        fail_run(out_dir,
+                                 "pre-flight cost gate exceeded")
+                    except Exception:  # noqa: BLE001
+                        pass
+                    sys.exit(1)
+            except SystemExit:
+                raise
+            except Exception as e:  # noqa: BLE001
+                sys.stderr.write(f"  (estimate skipped: {e})\n")
 
     elif action == "complete":
         if len(sys.argv) < 3:

--- a/raptor.py
+++ b/raptor.py
@@ -80,6 +80,62 @@ def _extract_target(args: list) -> str | None:
     return None
 
 
+def _extract_and_strip_max_cost_usd(args: list) -> tuple[float | None, list]:
+    """Extract ``--max-cost-usd <USD>`` (or ``--max-cost-usd=<USD>``)
+    from ``args``. Returns ``(cap_usd, args_without_flag)``.
+
+    Lives at the lifecycle level so the operator can declare a
+    per-run budget once at the entry point and the estimator gate
+    + downstream loop both see the same cap. Stripped before
+    forwarding so downstream scripts (scanner, agentic, codeql)
+    don't have to recognise the flag.
+
+    Invalid values (non-numeric, zero, negative) print a stderr
+    warning and return ``(None, args)`` unchanged — operator's
+    typo doesn't silently uncap the run, but the run also doesn't
+    refuse to start over a bad cap value. (A hard error here
+    would force every operator typo through a full lifecycle
+    failure, which is more brittle than this warn-and-skip
+    fallback.)
+    """
+    flag = "--max-cost-usd"
+    prefix = f"{flag}="
+    cap_str: str | None = None
+    out: list = []
+    i = 0
+    while i < len(args):
+        a = args[i]
+        if a == flag and i + 1 < len(args):
+            cap_str = args[i + 1]
+            i += 2
+            continue
+        if a.startswith(prefix):
+            cap_str = a[len(prefix):]
+            i += 1
+            continue
+        out.append(a)
+        i += 1
+    if cap_str is None:
+        return (None, args)
+    try:
+        cap = float(cap_str)
+    except ValueError:
+        print(
+            f"WARNING: --max-cost-usd value {cap_str!r} is not a number; "
+            "ignoring cap for this run",
+            file=sys.stderr,
+        )
+        return (None, args)
+    if cap <= 0:
+        print(
+            f"WARNING: --max-cost-usd must be > 0 (got {cap}); "
+            "ignoring cap for this run",
+            file=sys.stderr,
+        )
+        return (None, args)
+    return (cap, out)
+
+
 def _rewrite_target_arg(args: list, old: str, new: str) -> list:
     """Return ``args`` with the --repo/--binary/--url value ``old`` replaced by
     ``new`` (both ``--flag value`` and ``--flag=value`` forms)."""
@@ -195,6 +251,12 @@ def _run_with_lifecycle(command: str, script_path: Path, args: list,
     """
     target = _extract_target(args)
 
+    # Operator-declared per-run budget cap (QoL #21). Stripped from
+    # ``args`` before forwarding so downstream scripts don't have
+    # to recognise the flag. Pre-flight gate fires below, after
+    # the catalog estimate is computed.
+    max_cost_usd, args = _extract_and_strip_max_cost_usd(args)
+
     # CLAUDE.md DEFAULT TARGET DIRECTORY: back-fill --repo from
     # (1) active project → (2) RAPTOR_CALLER_DIR when args don't carry
     # an explicit target. Pre-fix, scanner.py's `--repo required=True`
@@ -279,6 +341,48 @@ def _run_with_lifecycle(command: str, script_path: Path, args: list,
             # License detection is non-essential; never fail the
             # lifecycle on a detector bug.
             print(f"  (license-detect skipped: {e})",
+                  file=sys.stderr, flush=True)
+
+    # Cost-and-time estimate from the target-type catalog (QoL #21).
+    # Operator sees the expected ballpark before any LLM cost
+    # incurs; Ctrl-C is the cancel path. When ``--max-cost-usd``
+    # is set, the upper bound of the catalog estimate is gated
+    # against the cap pre-flight — runs that would obviously
+    # blow the budget refuse to start rather than spending the
+    # cap to discover the cap was insufficient.
+    if target:
+        try:
+            from core.run.estimator import estimate_run, format_estimate
+            _est = estimate_run(Path(target))
+            _est_line = format_estimate(_est)
+            if _est_line:
+                print(_est_line, flush=True)
+            if (
+                max_cost_usd is not None
+                and _est is not None
+                and _est.cost_high > max_cost_usd
+            ):
+                print(
+                    f"✗ Pre-flight cost gate: catalog estimate "
+                    f"upper bound (${_est.cost_high:.2f}) exceeds "
+                    f"--max-cost-usd cap (${max_cost_usd:.2f}). "
+                    f"Raise the cap or accept the risk and re-run "
+                    f"without --max-cost-usd.",
+                    file=sys.stderr, flush=True,
+                )
+                # Mark the run failed so the lifecycle metadata
+                # reflects WHY this output dir didn't progress —
+                # operator inspecting the dir later sees the
+                # pre-flight refusal, not a phantom ``running``
+                # state.
+                try:
+                    fail_run(out_dir, "pre-flight cost gate exceeded")
+                except Exception:  # noqa: BLE001
+                    pass
+                return 1
+        except Exception as e:
+            # Estimator is best-effort; never break the lifecycle.
+            print(f"  (estimate skipped: {e})",
                   file=sys.stderr, flush=True)
 
     # SAGE: Pre-scan recall


### PR DESCRIPTION
Three substrates compose the target-type catalog at three lifecycle points. All backward-compatible (catalog absent / unmatched / broken → prior behaviour) and preserve operator overrides.

**lifecycle** (``core/run/estimator.py``, ``raptor.py:_run_with_lifecycle``,``libexec/raptor-run-lifecycle``):
Print catalog cost+time at run start —
``Expected: $25-$50, 40-75 min (target type: c.userspace-daemon)`` — on both dispatcher (/scan /agentic /codeql /fuzz /web) and skills (/understand /validate) surfaces. ``--max-cost-usd <USD>`` hard-fails pre-flight when the estimate's upper bound exceeds the cap; bad cap values (non-numeric, zero, negative) warn and proceed.

**project** (``core/project/cli.py``): ``raptor project create`` prints a tuning block after the create confirmation showing the detected target type, cost/time estimate, baseline packs, preferred dirs, and recommended pipeline. ``--require-target-type <name>`` asserts the detected type for strict-CI; mismatch refuses to create the project.

**report** (``core/run/orchestrated_report_schema.py``): JSON Schema draft-7 for ``orchestrated_report.json``. Permissive (``additionalProperties: true`` everywhere); ``required`` only on universal fields (``mode``, ``results``, per-finding ``finding_id``+``status``). Status enum asserted in lock-step with ``core.run.finding_status.ALL_STATUSES`` so producer / contract drift is caught at test time.

**Test coverage** (44 new tests): estimator (13), --max-cost-usd lifecycle gate (12), smart create (11), schema (8). Full suite 1765 passing, ruff clean.