### PR TITLE
fix(reachability): handle r2 5.x offset-keyed aflj in edge extraction

### DIFF
--- a/core/inventory/binary_oracle_edges.py
+++ b/core/inventory/binary_oracle_edges.py
@@ -83,6 +83,20 @@ def _content_hash(binary_path: Path) -> Optional[str]:
         return None
 
 
+def _fn_addr(f: Dict) -> Optional[int]:
+    """Function entry address from an ``aflj`` record. r2 6.x keys this
+    as ``addr``; r2 5.x (the version Ubuntu/Debian apt ships, used by the
+    nightly CI corpus job) keys it as ``offset``. Accept either so the
+    extractor works across the r2 versions operators actually have
+    installed. Returns ``None`` when neither key holds an int — the
+    caller skips that function rather than crashing on ``f['addr']``."""
+    for key in ("addr", "offset"):
+        v = f.get(key)
+        if isinstance(v, int):
+            return v
+    return None
+
+
 def _edge_cache_dir() -> Path:
     """Edge-index cache root: ``out/binary-oracle-precision/edge-cache/``
     (re-using the existing binary_oracle output convention). Cache
@@ -260,14 +274,19 @@ def extract_direct_call_edges(
     # Build addr → name map for resolving callee addresses.
     addr_to_name: Dict[int, str] = {}
     for f in fns:
-        addr = f.get("addr")
+        addr = _fn_addr(f)
         name = f.get("name")
-        if isinstance(addr, int) and isinstance(name, str):
+        if addr is not None and isinstance(name, str):
             addr_to_name[addr] = _clean_r2_function_name(name)
 
+    # Only functions with a resolvable entry address are eligible — the
+    # axffj script keys every batch on that address. A record missing
+    # both ``addr`` and ``offset`` (malformed / partial r2 output) is
+    # dropped here rather than KeyError-ing the whole extraction.
     eligible_fns = [f for f in fns
                     if not f.get("name", "").startswith("sym.imp.")
-                    and f.get("size", 0) > 0]
+                    and f.get("size", 0) > 0
+                    and _fn_addr(f) is not None]
 
     # Single r2 invocation for ALL axffj calls (adversarial review
     # B P2-2 perf cliff fix). The prior implementation re-ran the
@@ -285,8 +304,9 @@ def extract_direct_call_edges(
     import tempfile
     script_lines = ["aaa"]
     for f in eligible_fns:
-        script_lines.append(f"echo BATCH {f['addr']}")
-        script_lines.append(f"axffj @ {f['addr']}")
+        addr = _fn_addr(f)
+        script_lines.append(f"echo BATCH {addr}")
+        script_lines.append(f"axffj @ {addr}")
     with tempfile.NamedTemporaryFile(
             mode="w", suffix=".r2", delete=False,
             dir=str(binary_path.parent),

--- a/core/inventory/tests/test_binary_oracle_edges.py
+++ b/core/inventory/tests/test_binary_oracle_edges.py
@@ -11,6 +11,7 @@ from core.inventory.binary_oracle_edges import (
     BinaryCallEdge,
     BinaryEdgeIndex,
     _clean_r2_function_name,
+    _fn_addr,
     _parse_axffj_batch,
     annotate_inventory_with_edges,
     extract_direct_call_edges,
@@ -33,6 +34,72 @@ def test_clean_r2_function_name_strips_known_prefixes() -> None:
     assert _clean_r2_function_name("func.helper") == "helper"
     assert _clean_r2_function_name("fcn.0x1234") == "0x1234"
     assert _clean_r2_function_name("plain_name") == "plain_name"
+
+
+def test_fn_addr_accepts_addr_and_offset_keys() -> None:
+    """aflj records key the entry address as ``addr`` on r2 6.x and as
+    ``offset`` on r2 5.x (the apt-shipped version the nightly CI corpus
+    job installs). Both must resolve; a record with neither returns
+    None so the caller skips it instead of KeyError-ing."""
+    assert _fn_addr({"addr": 0x1149}) == 0x1149
+    assert _fn_addr({"offset": 0x1149}) == 0x1149
+    # addr wins when both are present.
+    assert _fn_addr({"addr": 0x1149, "offset": 0x2000}) == 0x1149
+    assert _fn_addr({"name": "f", "size": 10}) is None
+    # Non-int values are ignored (defensive against malformed output).
+    assert _fn_addr({"addr": "0x1149"}) is None
+
+
+def test_extract_handles_offset_keyed_aflj_without_crashing(
+    monkeypatch, tmp_path,
+) -> None:
+    """Regression: old-r2 (5.x) ``aflj`` keys the entry address as
+    ``offset`` rather than ``addr``. The extractor previously indexed
+    eligible functions with an unguarded ``f['addr']`` and raised
+    KeyError on that output (nightly CI installs apt radare2). With the
+    fix it resolves the address from either key and finds the edge."""
+    import core.sandbox as _sb
+    import core.inventory.binary_oracle_edges as _edges
+
+    # r2 may be absent on the fast tier — the extractor early-returns on
+    # ``which('r2') is None``. Pretend it is present; the sandbox run is
+    # mocked below so no real r2 is invoked.
+    monkeypatch.setattr(_edges.shutil, "which", lambda _name: "/usr/bin/r2")
+
+    binary = tmp_path / "x"
+    binary.write_bytes(b"\x7fELF placeholder")
+
+    # Two functions, addressed via the OLD ``offset`` key only.
+    aflj = (
+        '[{"offset":4425,"name":"main","size":20},'
+        '{"offset":4401,"name":"sym.leaf","size":16}]'
+    )
+    # axffj batch: main (4425) calls leaf (4401).
+    axffj = (
+        "BATCH 4425\n"
+        '[{"type":"CALL","at":4430,"ref":4401,"name":"sym.leaf"}]\n'
+        "BATCH 4401\n[]\n"
+    )
+
+    class _Proc:
+        def __init__(self, stdout):
+            self.stdout = stdout
+            self.stderr = ""
+            self.returncode = 0
+
+    def _fake_run(cmd, **kwargs):
+        joined = " ".join(cmd)
+        if "aflj" in joined:
+            return _Proc(aflj)
+        if "-i" in cmd:            # axffj script-file invocation
+            return _Proc(axffj)
+        return _Proc("")           # av (vtable) — no vtables
+
+    monkeypatch.setattr(_sb, "run", _fake_run, raising=False)
+
+    idx = extract_direct_call_edges(binary, use_cache=False)
+    assert "leaf" in idx.callees
+    assert any(e.caller == "main" and e.callee == "leaf" for e in idx.edges)
 
 
 def test_parse_axffj_batch_extracts_call_edges() -> None:


### PR DESCRIPTION
extract_direct_call_edges indexed eligible functions with an unguarded f['addr'], but r2 5.x (apt-shipped, used by the nightly CI corpus job) keys the aflj entry address as 'offset', not 'addr'. The KeyError crashed the whole extraction; the nightly only surfaced it once #747 made the slow test run against apt radare2.

Resolve the address from either key via a new _fn_addr helper, applied consistently in addr_to_name, the eligible_fns filter, and the axffj script loop. This stops the crash and restores address→name resolution on r2 5.x (previously silently empty).

Adds a fully-mocked regression test (offset-keyed aflj, no r2 needed) plus unit coverage of _fn_addr.