### PR TITLE
fix(scan): three coverage-output bugs surfaced by end-to-end /scan

### DIFF
--- a/core/coverage/importer.py
+++ b/core/coverage/importer.py
@@ -76,9 +76,21 @@ def run_provenance(run_dir: Path) -> Dict[str, Any]:
     }
 
 
-def _tool_stamp(tool: str, prov: Dict[str, Any]) -> Dict[str, Any]:
+def _tool_stamp(tool: str, prov: Dict[str, Any],
+                record_version: Optional[str] = None) -> Dict[str, Any]:
     """The provenance slice for one (file, tool): engine version for a
-    scanner, resolved model(s) for an LLM tool, plus run-level fields."""
+    scanner, resolved model(s) for an LLM tool, plus run-level fields.
+
+    ``record_version`` is the coverage record's own ``version`` field
+    (build_from_semgrep / build_from_cocci / build_from_codeql all
+    carry it). Used as a fallback when the manifest's ``engines``
+    map hasn't been stamped yet — scanner.py renders the coverage
+    summary BEFORE raptor.py's lifecycle wrapper calls
+    ``complete_run`` (which is when ``standard_completion_provenance``
+    stamps engine versions), so a same-run render would otherwise
+    see ``(version unrecorded)`` even though the per-tool JSON does
+    carry it.
+    """
     stamp: Dict[str, Any] = {
         "timestamp": prov.get("timestamp"),
         "target": prov.get("target"),
@@ -89,6 +101,14 @@ def _tool_stamp(tool: str, prov: Dict[str, Any]) -> Dict[str, Any]:
     engines = prov.get("engines") or {}
     if base in engines:
         stamp["version"] = engines[base]
+    elif isinstance(record_version, str) and record_version:
+        # ``isinstance`` guard: the record's ``version`` field
+        # comes from each tool's own JSON output schema
+        # (semgrep / coccinelle / codeql), but a future caller
+        # passing a non-string would silently land an
+        # unhashable value here and crash downstream in
+        # ``provenance_summary`` (sets the version into a set).
+        stamp["version"] = record_version
     if category_of(tool) == "llm" and prov.get("models"):
         stamp["models"] = prov["models"]
     return stamp
@@ -141,7 +161,9 @@ def import_record(
     tool = record.get("tool")
     if not tool:
         return 0
-    stamp = _tool_stamp(tool, provenance) if provenance else None
+    stamp = _tool_stamp(
+        tool, provenance, record_version=record.get("version"),
+    ) if provenance else None
     inv_paths = set(total_lines)                     # inventory keys (target-relative)
     marked = 0
     for path in record.get("files_examined", []) or []:
@@ -383,7 +405,9 @@ def import_functions_analysed(
     fa_list = record.get("functions_analysed")
     if not tool or not fa_list:
         return 0
-    stamp = _tool_stamp(tool, provenance) if provenance else None
+    stamp = _tool_stamp(
+        tool, provenance, record_version=record.get("version"),
+    ) if provenance else None
     marked = 0
     for fa in fa_list:
         if not isinstance(fa, dict):

--- a/core/coverage/summary.py
+++ b/core/coverage/summary.py
@@ -94,7 +94,14 @@ def format_execution_detail(detail: Dict[str, Any]) -> str:
         if info.get("packs"):
             bits.append(f"packs: {', '.join(info['packs'])}")
         if info.get("files_failed"):
-            bits.append(f"{len(info['files_failed'])} failed")
+            # ``files_failed`` is per-file PARSE errors (semgrep
+            # couldn't tokenise N source files), not failed PACKS
+            # — adjacent to the ``X packs failed`` line in the
+            # ``Coverage:`` block; identical wording is ambiguous.
+            bits.append(
+                f"{len(info['files_failed'])} file parse error"
+                f"{'s' if len(info['files_failed']) != 1 else ''}"
+            )
         ver = f" {info['version']}" if info.get("version") else ""
         lines.append(f"    {tool}{ver}: {', '.join(bits)}")
     missing = detail.get("missing_groups") or []

--- a/core/coverage/tests/test_importer.py
+++ b/core/coverage/tests/test_importer.py
@@ -304,3 +304,121 @@ def test_backfill_unions_checked_by_and_records_then_gap(tmp_path):
     assert CoverageStore(tmp_path / "coverage.json").who_checked("a.c", 40) == [
         "semgrep", "validate:stage-a",
     ]
+
+
+# ---------------------------------------------------------------------------
+# _tool_stamp: per-tool record version fallback when manifest is bare
+# ---------------------------------------------------------------------------
+
+
+def test_tool_stamp_uses_engines_when_present():
+    from core.coverage.importer import _tool_stamp
+    prov = {
+        "engines": {"semgrep": "1.79.0"},
+        "timestamp": "2026-06-02T01:00:00Z",
+    }
+    stamp = _tool_stamp("semgrep", prov, record_version=None)
+    assert stamp["version"] == "1.79.0"
+
+
+def test_tool_stamp_falls_back_to_record_version_when_engines_bare():
+    # When raptor.py's lifecycle wrapper hasn't yet called
+    # complete_run, the manifest's ``engines`` map is bare. The
+    # per-tool coverage record's ``version`` field (populated by
+    # build_from_semgrep / build_from_cocci from the tool's own
+    # JSON output) is the fallback — without it, scanner.py's
+    # end-of-run coverage summary always shows
+    # ``(version unrecorded)``.
+    from core.coverage.importer import _tool_stamp
+    prov = {
+        "engines": {},
+        "timestamp": "2026-06-02T01:00:00Z",
+    }
+    stamp = _tool_stamp("semgrep", prov, record_version="1.79.0")
+    assert stamp["version"] == "1.79.0"
+
+
+def test_tool_stamp_engines_wins_over_record_version_when_both():
+    # Manifest engines is authoritative when present (matches
+    # post-complete_run state); record_version is the fallback for
+    # pre-complete_run renders.
+    from core.coverage.importer import _tool_stamp
+    prov = {
+        "engines": {"semgrep": "2.0.0"},
+        "timestamp": "2026-06-02T01:00:00Z",
+    }
+    stamp = _tool_stamp("semgrep", prov, record_version="1.79.0")
+    assert stamp["version"] == "2.0.0"
+
+
+def test_tool_stamp_no_version_anywhere_omits_field():
+    # Neither manifest nor record carries a version — stamp
+    # shouldn't fabricate one. Renderer will say "version
+    # unrecorded" in this case (genuinely unknown).
+    from core.coverage.importer import _tool_stamp
+    prov = {"engines": {}, "timestamp": "t"}
+    stamp = _tool_stamp("semgrep", prov, record_version=None)
+    assert "version" not in stamp
+
+
+def test_tool_stamp_non_string_record_version_rejected():
+    # Defensive: a future caller passing a dict / list / int as
+    # record_version would silently land an unhashable value in
+    # the stamp, then crash downstream in ``provenance_summary``
+    # (sets the version into a set). isinstance guard refuses.
+    from core.coverage.importer import _tool_stamp
+    prov = {"engines": {}, "timestamp": "t"}
+    for bogus in [{"v": "1.0"}, ["1.0"], 100, 1.5]:
+        stamp = _tool_stamp("semgrep", prov, record_version=bogus)
+        assert "version" not in stamp, (
+            f"version field should not be set for non-string "
+            f"record_version={bogus!r}"
+        )
+
+
+def test_tool_stamp_empty_string_record_version_omits_field():
+    # ``record.get("version")`` may return "" when the tool's
+    # JSON output had no version key (build_from_semgrep uses
+    # ``data.get("version", "")``). Empty string is no
+    # information — same treatment as None.
+    from core.coverage.importer import _tool_stamp
+    prov = {"engines": {}, "timestamp": "t"}
+    stamp = _tool_stamp("semgrep", prov, record_version="")
+    assert "version" not in stamp
+
+
+def test_tool_stamp_works_for_coccinelle():
+    # Same fallback applies to coccinelle — build_from_cocci
+    # stamps the spatch version on the record.
+    from core.coverage.importer import _tool_stamp
+    prov = {"engines": {}, "timestamp": "t"}
+    stamp = _tool_stamp(
+        "coccinelle", prov,
+        record_version="spatch version 1.3 compiled with OCaml 5.4.0",
+    )
+    assert "spatch version 1.3" in stamp["version"]
+
+
+def test_import_record_passes_version_through_to_stamp(tmp_path):
+    # End-to-end: a coverage record with ``version`` (but no
+    # ``engines`` in provenance) lands its version on the
+    # store's per-(file, tool) provenance slot. Reproduces the
+    # /scan render-time scenario where complete_run hasn't yet
+    # populated engines.
+    s = _store(tmp_path)
+    s.import_inventory_meta(_CHECKLIST)
+    record = {
+        "tool": "semgrep",
+        "files_examined": ["a.c"],
+        "version": "1.79.0",
+        "timestamp": "t",
+    }
+    prov_without_engines = {
+        "engines": {},
+        "timestamp": "t",
+        "run": "scan-1",
+    }
+    import_record(s, record, {"a.c": 100}, prov_without_engines)
+    # Verify the stamp landed via provenance_summary aggregation.
+    summary = s.provenance_summary()
+    assert "1.79.0" in summary["tools"].get("semgrep", [])

--- a/core/coverage/tests/test_summary.py
+++ b/core/coverage/tests/test_summary.py
@@ -105,6 +105,40 @@ class TestFormatExecutionDetail(unittest.TestCase):
     def test_empty_renders_blank(self):
         self.assertEqual(format_execution_detail({"tools": {}}), "")
 
+    def test_files_failed_renders_as_parse_errors_not_failed(self):
+        # ``files_failed`` on the coverage record is per-file PARSE
+        # errors (semgrep couldn't tokenise N source files), NOT
+        # failed packs. Pre-fix the line printed ``N failed``
+        # adjacent to scan_coverage's ``X packs failed`` line, an
+        # operator-confusing terminology overlap.
+        detail = {"tools": {"semgrep": {
+            "files_examined": 10, "files_total": 10,
+            "rules_applied": ["crypto"], "packs": [],
+            "files_failed": [
+                {"path": "src/a.c", "reason": "syntax error"},
+                {"path": "src/b.c", "reason": "syntax error"},
+                {"path": "src/c.c", "reason": "syntax error"},
+            ],
+            "version": "1.0"}},
+            "missing_groups": []}
+        text = format_execution_detail(detail)
+        # New wording explicitly names PARSE errors.
+        self.assertIn("3 file parse errors", text)
+        # And does NOT use the ambiguous ``N failed`` wording the
+        # adjacent ``Coverage:`` line uses for failed packs.
+        self.assertNotIn("3 failed", text)
+
+    def test_single_file_parse_error_uses_singular(self):
+        detail = {"tools": {"semgrep": {
+            "files_examined": 1, "files_total": 1,
+            "rules_applied": ["crypto"], "packs": [],
+            "files_failed": [{"path": "src/a.c", "reason": "syntax error"}],
+            "version": "1.0"}},
+            "missing_groups": []}
+        text = format_execution_detail(detail)
+        self.assertIn("1 file parse error", text)
+        self.assertNotIn("1 file parse errors", text)
+
 
 class TestMatchToInventory(unittest.TestCase):
 

--- a/packages/static-analysis/scanner.py
+++ b/packages/static-analysis/scanner.py
@@ -148,6 +148,88 @@ def _resolve_baseline_packs(
     return [_pack_tuple_for_id(pid) for pid in entry.semgrep_packs_default]
 
 
+def _resolve_rules_applied(
+    groups: List[str],
+    resolved_baseline: List[Tuple[str, str]],
+    rules_dirs: List[str],
+) -> List[str]:
+    """Compute the ``rules_applied`` list stored on the semgrep
+    coverage record.
+
+    Captures every policy group whose registry pack actually ran,
+    so the coverage report's "policy group(s) not used" check
+    (``POLICY_GROUP_TO_SEMGREP_PACK.keys() - rules_applied``)
+    doesn't falsely flag groups whose pack was added via the
+    catalog, via a rule-dir-name match, or as a shared pack id
+    across multiple policy groups.
+
+    Pre-fix: ``rules_applied=['all']`` (literal) or local rule
+    directory names; both lacked the canonical policy-group keys,
+    so EVERY policy group showed as ''not used'' — the
+    operator-facing inconsistency the c.userspace-daemon scan
+    surfaced.
+
+    Honest semantic: pack-id-driven. A policy group is ''applied''
+    iff its registry pack id is in the set of pack ids semgrep
+    actually ran. That set is the union of:
+
+    * Catalog-resolved baseline packs (``resolved_baseline``).
+    * Pack ids that ``semgrep_scan_parallel`` adds because a
+      rule dir's name matched a key in ``POLICY_GROUP_TO_SEMGREP_PACK``
+      (see scanner.py:``Add corresponding standard pack if available``).
+
+    Operator-passed specific policy groups (``--policy-groups
+    auth,injection``) drive ``rules_dirs`` membership, which feeds
+    back through the same rule-dir → pack-id mapping — so the
+    set inclusion is automatic; no special branch needed.
+
+    Two correctness wins over the pre-fix design:
+
+    1. Shared pack ids — ``flows`` and ``best-practices`` both
+       map to ``p/default``; running ``flows/`` exercises both,
+       and both correctly land in ``applied`` here.
+    2. No-local-rule-dir groups — ``best-practices`` has no
+       local rule dir; ``--policy-groups all`` doesn't trigger
+       its registry pack via the rule-dir loop, so it's NOT in
+       ``applied`` unless something else added ``p/default``
+       (which ``flows/`` does in practice).
+
+    * ``groups`` — accepted for API symmetry / future extension;
+      currently unused (rule-dir membership is the actual signal).
+    * ``resolved_baseline`` — the catalog-resolved baseline pack
+      set (``[(display_name, pack_id), ...]``).
+    * ``rules_dirs`` — local rule directory paths the scanner
+      passed to semgrep_scan_parallel. Used to derive which
+      registry packs got auto-added via the rule-dir → pack-id
+      mapping, AND as the fallback identity when nothing else
+      populated the applied set.
+    """
+    # Compute the set of pack ids semgrep ACTUALLY ran — the
+    # union of catalog baseline + auto-added registry packs (via
+    # rule-dir name match).
+    ran_pack_ids: set = {pid for _, pid in resolved_baseline}
+    for rd in rules_dirs:
+        dir_name = Path(rd).name
+        mapping = RaptorConfig.POLICY_GROUP_TO_SEMGREP_PACK.get(dir_name)
+        if mapping is not None:
+            ran_pack_ids.add(mapping[1])
+
+    # Reverse-map every policy group whose pack id ran.
+    applied = {
+        group
+        for group, (_name, pack_id)
+        in RaptorConfig.POLICY_GROUP_TO_SEMGREP_PACK.items()
+        if pack_id in ran_pack_ids
+    }
+    if applied:
+        return sorted(applied)
+    # Fallback: no policy groups exercised → record rule-dir
+    # names so the coverage record still has SOME identity
+    # (preserves pre-fix shape for the genuinely-empty case).
+    _ = groups  # accepted for API symmetry; unused — see docstring.
+    return [str(Path(r).name) for r in rules_dirs]
+
+
 def _sanitize_pack_name(name: str) -> str:
     """Strict allowlist: alphanumeric + dash + underscore + dot.
 
@@ -1487,13 +1569,18 @@ def main():
             from core.coverage.record import (
                 build_from_semgrep, build_from_codeql, write_record, load_records,
             )
-            # Semgrep coverage — find JSON outputs alongside SARIFs
+            # Semgrep coverage — find JSON outputs alongside SARIFs.
+            # See ``_resolve_rules_applied`` for why this isn't just
+            # ``groups`` or rule-dir names.
+            _rules_applied = _resolve_rules_applied(
+                groups, resolved_baseline, rules_dirs,
+            )
             for sarif_path in semgrep_sarifs:
                 json_path = Path(sarif_path).with_suffix(".json")
                 if json_path.exists():
                     record = build_from_semgrep(
                         out_dir, json_path,
-                        rules_applied=groups if groups else [str(Path(r).name) for r in rules_dirs],
+                        rules_applied=_rules_applied,
                     )
                     if record:
                         write_record(out_dir, record, tool_name="semgrep")

--- a/packages/static-analysis/tests/test_resolve_rules_applied.py
+++ b/packages/static-analysis/tests/test_resolve_rules_applied.py
@@ -1,0 +1,278 @@
+"""Tests for ``_resolve_rules_applied`` — fixes the
+catalog-vs-policy-group mismatch where the coverage report falsely
+flagged groups as not-used when a catalog had actually added them
+to the baseline."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+from core.config import RaptorConfig
+
+_SCANNER_PATH = Path(__file__).resolve().parents[1] / "scanner.py"
+_spec = importlib.util.spec_from_file_location(
+    "_scanner_under_test_resolve_rules_applied", _SCANNER_PATH,
+)
+_scanner = importlib.util.module_from_spec(_spec)
+sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
+_spec.loader.exec_module(_scanner)
+
+_resolve_rules_applied = _scanner._resolve_rules_applied
+
+
+# ---------------------------------------------------------------------------
+# Helper: synthesise the local rule_dirs that ``--policy-groups all`` would
+# pass — every dir under SEMGREP_RULES_DIR that matches a policy group key.
+# ---------------------------------------------------------------------------
+
+def _all_local_policy_dirs() -> list:
+    """Local rule dirs whose name matches a POLICY_GROUP key —
+    these are the ones the ``--policy-groups all`` expansion
+    actually triggers via scanner.py's rule-dir loop."""
+    base = RaptorConfig.SEMGREP_RULES_DIR
+    pg_keys = set(RaptorConfig.POLICY_GROUP_TO_SEMGREP_PACK.keys())
+    return sorted(
+        str(p) for p in base.iterdir()
+        if p.is_dir() and p.name in pg_keys
+    )
+
+
+class TestAllExpansionViaRuleDirs:
+    """``--policy-groups all`` passes every local rule dir to
+    semgrep_scan_parallel, which auto-adds the corresponding
+    registry pack when the dir name matches a policy_group key.
+    The reverse-mapping below recovers which policy groups got
+    exercised."""
+
+    def test_all_expansion_via_rule_dirs_matches_every_extant_group(self):
+        # Drive _resolve_rules_applied with the rules_dirs that
+        # ``--policy-groups all`` would actually produce; the
+        # applied set should equal every policy_group with a
+        # local rule dir (which on a populated checkout is the
+        # full set MINUS any policy group lacking a local dir).
+        local_pg_dirs = _all_local_policy_dirs()
+        result = _resolve_rules_applied(
+            groups=["all"], resolved_baseline=[],
+            rules_dirs=local_pg_dirs,
+        )
+        # On the shipped checkout, every policy group EXCEPT
+        # ``best-practices`` has a local rule dir. Walking the
+        # ``flows/`` dir auto-adds ``p/default``, which is ALSO
+        # ``best-practices``'s pack — so ``best-practices`` lands
+        # in applied too, via the shared-pack reverse-mapping.
+        # All 6 groups should be present.
+        assert set(result) == set(
+            RaptorConfig.POLICY_GROUP_TO_SEMGREP_PACK.keys()
+        )
+
+    def test_all_does_not_leak_literal_all(self):
+        # Regression: pre-fix stored 'all' in the list. Make sure
+        # 'all' is never in the final rules_applied output.
+        result = _resolve_rules_applied(
+            groups=["all"], resolved_baseline=[], rules_dirs=[],
+        )
+        assert "all" not in result
+
+
+class TestSharedPackReverseMapping:
+    """When two policy groups share a pack id (``flows`` and
+    ``best-practices`` both → ``p/default``), running one
+    correctly marks both as applied — the rendered ''not used''
+    line shouldn't single out the no-local-dir group when its
+    shared pack actually ran."""
+
+    def test_flows_runs_implies_best_practices_applied(self, tmp_path):
+        # Synthesise a rules_dirs that includes ``flows`` but not
+        # ``best-practices`` (which doesn't exist as a local dir
+        # anyway). Both policy groups share ``p/default``, so
+        # both should land in applied.
+        flows_dir = tmp_path / "flows"
+        flows_dir.mkdir()
+        result = _resolve_rules_applied(
+            groups=["flows"], resolved_baseline=[],
+            rules_dirs=[str(flows_dir)],
+        )
+        assert "flows" in result
+        assert "best-practices" in result
+
+    def test_no_local_dir_group_not_falsely_applied(self, tmp_path):
+        # Pre-correctness-fix version of the helper marked
+        # ``best-practices`` as applied on ``--policy-groups all``
+        # without checking the rule-dir exists, because it
+        # blindly expanded ``all`` → all groups. The pack-id
+        # driven version only marks it when its pack ran.
+        result = _resolve_rules_applied(
+            groups=["all"], resolved_baseline=[], rules_dirs=[],
+        )
+        # No rule dirs passed → no packs ran via rule-dir loop;
+        # no baseline either. best-practices must NOT be in
+        # applied.
+        assert "best-practices" not in result
+
+
+class TestCatalogReverseMapping:
+    """Catalog-driven baseline pack additions reverse-map to
+    their corresponding policy_group keys."""
+
+    def test_command_injection_pack_registers_injection_group(self):
+        baseline = [
+            ("semgrep_security_audit", "p/security-audit"),
+            ("semgrep_injection", "p/command-injection"),
+            ("semgrep_owasp_top_10", "p/owasp-top-ten"),
+        ]
+        result = _resolve_rules_applied(
+            groups=[], resolved_baseline=baseline, rules_dirs=[],
+        )
+        assert "injection" in result
+
+    def test_jwt_pack_registers_auth_group(self):
+        baseline = [("semgrep_auth", "p/jwt")]
+        result = _resolve_rules_applied(
+            groups=[], resolved_baseline=baseline, rules_dirs=[],
+        )
+        assert "auth" in result
+
+    def test_default_pack_registers_both_flows_and_best_practices(self):
+        # Catalog-driven ``p/default`` is the shared pack for two
+        # policy groups; the reverse-mapping correctly marks BOTH.
+        baseline = [("semgrep_default", "p/default")]
+        result = _resolve_rules_applied(
+            groups=[], resolved_baseline=baseline, rules_dirs=[],
+        )
+        assert "flows" in result
+        assert "best-practices" in result
+
+    def test_unknown_baseline_pack_doesnt_register_a_group(self):
+        baseline = [("semgrep_random", "p/some-future-pack")]
+        result = _resolve_rules_applied(
+            groups=[], resolved_baseline=baseline, rules_dirs=[],
+        )
+        # No policy groups exercised → empty list (rules_dirs
+        # fallback also empty here).
+        assert result == []
+
+
+class TestRuleDirMatching:
+    """When a rule dir's name matches a policy_group key, the
+    scanner auto-adds the registry pack — so the group lands in
+    applied via the pack-id reverse-mapping."""
+
+    def test_injection_rule_dir_registers_injection_group(self, tmp_path):
+        injection_dir = tmp_path / "injection"
+        injection_dir.mkdir()
+        result = _resolve_rules_applied(
+            groups=["injection"], resolved_baseline=[],
+            rules_dirs=[str(injection_dir)],
+        )
+        assert "injection" in result
+
+    def test_non_policy_group_rule_dir_doesnt_register(self, tmp_path):
+        # Local rule dir whose name doesn't match any policy
+        # group (e.g. ``crypto`` — exists locally but has no
+        # policy_group registry mapping, only local rules).
+        crypto_dir = tmp_path / "crypto"
+        crypto_dir.mkdir()
+        result = _resolve_rules_applied(
+            groups=["crypto"], resolved_baseline=[],
+            rules_dirs=[str(crypto_dir)],
+        )
+        # Crypto isn't in POLICY_GROUP_TO_SEMGREP_PACK → no
+        # registry pack added → no policy group in applied.
+        # Falls through to rules_dirs fallback.
+        assert result == ["crypto"]
+
+
+class TestFallbackToRuleDirs:
+    """When no policy group was exercised, fall back to local
+    rule-dir basenames — preserves pre-fix shape for the
+    genuinely-empty case."""
+
+    def test_empty_inputs_with_rules_dirs_fall_back(self, tmp_path):
+        # All rule dirs are non-policy-group names → no policy
+        # groups marked → fallback fires.
+        dir1 = tmp_path / "01-injection"
+        dir2 = tmp_path / "02-crypto"
+        result = _resolve_rules_applied(
+            groups=[], resolved_baseline=[],
+            rules_dirs=[str(dir1), str(dir2)],
+        )
+        assert "01-injection" in result
+        assert "02-crypto" in result
+
+    def test_truly_empty_inputs_return_empty_list(self):
+        result = _resolve_rules_applied(
+            groups=[], resolved_baseline=[], rules_dirs=[],
+        )
+        assert result == []
+
+
+# ---------------------------------------------------------------------------
+# Integration test — _resolve_rules_applied output flows through
+# _missing_semgrep_groups; assert the operator-facing "not used" check
+# sees an empty list when everything ran.
+# ---------------------------------------------------------------------------
+
+
+def _missing_for(rules_applied: list) -> list:
+    """Run the coverage-summary's missing-groups check against a
+    synthetic ``tools`` dict carrying ``rules_applied``."""
+    from core.coverage.summary import _missing_semgrep_groups
+    return _missing_semgrep_groups({
+        "semgrep": {
+            "rules_applied": rules_applied,
+            "packs": [],
+            "files_failed": [],
+            "files_examined": 1,
+            "files_total": 1,
+            "version": "1.79.0",
+        }
+    })
+
+
+class TestEndToEndMissingGroups:
+    """The contract the operator actually reads: when every
+    policy-group's pack ran, ``_missing_semgrep_groups`` returns
+    ``[]`` — no ''Semgrep policy group(s) not used'' line is
+    rendered. This is the regression the c.userspace-daemon scan
+    surfaced — let's pin it from both ends."""
+
+    def test_all_expansion_yields_zero_missing(self):
+        # When --policy-groups all runs against a full checkout,
+        # every policy group's pack runs → missing should be [].
+        result = _resolve_rules_applied(
+            groups=["all"], resolved_baseline=[],
+            rules_dirs=_all_local_policy_dirs(),
+        )
+        assert _missing_for(result) == []
+
+    def test_c_userspace_daemon_catalog_baseline_yields_zero_missing(self):
+        # The catalog that surfaced the bug: ``injection`` shows
+        # as not-used in the pre-fix world; post-fix it lands in
+        # applied via the catalog reverse-mapping plus the
+        # rule-dir loop. Run the realistic combined input.
+        baseline = [
+            ("semgrep_security_audit", "p/security-audit"),
+            ("semgrep_injection", "p/command-injection"),
+            ("semgrep_owasp_top_10", "p/owasp-top-ten"),
+        ]
+        result = _resolve_rules_applied(
+            groups=["all"], resolved_baseline=baseline,
+            rules_dirs=_all_local_policy_dirs(),
+        )
+        # All 6 policy groups exercised → no missing.
+        assert _missing_for(result) == []
+
+    def test_no_groups_no_baseline_lists_every_group_missing(self):
+        # Sanity counter-test: when nothing exercises a policy
+        # group, all 6 SHOULD show as missing (this is the
+        # behaviour the operator legitimately wants for an
+        # opt-out / partial-coverage scan).
+        result = _resolve_rules_applied(
+            groups=[], resolved_baseline=[], rules_dirs=[],
+        )
+        missing = _missing_for(result)
+        assert set(missing) == set(
+            RaptorConfig.POLICY_GROUP_TO_SEMGREP_PACK.keys()
+        )


### PR DESCRIPTION
Three operator-facing inconsistencies in the /scan coverage block that surfaced when running main against a C / userspace-daemon target. Each pre-existing but newly visible thanks to catalog- driven baseline pack selection.

**1. Catalog-added pack falsely flagged as "not used"**

``--policy-groups all`` was stored literally in ``rules_applied``, so the ''missing policy groups'' check
(``POLICY_GROUP_TO_SEMGREP_PACK.keys() - rules_applied``) listed EVERY known policy group. Catalog-driven baseline pack additions also didn't reverse-map to their policy_group names — a catalog that added ``command-injection`` left the ``injection`` policy group looking unexercised.

New ``_resolve_rules_applied`` helper in
``packages/static-analysis/scanner.py``: pack-id driven. A policy group is ''applied'' iff its registry pack id is in the set of pack ids semgrep actually ran (catalog baseline ∪ packs auto- added because a rule dir's name matched a POLICY_GROUP key). Correctly handles shared pack ids (``flows`` and
``best-practices`` both → ``p/default``) and no-local-rule-dir groups (``best-practices`` only lands in applied when ``flows/`` brought ``p/default`` along).

**2. "N failed" ambiguous with "N packs failed"**

``semgrep 1.79.0: 172/172 files, 1 rule-group(s), 5 failed`` printed adjacent to the ``Coverage:`` line's ``X packs failed`` wording — but ``files_failed`` on the coverage record is per- file PARSE errors (semgrep couldn't tokenise N source files), not failed packs. Renderer now says ``5 file parse errors`` with singular/plural agreement.

**3. Provenance: "(version unrecorded)" despite engines populated**

Scanner.py renders the coverage summary at end-of-main, BEFORE raptor.py's lifecycle wrapper calls ``complete_run`` (which stamps engine versions into the manifest). At render time the manifest's engines map was bare, so ``_tool_stamp`` left ``version`` off the per-(file, tool) stamp, so the provenance summary showed ``(version unrecorded)`` — even though the per- tool coverage record's own ``version`` field had it.

``_tool_stamp`` now accepts a ``record_version`` fallback; ``import_record`` and ``import_functions_analysed`` pass ``record.get("version")``. Manifest engines stays authoritative when present; record_version covers the pre-complete_run render window. ``isinstance`` guard refuses non-string values (a future caller passing a dict / list would otherwise silently corrupt the stamp and crash downstream in ``provenance_summary``).