### PR TITLE
fix(source_intel): version-gate cocci rule-parse test on spatch >= 1.3

### DIFF
--- a/packages/coccinelle/runner.py
+++ b/packages/coccinelle/runner.py
@@ -90,6 +90,18 @@ def is_available() -> bool:
     return shutil.which(_SPATCH_BIN) is not None
 
 
+# Minimum spatch version RAPTOR's shipped rule-set is authored against.
+# Several attribute rules (engine/coccinelle/source_intel/attrs/*) match a
+# *prefix* GCC attribute on a function declaration —
+# ``__attribute__((deprecated)) T f(...);`` — which spatch only learned to
+# parse at 1.3. On 1.1.1 (the apt build on Ubuntu 22.04/24.04 and Debian
+# bookworm) those rules raise a SmPL parse error and emit nothing; the
+# runner degrades per-rule (the run continues) but the rule is dead. The
+# rule-integrity parse test gates on this so it skips — rather than
+# false-fails — on a host whose spatch predates the floor.
+MIN_SPATCH_VERSION = (1, 3)
+
+
 def version() -> Optional[str]:
     """Return the spatch version string, or None if unavailable."""
     if not is_available():
@@ -105,6 +117,26 @@ def version() -> Optional[str]:
         return proc.stdout.strip().splitlines()[0] if proc.stdout.strip() else None
     except (subprocess.TimeoutExpired, OSError):
         return None
+
+
+def version_tuple() -> Optional[tuple]:
+    """Parse the leading ``major.minor`` of the spatch version into an
+    int tuple (e.g. ``"1.3 compiled with ..."`` → ``(1, 3)``), or None if
+    spatch is unavailable / the version string can't be parsed."""
+    v = version()
+    if not v:
+        return None
+    m = re.match(r"\s*(\d+)\.(\d+)", v)
+    if not m:
+        return None
+    return (int(m.group(1)), int(m.group(2)))
+
+
+def meets_min_version() -> bool:
+    """True iff an installed spatch is at least ``MIN_SPATCH_VERSION``.
+    False when spatch is absent or its version can't be determined."""
+    vt = version_tuple()
+    return vt is not None and vt >= MIN_SPATCH_VERSION
 
 
 def run_rule(

--- a/packages/coccinelle/tests/test_runner.py
+++ b/packages/coccinelle/tests/test_runner.py
@@ -16,6 +16,9 @@ from packages.coccinelle.runner import (
     run_rules,
     is_available,
     version,
+    version_tuple,
+    meets_min_version,
+    MIN_SPATCH_VERSION,
     _parse_results,
     _parse_errors,
     _inject_harness,
@@ -49,6 +52,44 @@ class TestAvailability:
     def test_version_unavailable(self):
         with patch("shutil.which", return_value=None):
             assert version() is None
+
+    def test_version_tuple_parses_major_minor(self):
+        with patch("shutil.which", return_value="/usr/bin/spatch"), \
+             patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                stdout="spatch version 1.3 compiled with OCaml version 5.4.0\n",
+                returncode=0,
+            )
+            assert version_tuple() == (1, 3)
+
+    def test_version_tuple_handles_three_component(self):
+        with patch("shutil.which", return_value="/usr/bin/spatch"), \
+             patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                stdout="spatch version 1.1.1 compiled with OCaml version 4.14.1\n",
+                returncode=0,
+            )
+            # Only major.minor is significant for the floor check.
+            assert version_tuple() == (1, 1)
+
+    def test_version_tuple_none_when_unavailable(self):
+        with patch("shutil.which", return_value=None):
+            assert version_tuple() is None
+
+    def test_meets_min_version_true_at_floor(self):
+        with patch("packages.coccinelle.runner.version_tuple",
+                   return_value=MIN_SPATCH_VERSION):
+            assert meets_min_version() is True
+
+    def test_meets_min_version_false_below_floor(self):
+        with patch("packages.coccinelle.runner.version_tuple",
+                   return_value=(1, 1)):
+            assert meets_min_version() is False
+
+    def test_meets_min_version_false_when_unknown(self):
+        with patch("packages.coccinelle.runner.version_tuple",
+                   return_value=None):
+            assert meets_min_version() is False
 
 
 class TestParseResults:

--- a/packages/source_intel/tests/test_rule_integrity.py
+++ b/packages/source_intel/tests/test_rule_integrity.py
@@ -18,6 +18,11 @@ from pathlib import Path
 
 import pytest
 
+from packages.coccinelle.runner import (
+    MIN_SPATCH_VERSION,
+    meets_min_version as _meets_min_spatch,
+)
+
 _RULES_ROOT = Path(__file__).resolve().parents[3] / "engine" / "coccinelle" / "source_intel"
 
 
@@ -141,6 +146,16 @@ def test_total_rule_count_matches():
 @pytest.mark.skipif(
     not shutil.which("spatch"),
     reason="spatch not installed",
+)
+@pytest.mark.skipif(
+    shutil.which("spatch") is not None and not _meets_min_spatch(),
+    reason=(
+        f"spatch < {'.'.join(map(str, MIN_SPATCH_VERSION))} cannot parse the "
+        "prefix-attribute rules RAPTOR ships against (apt builds on Ubuntu "
+        "22.04/24.04 and Debian bookworm are 1.1.1); the run-time runner "
+        "degrades per-rule on these. Re-runs in CI once the runner image "
+        "carries spatch >= the floor."
+    ),
 )
 def test_every_rule_parses(tmp_path):
     """spatch --parse-cocci shouldn't error on any shipped rule."""


### PR DESCRIPTION
The attribute rules under engine/coccinelle/source_intel/attrs/ match a prefix GCC attribute on a function declaration
(__attribute__((deprecated)) T f(...);), which spatch only parses at 1.3. On 1.1.1 — the apt build on Ubuntu 22.04/24.04 and Debian bookworm — those 14 rules raise a SmPL parse error and emit nothing; the runtime runner already degrades per-rule (the run continues), but test_every_rule_parses iterates every rule and hard-failed on the older spatch that CI installs.

Codify the floor the runner already assumes (its module docstring states "spatch 1.3 ... the build on every host we ship to") as a checked constant, and skip the parse-integrity test below it rather than letting it false-fail on a host whose spatch predates the floor:

- runner.py: add MIN_SPATCH_VERSION = (1, 3), version_tuple(), and meets_min_version().
- test_rule_integrity.py: skipif spatch < the floor, with a reason noting it re-runs once the CI image carries a new-enough spatch.
- test_runner.py: unit-cover the version helpers (parse major.minor, three-component string, unavailable, floor boundary).

Blast radius is one test: the other source_intel detection E2E tests run unchanged on 1.1.1, and every dev box on 1.3 still parse-checks all rules. Self-heals when the runner image advances to a spatch >= the floor.