### PR TITLE
fix(security): gate agentic passes on human-or-sandbox, not stdin TTY

### DIFF
--- a/core/orchestration/agentic_passes.py
+++ b/core/orchestration/agentic_passes.py
@@ -153,10 +153,10 @@ def _run_understand_prepass_unsafe(
         return PrepassResult(ran=False, skipped_reason="cc_trust blocked dispatch (untrusted target)")
 
     from core.security.rule_of_two import (
-        NonInteractiveError, require_interactive_for_agentic_pass,
+        NonInteractiveError, require_human_or_sandbox_for_agentic_pass,
     )
     try:
-        require_interactive_for_agentic_pass("understand")
+        require_human_or_sandbox_for_agentic_pass("understand")
     except NonInteractiveError as e:
         return PrepassResult(ran=False, skipped_reason=str(e))
 
@@ -361,10 +361,10 @@ def _run_validate_postpass_unsafe(
         return PostpassResult(ran=False, skipped_reason="cc_trust blocked dispatch (untrusted target)")
 
     from core.security.rule_of_two import (
-        NonInteractiveError, require_interactive_for_agentic_pass,
+        NonInteractiveError, require_human_or_sandbox_for_agentic_pass,
     )
     try:
-        require_interactive_for_agentic_pass("validate")
+        require_human_or_sandbox_for_agentic_pass("validate")
     except NonInteractiveError as e:
         return PostpassResult(ran=False, skipped_reason=str(e))
 

--- a/core/orchestration/tests/test_agentic_passes.py
+++ b/core/orchestration/tests/test_agentic_passes.py
@@ -20,15 +20,18 @@ from core.orchestration.agentic_passes import (
     run_validate_postpass,
 )
 
-# Assume interactive for all tests except RuleOfTwoTests (which patches
-# is_interactive explicitly). Without this, every test that exercises the
-# full pass path fails in CI/pytest (no TTY).
+# Force the Rule-of-Two agentic-pass gate open for all tests except
+# RuleOfTwoTests (which drives the gate's legs explicitly). The gate allows
+# the pass when a human terminal OR an effective sandbox is present; we mock
+# the human-terminal leg True so the full pass path runs under CI/pytest
+# (no controlling terminal, sandbox capability varies).
 _interactive_patch = None
 
 def setUpModule():
     global _interactive_patch
     _interactive_patch = patch(
-        "core.security.rule_of_two.is_interactive", return_value=True,
+        "core.security.rule_of_two._session_has_human_terminal",
+        return_value=True,
     )
     _interactive_patch.start()
 
@@ -1372,24 +1375,43 @@ class MockContractTests(unittest.TestCase):
 
 
 class RuleOfTwoTests(unittest.TestCase):
-    """Agentic passes blocked in non-interactive mode (Rule of Two)."""
+    """Agentic-pass gate: allow when a human terminal OR an effective sandbox
+    is present; block only the no-human + no-sandbox quadrant.
 
-    def test_understand_blocked_in_ci(self):
-        with patch("core.security.rule_of_two.is_interactive", return_value=False):
+    Each test drives both legs explicitly via the gate's helper boundary, so
+    the outcome doesn't depend on the test host's process tree or sandbox
+    capability.
+    """
+
+    @staticmethod
+    def _legs(*, human: bool, sandbox: bool):
+        return (
+            patch("core.security.rule_of_two._session_has_human_terminal",
+                  return_value=human),
+            patch("core.security.rule_of_two._sandbox_will_contain",
+                  return_value=sandbox),
+        )
+
+    # --- block quadrant: neither human nor sandbox ---
+
+    def test_understand_blocked_when_neither(self):
+        h, s = self._legs(human=False, sandbox=False)
+        with h, s:
             result = run_understand_prepass(
                 target=Path("scratch/target"),
                 agentic_out_dir=Path("scratch/out"),
                 claude_bin="/fake/claude",
             )
         self.assertFalse(result.ran)
-        self.assertIn("not allowed in non-interactive", result.skipped_reason)
+        self.assertIn("Rule of Two", result.skipped_reason)
 
-    def test_validate_blocked_in_ci(self):
+    def test_validate_blocked_when_neither(self):
         with TemporaryDirectory() as tmp:
             tmp = Path(tmp)
             report = tmp / "report.json"
             report.write_text('{"results": []}')
-            with patch("core.security.rule_of_two.is_interactive", return_value=False):
+            h, s = self._legs(human=False, sandbox=False)
+            with h, s:
                 result = run_validate_postpass(
                     target=Path("scratch/target"),
                     agentic_out_dir=tmp,
@@ -1397,35 +1419,55 @@ class RuleOfTwoTests(unittest.TestCase):
                     claude_bin="/fake/claude",
                 )
         self.assertFalse(result.ran)
-        self.assertIn("not allowed in non-interactive", result.skipped_reason)
+        self.assertIn("Rule of Two", result.skipped_reason)
 
-    def test_understand_passes_gate_when_interactive(self):
-        with patch("core.security.rule_of_two.is_interactive", return_value=True), \
-             patch("core.orchestration.agentic_passes.shutil.which",
-                   return_value=None):
+    # --- allow quadrants: human present, OR sandbox effective ---
+
+    def test_understand_passes_gate_when_human(self):
+        h, s = self._legs(human=True, sandbox=False)
+        with h, s, patch(
+            "core.orchestration.agentic_passes.shutil.which", return_value=None
+        ):
             result = run_understand_prepass(
                 target=Path("scratch/nonexistent-target"),
                 agentic_out_dir=Path("scratch/nonexistent-out"),
             )
-        # Gets past the Rule of Two gate, fails at next check
+        # Past the gate (no Rule-of-Two block), fails at the next check.
         self.assertFalse(result.ran)
-        self.assertNotIn("non-interactive", result.skipped_reason)
+        self.assertNotIn("Rule of Two", result.skipped_reason or "")
+        self.assertIn("claude not on PATH", result.skipped_reason)
 
-    def test_validate_passes_gate_when_interactive(self):
+    def test_understand_passes_gate_when_sandboxed_noninteractive(self):
+        # The new capability: CI/cron with containment runs the pass.
+        h, s = self._legs(human=False, sandbox=True)
+        with h, s, patch(
+            "core.orchestration.agentic_passes.shutil.which", return_value=None
+        ):
+            result = run_understand_prepass(
+                target=Path("scratch/nonexistent-target"),
+                agentic_out_dir=Path("scratch/nonexistent-out"),
+            )
+        self.assertFalse(result.ran)
+        self.assertNotIn("Rule of Two", result.skipped_reason or "")
+        self.assertIn("claude not on PATH", result.skipped_reason)
+
+    def test_validate_passes_gate_when_sandboxed_noninteractive(self):
         with TemporaryDirectory() as tmp:
             tmp = Path(tmp)
             report = tmp / "report.json"
             report.write_text('{"results": []}')
-            with patch("core.security.rule_of_two.is_interactive", return_value=True), \
-                 patch("core.orchestration.agentic_passes.shutil.which",
-                       return_value=None):
+            h, s = self._legs(human=False, sandbox=True)
+            with h, s, patch(
+                "core.orchestration.agentic_passes.shutil.which",
+                return_value=None,
+            ):
                 result = run_validate_postpass(
                     target=Path("scratch/nonexistent-target"),
                     agentic_out_dir=tmp,
                     analysis_report=report,
                 )
         self.assertFalse(result.ran)
-        self.assertNotIn("non-interactive", result.skipped_reason)
+        self.assertNotIn("Rule of Two", result.skipped_reason or "")
 
 
 if __name__ == "__main__":

--- a/core/orchestration/tests/test_agentic_passes_integration.py
+++ b/core/orchestration/tests/test_agentic_passes_integration.py
@@ -25,8 +25,11 @@ _interactive_patch = None
 
 def setUpModule():
     global _interactive_patch
+    # Force the agentic-pass gate open: mock the human-terminal leg True so
+    # the full pass path runs under CI/pytest (no controlling terminal).
     _interactive_patch = patch(
-        "core.security.rule_of_two.is_interactive", return_value=True,
+        "core.security.rule_of_two._session_has_human_terminal",
+        return_value=True,
     )
     _interactive_patch.start()
 

--- a/core/orchestration/tests/test_validate_checklist_handoff_e2e.py
+++ b/core/orchestration/tests/test_validate_checklist_handoff_e2e.py
@@ -149,7 +149,7 @@ def test_agentic_launcher_writes_pointer_into_validate_dir(tmp_path):
          patch("core.orchestration.agentic_passes.shutil.which",
                return_value="/usr/bin/fake-claude"), \
          patch("core.security.rule_of_two."
-               "require_interactive_for_agentic_pass"):
+               "require_human_or_sandbox_for_agentic_pass"):
         result = agentic_passes.run_validate_postpass(
             target=target,
             agentic_out_dir=agentic_out,

--- a/core/security/rule_of_two.py
+++ b/core/security/rule_of_two.py
@@ -13,10 +13,20 @@ Two gates:
    non-interactive mode. CI pipelines must use a model that passes
    the defense envelope probe.
 
-2. **Agentic passes with Write/Bash**: --understand/--validate grant
-   Write+Bash to an agent processing untrusted target code (A+B).
-   Blocked in non-interactive mode — no HITL to catch prompt-injected
-   file writes or command execution.
+2. **Agentic passes with Write/Bash**: --understand/--validate dispatch an
+   autonomous ``claude -p`` sub-agent with Write+Bash over untrusted target
+   code (A + B/C). Rule of Two is satisfied by removing a leg (containment)
+   OR by a human in the loop, so this gate allows the pass when EITHER holds:
+   a human-attended session, OR an effective sandbox confining the sub-agent.
+   It blocks only the one quadrant with neither — a non-interactive run that
+   also has no sandbox.
+
+   Note on detecting "human-attended": stdin.isatty() is NOT used here.
+   Claude Code detaches the controlling terminal from its tool subprocesses,
+   so the local TTY check reports non-interactive even with a human driving
+   the session. Instead we walk the process tree for an ancestor that still
+   holds a controlling terminal (the interactive ``claude`` process does);
+   headless contexts (CI/cron/SDK) have none. See _has_terminal_ancestor().
 """
 
 from __future__ import annotations
@@ -113,23 +123,158 @@ def require_interactive_for_weakened_defenses() -> None:
         )
 
 
-def require_interactive_for_agentic_pass(pass_name: str) -> None:
-    """Block agentic passes with Write/Bash in non-interactive mode.
+def _proc_tty_and_ppid(pid: int):
+    """Return ``(tty_nr, ppid)`` for a Linux pid from ``/proc/<pid>/stat``.
 
-    These passes grant Write+Bash tools to an agent processing untrusted
-    target code (Rule of Two: A=untrusted input + B=sensitive access).
-    In interactive mode, Claude Code's permission prompt gates each action.
-    In CI/CD, there is no permission prompt.
+    ``None`` on any read/parse error. The comm field (stat field 2) is wrapped
+    in parens and may itself contain spaces or ``)``; split on the LAST ``)``
+    so the numeric fields after it parse regardless of the process name.
+    """
+    try:
+        with open(f"/proc/{pid}/stat", encoding="utf-8", errors="replace") as fh:
+            data = fh.read()
+        rp = data.rindex(")")
+        fields = data[rp + 2:].split()
+        ppid = int(fields[1])    # overall stat field 4 — parent pid
+        tty_nr = int(fields[4])  # overall stat field 7 — controlling tty (0 = none)
+        return tty_nr, ppid
+    except (OSError, ValueError, IndexError):
+        return None
+
+
+def _has_terminal_ancestor() -> bool:
+    """True if this process or any ancestor holds a controlling terminal (Linux).
+
+    Claude Code runs its tool subprocesses with the controlling terminal
+    detached — ``stdin.isatty()`` is False and ``/dev/tty`` is ENXIO — so a
+    local TTY check can't see the human. But the interactive ``claude``
+    process itself keeps its controlling terminal, so walking the parent chain
+    finds it. A headless run (cron, systemd, CI, SDK daemon) has no
+    controlling terminal anywhere in the chain and returns False.
+
+    Linux-only (reads ``/proc``); other platforms rely on the caller's
+    stdin-TTY fallback. Bounded hop count + visited-set guard against a
+    pathological/looping process table.
+    """
+    pid = os.getpid()
+    seen: set[int] = set()
+    hops = 0
+    while pid and pid not in seen and hops < 256:
+        seen.add(pid)
+        hops += 1
+        res = _proc_tty_and_ppid(pid)
+        if res is None:
+            break
+        tty_nr, ppid = res
+        if tty_nr != 0:
+            return True
+        if ppid == pid:
+            break
+        pid = ppid
+    return False
+
+
+def _session_has_human_terminal() -> bool:
+    """Best-effort 'a human is at a terminal in this session' probe.
+
+    True only when a controlling terminal is present AND no CI env var is set
+    (a CI runner that allocated a pseudo-TTY must not count as human-attended,
+    matching is_interactive()'s hardening). Fail-closed: any error → False.
+    """
+    if _is_ci():
+        return False
+    try:
+        if sys.platform.startswith("linux") and _has_terminal_ancestor():
+            return True
+        # Non-Linux, or /proc walk found nothing: fall back to the local TTY
+        # check (covers a human running RAPTOR directly in a terminal).
+        return bool(hasattr(sys.stdin, "isatty") and sys.stdin.isatty())
+    except Exception:  # noqa: BLE001 — detection must never crash the gate
+        return False
+
+
+def _sandbox_will_contain() -> bool:
+    """True if the untrusted-dispatch sandbox will actually confine the sub-agent.
+
+    The understand/validate sub-agent runs under ``run_untrusted_networked``,
+    whose threat is a prompt-injected agent writing/exec-ing outside its run
+    dir. "Contained" therefore means **filesystem confinement is in force**,
+    which requires all of:
+
+      1. the operator hasn't disabled the sandbox (--no-sandbox), AND
+      2. the *effective profile* actually engages filesystem confinement —
+         i.e. ``use_landlock`` is set for that profile. ``none`` and
+         ``network-only`` both have ``use_landlock=False`` (network-only
+         restricts egress but leaves the filesystem open), so neither
+         counts, AND
+      3. the platform can enforce it — Landlock on Linux, Seatbelt on macOS.
+
+    Fail-closed: any uncertainty (unknown profile, import error, capability
+    probe failure) returns False, so the pass falls back to requiring a human
+    terminal rather than running unconfined. Checking the profile's declared
+    intent — not just kernel capability — closes the network-only fail-open
+    where Landlock is available but the chosen profile doesn't use it.
+    """
+    try:
+        from core.sandbox import state
+        from core.sandbox.profiles import DEFAULT_PROFILE, PROFILES
+
+        if bool(getattr(state, "_cli_sandbox_disabled", False)):
+            return False
+        profile_name = getattr(state, "_cli_sandbox_profile", None) or DEFAULT_PROFILE
+        profile = PROFILES.get(profile_name)
+        # Unknown profile or one that doesn't engage filesystem confinement
+        # (none, network-only) → not contained for this purpose.
+        if not profile or not profile.get("use_landlock"):
+            return False
+
+        from core.sandbox.context import (
+            check_landlock_available,
+            check_seatbelt_available,
+        )
+        if sys.platform == "darwin":
+            return bool(check_seatbelt_available())
+        return bool(check_landlock_available())
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def require_human_or_sandbox_for_agentic_pass(pass_name: str) -> None:
+    """Gate the understand/validate agentic pass (Rule of Two).
+
+    The pass dispatches an autonomous ``claude -p`` sub-agent with Write+Bash
+    over untrusted target code (A=untrusted input + B/C=write/exec). Rule of
+    Two is satisfied by removing a leg (containment) OR by a human in the loop,
+    so the pass is allowed when EITHER holds:
+
+      * **human-attended session** — the operator asked for this at a terminal
+        (detected by walking the process tree for a controlling terminal,
+        since Claude Code detaches the TTY from tool subprocesses), OR
+      * **effective sandbox** — run_untrusted_networked confines the
+        sub-agent's writes to target + run dir, proxies network, and applies
+        Landlock/seccomp.
+
+    Blocks ONLY when NEITHER holds: a non-interactive run (CI/cron/SDK) that
+    also disabled the sandbox or runs where it can't be enforced. That single
+    quadrant — untrusted input + write/exec with no human and no containment —
+    is the genuine Rule-of-Two danger zone::
+
+                     | sandbox effective | sandbox off / unavailable
+        -------------+-------------------+--------------------------
+        interactive  |      allow        |        allow
+        non-interact |      allow        |        BLOCK
 
     Args:
         pass_name: "understand" or "validate" — for the error message.
     """
-    if not is_interactive():
-        raise NonInteractiveError(
-            f"--{pass_name} agentic pass is not allowed in non-interactive mode. "
-            f"The {pass_name} pass grants Write and Bash tools to an agent "
-            f"processing untrusted target code. In an interactive session, "
-            f"Claude Code's permission prompt gates each action. In CI/CD, "
-            f"there is no such gate (Rule of Two: untrusted input + write "
-            f"access requires human-in-the-loop)."
-        )
+    if _sandbox_will_contain() or _session_has_human_terminal():
+        return
+    raise NonInteractiveError(
+        f"--{pass_name} dispatches an autonomous agent with Write and Bash "
+        f"over untrusted target code, which requires either a human-attended "
+        f"session or an effective sandbox — this run has neither: it is "
+        f"non-interactive AND the sandbox is disabled or unavailable "
+        f"(Rule of Two: untrusted input + write access). Re-run with the "
+        f"sandbox enabled, or from an interactive session, to use "
+        f"--{pass_name}."
+    )

--- a/core/security/tests/test_rule_of_two.py
+++ b/core/security/tests/test_rule_of_two.py
@@ -7,10 +7,11 @@ from unittest.mock import patch
 
 import pytest
 
+import core.security.rule_of_two as r2
 from core.security.rule_of_two import (
     NonInteractiveError,
     is_interactive,
-    require_interactive_for_agentic_pass,
+    require_human_or_sandbox_for_agentic_pass,
     require_interactive_for_weakened_defenses,
 )
 
@@ -73,27 +74,159 @@ class TestWeakenedDefensesGate:
 
 
 class TestAgenticPassGate:
+    """Either/or gate: allow when a human terminal OR an effective sandbox is
+    present; block only the non-interactive + no-sandbox quadrant.
 
-    def test_passes_when_interactive(self):
-        with patch("core.security.rule_of_two.is_interactive", return_value=True):
-            require_interactive_for_agentic_pass("understand")
+    The two legs are mocked at their helper boundary so these tests don't
+    depend on the real process tree / sandbox capability of the test host.
+    """
 
-    def test_raises_when_non_interactive(self):
-        with patch("core.security.rule_of_two.is_interactive", return_value=False):
-            with pytest.raises(NonInteractiveError, match="not allowed in non-interactive"):
-                require_interactive_for_agentic_pass("understand")
+    @staticmethod
+    def _patch(*, human: bool, sandbox: bool):
+        return (
+            patch("core.security.rule_of_two._session_has_human_terminal",
+                  return_value=human),
+            patch("core.security.rule_of_two._sandbox_will_contain",
+                  return_value=sandbox),
+        )
+
+    def _run(self, *, human: bool, sandbox: bool, pass_name: str = "understand"):
+        p1, p2 = self._patch(human=human, sandbox=sandbox)
+        with p1, p2:
+            require_human_or_sandbox_for_agentic_pass(pass_name)
+
+    # --- the 2x2 matrix: only (no human, no sandbox) blocks ---
+
+    def test_human_and_sandbox_allows(self):
+        self._run(human=True, sandbox=True)  # no raise
+
+    def test_human_no_sandbox_allows(self):
+        # Interactive operator who disabled the sandbox — they own the risk.
+        self._run(human=True, sandbox=False)
+
+    def test_sandbox_no_human_allows(self):
+        # CI/cron with containment — the common automated case.
+        self._run(human=False, sandbox=True)
+
+    def test_neither_blocks(self):
+        with pytest.raises(NonInteractiveError):
+            self._run(human=False, sandbox=False)
+
+    # --- error message content (block quadrant) ---
 
     def test_error_includes_pass_name(self):
-        with patch("core.security.rule_of_two.is_interactive", return_value=False):
-            with pytest.raises(NonInteractiveError, match="--validate"):
-                require_interactive_for_agentic_pass("validate")
+        with pytest.raises(NonInteractiveError, match="--validate"):
+            self._run(human=False, sandbox=False, pass_name="validate")
 
     def test_error_mentions_rule_of_two(self):
-        with patch("core.security.rule_of_two.is_interactive", return_value=False):
-            with pytest.raises(NonInteractiveError, match="Rule of Two"):
-                require_interactive_for_agentic_pass("understand")
+        with pytest.raises(NonInteractiveError, match="Rule of Two"):
+            self._run(human=False, sandbox=False)
 
     def test_error_mentions_write_and_bash(self):
-        with patch("core.security.rule_of_two.is_interactive", return_value=False):
-            with pytest.raises(NonInteractiveError, match="Write and Bash"):
-                require_interactive_for_agentic_pass("understand")
+        with pytest.raises(NonInteractiveError, match="Write and Bash"):
+            self._run(human=False, sandbox=False)
+
+    def test_error_mentions_both_remedies(self):
+        # The message must point at both escape hatches: enable sandbox OR
+        # run interactively. Otherwise an operator only learns half the fix.
+        with pytest.raises(NonInteractiveError, match="sandbox"):
+            self._run(human=False, sandbox=False)
+        with pytest.raises(NonInteractiveError, match="interactive session"):
+            self._run(human=False, sandbox=False)
+
+
+class TestSessionHumanTerminal:
+
+    @pytest.fixture(autouse=True)
+    def _no_ci_env(self, monkeypatch):
+        for name in r2._CI_ENV_VARS:
+            monkeypatch.delenv(name, raising=False)
+
+    def test_true_when_terminal_ancestor(self, monkeypatch):
+        monkeypatch.setattr(r2.sys, "platform", "linux")
+        monkeypatch.setattr(r2, "_has_terminal_ancestor", lambda: True)
+        assert r2._session_has_human_terminal() is True
+
+    def test_false_in_ci_even_with_terminal(self, monkeypatch):
+        # A CI runner with a pseudo-TTY ancestor must not count as
+        # human-attended — same hole is_interactive() closes.
+        monkeypatch.setenv("CI", "true")
+        monkeypatch.setattr(r2, "_has_terminal_ancestor", lambda: True)
+        assert r2._session_has_human_terminal() is False
+
+    def test_falls_back_to_stdin_tty_when_no_ancestor(self, monkeypatch):
+        monkeypatch.setattr(r2.sys, "platform", "linux")
+        monkeypatch.setattr(r2, "_has_terminal_ancestor", lambda: False)
+        with patch("sys.stdin") as mock_stdin:
+            mock_stdin.isatty.return_value = True
+            assert r2._session_has_human_terminal() is True
+
+    def test_fail_closed_on_error(self, monkeypatch):
+        def boom():
+            raise RuntimeError("proc walk exploded")
+        monkeypatch.setattr(r2.sys, "platform", "linux")
+        monkeypatch.setattr(r2, "_has_terminal_ancestor", boom)
+        # stdin.isatty also raises → overall fail-closed to False.
+        with patch("sys.stdin") as mock_stdin:
+            mock_stdin.isatty.side_effect = RuntimeError("nope")
+            assert r2._session_has_human_terminal() is False
+
+
+class TestSandboxWillContain:
+
+    def test_false_when_cli_disabled(self, monkeypatch):
+        from core.sandbox import state
+        monkeypatch.setattr(state, "_cli_sandbox_disabled", True, raising=False)
+        assert r2._sandbox_will_contain() is False
+
+    def test_false_when_profile_none(self, monkeypatch):
+        from core.sandbox import state
+        monkeypatch.setattr(state, "_cli_sandbox_disabled", False, raising=False)
+        monkeypatch.setattr(state, "_cli_sandbox_profile", "none", raising=False)
+        assert r2._sandbox_will_contain() is False
+
+    def test_true_when_enabled_and_capable(self, monkeypatch):
+        from core.sandbox import state
+        monkeypatch.setattr(state, "_cli_sandbox_disabled", False, raising=False)
+        monkeypatch.setattr(state, "_cli_sandbox_profile", None, raising=False)
+        monkeypatch.setattr(r2.sys, "platform", "linux")
+        monkeypatch.setattr(
+            "core.sandbox.context.check_landlock_available", lambda: True
+        )
+        assert r2._sandbox_will_contain() is True
+
+    def test_false_when_platform_cannot_enforce(self, monkeypatch):
+        from core.sandbox import state
+        monkeypatch.setattr(state, "_cli_sandbox_disabled", False, raising=False)
+        monkeypatch.setattr(state, "_cli_sandbox_profile", None, raising=False)
+        monkeypatch.setattr(r2.sys, "platform", "linux")
+        monkeypatch.setattr(
+            "core.sandbox.context.check_landlock_available", lambda: False
+        )
+        assert r2._sandbox_will_contain() is False
+
+    def test_false_when_network_only_profile(self, monkeypatch):
+        # network-only has use_landlock=False — egress is restricted but the
+        # filesystem is open, so the untrusted sub-agent isn't write-confined.
+        # Must NOT count as contained even though Landlock is available.
+        from core.sandbox import state
+        monkeypatch.setattr(state, "_cli_sandbox_disabled", False, raising=False)
+        monkeypatch.setattr(state, "_cli_sandbox_profile", "network-only",
+                            raising=False)
+        monkeypatch.setattr(r2.sys, "platform", "linux")
+        monkeypatch.setattr(
+            "core.sandbox.context.check_landlock_available", lambda: True
+        )
+        assert r2._sandbox_will_contain() is False
+
+    def test_true_for_debug_profile_when_capable(self, monkeypatch):
+        # debug relaxes seccomp (ptrace) but keeps use_landlock=True, so
+        # filesystem writes are still confined → contained.
+        from core.sandbox import state
+        monkeypatch.setattr(state, "_cli_sandbox_disabled", False, raising=False)
+        monkeypatch.setattr(state, "_cli_sandbox_profile", "debug", raising=False)
+        monkeypatch.setattr(r2.sys, "platform", "linux")
+        monkeypatch.setattr(
+            "core.sandbox.context.check_landlock_available", lambda: True
+        )
+        assert r2._sandbox_will_contain() is True


### PR DESCRIPTION
The --understand/--validate pre-passes dispatch an autonomous claude -p sub-agent with Write+Bash over untrusted target code. Their Rule-of-Two gate required an interactive session, detected via stdin.isatty(). But Claude Code detaches the controlling terminal from its tool subprocesses, so isatty() reports non-interactive even with a human driving the session — the passes silently skipped on the normal operator path, and the supplied flag did nothing.

Replace the interactivity-only gate with either/or containment:

                 | sandbox effective | sandbox off / unavailable
    -------------+-------------------+--------------------------
    interactive  |      allow        |        allow
    non-interact |      allow        |        BLOCK

A pass is allowed when a human-attended session OR an effective sandbox is present; only the no-human + no-containment quadrant blocks. This is the genuine Rule-of-Two danger zone, and it makes the flag function in both interactive and CI use.

- Human detection walks the process tree for an ancestor holding a controlling terminal (the interactive claude process does), instead of the subprocess-local stdin.isatty(); excludes CI envs; fail-closed.
- Containment requires the sandbox not be disabled AND the effective profile actually engage filesystem confinement (use_landlock) AND the platform enforce it. Checking the profile's intent — not just kernel capability — means network-only (use_landlock=False) does not count as contained.

is_interactive() and the separate --accept-weakened-defenses gate are unchanged. Tests cover the 2x2 matrix, the terminal-ancestry probe (CI exclusion, fallback, fail-closed), and the containment predicate (disabled / none / network-only / debug / capability).