### PR TITLE
fix(llm): use max_completion_tokens for OpenAI reasoning models (gpt-5.x, o-series)

### DIFF
--- a/core/llm/providers.py
+++ b/core/llm/providers.py
@@ -873,6 +873,40 @@ def _dict_schema_to_pydantic(schema: Union[Dict[str, Any], Type['BaseModel']]):
     return model
 
 
+def _is_openai_reasoning_model(model_name: str) -> bool:
+    """True for OpenAI reasoning-tier models (gpt-5.x, o1/o3/o4 families).
+
+    These models changed the chat.completions contract: they reject the
+    legacy ``max_tokens`` param (require ``max_completion_tokens``) and only
+    accept the default ``temperature`` (1) — passing ``temperature=0.7``
+    returns HTTP 400. Matched by bare model-name prefix so aggregator/
+    provider prefixes (``openai/gpt-5.5``) and date suffixes are tolerated.
+    Non-OpenAI compat models (Ollama ``qwen3``, ``claude-*`` via compat) do
+    not match and keep the legacy params.
+    """
+    m = (model_name or "").lower().rsplit("/", 1)[-1]
+    return m.startswith(("gpt-5", "o1", "o3", "o4"))
+
+
+def _openai_sampling_kwargs(
+    model_name: str,
+    max_tokens: int,
+    temperature: Optional[float] = None,
+) -> Dict[str, Any]:
+    """Return the correct token-limit (+ optional temperature) kwargs for an
+    OpenAI chat.completions call, branching on the reasoning-model contract.
+
+    Reasoning models → ``max_completion_tokens`` and NO temperature (default
+    only). Classic models → ``max_tokens`` and the requested temperature.
+    """
+    if _is_openai_reasoning_model(model_name):
+        return {"max_completion_tokens": max_tokens}
+    kw: Dict[str, Any] = {"max_tokens": max_tokens}
+    if temperature is not None:
+        kw["temperature"] = temperature
+    return kw
+
+
 class OpenAICompatibleProvider(LLMProvider):
     """
     LLM provider using the OpenAI SDK.
@@ -950,8 +984,11 @@ class OpenAICompatibleProvider(LLMProvider):
             response = self.client.chat.completions.create(
                 model=self.config.model_name,
                 messages=messages,
-                temperature=kwargs.get("temperature", self.config.temperature),
-                max_tokens=kwargs.get("max_tokens", self.config.max_tokens),
+                **_openai_sampling_kwargs(
+                    self.config.model_name,
+                    kwargs.get("max_tokens", self.config.max_tokens),
+                    kwargs.get("temperature", self.config.temperature),
+                ),
             )
             duration = time.monotonic() - t_start
 
@@ -1049,8 +1086,11 @@ class OpenAICompatibleProvider(LLMProvider):
                     model=self.config.model_name,
                     response_model=pydantic_model,
                     messages=messages,
-                    temperature=temperature,
-                    max_tokens=self.config.max_tokens,
+                    **_openai_sampling_kwargs(
+                        self.config.model_name,
+                        self.config.max_tokens,
+                        temperature,
+                    ),
                 )
                 duration = time.monotonic() - t_start
 
@@ -1175,8 +1215,8 @@ class OpenAICompatibleProvider(LLMProvider):
         # ---- dispatch (with retry on transient errors) ---------------
         kwargs: Dict[str, Any] = {
             "model": self.config.model_name,
-            "max_tokens": max_tokens,
             "messages": wire_messages,
+            **_openai_sampling_kwargs(self.config.model_name, max_tokens),
         }
         if tool_schemas:
             kwargs["tools"] = tool_schemas

--- a/core/llm/tests/test_openai_reasoning_tokens.py
+++ b/core/llm/tests/test_openai_reasoning_tokens.py
@@ -1,0 +1,55 @@
+"""Unit tests for the OpenAI reasoning-model token/temperature contract.
+
+gpt-5.x and the o1/o3/o4 families reject the legacy ``max_tokens`` param
+(require ``max_completion_tokens``) and only accept the default
+``temperature``. These tests pin the classifier + kwargs builder so the
+provider never regresses to sending the wrong params (which 400s every
+gpt-5.x call). See core/llm/providers.py.
+"""
+import os
+import sys
+
+sys.path.insert(0, os.environ.get("RAPTOR_DIR", os.getcwd()))
+
+from core.llm.providers import (  # noqa: E402
+    _is_openai_reasoning_model,
+    _openai_sampling_kwargs,
+)
+
+
+def test_reasoning_models_detected():
+    for m in ("gpt-5", "gpt-5.4", "gpt-5.5", "gpt-5.5-pro",
+              "openai/gpt-5.5", "o1", "o3-mini", "o4-mini"):
+        assert _is_openai_reasoning_model(m), m
+
+
+def test_classic_models_not_detected():
+    for m in ("gpt-4.1", "gpt-4o", "gpt-4o-mini", "gpt-4-turbo",
+              "claude-opus-4-8", "qwen3", "", None):
+        assert not _is_openai_reasoning_model(m), m
+
+
+def test_reasoning_kwargs_use_max_completion_tokens_and_drop_temperature():
+    kw = _openai_sampling_kwargs("gpt-5.5", 1234, temperature=0.7)
+    assert kw == {"max_completion_tokens": 1234}
+    assert "max_tokens" not in kw
+    assert "temperature" not in kw
+
+
+def test_classic_kwargs_keep_legacy_params():
+    kw = _openai_sampling_kwargs("gpt-4o", 1234, temperature=0.7)
+    assert kw == {"max_tokens": 1234, "temperature": 0.7}
+
+
+def test_classic_kwargs_omit_temperature_when_none():
+    kw = _openai_sampling_kwargs("gpt-4o", 999, temperature=None)
+    assert kw == {"max_tokens": 999}
+
+
+if __name__ == "__main__":
+    test_reasoning_models_detected()
+    test_classic_models_not_detected()
+    test_reasoning_kwargs_use_max_completion_tokens_and_drop_temperature()
+    test_classic_kwargs_keep_legacy_params()
+    test_classic_kwargs_omit_temperature_when_none()
+    print("all reasoning-token tests passed")


### PR DESCRIPTION
## Problem

`OpenAICompatibleProvider` hardcoded the legacy `max_tokens` (and a non-default `temperature`) on every `chat.completions` call. The OpenAI **reasoning-tier** families — `gpt-5.x` and `o1`/`o3`/`o4` — rejected both:

```
HTTP 400 — Unsupported parameter: 'max_tokens' is not supported with this model.
Use 'max_completion_tokens' instead.
```

(reasoning models also only accept the default `temperature`). The effect: **every `gpt-5.x` call failed**, silently knocking the strongest OpenAI models out of `/understand --hunt` and `/agentic` multi-model runs. In practice this forced a fallback to weaker `gpt-4` models, which a multi-model audit specifically does not want.

## Fix

Add two small helpers in `core/llm/providers.py`:

- `_is_openai_reasoning_model(name)` — prefix match on `gpt-5`, `o1`, `o3`, `o4` (bare model id, so `openai/gpt-5.5` and date suffixes are tolerated).
- `_openai_sampling_kwargs(name, max_tokens, temperature=None)` — returns `{"max_completion_tokens": …}` (no temperature) for reasoning models, else the legacy `{"max_tokens": …, "temperature": …}`.

Applied at **all three** OpenAI call sites: `generate()`, the Instructor structured-output path, and `turn()` (the multi-model hunt/agentic codepath).

Non-OpenAI compat models (Ollama `qwen3`, `claude-*` via OpenAI-compat) and classic OpenAI models (`gpt-4o`, `gpt-4.1`) are **unchanged** — they keep `max_tokens` + `temperature`.

## Verification

- New unit test `core/llm/tests/test_openai_reasoning_tokens.py` pins the classifier + kwargs builder.
- Live: `gpt-5.5` and `gpt-5.4` now return **200** through both `generate()` and `turn()`; `gpt-4o` / `gpt-4.1` / `claude-opus-4-8` / `qwen3` behaviour unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)