### PR TITLE
refactor(sca): centralise reachability label/order + refresh stale docs

### DIFF
--- a/docs/sca.md
+++ b/docs/sca.md
@@ -249,7 +249,6 @@ The diff command's exit code is 0 = no regression at threshold,
 
 ## Limitations + follow-ups
 
-- **Sandboxing** — registry HTTP calls go through `packages/sca/http.py` directly today. The sandbox seam will be retrofitted once `core/sandbox/` lands.
-- **Recent-publish + maintainer-change supply-chain checks** — need extra registry metadata (publish dates, maintainer lists). Deferred until sandbox lands.
-- **Variable-expanded inline installs** (`PKG="x=1"; apt install $PKG`) — would need a mini shell interpreter; deferred to a future LLM tier.
-- **Maven `mvn install:install-file`** — not yet rewritable; rare in inline contexts.
+- **Library-mode floor-raise unsupported on a handful of ecosystems** — `harden` refuses to corridor-pin a library's deps and emits `library_floor_raise_unsupported` for cases that can't be expressed as a range: inline-install (Dockerfile `RUN pip install foo`), Debian, Cargo, Go modules, RubyGems. The application path still pins these.
+- **OSV `affected_functions` coverage is patchy** — function-level reachability (the `not_function_reachable` / `likely_called` verdicts) only fires when an advisory ships symbol-level metadata. Python + Go are the best-covered ecosystems; npm / Maven / others mostly stay at the module-level `imported` verdict.
+- **CHA-precision for dynamic dispatch in Java / C#** — virtual / interface dispatch currently lands in `not_function_reachable` when the static graph can't narrow the receiver type. The reachability substrate has a scoping doc; the precision improvement is deferred until an operator signal justifies it.

--- a/packages/sca/models.py
+++ b/packages/sca/models.py
@@ -236,6 +236,33 @@ class Reachability:
     evidence: List[str] = field(default_factory=list)  # file:line refs
 
 
+# Operator-facing display labels for each verdict. Title-cased for the
+# rendered tables (the schema enum stays snake_case for the JSON/CLI
+# contract). Single source of truth — renderers + reports import from
+# here so a new verdict only needs one update.
+REACHABILITY_LABELS: dict[str, str] = {
+    "likely_called": "Likely called",
+    "imported": "Imported",
+    "called_in_dead_code": "Called in dead code",
+    "not_reachable": "Not reachable",
+    "not_function_reachable": "Not function reachable",
+    "not_evaluated": "Not evaluated",
+}
+
+# Display order for breakdown tables: reachable-tier first, then
+# uncertain, then not-reachable. Matches the triage-by-impact ordering
+# operators want at a glance. New verdicts not in this tuple sort to
+# the end (renderers handle the leftover set).
+REACHABILITY_ORDER: tuple[str, ...] = (
+    "likely_called",
+    "imported",
+    "called_in_dead_code",
+    "not_reachable",
+    "not_function_reachable",
+    "not_evaluated",
+)
+
+
 # ---------------------------------------------------------------------------
 # Findings — every finding flows into the shared findings.json schema
 # ---------------------------------------------------------------------------

--- a/packages/sca/render.py
+++ b/packages/sca/render.py
@@ -32,6 +32,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Sequence, Tuple
 
 from .findings import severity_rank
+from .models import REACHABILITY_LABELS, REACHABILITY_ORDER
 from .sarif import write_sarif
 
 logger = logging.getLogger(__name__)
@@ -219,23 +220,6 @@ _SEV_LABEL = {
     "none": "None",
 }
 
-_REACHABILITY_LABELS = {
-    "likely_called": "Likely called",
-    "imported": "Imported",
-    "called_in_dead_code": "Called in dead code",
-    "not_reachable": "Not reachable",
-    "not_function_reachable": "Not function reachable",
-    "not_evaluated": "Not evaluated",
-}
-
-_REACHABILITY_ORDER = (
-    "likely_called",
-    "imported",
-    "called_in_dead_code",
-    "not_reachable",
-    "not_function_reachable",
-    "not_evaluated",
-)
 
 
 def _render_markdown(rows: List[Dict[str, Any]], *, target: Path) -> str:
@@ -322,11 +306,11 @@ def _render_reachability_breakdown(rows: List[Dict[str, Any]]) -> str:
     buf = StringIO()
     buf.write("### Reachability breakdown\n\n")
     buf.write("| Verdict | Count |\n|---|---:|\n")
-    for verdict in _REACHABILITY_ORDER:
+    for verdict in REACHABILITY_ORDER:
         if counts.get(verdict):
-            label = _REACHABILITY_LABELS.get(verdict, verdict)
+            label = REACHABILITY_LABELS.get(verdict, verdict)
             buf.write(f"| {label} | {counts[verdict]} |\n")
-    for verdict in sorted(set(counts) - set(_REACHABILITY_ORDER)):
+    for verdict in sorted(set(counts) - set(REACHABILITY_ORDER)):
         buf.write(f"| {verdict} | {counts[verdict]} |\n")
     buf.write("\n")
     return buf.getvalue()
@@ -359,7 +343,7 @@ def _render_vuln_table(buf: StringIO, rows: List[Dict[str, Any]]) -> None:
         kev = "yes" if sca.get("in_kev") else ""
         epss = f"{sca['epss']:.2f}" if sca.get("epss") is not None else ""
         fix = sca.get("fixed_version") or ""
-        reach = _REACHABILITY_LABELS.get(
+        reach = REACHABILITY_LABELS.get(
             _row_reachability_verdict(r),
             _row_reachability_verdict(r),
         )

--- a/packages/sca/report.py
+++ b/packages/sca/report.py
@@ -51,6 +51,8 @@ from .findings import severity_rank
 from .models import (
     Advisory,
     HygieneFinding,
+    REACHABILITY_LABELS,
+    REACHABILITY_ORDER,
     SupplyChainFinding,
     VulnFinding,
 )
@@ -85,24 +87,6 @@ _SEV_LABEL: dict[str, str] = {
     # placeholder.
     "none": "None (CVSS 0.0)",
 }
-
-_REACHABILITY_LABELS: dict[str, str] = {
-    "likely_called": "Likely called",
-    "imported": "Imported",
-    "called_in_dead_code": "Called in dead code",
-    "not_reachable": "Not reachable",
-    "not_function_reachable": "Not function reachable",
-    "not_evaluated": "Not evaluated",
-}
-
-_REACHABILITY_ORDER = (
-    "likely_called",
-    "imported",
-    "called_in_dead_code",
-    "not_reachable",
-    "not_function_reachable",
-    "not_evaluated",
-)
 
 _REACHABILITY_GROUPS = (
     ("Reachable / likely used", {"likely_called", "imported"}),
@@ -371,13 +355,13 @@ def _render_reachability_breakdown(
         "| Verdict | Count |",
         "|---|---:|",
     ]
-    for verdict in _REACHABILITY_ORDER:
+    for verdict in REACHABILITY_ORDER:
         if counts.get(verdict):
             rows.append(
-                f"| {_REACHABILITY_LABELS.get(verdict, verdict)} "
+                f"| {REACHABILITY_LABELS.get(verdict, verdict)} "
                 f"| {counts[verdict]} |"
             )
-    for verdict in sorted(set(counts) - set(_REACHABILITY_ORDER)):
+    for verdict in sorted(set(counts) - set(REACHABILITY_ORDER)):
         rows.append(f"| {verdict} | {counts[verdict]} |")
     rows.append("")
     return "\n".join(rows)


### PR DESCRIPTION
copies in both render.py and report.py. Moving them into models.py (alongside the ReachabilityVerdict enum + Reachability dataclass they describe) so adding a new verdict only needs one update — pre-fix it needed three (enum + two display tables).

_REACHABILITY_GROUPS stays in report.py: it's the long-report's operator-facing triage bucketing — a render-time presentation choice rather than a schema property, so it belongs next to the renderer that uses it.

Also refresh the docs/sca.md "Limitations + follow-ups" section. All four prior entries had quietly become obsolete: core/sandbox now ships and SCA uses it (harden, agent, resolvers); recent-publish + maintainer-change supply-chain checks are real check codes (models.py / harden.py); variable-expanded inline-install detection landed as the LLM-tier prompt; mvn install:install-file has a rewriter in update.py. Replaced with three caveats that ARE currently true: library-mode floor-raise unsupported on inline-install / Debian / Cargo / Go / RubyGems; OSV affected_functions coverage patchy outside Python + Go; CHA-precision for Java/C# virtual dispatch deferred pending operator signal.

No behavior change. SCA suite: 3524 passed.