### PR TITLE
fix(llm): version-gate OpenAI reasoning detection so future gpt-6/o5 don't 400

### DIFF
--- a/core/llm/providers.py
+++ b/core/llm/providers.py
@@ -873,19 +873,41 @@ def _dict_schema_to_pydantic(schema: Union[Dict[str, Any], Type['BaseModel']]):
     return model
 
 
+_OPENAI_REASONING_GPT_FROM = 5
+_GPT_VERSION_RE = re.compile(r"^gpt-(\d+)")
+_O_SERIES_RE = re.compile(r"^o\d")
+
+
 def _is_openai_reasoning_model(model_name: str) -> bool:
-    """True for OpenAI reasoning-tier models (gpt-5.x, o1/o3/o4 families).
+    """True for OpenAI reasoning-tier models (the o-series + gpt major >= 5).
 
     These models changed the chat.completions contract: they reject the
     legacy ``max_tokens`` param (require ``max_completion_tokens``) and only
     accept the default ``temperature`` (1) — passing ``temperature=0.7``
-    returns HTTP 400. Matched by bare model-name prefix so aggregator/
-    provider prefixes (``openai/gpt-5.5``) and date suffixes are tolerated.
-    Non-OpenAI compat models (Ollama ``qwen3``, ``claude-*`` via compat) do
-    not match and keep the legacy params.
+    returns HTTP 400.
+
+    We gate on the version number rather than a literal prefix list, mirroring
+    :func:`supports_temperature`: the whole ``o`` series is reasoning (``o1``,
+    ``o3``, ``o4`` today; ``o5``/``o6`` when they ship), and ``gpt`` is
+    reasoning from major version >= 5 (``gpt-5.x``, and ``gpt-6``/``gpt-10``
+    once released). Classic ``gpt-4o`` / ``gpt-4.1`` / ``gpt-4-turbo`` stay on
+    the legacy contract. A prefix list would silently 400 every call the day a
+    ``gpt-6`` or ``o5`` shipped, so version-gating is forward-safe — and
+    over-classifying a hypothetical future tier costs nothing.
+
+    Matched on the bare model name (last ``/`` segment) so aggregator/provider
+    prefixes (``openai/gpt-6``) and date suffixes (``gpt-5.5-2026-01-01``) are
+    tolerated. The ``o\\d`` anchor requires a digit right after the ``o`` so
+    non-OpenAI names that merely start with ``o`` (``olmo``, ``orca``) do not
+    match; Ollama ``qwen3`` and ``claude-*`` via compat keep the legacy params.
     """
     m = (model_name or "").lower().rsplit("/", 1)[-1]
-    return m.startswith(("gpt-5", "o1", "o3", "o4"))
+    if _O_SERIES_RE.match(m):
+        return True
+    gm = _GPT_VERSION_RE.match(m)
+    if gm:
+        return int(gm.group(1)) >= _OPENAI_REASONING_GPT_FROM
+    return False
 
 
 def _openai_sampling_kwargs(

--- a/core/llm/tests/test_openai_reasoning_tokens.py
+++ b/core/llm/tests/test_openai_reasoning_tokens.py
@@ -6,10 +6,10 @@ gpt-5.x and the o1/o3/o4 families reject the legacy ``max_tokens`` param
 provider never regresses to sending the wrong params (which 400s every
 gpt-5.x call). See core/llm/providers.py.
 """
-import os
 import sys
+from pathlib import Path
 
-sys.path.insert(0, os.environ.get("RAPTOR_DIR", os.getcwd()))
+sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
 
 from core.llm.providers import (  # noqa: E402
     _is_openai_reasoning_model,
@@ -19,13 +19,19 @@ from core.llm.providers import (  # noqa: E402
 
 def test_reasoning_models_detected():
     for m in ("gpt-5", "gpt-5.4", "gpt-5.5", "gpt-5.5-pro",
-              "openai/gpt-5.5", "o1", "o3-mini", "o4-mini"):
+              "openai/gpt-5.5", "o1", "o3-mini", "o4-mini",
+              # future families must classify as reasoning the day they ship —
+              # a prefix list would silently 400 every one of these calls.
+              "gpt-6", "gpt-10", "openai/gpt-6", "gpt-6-2026-01-01",
+              "o5", "o6", "o5-mini"):
         assert _is_openai_reasoning_model(m), m
 
 
 def test_classic_models_not_detected():
     for m in ("gpt-4.1", "gpt-4o", "gpt-4o-mini", "gpt-4-turbo",
-              "claude-opus-4-8", "qwen3", "", None):
+              "claude-opus-4-8", "qwen3", "", None,
+              # 'o'-prefixed non-OpenAI names must NOT trip the o-series anchor.
+              "olmo", "olmo-7b", "orca", "orca-2"):
         assert not _is_openai_reasoning_model(m), m
 
 


### PR DESCRIPTION
Hi, 
   This should be better handled now.

## Problem

`_is_openai_reasoning_model()` matched a **literal prefix list** (`gpt-5`/`o1`/`o3`/`o4`):

```python
return m.startswith(("gpt-5", "o1", "o3", "o4"))
```

So `gpt-6`, `gpt-10`, `o5`, `o6` would silently fall back to the classic `max_tokens` + `temperature` contract and return **HTTP 400 on every call** the day OpenAI shipped them — re-introducing the exact regression #765 fixed, just deferred a model generation.

## Fix

Gate on the version number instead, mirroring `supports_temperature`:

```python
_OPENAI_REASONING_GPT_FROM = 5
_GPT_VERSION_RE = re.compile(r"^gpt-(\d+)")
_O_SERIES_RE = re.compile(r"^o\d")
```

- **Whole o-series is reasoning** — the `o\d` anchor requires a digit right after `o`, so `o1`…`o6` match but `olmo`/`orca` don't.
- **`gpt` is reasoning from major version >= 5** — `gpt-5.x`, `gpt-6`, `gpt-10`. `gpt-4o` / `gpt-4.1` / `gpt-4-turbo` (major 4) stay classic.
- Bare-name match (`rsplit("/")`) still tolerates provider prefixes (`openai/gpt-6`) and date suffixes (`gpt-6-2026-01-01`).

## Tests

- Fixed the test's path bootstrap to use `Path(__file__).resolve().parents[3]` (the dir convention) instead of an `os.getcwd()` fallback.
- Extended the unit tests with future `gpt-6`/`gpt-10` and `o5`/`o6` cases plus `olmo`/`orca` negatives.

Validated: all five test functions pass; direct boundary sweep of 23 model names has no mismatches; `None` → `False`; `gpt-6` → `{'max_completion_tokens': ...}`, `gpt-4o` → `{'max_tokens': ..., 'temperature': ...}` (classic unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)