### PR TITLE
Improve SCA reachability reporting

### DIFF
--- a/docs/sca.md
+++ b/docs/sca.md
@@ -120,6 +120,54 @@ Reports include a reachability breakdown for vulnerable dependencies and group
 the detailed vulnerability section into `Reachable / likely used`, `Present,
 needs review`, and `Probably not reachable`.
 
+## Reachability analysis
+
+SCA reachability is mechanical. RAPTOR does not ask an LLM whether a dependency
+is reachable; it derives the verdict from source evidence and advisory metadata.
+LLM review can still run later in the pipeline, unless `--no-llm` is set, but it
+is not the source of truth for the reachability verdict.
+
+Best results come from scanning the full source tree. SBOM-only scans can still
+identify vulnerable components, but they usually do not contain enough source
+context to prove whether a vulnerable package or function is used.
+
+```bash
+# Source-first scan: best for reachability
+python3 raptor.py sca --repo /path/to/full/source --no-llm --no-progress
+
+# SBOM plus source: imports the component list, then uses source for reachability
+python3 raptor.py sca \
+  --repo /path/to/full/source \
+  --sbom /path/to/sbom.cdx.json \
+  --no-llm \
+  --no-progress
+```
+
+The reachability flow has two tiers:
+
+| Tier | What RAPTOR checks |
+|---|---|
+| Module/package reachability | Whether project source imports or requires the vulnerable dependency. Python uses AST import parsing; npm currently uses lightweight import/require scanning; other ecosystems use their own import scanners. |
+| Function-level reachability | When advisory data names affected functions or symbols, RAPTOR builds a source inventory/call graph and checks whether those affected functions appear to be called from project code. |
+
+Reachability verdicts:
+
+| Verdict | Meaning |
+|---|---|
+| `likely_called` | RAPTOR found evidence that an advisory-listed affected function or symbol is called from project source. |
+| `imported` | The vulnerable package is imported or required from non-test source, but RAPTOR has not proven a specific affected function call. |
+| `not_function_reachable` | The package is present or imported, but advisory-listed affected functions were not found in the project call evidence. |
+| `not_reachable` | RAPTOR found no production import/use evidence for the dependency. |
+| `called_in_dead_code` | A call was found, but the call site appears to live in dead or unreachable code. |
+| `not_evaluated` | RAPTOR could not make a reliable reachability claim for this dependency/ecosystem/run shape. |
+
+Treat `not_reachable` and `not_function_reachable` as triage signals, not as
+mathematical proof that the vulnerability is impossible to trigger. Dynamic
+dispatch, plugin loading, reflection, generated code, incomplete source trees,
+and SBOM-only input can all reduce confidence. In security review, these verdicts
+are useful for prioritisation; they should not be used as the only reason to
+ignore a high-impact issue.
+
 ### render
 
 ```

--- a/docs/sca.md
+++ b/docs/sca.md
@@ -116,6 +116,22 @@ Registries supported: PyPI, npm, crates.io, RubyGems, Go (proxy.golang.org), Mav
 --offline                 skip network; cache-only
 ```
 
+Reports include a reachability breakdown for vulnerable dependencies and group
+the detailed vulnerability section into `Reachable / likely used`, `Present,
+needs review`, and `Probably not reachable`.
+
+### render
+
+```
+--only-reachable          render only likely_called/imported vuln findings
+--hide-not-reachable      hide not_reachable/not_function_reachable vuln findings
+--reachability <list>     comma-separated vuln reachability allowlist
+```
+
+Reachability filters apply only to `sca:vulnerable_dependency` rows; hygiene,
+supply-chain, and license rows are preserved when re-rendering an existing
+`findings.json`.
+
 ### fix
 
 ```

--- a/packages/sca/render.py
+++ b/packages/sca/render.py
@@ -65,6 +65,11 @@ def main(argv: Sequence[str]) -> int:
     sarif_path = Path(args.out_sarif).resolve() if args.out_sarif else (
         base_dir / "findings.sarif"
     )
+    try:
+        rows = _apply_reachability_filters(rows, args)
+    except ValueError as e:
+        print(f"raptor-sca render: {e}", file=sys.stderr)
+        return 2
 
     target = Path(args.target).resolve() if args.target else base_dir
     wrote: List[str] = []
@@ -120,11 +125,85 @@ def _parse_args(argv: Sequence[str]) -> argparse.Namespace:
     p.add_argument("--target",
                    help="target root used to relativise SARIF artefact URIs "
                         "(default: parent of findings.json)")
+    p.add_argument("--only-reachable", action="store_true",
+                   help="render only vulnerable dependency findings whose "
+                        "reachability is likely_called or imported. "
+                        "Non-vulnerability SCA rows are preserved.")
+    p.add_argument("--hide-not-reachable", action="store_true",
+                   help="hide vulnerable dependency findings whose "
+                        "reachability is not_reachable or "
+                        "not_function_reachable. Non-vulnerability SCA rows "
+                        "are preserved.")
+    p.add_argument("--reachability",
+                   help="comma-separated reachability verdict allowlist for "
+                        "vulnerable dependency findings, e.g. "
+                        "likely_called,imported,not_evaluated. "
+                        "Non-vulnerability SCA rows are preserved.")
     # CI gate flags — exit 1 if findings exceed thresholds.
     from .thresholds import add_threshold_args
     add_threshold_args(p)
     p.add_argument("-v", "--verbose", action="count", default=0)
     return p.parse_args(argv)
+
+
+_REACHABLE_VERDICTS = {"likely_called", "imported"}
+_NOT_REACHABLE_VERDICTS = {"not_reachable", "not_function_reachable"}
+
+
+def _apply_reachability_filters(
+    rows: List[Dict[str, Any]], args: argparse.Namespace,
+) -> List[Dict[str, Any]]:
+    """Filter vuln rows by reachability while preserving other rows."""
+    requested = []
+    if args.only_reachable:
+        requested.append("--only-reachable")
+    if args.hide_not_reachable:
+        requested.append("--hide-not-reachable")
+    if args.reachability:
+        requested.append("--reachability")
+    if len(requested) > 1:
+        raise ValueError(
+            "reachability filters are mutually exclusive: "
+            + ", ".join(requested)
+        )
+
+    allowed = None
+    denied = None
+    if args.only_reachable:
+        allowed = set(_REACHABLE_VERDICTS)
+    elif args.hide_not_reachable:
+        denied = set(_NOT_REACHABLE_VERDICTS)
+    elif args.reachability:
+        allowed = {
+            item.strip()
+            for item in str(args.reachability).split(",")
+            if item.strip()
+        }
+        if not allowed:
+            raise ValueError("--reachability needs at least one verdict")
+
+    if allowed is None and denied is None:
+        return rows
+
+    out: List[Dict[str, Any]] = []
+    for row in rows:
+        if row.get("vuln_type") != "sca:vulnerable_dependency":
+            out.append(row)
+            continue
+        verdict = _row_reachability_verdict(row)
+        if allowed is not None and verdict not in allowed:
+            continue
+        if denied is not None and verdict in denied:
+            continue
+        out.append(row)
+    return out
+
+
+def _row_reachability_verdict(row: Dict[str, Any]) -> str:
+    sca = row.get("sca") or {}
+    reach = sca.get("reachability") or {}
+    verdict = reach.get("verdict")
+    return str(verdict) if verdict else "not_evaluated"
 
 
 # ---------------------------------------------------------------------------
@@ -140,6 +219,24 @@ _SEV_LABEL = {
     "none": "None",
 }
 
+_REACHABILITY_LABELS = {
+    "likely_called": "Likely called",
+    "imported": "Imported",
+    "called_in_dead_code": "Called in dead code",
+    "not_reachable": "Not reachable",
+    "not_function_reachable": "Not function reachable",
+    "not_evaluated": "Not evaluated",
+}
+
+_REACHABILITY_ORDER = (
+    "likely_called",
+    "imported",
+    "called_in_dead_code",
+    "not_reachable",
+    "not_function_reachable",
+    "not_evaluated",
+)
+
 
 def _render_markdown(rows: List[Dict[str, Any]], *, target: Path) -> str:
     # Defensive — hand-edited findings.json may contain non-dict
@@ -153,6 +250,9 @@ def _render_markdown(rows: List[Dict[str, Any]], *, target: Path) -> str:
     supply_rows = [r for r in rows
                    if isinstance(r.get("vuln_type"), str)
                    and r["vuln_type"].startswith("sca:supply_chain:")]
+    license_rows = [r for r in rows
+                    if isinstance(r.get("vuln_type"), str)
+                    and r["vuln_type"].startswith("sca:license:")]
 
     suppressed_count = sum(1 for r in vuln_rows if r.get("suppressed"))
     severity_counts: Counter[str] = Counter()
@@ -186,7 +286,13 @@ def _render_markdown(rows: List[Dict[str, Any]], *, target: Path) -> str:
               f"suppressed: **{suppressed_count}**)\n")
     buf.write(f"- KEV-listed: **{kev_count}**\n")
     buf.write(f"- Supply-chain findings: **{len(supply_rows)}**\n")
-    buf.write(f"- Hygiene findings: **{len(hygiene_rows)}**\n\n")
+    buf.write(f"- Hygiene findings: **{len(hygiene_rows)}**\n")
+    if license_rows:
+        buf.write(f"- License findings: **{len(license_rows)}**\n")
+    buf.write("\n")
+    reach_table = _render_reachability_breakdown(vuln_rows)
+    if reach_table:
+        buf.write(reach_table)
 
     if vuln_rows:
         buf.write("## Vulnerable dependencies\n\n")
@@ -197,8 +303,32 @@ def _render_markdown(rows: List[Dict[str, Any]], *, target: Path) -> str:
     if hygiene_rows:
         buf.write("## Hygiene findings\n\n")
         _render_kind_table(buf, hygiene_rows)
-    if not (vuln_rows or supply_rows or hygiene_rows):
+    if license_rows:
+        buf.write("## License findings\n\n")
+        _render_kind_table(buf, license_rows)
+    if not (vuln_rows or supply_rows or hygiene_rows or license_rows):
         buf.write("No findings.\n")
+    return buf.getvalue()
+
+
+def _render_reachability_breakdown(rows: List[Dict[str, Any]]) -> str:
+    counts: Counter[str] = Counter()
+    for row in rows:
+        if row.get("suppressed"):
+            continue
+        counts[_row_reachability_verdict(row)] += 1
+    if not counts:
+        return ""
+    buf = StringIO()
+    buf.write("### Reachability breakdown\n\n")
+    buf.write("| Verdict | Count |\n|---|---:|\n")
+    for verdict in _REACHABILITY_ORDER:
+        if counts.get(verdict):
+            label = _REACHABILITY_LABELS.get(verdict, verdict)
+            buf.write(f"| {label} | {counts[verdict]} |\n")
+    for verdict in sorted(set(counts) - set(_REACHABILITY_ORDER)):
+        buf.write(f"| {verdict} | {counts[verdict]} |\n")
+    buf.write("\n")
     return buf.getvalue()
 
 
@@ -212,8 +342,8 @@ def _render_vuln_table(buf: StringIO, rows: List[Dict[str, Any]]) -> None:
             (r.get("sca") or {}).get("name") or "",
         ),
     )
-    buf.write("| Severity | Dep | Advisory | KEV | EPSS | Fix |\n")
-    buf.write("|---|---|---|---|---|---|\n")
+    buf.write("| Severity | Dep | Advisory | Reachability | KEV | EPSS | Fix |\n")
+    buf.write("|---|---|---|---|---|---|---|\n")
     for r in ordered:
         sca = r.get("sca") or {}
         adv = sca.get("advisory") or {}
@@ -229,7 +359,14 @@ def _render_vuln_table(buf: StringIO, rows: List[Dict[str, Any]]) -> None:
         kev = "yes" if sca.get("in_kev") else ""
         epss = f"{sca['epss']:.2f}" if sca.get("epss") is not None else ""
         fix = sca.get("fixed_version") or ""
-        buf.write(f"| {sev} | {dep} | {adv_label} | {kev} | {epss} | {fix} |\n")
+        reach = _REACHABILITY_LABELS.get(
+            _row_reachability_verdict(r),
+            _row_reachability_verdict(r),
+        )
+        buf.write(
+            f"| {sev} | {dep} | {adv_label} | {reach} "
+            f"| {kev} | {epss} | {fix} |\n"
+        )
     buf.write("\n")
 
 

--- a/packages/sca/report.py
+++ b/packages/sca/report.py
@@ -86,6 +86,30 @@ _SEV_LABEL: dict[str, str] = {
     "none": "None (CVSS 0.0)",
 }
 
+_REACHABILITY_LABELS: dict[str, str] = {
+    "likely_called": "Likely called",
+    "imported": "Imported",
+    "called_in_dead_code": "Called in dead code",
+    "not_reachable": "Not reachable",
+    "not_function_reachable": "Not function reachable",
+    "not_evaluated": "Not evaluated",
+}
+
+_REACHABILITY_ORDER = (
+    "likely_called",
+    "imported",
+    "called_in_dead_code",
+    "not_reachable",
+    "not_function_reachable",
+    "not_evaluated",
+)
+
+_REACHABILITY_GROUPS = (
+    ("Reachable / likely used", {"likely_called", "imported"}),
+    ("Present, needs review", {"not_evaluated", "called_in_dead_code"}),
+    ("Probably not reachable", {"not_reachable", "not_function_reachable"}),
+)
+
 
 def render_markdown_report(
     *,
@@ -312,6 +336,10 @@ def _render_summary(
         rows.append(cache_line)
     rows.append("")
 
+    reachability_table = _render_reachability_breakdown(vuln_findings)
+    if reachability_table:
+        rows.append(reachability_table)
+
     # Build-stage breakdown: only render when more than one distinct
     # scope appears across vuln findings (otherwise it would be a
     # single-row table with no value). Multi-stage Dockerfiles
@@ -322,6 +350,36 @@ def _render_summary(
     if stage_table:
         rows.append(stage_table)
 
+    return "\n".join(rows)
+
+
+def _render_reachability_breakdown(
+    vuln_findings: Sequence[VulnFinding],
+) -> str:
+    """Render a compact verdict-count table for vulnerable findings."""
+    counts: Counter[str] = Counter()
+    for f in vuln_findings:
+        if f.suppressed:
+            continue
+        verdict = getattr(f.reachability, "verdict", None) or "not_evaluated"
+        counts[verdict] += 1
+    if not counts:
+        return ""
+
+    rows = [
+        "### Reachability breakdown\n",
+        "| Verdict | Count |",
+        "|---|---:|",
+    ]
+    for verdict in _REACHABILITY_ORDER:
+        if counts.get(verdict):
+            rows.append(
+                f"| {_REACHABILITY_LABELS.get(verdict, verdict)} "
+                f"| {counts[verdict]} |"
+            )
+    for verdict in sorted(set(counts) - set(_REACHABILITY_ORDER)):
+        rows.append(f"| {verdict} | {counts[verdict]} |")
+    rows.append("")
     return "\n".join(rows)
 
 
@@ -393,20 +451,50 @@ def _render_vuln_section(findings: Sequence[VulnFinding]) -> str:
     """
     lines: List[str] = ["## Vulnerable dependencies\n"]
     groups = _group_vulns(findings)
-    # Track which (name, version) deps we've already emitted a
-    # full dep-level header for; subsequent advisories on the same
-    # dep render in compact form.
-    seen_dep_keys: set = set()
-    for group in groups:
-        primary = group[0]
-        dep_key = (primary.dependency.name,
-                    primary.dependency.version or "")
-        is_first_for_dep = dep_key not in seen_dep_keys
-        seen_dep_keys.add(dep_key)
-        lines.append(_render_one_vuln_group(
-            group, omit_dep_shared=not is_first_for_dep,
-        ))
+    for group_title, grouped in _bucket_vuln_groups_by_reachability(groups):
+        lines.append(f"### {group_title}\n")
+        # Track which (name, version) deps we've already emitted a
+        # full dep-level header for within this reachability bucket;
+        # subsequent advisories on the same dep render compact.
+        seen_dep_keys: set = set()
+        for group in grouped:
+            primary = group[0]
+            dep_key = (primary.dependency.name,
+                       primary.dependency.version or "")
+            is_first_for_dep = dep_key not in seen_dep_keys
+            seen_dep_keys.add(dep_key)
+            lines.append(_render_one_vuln_group(
+                group, omit_dep_shared=not is_first_for_dep,
+                heading_level=4,
+            ))
     return "\n".join(lines)
+
+
+def _bucket_vuln_groups_by_reachability(
+    groups: Sequence[Sequence[VulnFinding]],
+) -> List[tuple[str, List[Sequence[VulnFinding]]]]:
+    """Partition vuln groups into operator-facing reachability buckets.
+
+    Input ordering is already severity/KEV/EPSS sorted by the caller;
+    preserve that order inside each bucket.
+    """
+    buckets: List[tuple[str, List[Sequence[VulnFinding]]]] = [
+        (title, []) for title, _ in _REACHABILITY_GROUPS
+    ]
+    fallback: List[Sequence[VulnFinding]] = []
+    for group in groups:
+        verdict = getattr(group[0].reachability, "verdict", None)
+        placed = False
+        for idx, (_title, verdicts) in enumerate(_REACHABILITY_GROUPS):
+            if verdict in verdicts:
+                buckets[idx][1].append(group)
+                placed = True
+                break
+        if not placed:
+            fallback.append(group)
+    if fallback:
+        buckets.append(("Other reachability verdicts", fallback))
+    return [(title, grouped) for title, grouped in buckets if grouped]
 
 
 def _group_vulns(
@@ -433,6 +521,7 @@ def _group_vulns(
 def _render_one_vuln_group(
     group: Sequence[VulnFinding], *,
     omit_dep_shared: bool = False,
+    heading_level: int = 3,
 ) -> str:
     """Render a vuln finding group: one section per (dep, advisory),
     with each manifest source listed in a Sources sub-list.
@@ -456,6 +545,7 @@ def _render_one_vuln_group(
         primary,
         omit_source=len(paths) > 1 or omit_dep_shared,
         omit_dep_shared=omit_dep_shared,
+        heading_level=heading_level,
     )
     if omit_dep_shared or len(paths) <= 1:
         return body
@@ -472,13 +562,15 @@ def _render_one_vuln(
     f: VulnFinding, *,
     omit_source: bool = False,
     omit_dep_shared: bool = False,
+    heading_level: int = 3,
 ) -> str:
     dep = f.dependency
     primary: Optional[Advisory] = f.advisories[0] if f.advisories else None
     label = _SEV_LABEL.get(f.severity, f.severity.title())
     # Dep name comes from the operator's manifest — sanitise defensively
     # against ANSI / BIDI / control-character smuggling in package names.
-    head = f"### {label} — {escape_nonprintable(dep.name)} " \
+    heading = "#" * max(3, heading_level)
+    head = f"{heading} {label} — {escape_nonprintable(dep.name)} " \
            f"{escape_nonprintable(dep.version or '*')}"
     if f.fixed_version:
         head += f" → fix: {escape_nonprintable(f.fixed_version)}"

--- a/packages/sca/tests/test_render.py
+++ b/packages/sca/tests/test_render.py
@@ -16,9 +16,11 @@ def _vuln_row(
     in_kev: bool = True,
     epss: float | None = 0.94,
     fix: str = "2.15.0",
+    name: str = "org.apache.logging.log4j:log4j-core",
+    reachability: str = "not_evaluated",
 ) -> Dict[str, Any]:
     return {
-        "id": "sca:vuln:Maven:log4j:2.14.1:GHSA-jfh8-c2jp-5v3q",
+        "id": f"sca:vuln:Maven:{name}:2.14.1:GHSA-jfh8-c2jp-5v3q",
         "vuln_type": "sca:vulnerable_dependency",
         "tool": "sca",
         "file": "/repo/pom.xml",
@@ -29,15 +31,20 @@ def _vuln_row(
         "description": "Log4Shell",
         "sca": {
             "ecosystem": "Maven",
-            "name": "org.apache.logging.log4j:log4j-core",
+            "name": name,
             "version": "2.14.1",
-            "purl": "pkg:maven/org.apache.logging.log4j:log4j-core@2.14.1",
+            "purl": f"pkg:maven/{name}@2.14.1",
             "advisory": {"id": "GHSA-jfh8-c2jp-5v3q",
                          "aliases": ["CVE-2021-44228"]},
             "in_kev": in_kev,
             "epss": epss,
             "fixed_version": fix,
             "cvss_score": 10.0,
+            "reachability": {
+                "verdict": reachability,
+                "confidence": {"level": "high", "reason": "test"},
+                "evidence": [],
+            },
         },
     }
 
@@ -52,6 +59,19 @@ def _hygiene_row(kind: str = "loose_pin") -> Dict[str, Any]:
         "suppressed": False,
         "description": "loose pin shape",
         "sca": {"ecosystem": "npm", "name": "lodash", "kind": kind},
+    }
+
+
+def _license_row(kind: str = "unknown") -> Dict[str, Any]:
+    return {
+        "id": f"sca:license:{kind}:Maven:private-lib",
+        "vuln_type": f"sca:license:{kind}",
+        "file": "/repo/pom.xml",
+        "line": 0,
+        "severity": "info",
+        "suppressed": False,
+        "description": "No license metadata for private-lib",
+        "sca": {"ecosystem": "Maven", "name": "private-lib", "kind": kind},
     }
 
 
@@ -82,6 +102,7 @@ def test_report_contains_severity_summary_and_kev_count(tmp_path: Path) -> None:
     assert "| Critical | 1 |" in md
     assert "| Medium | 1 |" in md
     assert "KEV-listed: **1**" in md
+    assert "### Reachability breakdown" in md
 
 
 def test_suppressed_rows_marked_in_table(tmp_path: Path) -> None:
@@ -102,6 +123,17 @@ def test_hygiene_section_emitted_when_hygiene_rows_present(
     md = (tmp_path / "report.md").read_text()
     assert "## Hygiene findings" in md
     assert "loose_pin" in md
+
+
+def test_license_section_emitted_when_license_rows_present(
+    tmp_path: Path,
+) -> None:
+    f = _findings_file(tmp_path, [_license_row()])
+    render.main([str(f)])
+    md = (tmp_path / "report.md").read_text()
+    assert "License findings: **1**" in md
+    assert "## License findings" in md
+    assert "private-lib" in md
 
 
 def test_no_findings_message(tmp_path: Path) -> None:
@@ -151,6 +183,63 @@ def test_no_sarif_skips_sarif(tmp_path: Path) -> None:
 def test_no_md_and_no_sarif_returns_2(tmp_path: Path) -> None:
     f = _findings_file(tmp_path, [_vuln_row()])
     rc = render.main([str(f), "--no-md", "--no-sarif"])
+    assert rc == 2
+
+
+def test_only_reachable_filters_vuln_rows_but_keeps_hygiene(
+    tmp_path: Path,
+) -> None:
+    rows = [
+        _vuln_row(name="reachable", reachability="likely_called"),
+        _vuln_row(name="unused", reachability="not_reachable"),
+        _hygiene_row(),
+    ]
+    f = _findings_file(tmp_path, rows)
+    rc = render.main([str(f), "--only-reachable", "--no-sarif"])
+    assert rc == 0
+    md = (tmp_path / "report.md").read_text()
+    assert "Maven:reachable@2.14.1" in md
+    assert "Maven:unused@2.14.1" not in md
+    assert "## Hygiene findings" in md
+
+
+def test_hide_not_reachable_filters_not_reachable_verdicts(
+    tmp_path: Path,
+) -> None:
+    rows = [
+        _vuln_row(name="imported", reachability="imported"),
+        _vuln_row(name="not-fn", reachability="not_function_reachable"),
+    ]
+    f = _findings_file(tmp_path, rows)
+    rc = render.main([str(f), "--hide-not-reachable", "--no-sarif"])
+    assert rc == 0
+    md = (tmp_path / "report.md").read_text()
+    assert "Maven:imported@2.14.1" in md
+    assert "Maven:not-fn@2.14.1" not in md
+
+
+def test_reachability_allowlist_filters_to_requested_verdicts(
+    tmp_path: Path,
+) -> None:
+    rows = [
+        _vuln_row(name="review", reachability="not_evaluated"),
+        _vuln_row(name="unused", reachability="not_reachable"),
+    ]
+    f = _findings_file(tmp_path, rows)
+    rc = render.main([
+        str(f), "--reachability", "not_evaluated", "--no-sarif",
+    ])
+    assert rc == 0
+    md = (tmp_path / "report.md").read_text()
+    assert "Maven:review@2.14.1" in md
+    assert "Maven:unused@2.14.1" not in md
+
+
+def test_reachability_filters_are_mutually_exclusive(tmp_path: Path) -> None:
+    f = _findings_file(tmp_path, [_vuln_row()])
+    rc = render.main([
+        str(f), "--only-reachable", "--hide-not-reachable",
+    ])
     assert rc == 2
 
 

--- a/packages/sca/tests/test_report.py
+++ b/packages/sca/tests/test_report.py
@@ -14,6 +14,7 @@ from packages.sca.models import (
     Dependency,
     HygieneFinding,
     PinStyle,
+    Reachability,
 )
 from packages.sca.osv import OsvResult
 from packages.sca.report import (
@@ -624,6 +625,43 @@ def test_dep_shared_lines_emitted_only_for_first_advisory() -> None:
     assert "CVE-2099-AAAA" in md
     assert "CVE-2099-BBBB" in md
     assert "CVE-2099-CCCC" in md
+
+
+def test_report_groups_vulns_by_reachability_and_summarises_counts() -> None:
+    """The report should show an at-a-glance reachability breakdown
+    and group vulnerable dependencies by triage usefulness."""
+    d_reach = _dep("reachable-pkg", "1.0.0")
+    d_imported = _dep("imported-pkg", "1.0.0")
+    d_not_reach = _dep("unused-pkg", "1.0.0")
+    findings = []
+    for dep, verdict in (
+        (d_reach, "likely_called"),
+        (d_imported, "imported"),
+        (d_not_reach, "not_reachable"),
+    ):
+        f = build_vuln_findings(
+            [dep], [OsvResult(dep.key(), [_adv(f"GHSA-{dep.name}")])],
+        )[0]
+        f.reachability = Reachability(
+            verdict=verdict,  # type: ignore[arg-type]
+            confidence=Confidence("high", reason="test verdict"),
+            evidence=[],
+        )
+        findings.append(f)
+
+    md = render_markdown_report(
+        target=Path("/x"), deps_analysed=3,
+        vuln_findings=findings, hygiene_findings=[],
+    )
+
+    assert "### Reachability breakdown" in md
+    assert "| Likely called | 1 |" in md
+    assert "| Imported | 1 |" in md
+    assert "| Not reachable | 1 |" in md
+    assert "### Reachable / likely used" in md
+    assert "### Probably not reachable" in md
+    assert "#### Critical — reachable-pkg" in md
+    assert "#### Critical — unused-pkg" in md
 
 
 def test_zero_epss_suppressed_in_badges() -> None:


### PR DESCRIPTION
This makes the SCA report much easier to triage.

Before this, reachability was technically present in each individual finding, but you had to dig through the report to work out what was actually reachable. That is not great when the headline says something like '21 vulnerable dependencies' and the useful question is really 'which of these can I probably hit in this codebase?'.

What changed:

- Adds a reachability breakdown to the SCA report summary.
- Groups vulnerable dependencies into 'Reachable / likely used', 'Present, needs review', and 'Probably not reachable'.
- Adds render-time filters for old findings files: --only-reachable, --hide-not-reachable, and --reachability likely_called,imported.
- Keeps non-vulnerability SCA rows visible when filtering, including hygiene, supply-chain, and licence findings.
- Documents the new report behaviour and render flags in docs/sca.md.

Example:

Instead of just seeing:

21 vulnerable dependency findings

The report can now show:

Reachability breakdown
- Likely called: 3
- Imported: 5
- Not reachable: 9
- Not evaluated: 4

That gives the operator a much better starting point: fix the reachable bits first, review the uncertain ones, and avoid wasting time on dependency noise that is present but probably not in play.

Validation:

- python3 -m pytest packages/sca/tests/test_report.py packages/sca/tests/test_render.py packages/sca/tests/test_thresholds.py packages/sca/tests/test_sarif.py packages/sca/tests/test_output_schemas.py
- 106 tests passed