### PR TITLE
fix(log): dedupe retry-failure cluster (4 lines → 1 per failed attempt)

### DIFF
--- a/core/llm/client.py
+++ b/core/llm/client.py
@@ -1317,7 +1317,15 @@ class LLMClient:
                 for attempt in range(self.config.max_retries):
                     try:
                         if attempt > 0:
-                            logger.info(f"Retrying {model.provider}/{model.model_name} (attempt {attempt + 1}/{self.config.max_retries})")
+                            # DEBUG, not INFO: the prior attempt's
+                            # WARNING ("Attempt N/M failed ...") already
+                            # signalled that a retry will follow. The
+                            # next attempt either succeeds (silent) or
+                            # fails (another WARNING) — operator infers
+                            # the retry from either. Adding an INFO
+                            # bookend produces operator log noise
+                            # without new signal.
+                            logger.debug(f"Retrying {model.provider}/{model.model_name} (attempt {attempt + 1}/{self.config.max_retries})")
 
                         provider = self._get_provider(model)
                         # Acquire budget reservation immediately before the
@@ -1401,8 +1409,28 @@ class LLMClient:
                                 _esc(quota_guidance),
                             )
 
-                        logger.warning(f"Attempt {attempt + 1}/{self.config.max_retries} failed for "
-                                     f"{model.provider}/{model.model_name}: {_sanitize_log_message(str(e))}")
+                        # Sanitisation is the BROADER of the two
+                        # available paths: redact_secrets covers more
+                        # patterns than _sanitize_log_message's API-key
+                        # regex; escape_nonprintable defangs ANSI/control
+                        # bytes; [:1024] caps the length. This was the
+                        # sanitisation the (now-demoted) provider ERROR
+                        # used; moving it to the surviving operator-
+                        # visible line preserves the safety properties
+                        # at the right level. See the retry-dedupe
+                        # adversarial-review notes for rationale.
+                        from core.security.log_sanitisation import (
+                            escape_nonprintable as _esc_np,
+                        )
+                        from core.security.redaction import (
+                            redact_secrets as _redact,
+                        )
+                        _safe_e = _esc_np(_redact(str(e)))[:1024]
+                        logger.warning(
+                            f"Attempt {attempt + 1}/{self.config.max_retries} "
+                            f"failed for {model.provider}/{model.model_name}: "
+                            f"{_safe_e}"
+                        )
 
                         if not _is_retryable_error(e):
                             logger.info(f"Non-retryable error — skipping remaining retries for {model.provider}/{model.model_name}")
@@ -1576,7 +1604,9 @@ class LLMClient:
                 for attempt in range(self.config.max_retries):
                     try:
                         if attempt > 0:
-                            logger.info(f"Retrying {model.provider}/{model.model_name} (attempt {attempt + 1}/{self.config.max_retries})")
+                            # DEBUG, not INFO — see ``generate`` above
+                            # for the same noise-vs-signal rationale.
+                            logger.debug(f"Retrying {model.provider}/{model.model_name} (attempt {attempt + 1}/{self.config.max_retries})")
 
                         provider = self._get_provider(model)
 
@@ -1687,7 +1717,19 @@ class LLMClient:
                                 _esc(quota_guidance),
                             )
 
-                        logger.warning(_sanitize_log_message(f"Structured generation attempt {attempt + 1} failed: {str(e)}"))
+                        # Broader sanitisation — same rationale as the
+                        # ``generate`` retry loop above.
+                        from core.security.log_sanitisation import (
+                            escape_nonprintable as _esc_np,
+                        )
+                        from core.security.redaction import (
+                            redact_secrets as _redact,
+                        )
+                        _safe_e = _esc_np(_redact(str(e)))[:1024]
+                        logger.warning(
+                            f"Structured generation attempt {attempt + 1} "
+                            f"failed: {_safe_e}"
+                        )
 
                         if not _is_retryable_error(e):
                             logger.info(f"Non-retryable error — skipping remaining retries for {model.provider}/{model.model_name}")

--- a/core/llm/dispatcher/server.py
+++ b/core/llm/dispatcher/server.py
@@ -63,12 +63,22 @@ from .auth import (
 _logger = logging.getLogger(__name__)
 
 
-# Audit event types that fire on every successful LLM call and
-# would otherwise flood operator output. Consumed by ``_audit``
-# to route ok-status events here to DEBUG; everything else
-# (failures, lifecycle, unknown types) stays at INFO. See
-# ``_audit`` for the routing rationale.
-_HIGH_FREQ_OK_EVENTS = frozenset({"request.dispatch"})
+# Audit event types whose terminal-visible log is duplicated by a
+# higher-level layer's own visibility — demote to DEBUG so operator
+# output isn't flooded. Consumed by ``_audit``; events not in this
+# set stay at INFO. Audit log on disk records every event at full
+# fidelity regardless.
+#
+# * ``request.dispatch`` (status="ok"): one per successful LLM call;
+#   ~100+ per /agentic run. No operator action on success.
+# * ``request.error`` (status="error"): one per upstream API
+#   failure. The LLMClient retry loop catches the underlying
+#   exception and emits its own WARNING ("Attempt N/M failed
+#   for <provider>/<model>: <reason>") at the operator-relevant
+#   abstraction layer. The dispatcher's INFO-level audit was a
+#   third copy of the same fact, alongside the provider's own
+#   error log — see the retry-dedupe commit for the full cluster.
+_DEMOTED_AUDIT_EVENTS = frozenset({"request.dispatch", "request.error"})
 
 
 def _scrub(value: Optional[str]) -> Optional[str]:
@@ -488,24 +498,20 @@ class LLMDispatcher:
         # are internally produced strings.
         safe_worker = _scrub(ev.worker_label)
         safe_reason = _scrub(ev.reason)
-        # Log level chosen by event type + status:
-        # * High-frequency successful events (e.g. ``request.dispatch
-        #   ok``) → DEBUG. One per LLM call; floods operator
-        #   output during /agentic / /understand / /validate
-        #   without adding signal a human reads. Held in a SET so
-        #   a future high-frequency event type (cache hits,
-        #   prefetch acks, …) joins the demotion list cleanly
-        #   without re-introducing the noise on its own.
-        # * Everything else (server lifecycle, token issuance,
-        #   ANY failure, any unknown event type) → INFO. These
-        #   are low-frequency, operator-actionable, or both.
+        # Log level chosen by event type:
+        # * Events in ``_DEMOTED_AUDIT_EVENTS`` → DEBUG. These are
+        #   duplicated by a higher-level layer's own operator-
+        #   visible logging (LLMClient retry loop) or fire on
+        #   every LLM call without operator action (request.dispatch
+        #   ok). See the constant's docstring for per-event
+        #   rationale.
+        # * Server lifecycle, token issuance, any unknown event
+        #   type → INFO. Low-frequency, operator-actionable, or
+        #   both.
         # Audit log on disk continues to record EVERY event at
         # full fidelity — this only affects the stdlib logger
         # that terminal output uses.
-        if (
-            ev.event in _HIGH_FREQ_OK_EVENTS
-            and ev.status == "ok"
-        ):
+        if ev.event in _DEMOTED_AUDIT_EVENTS:
             level = logging.DEBUG
         else:
             level = logging.INFO

--- a/core/llm/providers.py
+++ b/core/llm/providers.py
@@ -1075,7 +1075,16 @@ class OpenAICompatibleProvider(LLMProvider):
             # entries on operator TTYs.
             from core.security.log_sanitisation import escape_nonprintable
             from core.security.redaction import redact_secrets
-            logger.error("OpenAI completion failed: %s",
+            # DEBUG, not ERROR: the LLMClient retry loop catches this
+            # exception and emits its own WARNING ("Attempt N/M failed
+            # for openai/<model>: <reason>") with the same fact at
+            # the operator-relevant abstraction layer. Logging both
+            # produces a 3-line cluster per upstream failure — see
+            # the log-noise commit history. DEBUG keeps the deep-
+            # debugging detail (escaped + redacted exception body)
+            # available with ``-v`` / RAPTOR_LOG_LEVEL=DEBUG without
+            # spamming normal runs.
+            logger.debug("OpenAI completion failed: %s",
                          escape_nonprintable(redact_secrets(str(e)))[:1024])
             raise
 
@@ -1661,7 +1670,10 @@ class AnthropicProvider(LLMProvider):
             # above — SDK exception bodies can include prompt + headers.
             from core.security.log_sanitisation import escape_nonprintable
             from core.security.redaction import redact_secrets
-            logger.error("Anthropic completion failed: %s",
+            # DEBUG, not ERROR — same rationale as OpenAI above:
+            # the LLMClient retry loop emits an operator-visible
+            # WARNING for the same failure.
+            logger.debug("Anthropic completion failed: %s",
                          escape_nonprintable(redact_secrets(str(e)))[:1024])
             raise
 
@@ -2235,7 +2247,10 @@ class GeminiProvider(LLMProvider):
             # Same hardening rationale as OpenAICompatibleProvider.generate.
             from core.security.log_sanitisation import escape_nonprintable
             from core.security.redaction import redact_secrets
-            logger.error("Gemini completion failed: %s",
+            # DEBUG, not ERROR — same rationale as OpenAI above:
+            # the LLMClient retry loop emits an operator-visible
+            # WARNING for the same failure.
+            logger.debug("Gemini completion failed: %s",
                          escape_nonprintable(redact_secrets(str(e)))[:1024])
             raise
 

--- a/core/llm/tests/test_log_quiet.py
+++ b/core/llm/tests/test_log_quiet.py
@@ -133,12 +133,19 @@ class TestDispatcherAuditLogLevel:
             "request.dispatch", "ok",
         ) == logging.DEBUG
 
-    def test_request_dispatch_error_stays_info(self):
-        # Errors are operator-relevant; stay at INFO so the
-        # operator sees them in the terminal stream.
+    def test_request_dispatch_demoted_regardless_of_status(self):
+        # The retry-dedupe commit moved from a status-gated check
+        # (event AND status==ok → DEBUG) to a pure event-set check
+        # (event in _DEMOTED_AUDIT_EVENTS → DEBUG). ``request.dispatch``
+        # is emitted by the dispatcher only with status="ok" today;
+        # the defensive "what if it's error" branch goes to DEBUG
+        # too because the LLMClient retry loop carries the WARNING.
+        # If a future dispatcher refactor starts emitting
+        # request.dispatch with other statuses, this test pins
+        # the behaviour explicitly.
         assert self._capture_log_call(
             "request.dispatch", "error",
-        ) == logging.INFO
+        ) == logging.DEBUG
 
     def test_server_start_stays_info(self):
         # Low-frequency lifecycle events stay at INFO.
@@ -152,30 +159,35 @@ class TestDispatcherAuditLogLevel:
             "token.issue", "ok",
         ) == logging.INFO
 
-    def test_request_error_stays_info(self):
-        # Real dispatcher emits ``request.error`` events; they
-        # must always be visible to operators.
+    def test_request_error_now_demoted_to_debug(self):
+        # Updated by the retry-dedupe commit: ``request.error`` is
+        # now in ``_DEMOTED_AUDIT_EVENTS`` because the LLMClient
+        # retry loop emits its own operator-visible WARNING for
+        # the same failure ("Attempt N/M failed for <provider>/
+        # <model>: <reason>"). The dispatcher's INFO-level audit
+        # was a third copy of the same fact. Audit log on disk
+        # continues to record every event at full fidelity.
         assert self._capture_log_call(
             "request.error", "error",
-        ) == logging.INFO
+        ) == logging.DEBUG
 
     def test_unknown_event_type_defaults_to_info(self):
         # New event types added later default to INFO (the
-        # ``_HIGH_FREQ_OK_EVENTS`` set is opt-in, not opt-out)
+        # ``_DEMOTED_AUDIT_EVENTS`` set is opt-in, not opt-out)
         # — operator-conservative: a new event type that turns
-        # out to be high-frequency would surface here rather
-        # than silently disappear into DEBUG.
+        # out to be high-frequency or duplicate would surface
+        # here rather than silently disappear into DEBUG.
         assert self._capture_log_call(
             "future.event", "ok",
         ) == logging.INFO
 
-    def test_high_freq_set_is_a_set(self):
-        # The set-based dispatch is a regression guard for the
-        # comment in scanner.py — future high-frequency event
-        # types join the demotion list cleanly without
-        # re-introducing the noise on their own. Pin the type
-        # so a refactor doesn't accidentally swap it for a
-        # string equality check again.
+    def test_demoted_audit_events_set_shape(self):
+        # The set-based dispatch is a regression guard so a
+        # refactor can't accidentally swap it for a string
+        # equality check. Pins the membership too — adding to
+        # the set is a deliberate visibility-reducing change
+        # and should land with an explicit test update.
         from core.llm.dispatcher import server as server_mod
-        assert isinstance(server_mod._HIGH_FREQ_OK_EVENTS, frozenset)
-        assert "request.dispatch" in server_mod._HIGH_FREQ_OK_EVENTS
+        assert isinstance(server_mod._DEMOTED_AUDIT_EVENTS, frozenset)
+        assert "request.dispatch" in server_mod._DEMOTED_AUDIT_EVENTS
+        assert "request.error" in server_mod._DEMOTED_AUDIT_EVENTS

--- a/core/llm/tests/test_retry_log_dedup.py
+++ b/core/llm/tests/test_retry_log_dedup.py
@@ -1,0 +1,219 @@
+"""End-to-end regression test for the retry-failure log dedup.
+
+Pre-fix each upstream failure produced 4 operator-visible lines
+(dispatcher request.error INFO + provider 'X completion failed'
+ERROR + client 'Attempt N/M failed' WARNING + client 'Retrying'
+INFO). Post-fix only the WARNING survives at operator-visible
+levels; the rest demote to DEBUG.
+
+These tests exercise the CLIENT path of the dedup — they patch
+the LLMClient's logger methods and count emissions per level
+after a forced provider failure. The dispatcher path is covered
+by ``test_log_quiet.py``; the provider path's demotion is
+verified by inspecting the source-level log calls (see
+``test_provider_completion_failed_uses_debug`` below).
+
+The RaptorLogger sets ``propagate=False`` (see
+``core/logging/__init__.py:RaptorLogger``), so ``caplog`` does
+not capture from it; ``monkeypatch.setattr`` on each level
+method is the working capture strategy.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from core.llm.client import LLMClient
+from core.llm.config import LLMConfig, ModelConfig
+
+
+def _captured_logger(monkeypatch, module):
+    """Patch every log-level method on ``module.logger`` and return
+    a dict that collects per-level message strings as the test
+    runs. Restored automatically by monkeypatch on test teardown."""
+    captured: dict = {
+        "debug": [], "info": [], "warning": [], "error": [],
+    }
+    # Each level captured in its own list — bind the level into
+    # the closure via a default-arg trick (avoids the classic
+    # late-binding-loop bug).
+    for level in ("debug", "info", "warning", "error"):
+        def _make_sink(_level=level):
+            def _sink(msg, *args, **kwargs):
+                # Honour %-formatting the way logger.warning("x %s", y) would.
+                try:
+                    rendered = str(msg) % args if args else str(msg)
+                except (TypeError, ValueError):
+                    rendered = str(msg)
+                captured[_level].append(rendered)
+            return _sink
+        monkeypatch.setattr(module.logger, level, _make_sink())
+    return captured
+
+
+def _model(provider: str, name: str) -> ModelConfig:
+    return ModelConfig(
+        provider=provider, model_name=name, api_key="test-key",
+    )
+
+
+def _config(primary: ModelConfig, *, max_retries: int = 3) -> LLMConfig:
+    return LLMConfig(
+        primary_model=primary, fallback_models=[],
+        enable_caching=False, max_retries=max_retries,
+        enable_fallback=False,
+    )
+
+
+class TestClientRetryLogCluster:
+    """One operator-visible WARNING per attempt; no 'Retrying' INFO
+    or other interstitial chatter."""
+
+    def test_three_attempts_emit_only_warnings(self, monkeypatch):
+        # Setup: single model, 3 retries, every attempt fails with
+        # a RETRYABLE error ("timeout" matches _is_retryable_error's
+        # pattern set; non-retryable errors break after attempt 1).
+        # Patch time.sleep to instant — the retry backoff would
+        # otherwise add 6+ seconds per test.
+        import core.llm.client as client_mod
+        monkeypatch.setattr(client_mod.time, "sleep", lambda _s: None)
+
+        primary = _model("anthropic", "primary")
+        config = _config(primary, max_retries=3)
+        client = LLMClient(config)
+
+        cap = _captured_logger(monkeypatch, client_mod)
+
+        with patch.object(client, "_get_provider") as mock_get:
+            prov = MagicMock()
+            prov.generate.side_effect = RuntimeError(
+                "simulated timeout from upstream",
+            )
+            mock_get.return_value = prov
+            with pytest.raises(Exception):
+                client.generate("test prompt")
+
+        # Operator-visible WARNINGs: 3 'Attempt N/3 failed' + 1
+        # 'All attempts failed' terminal. No fallback model, so
+        # no 'Falling back to:' line.
+        attempt_warnings = [
+            m for m in cap["warning"]
+            if "Attempt" in m and "failed for" in m
+        ]
+        assert len(attempt_warnings) == 3, (
+            f"expected 3 'Attempt N/3 failed' warnings, got: "
+            f"{attempt_warnings}"
+        )
+        assert any(
+            "All attempts failed" in m for m in cap["warning"]
+        ), f"expected 'All attempts failed' warning, got: {cap['warning']}"
+
+        # CRITICAL: no 'Retrying ...' INFO. Pre-fix this fired
+        # twice (between attempts 1→2 and 2→3); post-fix it's DEBUG.
+        retrying_infos = [m for m in cap["info"] if "Retrying" in m]
+        assert retrying_infos == [], (
+            f"'Retrying ...' should now be DEBUG; got INFO: "
+            f"{retrying_infos}"
+        )
+
+        # The DEBUG counterpart of the demoted "Retrying
+        # <provider>/<model>" line should fire — confirms the
+        # demotion is a level change, not deletion. Use a
+        # specific match (mentions the attempt counter) so the
+        # pre-existing "Retrying in Ns..." backoff DEBUG line
+        # isn't counted.
+        retrying_attempt_debugs = [
+            m for m in cap["debug"]
+            if "Retrying" in m and "(attempt" in m
+        ]
+        assert len(retrying_attempt_debugs) == 2, (
+            f"expected 2 'Retrying ... (attempt N/3)' DEBUG lines "
+            f"between attempts, got: {retrying_attempt_debugs}"
+        )
+
+    def test_single_attempt_emits_one_warning_no_retrying(
+        self, monkeypatch,
+    ):
+        # max_retries=1 → one attempt, no 'Retrying' anywhere.
+        primary = _model("anthropic", "primary")
+        config = _config(primary, max_retries=1)
+        client = LLMClient(config)
+
+        import core.llm.client as client_mod
+        cap = _captured_logger(monkeypatch, client_mod)
+
+        with patch.object(client, "_get_provider") as mock_get:
+            prov = MagicMock()
+            prov.generate.side_effect = RuntimeError("simulated timeout")
+            mock_get.return_value = prov
+            with pytest.raises(Exception):
+                client.generate("test")
+
+        attempt_warnings = [
+            m for m in cap["warning"]
+            if "Attempt" in m and "failed for" in m
+        ]
+        assert len(attempt_warnings) == 1
+        # No 'Retrying' at any level (only one attempt).
+        assert not any(
+            "Retrying" in m
+            for level in cap.values()
+            for m in level
+        )
+
+
+class TestProviderCompletionFailedDemoted:
+    """Source-level verification: each provider's ``except``
+    block uses ``logger.debug`` (not ``logger.error``) for the
+    'X completion failed' line.
+
+    Source inspection rather than runtime — exercising the real
+    provider's except block would need an HTTP-level failure
+    against the dispatcher, which is integration-test territory.
+    A future refactor that flips one of these back to ERROR (or
+    deletes the log entirely) surfaces here at unit-test cost.
+    """
+
+    def test_openai_uses_debug_for_completion_failed(self):
+        self._assert_uses_debug_not_error("OpenAI completion failed")
+
+    def test_anthropic_uses_debug_for_completion_failed(self):
+        self._assert_uses_debug_not_error("Anthropic completion failed")
+
+    def test_gemini_uses_debug_for_completion_failed(self):
+        self._assert_uses_debug_not_error("Gemini completion failed")
+
+    def _assert_uses_debug_not_error(self, message_prefix: str):
+        from pathlib import Path
+        providers_src = (
+            Path(__file__).resolve().parents[1] / "providers.py"
+        ).read_text()
+        # Find the line containing the message; assert the
+        # preceding logger call on that or the previous line is
+        # `.debug(` not `.error(`. Cheap regex sufficient — full
+        # AST would over-engineer this guard.
+        lines = providers_src.splitlines()
+        for i, line in enumerate(lines):
+            if message_prefix in line:
+                # The logger call could be on this line or on the
+                # previous line (multi-line call). Look back up to
+                # 2 lines for the logger.X( token.
+                context = "\n".join(lines[max(0, i - 2): i + 1])
+                assert ".debug(" in context, (
+                    f"{message_prefix!r} should be logged at DEBUG "
+                    f"(LLMClient retry loop emits the WARNING); "
+                    f"found context:\n{context}"
+                )
+                assert ".error(" not in context, (
+                    f"{message_prefix!r} found at ERROR level — "
+                    f"would double up with the LLMClient WARNING. "
+                    f"Context:\n{context}"
+                )
+                return
+        pytest.fail(
+            f"could not find {message_prefix!r} in providers.py — "
+            f"the log line may have been moved or renamed; "
+            f"update the test"
+        )


### PR DESCRIPTION
Each upstream LLM API failure produced four operator-visible lines saying the same thing at different abstraction layers. With ~10 Gemini failures per /agentic run that's ~30 lines of noise. Demote three to DEBUG; keep the one operator-actionable line. Before::

    [INFO] llm-dispatcher request.error error ... reason=ReadTimeout
    [ERROR] Gemini completion failed: 502 None. {'error': '...'}
    [WARNING] Attempt 1/3 failed for gemini/gemini-2.5-pro: 502 None. {...}
    [INFO] Retrying gemini/gemini-2.5-pro (attempt 2/3)

After: only the WARNING. Audit log on disk records every event at full fidelity regardless.

**Three demotions:**

1. Dispatcher's ``request.error`` audit event — renamed ``_HIGH_FREQ_OK_EVENTS`` → ``_DEMOTED_AUDIT_EVENTS`` and added ``request.error``. Routing now pure event-set membership.
2. Provider ``X completion failed`` logs (OpenAI / Anthropic / Gemini) — ``logger.error`` → ``logger.debug``. Each raises after logging; LLMClient catches and emits the WARNING.
3. Client's ``Retrying ...`` log (``generate`` + ``generate_structured``) — ``logger.info`` → ``logger.debug``. The prior WARNING already implied a retry.

**Sanitisation hardening:** the demoted provider ERROR used ``escape_nonprintable(redact_secrets(str(e)))[:1024]``. The retry-loop WARNING used a narrower API-key regex. Moved the broader sanitisation to both WARNING sites so the safety properties stay at the new operator-visible layer.

**Test coverage** (5 new + 3 updated):

* ``test_retry_log_dedup.py`` — end-to-end: synthetic retryable failure through ``LLMClient.generate``, capture every logger call, assert exact cluster shape (3 attempts → 4 WARNINGs + 0 ``Retrying`` INFOs + 2 ``Retrying`` DEBUGs). Source-level guard per provider that ``X completion failed`` uses ``.debug(``.
* ``test_log_quiet.py`` — updated dispatcher routing tests for the renamed set + the new request.error membership.

Full suite: 1360 core/llm tests pass. Ruff clean.