### PR TITLE
fix(log): silence noisy third-party loggers, demote dispatcher per-request

### DIFF
--- a/core/llm/dispatcher/server.py
+++ b/core/llm/dispatcher/server.py
@@ -63,6 +63,14 @@ from .auth import (
 _logger = logging.getLogger(__name__)
 
 
+# Audit event types that fire on every successful LLM call and
+# would otherwise flood operator output. Consumed by ``_audit``
+# to route ok-status events here to DEBUG; everything else
+# (failures, lifecycle, unknown types) stays at INFO. See
+# ``_audit`` for the routing rationale.
+_HIGH_FREQ_OK_EVENTS = frozenset({"request.dispatch"})
+
+
 def _scrub(value: Optional[str]) -> Optional[str]:
     """Defang nonprintable + ANSI escapes in operator-visible
     fields (``worker_label``, ``reason``) before they hit the
@@ -331,6 +339,14 @@ class LLMDispatcher:
         )
         self._thread.start()
 
+        # Quiet third-party loggers (httpx HTTP-request lines,
+        # google.genai AFC banner, etc.) so operator output during
+        # /agentic / /understand / /validate isn't drowned in
+        # transport-layer chatter. WARNING and above still
+        # surface so real failures aren't hidden.
+        from core.llm.log_quiet import quiet_noisy_loggers
+        quiet_noisy_loggers()
+
         self._audit(AuditEvent(
             ts=time.time(),
             event="server.start",
@@ -472,6 +488,27 @@ class LLMDispatcher:
         # are internally produced strings.
         safe_worker = _scrub(ev.worker_label)
         safe_reason = _scrub(ev.reason)
+        # Log level chosen by event type + status:
+        # * High-frequency successful events (e.g. ``request.dispatch
+        #   ok``) → DEBUG. One per LLM call; floods operator
+        #   output during /agentic / /understand / /validate
+        #   without adding signal a human reads. Held in a SET so
+        #   a future high-frequency event type (cache hits,
+        #   prefetch acks, …) joins the demotion list cleanly
+        #   without re-introducing the noise on its own.
+        # * Everything else (server lifecycle, token issuance,
+        #   ANY failure, any unknown event type) → INFO. These
+        #   are low-frequency, operator-actionable, or both.
+        # Audit log on disk continues to record EVERY event at
+        # full fidelity — this only affects the stdlib logger
+        # that terminal output uses.
+        if (
+            ev.event in _HIGH_FREQ_OK_EVENTS
+            and ev.status == "ok"
+        ):
+            level = logging.DEBUG
+        else:
+            level = logging.INFO
         # Always log via stdlib logger for terminal visibility.
         # nosemgrep: python.lang.security.audit.logging.logger-credential-leak.python-logger-credential-disclosure
         # ``ev.token_id`` is a 12-character correlation prefix (see
@@ -479,7 +516,8 @@ class LLMDispatcher:
         # full token. Operator visibility for the auth flow needs
         # SOME identifier; the prefix gives correlation without
         # disclosure.
-        _logger.info(
+        _logger.log(
+            level,
             "llm-dispatcher %s %s pid=%s uid=%s token=%s label=%s%s",
             ev.event, ev.status, ev.peer_pid, ev.peer_uid,
             ev.token_id or "-", safe_worker or "-",

--- a/core/llm/dispatcher/tests/test_dispatcher.py
+++ b/core/llm/dispatcher/tests/test_dispatcher.py
@@ -892,3 +892,58 @@ class TestE2EResponseEncodingPreserved:
         finally:
             upstream.shutdown()
             d.shutdown()
+
+
+# ---------------------------------------------------------------------------
+# Integration: dispatcher init must wire ``quiet_noisy_loggers()`` so the
+# httpx / google.genai INFO chatter doesn't flood operator output.
+# Closes the gap between the helper's unit tests (in
+# ``core/llm/tests/test_log_quiet.py``) and the real LLM call path.
+# ---------------------------------------------------------------------------
+
+
+class TestQuietNoisyLoggersWired:
+
+    def test_dispatcher_init_silences_noisy_third_party_loggers(
+        self, fake_creds, tmp_path,
+    ):
+        """Regression guard: if a future refactor drops the
+        ``quiet_noisy_loggers()`` call from ``LLMDispatcher._init_server``,
+        every other test still passes — only operator runs show the
+        flood. This test pins the wire."""
+        import logging as _logging
+        from core.llm.log_quiet import _NOISY_LOGGERS
+
+        # Reset to a known noisy state BEFORE constructing the
+        # dispatcher — otherwise a stale process-wide setLevel
+        # (from a previous test that ran the dispatcher) could
+        # mask a missing wire here.
+        saved: dict = {}
+        for name in _NOISY_LOGGERS:
+            lg = _logging.getLogger(name)
+            saved[name] = lg.level
+            lg.setLevel(_logging.INFO)
+
+        audit = tmp_path / "audit.jsonl"
+        d = LLMDispatcher(
+            run_id="quiet-wire-test", audit_path=audit,
+            token_ttl_s=3600, token_budget=100, creds=fake_creds,
+        )
+        try:
+            # Every targeted logger landed at WARNING or stricter.
+            # ``>=`` accommodates an operator override that
+            # raised the level further (ERROR / CRITICAL).
+            for name in _NOISY_LOGGERS:
+                level = _logging.getLogger(name).level
+                assert level >= _logging.WARNING, (
+                    f"Logger {name!r}: expected WARNING+ after "
+                    f"dispatcher init (means quiet_noisy_loggers "
+                    f"is wired); got level={level}. Check that "
+                    f"LLMDispatcher._init_server still calls "
+                    f"core.llm.log_quiet.quiet_noisy_loggers."
+                )
+        finally:
+            d.shutdown()
+            # Restore prior state for isolation from other tests.
+            for name, lvl in saved.items():
+                _logging.getLogger(name).setLevel(lvl)

--- a/core/llm/log_quiet.py
+++ b/core/llm/log_quiet.py
@@ -1,0 +1,68 @@
+"""Quiet noisy third-party loggers that flood operator output
+during /agentic and other LLM-driven runs.
+
+The Gemini SDK (``google.genai``) and the underlying ``httpx``
+HTTP client both emit INFO-level lines on every API call:
+
+* ``[INFO] AFC is enabled with max remote calls: 10.`` — google.genai's
+  automatic-function-calling banner, logged on every model
+  initialisation.
+* ``[INFO] HTTP Request: POST https://generativelanguage.googleapis.com/...`` —
+  httpx's per-request log; fires twice per RAPTOR LLM call
+  (once for the real provider endpoint, once for the dispatcher
+  proxy on the loopback unix socket).
+
+Neither line carries operator-relevant signal at INFO. They're
+debugging detail at the SDK / transport layer. Operators looking
+at /agentic output want per-finding analysis progress and cost,
+not the HTTP plumbing.
+
+This module is the single chokepoint for these adjustments —
+called once from the dispatcher's ``start()`` so EVERY run path
+(/agentic, /codeql, /understand, /validate, /scan with LLM
+enrichment) gets the quiet treatment uniformly.
+"""
+
+from __future__ import annotations
+
+import logging
+
+# Logger names known to flood INFO during normal RAPTOR operation.
+# Order doesn't matter; ``setLevel`` is idempotent.
+#
+# Coverage rationale:
+# * ``httpx`` — every API call emits ``HTTP Request: POST <url> "HTTP/1.1 NNN ..."``
+#   at INFO. Fires on the real upstream call AND the dispatcher
+#   proxy call (the unix-socket forwarder). Two lines per LLM
+#   request before this module silenced them.
+# * ``httpcore`` — httpx's underlying transport library; can emit
+#   connection / TLS lines depending on configuration. Quieted
+#   defensively.
+# * ``google.genai`` and ``google_genai`` — both names appear
+#   across SDK versions; alias-cover for safety.
+# * ``google.api_core``, ``google.auth`` — supporting libraries
+#   that occasionally emit auth-related INFO. Quiet by default;
+#   anything that's actually wrong surfaces at WARNING regardless.
+_NOISY_LOGGERS = (
+    "httpx",
+    "httpcore",
+    "google.genai",
+    "google_genai",
+    "google.api_core",
+    "google.auth",
+)
+
+
+def quiet_noisy_loggers(level: int = logging.WARNING) -> None:
+    """Set the listed third-party loggers to ``level`` (default
+    WARNING) so their INFO chatter stops flooding /agentic output.
+
+    Idempotent — safe to call repeatedly. WARNING and above
+    still surface so real failures (HTTP errors, auth failures)
+    aren't hidden.
+    """
+    for name in _NOISY_LOGGERS:
+        logging.getLogger(name).setLevel(level)
+
+
+__all__ = ["quiet_noisy_loggers"]

--- a/core/llm/tests/test_log_quiet.py
+++ b/core/llm/tests/test_log_quiet.py
@@ -1,0 +1,181 @@
+"""Tests for ``core/llm/log_quiet.py`` — the third-party logger
+silencer that suppresses INFO chatter from ``httpx`` /
+``google.genai`` during /agentic and friends."""
+
+from __future__ import annotations
+
+import logging
+
+from core.llm.log_quiet import quiet_noisy_loggers, _NOISY_LOGGERS
+
+
+class TestQuietNoisyLoggers:
+    """The level-setting is idempotent and only touches the
+    listed third-party loggers; it must NOT raise the root or
+    RAPTOR's own loggers."""
+
+    def test_default_level_is_warning(self):
+        # Capture pre-state, mutate, capture post-state, restore.
+        before = {n: logging.getLogger(n).level for n in _NOISY_LOGGERS}
+        try:
+            quiet_noisy_loggers()
+            for name in _NOISY_LOGGERS:
+                assert logging.getLogger(name).level == logging.WARNING
+        finally:
+            for n, lvl in before.items():
+                logging.getLogger(n).setLevel(lvl)
+
+    def test_explicit_level_honoured(self):
+        before = {n: logging.getLogger(n).level for n in _NOISY_LOGGERS}
+        try:
+            quiet_noisy_loggers(logging.ERROR)
+            for name in _NOISY_LOGGERS:
+                assert logging.getLogger(name).level == logging.ERROR
+        finally:
+            for n, lvl in before.items():
+                logging.getLogger(n).setLevel(lvl)
+
+    def test_root_logger_unaffected(self):
+        # Defensive: must NOT touch the root logger — that would
+        # silence RAPTOR's own diagnostics globally.
+        root_before = logging.getLogger().level
+        try:
+            quiet_noisy_loggers()
+            assert logging.getLogger().level == root_before
+        finally:
+            logging.getLogger().setLevel(root_before)
+
+    def test_idempotent(self):
+        before = {n: logging.getLogger(n).level for n in _NOISY_LOGGERS}
+        try:
+            quiet_noisy_loggers()
+            quiet_noisy_loggers()  # second call no-ops
+            quiet_noisy_loggers(logging.ERROR)  # raise to ERROR
+            quiet_noisy_loggers(logging.WARNING)  # back to WARNING
+            for name in _NOISY_LOGGERS:
+                assert logging.getLogger(name).level == logging.WARNING
+        finally:
+            for n, lvl in before.items():
+                logging.getLogger(n).setLevel(lvl)
+
+    def test_targets_include_known_offenders(self):
+        # Pin the membership so a future cleanup that drops a
+        # logger name from the list has to acknowledge the
+        # operator-facing regression in the test.
+        assert "httpx" in _NOISY_LOGGERS
+        assert "google.genai" in _NOISY_LOGGERS
+        # Variant naming (older SDK form) also covered.
+        assert "google_genai" in _NOISY_LOGGERS
+
+
+class TestDispatcherAuditLogLevel:
+    """``LLMDispatcher._audit`` routes high-frequency successful
+    events to DEBUG; everything else stays at INFO. Audit log on
+    disk continues to record every event at full fidelity — this
+    is purely about terminal-output noise.
+
+    These tests patch the actual ``_logger.log`` call inside
+    server.py so a regression in the conditional surfaces here
+    instead of in operator runs.
+    """
+
+    def _capture_log_call(self, event: str, status: str):
+        """Invoke ``LLMDispatcher._audit`` (the bound method)
+        with a synthetic event, capturing the log level it passed
+        to ``_logger.log``. Mocks the audit-file path so no disk
+        I/O happens.
+
+        Strict: if ``_audit`` is refactored to call
+        ``_logger.info`` / ``_logger.debug`` directly instead of
+        ``_logger.log(level, ...)``, the spy sees no calls and
+        the assertion catches the regression loudly (vs.
+        silently returning None and passing a vacuous comparison)."""
+        import threading as _thr
+        from unittest.mock import patch
+        from core.llm.dispatcher import server as server_mod
+        # Build the AuditEvent shape ``_audit`` expects.
+        ev = server_mod.AuditEvent(
+            ts=0.0, event=event,
+            peer_pid=None, peer_uid=None,
+            token_id=None, worker_label=None,
+            status=status,
+        )
+        # ``_audit`` is bound to ``LLMDispatcher``; we don't
+        # need a real instance — just enough shape to satisfy
+        # the method. Bypass ``__init__`` and stub the
+        # attributes ``_audit`` reads. ``_audit_path = None``
+        # short-circuits the disk path; the lock + warned-flag
+        # are belt-and-braces against a future ``_audit`` body
+        # that reads them BEFORE the short-circuit.
+        inst = server_mod.LLMDispatcher.__new__(
+            server_mod.LLMDispatcher,
+        )
+        inst._audit_path = None
+        inst._audit_lock = _thr.Lock()
+        inst._audit_warned = False
+        captured: dict = {}
+        def _spy_log(level, *args, **kwargs):
+            captured["level"] = level
+            captured["called"] = True
+        with patch.object(server_mod._logger, "log", side_effect=_spy_log):
+            server_mod.LLMDispatcher._audit(inst, ev)
+        assert captured.get("called"), (
+            "_audit did not call _logger.log — implementation may "
+            "have switched to _logger.info/_logger.debug directly. "
+            "Update the test to follow the new shape."
+        )
+        return captured["level"]
+
+    def test_request_dispatch_ok_uses_debug(self):
+        # The high-frequency case that's responsible for the
+        # bulk of operator log noise during /agentic.
+        assert self._capture_log_call(
+            "request.dispatch", "ok",
+        ) == logging.DEBUG
+
+    def test_request_dispatch_error_stays_info(self):
+        # Errors are operator-relevant; stay at INFO so the
+        # operator sees them in the terminal stream.
+        assert self._capture_log_call(
+            "request.dispatch", "error",
+        ) == logging.INFO
+
+    def test_server_start_stays_info(self):
+        # Low-frequency lifecycle events stay at INFO.
+        assert self._capture_log_call(
+            "server.start", "ok",
+        ) == logging.INFO
+
+    def test_token_issue_stays_info(self):
+        # Token issuance — rare, security-relevant — stays at INFO.
+        assert self._capture_log_call(
+            "token.issue", "ok",
+        ) == logging.INFO
+
+    def test_request_error_stays_info(self):
+        # Real dispatcher emits ``request.error`` events; they
+        # must always be visible to operators.
+        assert self._capture_log_call(
+            "request.error", "error",
+        ) == logging.INFO
+
+    def test_unknown_event_type_defaults_to_info(self):
+        # New event types added later default to INFO (the
+        # ``_HIGH_FREQ_OK_EVENTS`` set is opt-in, not opt-out)
+        # — operator-conservative: a new event type that turns
+        # out to be high-frequency would surface here rather
+        # than silently disappear into DEBUG.
+        assert self._capture_log_call(
+            "future.event", "ok",
+        ) == logging.INFO
+
+    def test_high_freq_set_is_a_set(self):
+        # The set-based dispatch is a regression guard for the
+        # comment in scanner.py — future high-frequency event
+        # types join the demotion list cleanly without
+        # re-introducing the noise on their own. Pin the type
+        # so a refactor doesn't accidentally swap it for a
+        # string equality check again.
+        from core.llm.dispatcher import server as server_mod
+        assert isinstance(server_mod._HIGH_FREQ_OK_EVENTS, frozenset)
+        assert "request.dispatch" in server_mod._HIGH_FREQ_OK_EVENTS

--- a/raptor.py
+++ b/raptor.py
@@ -410,9 +410,19 @@ def _run_with_lifecycle(command: str, script_path: Path, args: list,
         from core.sage.hooks import recall_context_for_scan
         sage_context = recall_context_for_scan(target or "")
         if sage_context:
-            print(f"📚 SAGE: Recalled {len(sage_context)} historical memories")
+            # Same flush rationale as the lifecycle banner —
+            # when stdout is piped (operator's ``| tee``), block-
+            # buffering makes these lines appear AFTER the
+            # subprocess output unless explicitly flushed.
+            print(
+                f"📚 SAGE: Recalled {len(sage_context)} historical memories",
+                flush=True,
+            )
             for mem in sage_context[:3]:
-                print(f"   [{mem['confidence']:.0%}] {mem['content'][:80]}...")
+                print(
+                    f"   [{mem['confidence']:.0%}] {mem['content'][:80]}...",
+                    flush=True,
+                )
     except Exception:
         pass
 
@@ -420,7 +430,15 @@ def _run_with_lifecycle(command: str, script_path: Path, args: list,
     if "--out" not in args:
         args = args + ["--out", str(out_dir)]
 
-    print(f"\n[*] {label}\n")
+    # ``flush=True``: when stdout is piped (e.g. operator's ``| tee
+    # run.log``) Python switches to block-buffering, so the banner
+    # lands AFTER the subprocess's already-flushed output. The
+    # subprocess uses its own writes (often flushed eagerly), so
+    # without the explicit flush here the parent's "starting"
+    # banner can appear near the END of the log after the child's
+    # final summary — a confusing ordering artefact operators
+    # actually noticed.
+    print(f"\n[*] {label}\n", flush=True)
     rc = _run_script(script_path, args)
 
     # Write coverage records from tool outputs (before lifecycle complete)


### PR DESCRIPTION
Three operator-facing log-noise issues surfaced during the /agentic run against monit. Pre-fix output included ~367 noise lines (173 httpx HTTP-Request, 105 dispatcher per-request, 89 google.genai AFC banner) out of 814 total — operators couldn't see the actual analysis progress through the transport-layer chatter.