### PR TITLE
fix(cli): make <mode> --help side-effect-free and complete

### DIFF
--- a/.claude/commands/agentic.md
+++ b/.claude/commands/agentic.md
@@ -21,6 +21,15 @@ Nothing will be applied to your code - only generated in the out/ directory.
 
 Execute: `libexec/raptor-agentic --repo <path>`
 
+## Handling `--help` / `-h`
+
+If ARGUMENTS is exactly `--help` or `-h` (the operator wants the flag list, not a run),
+run `libexec/raptor-agentic --help` and present its output. That command is
+side-effect-free — it spawns the agentic script's own argparse help and exits, with
+no run directory, license/cost preamble, or LLM dispatcher. It is the authoritative,
+complete flag list; the prose tables below are a curated subset. Do NOT start a run
+and do NOT hand-summarise the flags from this doc when `--help` is requested.
+
 ## Optional enrichment flags
 
 By default, `/agentic` scans and analyses findings in isolation. Two optional flags add richer context for more thorough results. They are opt-in because they add time and cost, but if you are doing a proper security review rather than a quick scan, they are well worth it.

--- a/.claude/commands/analyze.md
+++ b/.claude/commands/analyze.md
@@ -8,6 +8,8 @@ Analyzes existing SARIF files with LLM (for findings from previous scans).
 
 Execute: `python3 raptor.py analyze --repo <path> --sarif <sarif-file>`
 
+**`--help` / `-h`:** If the user passes only `--help` or `-h`, run `python3 raptor.py analyze --help` and present its output. That command is side-effect-free (no run, lifecycle, output directory, or LLM dispatcher) and is the complete, authoritative flag list — do NOT start analysis or hand-summarise flags from this doc.
+
 Use when you already have SARIF findings and want LLM analysis.
 
 ## Multi-model support

--- a/.claude/commands/codeql.md
+++ b/.claude/commands/codeql.md
@@ -4,6 +4,8 @@ description: CodeQL deep static analysis with dataflow validation
 
 # /codeql - RAPTOR CodeQL Analysis
 
+**`--help` / `-h`:** If the user passes only `--help` or `-h`, run `python3 raptor.py codeql --help` and present its output. That command is side-effect-free (no run, lifecycle, output directory, or LLM dispatcher) and is the complete, authoritative flag list — do NOT start a scan or hand-summarise flags from this doc.
+
 Runs CodeQL deep static analysis with dataflow validation. Slower but finds complex vulnerabilities that Semgrep misses (tainted flows, use-after-free, injection chains).
 
 ## Usage

--- a/.claude/commands/fuzz.md
+++ b/.claude/commands/fuzz.md
@@ -4,6 +4,8 @@ description: Binary fuzzing with AFL++ integration
 
 # /fuzz - RAPTOR Binary Fuzzer
 
+**`--help` / `-h`:** If the user passes only `--help` or `-h`, run `python3 raptor.py fuzz --help` and present its output. That command is side-effect-free (no run, lifecycle, output directory, or LLM dispatcher) and is the complete, authoritative flag list — do NOT start a fuzzing campaign or hand-summarise flags from this doc.
+
 You are helping the user fuzz a binary executable with RAPTOR's AFL++ integration.
 
 ## Your Task

--- a/.claude/commands/raptor-sca.md
+++ b/.claude/commands/raptor-sca.md
@@ -4,6 +4,8 @@ description: Software Composition Analysis — find vulnerable dependencies, gat
 
 # RAPTOR Software Composition Analysis
 
+**`--help` / `-h`:** If the user passes only `--help` or `-h`, run `python3 raptor.py sca --help` and present its output. That command is side-effect-free (no run, lifecycle, output directory, or LLM dispatcher) and is the complete, authoritative command/flag list — do NOT start a scan or hand-summarise from this doc.
+
 You are helping the user analyse a project's third-party dependencies for known vulnerabilities, supply-chain red flags, and hygiene issues.
 
 ## Your task

--- a/.claude/commands/scan.md
+++ b/.claude/commands/scan.md
@@ -4,6 +4,8 @@ description: Scan a repository with Semgrep and CodeQL
 
 # /scan - RAPTOR Code Security Scan
 
+**`--help` / `-h`:** If the user passes only `--help` or `-h`, run `python3 raptor.py scan --help` and present its output. That command is side-effect-free (no run, lifecycle, output directory, or LLM dispatcher) and is the complete, authoritative flag list — do NOT start a scan or hand-summarise flags from this doc.
+
 You are helping the user run RAPTOR's autonomous security scanning on a code repository.
 
 ## Your Task

--- a/.claude/commands/web.md
+++ b/.claude/commands/web.md
@@ -7,6 +7,8 @@ description: Web application security scanner (alpha)
 WARNING: `/web` is in alpha — expect false positives and incomplete
 coverage. Use against test endpoints you own.
 
+**`--help` / `-h`:** If the user passes only `--help` or `-h`, run `python3 raptor.py web --help` and present its output. That command is side-effect-free (no run, lifecycle, output directory, or LLM dispatcher) and is the complete, authoritative flag list — do NOT start a scan or hand-summarise flags from this doc.
+
 You are helping the user scan a web application for security vulnerabilities.
 
 1. **Understand the target**: Get the web application URL

--- a/core/startup/doctor.py
+++ b/core/startup/doctor.py
@@ -228,6 +228,14 @@ def main(argv: Optional[List[str]] = None) -> int:
             strict = True
         elif a in ("--verbose", "-v"):
             verbose = True
+        elif a in ("--help", "-h"):
+            # `--help` is a help request, not a usage error: print usage to
+            # stdout and exit 0, matching every other raptor.py mode. Pre-fix
+            # it fell into the else branch (usage to stderr, exit 2), making
+            # `doctor --help` the one mode where the documented help flag
+            # looked like a failure.
+            print(_USAGE)
+            return 0
         else:
             print(_USAGE, file=sys.stderr)
             return 2

--- a/core/startup/tests/test_cli_smoke.py
+++ b/core/startup/tests/test_cli_smoke.py
@@ -179,6 +179,52 @@ def test_fuzz_accepts_autonomous():
 
 
 # ---------------------------------------------------------------------------
+# Section 3b: `<mode> --help` is side-effect-free
+# ---------------------------------------------------------------------------
+#
+# Regression guard: `<mode> --help` used to fall through to the mode handler,
+# which wraps the child in the run lifecycle — resolving a target, creating
+# AND sealing an output directory, printing the OUTPUT_DIR sentinel + license
+# + cost-estimate preamble, and starting the LLM dispatcher, all before the
+# child argparse ever processed --help. A help request must do none of that.
+
+
+# Every recognised mode, with a substring that proves its OWN help rendered.
+# (sca/doctor render bespoke usage text, not an argparse "usage:" line.)
+_HELP_MARKER = {
+    "scan": "usage:",
+    "fuzz": "usage:",
+    "web": "usage:",
+    "agentic": "usage:",
+    "codeql": "usage:",
+    "analyze": "usage:",
+    "sca": "raptor-sca",
+    "doctor": "raptor doctor",
+}
+
+
+@pytest.mark.parametrize("mode", sorted(_HELP_MARKER))
+@pytest.mark.parametrize("help_flag", ["--help", "-h"])
+def test_mode_help_is_side_effect_free(mode: str, help_flag: str):
+    """`<mode> --help`/`-h` prints only that mode's help and exits 0.
+
+    Asserts no run lifecycle ever engaged (no OUTPUT_DIR sentinel, license,
+    or "[*] Starting" preamble), no LLM dispatcher started, and the mode's
+    own help DID render. The OUTPUT_DIR sentinel is the lifecycle's first
+    observable action (printed right after the run dir is created), so its
+    absence also proves no run directory was created.
+    """
+    r = _run_raptor(mode, help_flag, timeout=20)
+    combined = r.stdout + r.stderr
+    assert r.returncode == 0, f"{mode} {help_flag} exited {r.returncode}: {combined}"
+    assert "OUTPUT_DIR=" not in combined, f"lifecycle ran for {mode} {help_flag}"
+    assert "Target license:" not in combined
+    assert "[*] Starting" not in combined
+    assert "llm-dispatcher server.start" not in combined, "dispatcher started"
+    assert _HELP_MARKER[mode].lower() in combined.lower(), "mode help did not render"
+
+
+# ---------------------------------------------------------------------------
 # Section 4: module-import smoke
 # ---------------------------------------------------------------------------
 

--- a/core/startup/tests/test_doctor.py
+++ b/core/startup/tests/test_doctor.py
@@ -181,6 +181,26 @@ class TestUsage:
         assert rc == 2
         assert "usage: raptor doctor" in captured.err
 
+    def test_help_flag_returns_zero_on_stdout(self, capsys):
+        """`--help` is a help request: usage to stdout, exit 0.
+
+        Distinct from an unknown flag (stderr, exit 2). Guards against the
+        regression where --help fell into the unknown-arg branch.
+        """
+        rc = main(["--help"])
+        captured = capsys.readouterr()
+        assert rc == 0
+        assert "usage: raptor doctor" in captured.out
+        assert captured.err == ""
+
+    def test_short_help_flag_returns_zero_on_stdout(self, capsys):
+        """`-h` behaves identically to `--help`."""
+        rc = main(["-h"])
+        captured = capsys.readouterr()
+        assert rc == 0
+        assert "usage: raptor doctor" in captured.out
+        assert captured.err == ""
+
     def test_strict_and_verbose_combinable(self, capsys, monkeypatch):
         monkeypatch.setattr(
             doctor, "_gather",

--- a/raptor.py
+++ b/raptor.py
@@ -242,6 +242,17 @@ def _unpack_archive_target(target: str, args: list, out_dir: Path):
     return new_args, identity
 
 
+def _wants_help(args: list) -> bool:
+    """True if args request argparse help (``--help`` / ``-h``).
+
+    Single source of truth for the help short-circuits. A help request is
+    not a run: it must never resolve a target, create/seal an output
+    directory, print the OUTPUT_DIR sentinel or license/cost preamble, or
+    start the LLM dispatcher.
+    """
+    return "--help" in args or "-h" in args
+
+
 def _run_with_lifecycle(command: str, script_path: Path, args: list,
                         label: str) -> int:
     """Run a script with lifecycle start/complete/fail wrapping.
@@ -249,6 +260,15 @@ def _run_with_lifecycle(command: str, script_path: Path, args: list,
     Resolves the output directory via the run lifecycle, injects --out
     into the downstream script args, and marks the run complete or failed.
     """
+    # Defense-in-depth behind main()'s per-mode help short-circuit: if any
+    # caller reaches the lifecycle wrapper with --help/-h, skip the entire
+    # lifecycle and delegate straight to _run_script (which has its own
+    # --help guard for the dispatcher). The child's argparse prints help and
+    # exits during parse_args, before its body runs — so no run directory,
+    # sentinel, license/cost preamble, coverage, or complete_run.
+    if _wants_help(args):
+        return _run_script(script_path, args)
+
     target = _extract_target(args)
 
     # Operator-declared per-run budget cap (QoL #21). Stripped from
@@ -615,6 +635,21 @@ def _run_script(script_path: Path, args: list) -> int:
     """
     cmd = [sys.executable, str(script_path)] + args
 
+    # --help/-h is not a run: render the child's argparse help with a plain
+    # subprocess (safe env, short timeout) and skip the LLM dispatcher
+    # entirely. argparse prints help and exits during parse_args, before the
+    # script body — so starting the dispatcher would be a pure side effect.
+    if _wants_help(args):
+        from core.config import RaptorConfig
+        try:
+            return subprocess.run(
+                cmd, env=RaptorConfig.get_safe_env(), timeout=15,
+            ).returncode
+        except subprocess.TimeoutExpired:
+            print(f"✗ Help rendering for {script_path.name} timed out",
+                  file=sys.stderr)
+            return 1
+
     try:
         from core.config import RaptorConfig
         # Phase B: opt the spawn into the credential-isolation
@@ -892,11 +927,15 @@ def mode_doctor(args: list) -> int:
     return doctor_main(args)
 
 
-def show_mode_help(mode: str) -> None:
-    """Show detailed help for a specific mode."""
+def _mode_help_scripts() -> dict:
+    """Map mode name → the script whose argparse renders that mode's help.
+
+    Single source of truth shared by show_mode_help (renders the help) and
+    the `<mode> --help` short-circuit in main() (decides which modes get the
+    side-effect-free help path vs. falling through to their handler).
+    """
     script_root = Path(__file__).parent
-    
-    mode_scripts = {
+    return {
         'scan': script_root / "packages/static-analysis/scanner.py",
         'fuzz': script_root / "raptor_fuzzing.py",
         'web': script_root / "packages/web/scanner.py",
@@ -904,18 +943,40 @@ def show_mode_help(mode: str) -> None:
         'codeql': script_root / "raptor_codeql.py",
         'analyze': script_root / "packages/llm_analysis/agent.py",
     }
-    
+
+
+# Modes whose `<mode> --help` is rendered by spawning the child script's own
+# argparse (no run lifecycle). Derived from _mode_help_scripts so it stays in
+# lockstep with what show_mode_help can actually render.
+_HELP_RENDER_MODES = frozenset(_mode_help_scripts().keys())
+
+
+def show_mode_help(mode: str, preamble: bool = True) -> None:
+    """Show detailed help for a specific mode.
+
+    preamble=True prints a "[*] Help for mode: <mode>" header (the
+    `raptor.py help <mode>` surface). The `<mode> --help` short-circuit
+    passes preamble=False so the output is *only* the mode's argparse
+    help, with nothing above it.
+    """
+    mode_scripts = _mode_help_scripts()
+
     if mode not in mode_scripts:
         print(f"✗ Unknown mode: {mode}", file=sys.stderr)
         print(f"Available modes: {', '.join(mode_scripts.keys())}")
         return
-    
+
     script_path = mode_scripts[mode]
     if not script_path.exists():
         print(f"✗ Script not found: {script_path}", file=sys.stderr)
         return
-    
-    print(f"\n[*] Help for mode: {mode}\n")
+
+    if preamble:
+        # flush=True so the header lands ABOVE the child's help. Without
+        # it, Python block-buffers the print when stdout is a pipe while
+        # the subprocess writes to fd 1 directly — interleaving the
+        # header to the bottom of the output.
+        print(f"\n[*] Help for mode: {mode}\n", flush=True)
     # `env=` to a stripped environment so the help-rendering
     # subprocess doesn't inherit the parent's full env. Pre-fix the
     # bare subprocess.run carried LD_PRELOAD / LD_LIBRARY_PATH /
@@ -1058,7 +1119,23 @@ def main():
             print("Usage: raptor.py help <mode>")
             print("Example: raptor.py help scan")
         return 0
-    
+
+    # `<mode> --help` / `<mode> -h`: render the mode's own argparse help
+    # WITHOUT entering the run lifecycle. Pre-fix, --help fell through to
+    # the mode handler (mode_agentic etc.), which wraps the child in
+    # _run_with_lifecycle — resolving a target, creating AND sealing an
+    # output directory, printing the OUTPUT_DIR sentinel + license + cost
+    # estimate preamble, starting the LLM dispatcher, then emitting a
+    # coverage summary, all before the child's argparse ever saw --help.
+    # A help request must be side-effect-free. show_mode_help spawns
+    # `python3 raptor_<mode>.py --help` directly (safe env, timeout, no
+    # lifecycle, no dispatcher). Gated to the modes show_mode_help knows
+    # how to render; 'doctor' parses --help inside its own handler and
+    # 'sca' has no subprocess help script, so both fall through.
+    if mode in _HELP_RENDER_MODES and _wants_help(remaining):
+        show_mode_help(mode, preamble=False)
+        return 0
+
     # Route to appropriate mode
     mode_handlers = {
         'scan': mode_scan,


### PR DESCRIPTION
`<mode> --help` / `-h` entered the run lifecycle before argparse could handle the help flag: it resolved a target, created AND sealed an output directory, printed the OUTPUT_DIR sentinel + license + cost-estimate preamble, started the LLM dispatcher, then emitted a coverage summary — so asking for help left a completed run directory behind and buried the flag list under operational noise.

Short-circuit help at two layers:
- main() routes `<mode> --help`/`-h` (scan, sca, fuzz, web, agentic, codeql, analyze) to show_mode_help() before the lifecycle-wrapping handler runs. show_mode_help gains a preamble=False mode so the output is only the mode's argparse help, and flushes its header so the `help <mode>` path renders in order.
- Defense in depth at the chokepoints: a shared _wants_help() guard makes _run_with_lifecycle skip the lifecycle (delegating to _run_script) and _run_script skip the LLM dispatcher when help is requested, so any mode reaching them with --help stays side-effect-free.

doctor hand-parsed args and treated --help/-h as an unknown argument (usage to stderr, exit 2); it now prints usage to stdout and exits 0, matching every other mode.

Add the side-effect-free help instruction to the slash-command docs (agentic, scan, codeql, fuzz, web, analyze, raptor-sca) so the assistant runs the real --help and presents the authoritative flag list instead of paraphrasing the prose.

Tests: cli-smoke asserts all modes x {--help,-h} exit 0 with no OUTPUT_DIR/license/dispatcher and a rendered usage block; doctor gains --help/-h returns-zero-on-stdout tests.