### PR TITLE
style(llm): make OpenAI reasoning-model anchors explicit

### DIFF
--- a/core/llm/providers.py
+++ b/core/llm/providers.py
@@ -878,8 +878,8 @@ def _dict_schema_to_pydantic(schema: Union[Dict[str, Any], Type['BaseModel']]):
 # ``supports_temperature``'s version-threshold approach. The whole o-series
 # is reasoning; gpt is reasoning from major version 5.
 _OPENAI_REASONING_GPT_FROM = 5
-_OPENAI_GPT_VERSION_RE = re.compile(r"gpt-(\d+)")
-_OPENAI_OSERIES_RE = re.compile(r"o\d+")
+_OPENAI_GPT_VERSION_RE = re.compile(r"^gpt-(\d+)")
+_OPENAI_OSERIES_RE = re.compile(r"^o\d")
 
 
 def _is_openai_reasoning_model(model_name: str) -> bool:


### PR DESCRIPTION
The regexes are matched with ``re.match`` which already anchors at the start of the string, so functionally nothing changes. Adopting the explicit ``^`` anchor + ``\d`` (instead of ``\d+``) form keeps the intent obvious to a reader and immune to a future refactor that switches the call site to ``re.search``. Mirrors the style Nicolas Krassas proposed in PR #767 (independent fix for the same forward- proofing #766 landed).