### PR TITLE
fix(llm): future-proof OpenAI reasoning-model detection by version

### DIFF
--- a/core/llm/providers.py
+++ b/core/llm/providers.py
@@ -873,19 +873,36 @@ def _dict_schema_to_pydantic(schema: Union[Dict[str, Any], Type['BaseModel']]):
     return model
 
 
+# OpenAI reasoning-tier detection. Gated on the version *number*, not a
+# literal name list, so gpt-6 / o5 are caught when they ship — mirrors
+# ``supports_temperature``'s version-threshold approach. The whole o-series
+# is reasoning; gpt is reasoning from major version 5.
+_OPENAI_REASONING_GPT_FROM = 5
+_OPENAI_GPT_VERSION_RE = re.compile(r"gpt-(\d+)")
+_OPENAI_OSERIES_RE = re.compile(r"o\d+")
+
+
 def _is_openai_reasoning_model(model_name: str) -> bool:
-    """True for OpenAI reasoning-tier models (gpt-5.x, o1/o3/o4 families).
+    """True for OpenAI reasoning-tier models (gpt-5+ and the o-series).
 
     These models changed the chat.completions contract: they reject the
     legacy ``max_tokens`` param (require ``max_completion_tokens``) and only
     accept the default ``temperature`` (1) — passing ``temperature=0.7``
-    returns HTTP 400. Matched by bare model-name prefix so aggregator/
-    provider prefixes (``openai/gpt-5.5``) and date suffixes are tolerated.
-    Non-OpenAI compat models (Ollama ``qwen3``, ``claude-*`` via compat) do
-    not match and keep the legacy params.
+    returns HTTP 400.
+
+    Future-proofed like ``supports_temperature``: we gate on the version
+    *number*, not a literal name list, so gpt-6 / o5 are caught automatically
+    when they ship. The whole o-series is reasoning; gpt is reasoning from
+    major version >= 5 (gpt-4o / gpt-4.1 stay classic). Matched on the bare
+    model name so aggregator/provider prefixes (``openai/gpt-5.5``) and date
+    suffixes are tolerated. Non-OpenAI compat models (Ollama ``qwen3``,
+    ``olmo``, ``claude-*`` via compat) do not match and keep the legacy params.
     """
     m = (model_name or "").lower().rsplit("/", 1)[-1]
-    return m.startswith(("gpt-5", "o1", "o3", "o4"))
+    if _OPENAI_OSERIES_RE.match(m):
+        return True
+    gm = _OPENAI_GPT_VERSION_RE.match(m)
+    return bool(gm) and int(gm.group(1)) >= _OPENAI_REASONING_GPT_FROM
 
 
 def _openai_sampling_kwargs(

--- a/core/llm/tests/test_openai_reasoning_tokens.py
+++ b/core/llm/tests/test_openai_reasoning_tokens.py
@@ -6,10 +6,12 @@ gpt-5.x and the o1/o3/o4 families reject the legacy ``max_tokens`` param
 provider never regresses to sending the wrong params (which 400s every
 gpt-5.x call). See core/llm/providers.py.
 """
-import os
 import sys
+from pathlib import Path
 
-sys.path.insert(0, os.environ.get("RAPTOR_DIR", os.getcwd()))
+# core/llm/tests/test_openai_reasoning_tokens.py -> parents[3] = repo root
+REPO = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(REPO))
 
 from core.llm.providers import (  # noqa: E402
     _is_openai_reasoning_model,
@@ -26,6 +28,20 @@ def test_reasoning_models_detected():
 def test_classic_models_not_detected():
     for m in ("gpt-4.1", "gpt-4o", "gpt-4o-mini", "gpt-4-turbo",
               "claude-opus-4-8", "qwen3", "", None):
+        assert not _is_openai_reasoning_model(m), m
+
+
+def test_future_reasoning_models_detected_by_version():
+    # gpt-6+/o5+ don't exist yet but must be treated as reasoning when they
+    # ship — detection is version-gated, not a literal name list.
+    for m in ("gpt-6", "gpt-6-mini", "gpt-10", "openai/gpt-6",
+              "o5", "o5-pro", "o6-mini"):
+        assert _is_openai_reasoning_model(m), m
+
+
+def test_non_reasoning_o_prefix_names_not_detected():
+    # Names that merely start with 'o' but aren't o-series reasoning models.
+    for m in ("olmo", "olmo-2", "orca-2", "openchat"):
         assert not _is_openai_reasoning_model(m), m
 
 
@@ -49,6 +65,8 @@ def test_classic_kwargs_omit_temperature_when_none():
 if __name__ == "__main__":
     test_reasoning_models_detected()
     test_classic_models_not_detected()
+    test_future_reasoning_models_detected_by_version()
+    test_non_reasoning_o_prefix_names_not_detected()
     test_reasoning_kwargs_use_max_completion_tokens_and_drop_temperature()
     test_classic_kwargs_keep_legacy_params()
     test_classic_kwargs_omit_temperature_when_none()


### PR DESCRIPTION
_is_openai_reasoning_model matched a literal prefix list (gpt-5/o1/o3/o4), so gpt-6 and o5 would silently fall back to the classic max_tokens contract and 400 every call once they ship.

Gate on the version number instead, mirroring supports_temperature: the whole o-series is reasoning, and gpt is reasoning from major version >= 5. gpt-4o / gpt-4.1 stay classic. Bare-name match still tolerates provider prefixes (openai/gpt-6) and date suffixes.

Also fix the test's path bootstrap to use Path(__file__).resolve() .parents[3] (the dir convention) instead of an os.getcwd() fallback.

Extends the unit tests with future gpt-6/gpt-10 and o5/o6 cases plus olmo/orca negatives.

@dinosn appreciate your testing this for us if possible