### PR TITLE
feat(describe): read-only target inspection + license-substrate overhaul + PM-aware install hints

### DIFF
--- a/.claude/commands/describe.md
+++ b/.claude/commands/describe.md
@@ -1,0 +1,71 @@
+---
+description: Describe a target — language mix, build system, catalog match, target-specific tool gaps, cost estimate. Read-only; no commands executed.
+dispatch: libexec/raptor-describe --target <path>
+---
+
+# /describe
+
+Tell me what THIS target is. **Read-only**: /describe inspects the tree and prints a description. It never executes target code, never runs builds, never recommends operator-typed shell commands.
+
+**Complementary to `/doctor`**: /doctor is the host-level diagnostic ("is RAPTOR set up on this machine"); /describe is the target-level pre-flight ("what is this target and what would RAPTOR do with it"). Operators typically run both at first contact with a new target: `/doctor` once per host, `/describe` per target.
+
+## Usage
+
+```
+/describe <target>           Operator-facing text block
+/describe <target> --json    Machine-readable JSON (for CI / dashboards)
+```
+
+If `<target>` is omitted, the active project's target is used (see CLAUDE.md DEFAULT TARGET DIRECTORY).
+
+## Execute
+
+When invoked, run:
+
+```
+libexec/raptor-describe --target <resolved_target> [--json]
+```
+
+Resolve `<resolved_target>` per CLAUDE.md (active project → `$RAPTOR_CALLER_DIR` → ask). Pass through `--json` if the operator supplied it.
+
+## Example output
+
+```
+Target analysis:
+  Languages: C++ (100%)
+  Build system: autotools
+  Size: ~74k LOC, 194 source files
+  Detected type: c.userspace-daemon
+
+Defaults for this target type:
+  /scan baseline packs: security-audit, command-injection, owasp-top-ten
+  /agentic preferred dirs: src/http, src/net, src/protocols, src/notification, src/api
+  Pipeline: understand-map → scan-with-codeql → agentic-with-validate
+
+Target-specific tool gaps:
+  ⚠ CodeQL (2.23.8)              — DB build needs libtool for autotools build system
+      hint: sudo apt install libtool
+  ✓ Coccinelle (1.3)             — C rule pack applicable to target
+  ⚠ Binary oracle                — no build artefacts found — will activate after build
+
+Cost estimate (when running /agentic): $25-$50, 40-75 min
+
+For host-level setup, run `raptor doctor`.
+To start analysis, run `raptor.py agentic --repo <target>` (prints same estimate at start; runs sandboxed).
+```
+
+## What /describe does NOT do
+
+- **No runnable commands.** /describe never recommends `./configure`, `make`, `apt install`, or any shell command the operator should type. A Makefile can do anything (`rm -rf /`, exfiltrate, format disk); recommending the operator type `make` against arbitrary target code is a security boundary RAPTOR doesn't cross.
+- **No execution.** Description only. Target code is never invoked.
+- **No host diagnostics.** Binary presence, API keys, env vars — all live in `/doctor`. /describe only checks target-specific signals (build deps for THIS build system, rule pack vs THIS language, etc.).
+
+When RAPTOR needs to build the target (for /codeql's database, for /agentic's binary-oracle enrichment), it'll do so inside its own sandbox — not by telling you to type `make`.
+
+## Substrate
+
+`packages/describe/` — composes existing substrates:
+- `core/run/target_types` (catalog-driven defaults; QoL #17)
+- `core/run/estimator` (cost/time hints; QoL #21)
+- `packages/codeql/language_detector` + `build_detector` (language + build-system inference)
+- `core/build/recipe` (build-command construction — kept as future /codeql consumer; not invoked by /describe)

--- a/core/archive/__init__.py
+++ b/core/archive/__init__.py
@@ -8,8 +8,10 @@ packages.
 Public API:
     from core.archive import detect_format, is_archive, extract_to_dir
     from core.archive import ArchiveError, UnsupportedArchive, DecompressionLimitExceeded
+    from core.archive import safe_cache_name
 """
 
+from .cache import safe_cache_name
 from .detect import detect_format, is_archive
 from .errors import ArchiveError, DecompressionLimitExceeded, UnsupportedArchive
 from .extract import (
@@ -27,4 +29,5 @@ __all__ = [
     "detect_format",
     "extract_to_dir",
     "is_archive",
+    "safe_cache_name",
 ]

--- a/core/archive/cache.py
+++ b/core/archive/cache.py
@@ -1,0 +1,36 @@
+"""Content-addressed cache-name helper for extracted archives.
+
+The cache layout is ``<sources_root>/<safe-archive-name>-<sha>/``.
+Used by ``raptor.py:_unpack_archive_target`` when /scan / /agentic
+unpack into a project's ``_sources/`` shared cache, and by
+``packages/describe/cli.py`` to check whether the operator already
+extracted the archive via a prior run (cache hit → reuse without
+re-extracting).
+
+The function is colocated with the rest of the archive substrate
+(``core.archive``) rather than left private to ``raptor.py`` —
+two consumers proves the abstraction.
+"""
+
+from __future__ import annotations
+
+_CACHE_NAME_ALLOWED = frozenset(
+    "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789._-")
+
+
+def safe_cache_name(archive_name: str, sha: str) -> str:
+    """Content-cache dir name: ``<sanitised archive name>-<sha>``.
+
+    Readable AND collision-free. The archive name is
+    attacker-influenced, so it's reduced to a safe charset,
+    stripped of leading separators, length-capped, and then the
+    sha (which alone guarantees uniqueness) is appended.
+    """
+    base = "".join(
+        c if c in _CACHE_NAME_ALLOWED else "_" for c in archive_name
+    )
+    base = base.strip("._-")[:64] or "archive"
+    return f"{base}-{sha}"
+
+
+__all__ = ["safe_cache_name"]

--- a/core/build/recipe.py
+++ b/core/build/recipe.py
@@ -1,0 +1,301 @@
+"""Build-recipe construction — operator-runnable command sequence
+for a target's detected build system.
+
+The codeql ``BuildDetector`` returns a static ``command`` per
+build-system type (``./configure && make`` for autotools, ``make``
+for plain Makefile, etc.). That's enough for codeql's "run this
+under our control" use case, but not enough for /describe's
+"tell the operator what to type" — particularly for autotools,
+where the operator's clean checkout may need a bootstrap step
+to generate ``configure`` from ``configure.ac``.
+
+This module wraps ``BuildDetector`` output and produces a full
+recipe by inspecting the target tree for the right bootstrap
+script. Multiple consumers benefit (right now /describe; future
+``raptor execute`` flag from QoL #14e would too).
+
+The recipe is a list of ``RecipeStep`` rather than a single
+shell string so renderers can show steps with hints / optional
+markers / why-rationale individually.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import List, Optional
+
+
+@dataclass(frozen=True)
+class RecipeStep:
+    """One step of a build recipe. ``command`` is the operator-
+    runnable shell line (without a leading ``$`` prompt or the
+    ``cd <target>``; renderers add the target prefix). ``why``
+    is one-line operator-readable rationale."""
+    command: str
+    why: Optional[str] = None
+    optional: bool = False
+
+
+@dataclass(frozen=True)
+class BuildRecipe:
+    """A full operator-runnable build recipe for a target.
+    Empty ``steps`` when the build system is unknown / not
+    handled — caller renders "(build instructions: consult the
+    project's README)" or similar."""
+    build_system: str  # e.g. "autotools", "cmake", "make", "" (unknown)
+    steps: List[RecipeStep] = field(default_factory=list)
+
+
+# Bootstrap-script preference for autotools: pick the first
+# one that exists in the target root. Falls back to
+# ``autoreconf -fi`` (the canonical generator) when none of
+# the project-specific shims are present.
+_AUTOTOOLS_BOOTSTRAP_CANDIDATES = (
+    "./autogen.sh",
+    "./bootstrap",
+    "./buildconf",  # used by some Apache projects
+)
+
+
+def build_recipe(target_path: Path, build_system: str) -> BuildRecipe:
+    """Construct the recipe for ``target_path`` given its
+    detected ``build_system`` type. Inspects the tree for
+    bootstrap scripts / generated artefacts so the recipe
+    matches what an operator would actually need to run.
+
+    Unknown build system → empty recipe; caller decides how to
+    handle (skip the step, or render "consult README")."""
+    target_path = Path(target_path)
+    builder = _RECIPES.get(build_system)
+    if builder is None:
+        return BuildRecipe(build_system=build_system)
+    return builder(target_path)
+
+
+# ---------------------------------------------------------------------------
+# Per-build-system recipe builders
+# ---------------------------------------------------------------------------
+
+
+def _autotools_recipe(target: Path) -> BuildRecipe:
+    """autotools — out-of-source build by default. configure.ac
+    is the source of truth; configure + Makefile + Makefile.in
+    are generated. autotools fully supports building from a
+    separate directory (``mkdir build && cd build && ../configure
+    && make``), which keeps object files out of the source tree
+    AND puts them in ``build/`` where binary-oracle's auto-detect
+    picks them up. Same number of operator commands; strictly
+    better outcome.
+
+    Sequence:
+      1. (if ``configure`` is missing) regenerate it via the
+         project's bootstrap script OR ``autoreconf -fi``
+         (runs in source root, the only step that touches it)
+      2. ``mkdir -p build && cd build && ../configure`` — generates
+         the per-host Makefile inside build/
+      3. ``make`` (in build/) — actually builds
+
+    When ``configure`` already exists in source root, step 1 is
+    omitted.
+    """
+    steps: List[RecipeStep] = []
+    configure_present = (target / "configure").is_file()
+    if not configure_present:
+        bootstrap = _find_autotools_bootstrap(target)
+        if bootstrap:
+            steps.append(RecipeStep(
+                command=f"cd <target> && {bootstrap}",
+                why=(
+                    f"{bootstrap} regenerates ./configure from "
+                    f"configure.ac (configure is not in the checkout)"
+                ),
+            ))
+        else:
+            steps.append(RecipeStep(
+                command="cd <target> && autoreconf -fi",
+                why=(
+                    "no bootstrap script found; autoreconf -fi "
+                    "regenerates ./configure from configure.ac"
+                ),
+            ))
+    # Out-of-source build — keeps object files out of the
+    # source tree AND lands them in ``build/`` (one of
+    # binary-oracle's auto-detect paths).
+    steps.append(RecipeStep(
+        command=(
+            "cd <target> && mkdir -p build && cd build "
+            "&& ../configure && make"
+        ),
+        why=(
+            "out-of-source build keeps object files out of "
+            "the source tree and in build/ where binary-oracle "
+            "auto-detects them"
+        ),
+    ))
+    return BuildRecipe(build_system="autotools", steps=steps)
+
+
+def _cmake_recipe(target: Path) -> BuildRecipe:
+    """cmake — out-of-source build is the modern convention.
+    Reuse an existing build dir if one is present (checks the
+    common conventions: ``build``, ``_build``, ``out/build``,
+    ``cmake-build-debug``, ``cmake-build-release``); otherwise
+    create the canonical ``build`` dir.
+
+    Projects with a less conventional build-dir name (e.g.
+    ``my-build``) still get the default-``build`` recipe and
+    have to adapt — same trade-off as every IDE that has to
+    pick a default."""
+    steps: List[RecipeStep] = []
+    for existing in (
+        "build", "_build", "out/build",
+        "cmake-build-debug", "cmake-build-release",
+    ):
+        if (target / existing).is_dir():
+            steps.append(RecipeStep(
+                command=f"cd <target>/{existing} && cmake .. && make",
+            ))
+            return BuildRecipe(build_system="cmake", steps=steps)
+    # No existing build dir — create the canonical one.
+    steps.append(RecipeStep(
+        command=(
+            "cd <target> && mkdir -p build && cd build "
+            "&& cmake .. && make"
+        ),
+        why="out-of-source build keeps generated files separate",
+    ))
+    return BuildRecipe(build_system="cmake", steps=steps)
+
+
+def _meson_recipe(target: Path) -> BuildRecipe:
+    return BuildRecipe(
+        build_system="meson",
+        steps=[RecipeStep(
+            command=(
+                "cd <target> && meson setup build && "
+                "meson compile -C build"
+            ),
+        )],
+    )
+
+
+def _make_recipe(target: Path) -> BuildRecipe:
+    """Plain hand-written Makefile (no autotools/cmake/meson
+    generators present). Just ``make``.
+
+    No out-of-source recipe — plain make obeys the Makefile's
+    own object-file conventions, which usually drop ``.o`` files
+    next to ``.c`` files in the source tree. Operators on
+    untrusted targets should fresh-clone before building."""
+    return BuildRecipe(
+        build_system="make",
+        steps=[RecipeStep(
+            command="cd <target> && make",
+            why=(
+                "warning: plain Makefile builds in-tree, "
+                "object files land next to source files"
+            ),
+        )],
+    )
+
+
+def _cargo_recipe(target: Path) -> BuildRecipe:
+    return BuildRecipe(
+        build_system="cargo",
+        steps=[RecipeStep(command="cd <target> && cargo build --release")],
+    )
+
+
+def _go_recipe(target: Path) -> BuildRecipe:
+    return BuildRecipe(
+        build_system="go",
+        steps=[RecipeStep(command="cd <target> && go build ./...")],
+    )
+
+
+def _poetry_recipe(target: Path) -> BuildRecipe:
+    return BuildRecipe(
+        build_system="poetry",
+        steps=[RecipeStep(command="cd <target> && poetry install")],
+    )
+
+
+def _pip_recipe(target: Path) -> BuildRecipe:
+    """Pip — install the package in editable mode if pyproject /
+    setup.py is present; else install requirements.txt."""
+    steps: List[RecipeStep] = []
+    if (target / "pyproject.toml").exists() or (target / "setup.py").exists():
+        steps.append(RecipeStep(
+            command="cd <target> && pip install -e .",
+        ))
+    elif (target / "requirements.txt").exists():
+        steps.append(RecipeStep(
+            command="cd <target> && pip install -r requirements.txt",
+        ))
+    else:
+        # Pip detected without recognisable manifest — fall back
+        # to editable install and let pip error if nothing's there.
+        steps.append(RecipeStep(
+            command="cd <target> && pip install -e .",
+        ))
+    return BuildRecipe(build_system="pip", steps=steps)
+
+
+def _npm_recipe(target: Path) -> BuildRecipe:
+    return BuildRecipe(
+        build_system="npm",
+        steps=[RecipeStep(command="cd <target> && npm install")],
+    )
+
+
+def _yarn_recipe(target: Path) -> BuildRecipe:
+    return BuildRecipe(
+        build_system="yarn",
+        steps=[RecipeStep(command="cd <target> && yarn install")],
+    )
+
+
+def _maven_recipe(target: Path) -> BuildRecipe:
+    return BuildRecipe(
+        build_system="maven",
+        steps=[RecipeStep(command="cd <target> && mvn package -DskipTests")],
+    )
+
+
+def _gradle_recipe(target: Path) -> BuildRecipe:
+    return BuildRecipe(
+        build_system="gradle",
+        steps=[RecipeStep(command="cd <target> && ./gradlew build -x test")],
+    )
+
+
+_RECIPES = {
+    "autotools": _autotools_recipe,
+    "cmake": _cmake_recipe,
+    "meson": _meson_recipe,
+    "make": _make_recipe,
+    "cargo": _cargo_recipe,
+    "go": _go_recipe,
+    "poetry": _poetry_recipe,
+    "pip": _pip_recipe,
+    "npm": _npm_recipe,
+    "yarn": _yarn_recipe,
+    "maven": _maven_recipe,
+    "gradle": _gradle_recipe,
+}
+
+
+def _find_autotools_bootstrap(target: Path) -> Optional[str]:
+    """Walk ``_AUTOTOOLS_BOOTSTRAP_CANDIDATES`` and return the
+    first one present + executable. Returns None when no
+    project-specific bootstrap is shipped (caller falls back to
+    the canonical ``autoreconf -fi``)."""
+    for candidate in _AUTOTOOLS_BOOTSTRAP_CANDIDATES:
+        path = target / candidate.lstrip("./")
+        if path.is_file():
+            return candidate
+    return None
+
+
+__all__ = ["BuildRecipe", "RecipeStep", "build_recipe"]

--- a/core/build/tests/test_recipe.py
+++ b/core/build/tests/test_recipe.py
@@ -1,0 +1,250 @@
+"""Tests for ``core/build/recipe.py`` — operator-runnable
+build recipes per detected build system. Key adversarial test:
+autotools recipes adapt to the bootstrap script the project
+actually ships (autogen.sh / bootstrap / autoreconf -fi)."""
+
+from __future__ import annotations
+
+from core.build.recipe import (
+    RecipeStep,
+    build_recipe,
+)
+
+
+class TestUnknownBuildSystem:
+    def test_unknown_returns_empty_recipe(self, tmp_path):
+        result = build_recipe(tmp_path, "imaginary")
+        assert result.build_system == "imaginary"
+        assert result.steps == []
+
+    def test_empty_string_returns_empty_recipe(self, tmp_path):
+        result = build_recipe(tmp_path, "")
+        assert result.steps == []
+
+
+class TestAutotoolsRecipe:
+    """The headline adversarial test — autotools recipes must
+    adapt to what's in the tree."""
+
+    def test_clean_checkout_with_autogen_sh_recommends_it(self, tmp_path):
+        # Clean autotools checkout: no configure script;
+        # autogen.sh is the conventional bootstrap. Recipe
+        # uses OUT-OF-SOURCE build (bootstrap in source root,
+        # then configure + make in build/ subdir) to keep
+        # object files out of the source tree.
+        (tmp_path / "configure.ac").write_text("")
+        (tmp_path / "autogen.sh").write_text("#!/bin/sh\nautoreconf -fi")
+        recipe = build_recipe(tmp_path, "autotools")
+        cmds = [s.command for s in recipe.steps]
+        # 2 steps: bootstrap (in source root) + combined
+        # mkdir/cd/configure/make in build/.
+        assert len(recipe.steps) == 2
+        assert "./autogen.sh" in cmds[0]
+        # Combined out-of-source step does configure + make.
+        assert "mkdir -p build" in cmds[1]
+        assert "../configure" in cmds[1]
+        assert "make" in cmds[1]
+        # Bootstrap step explains why.
+        assert recipe.steps[0].why and "autogen.sh" in recipe.steps[0].why
+        # Out-of-source step explains its anti-pollution
+        # rationale.
+        assert recipe.steps[1].why and "out-of-source" in recipe.steps[1].why
+
+    def test_clean_checkout_with_bootstrap_script(self, tmp_path):
+        # ``bootstrap`` (as monit ships) is also recognised.
+        (tmp_path / "configure.ac").write_text("")
+        (tmp_path / "bootstrap").write_text("#!/bin/sh\nautoreconf -fi")
+        recipe = build_recipe(tmp_path, "autotools")
+        assert "./bootstrap" in recipe.steps[0].command
+
+    def test_buildconf_bootstrap_apache_style(self, tmp_path):
+        # Apache projects ship ./buildconf rather than bootstrap.
+        (tmp_path / "configure.ac").write_text("")
+        (tmp_path / "buildconf").write_text("#!/bin/sh\nautoreconf -fi")
+        recipe = build_recipe(tmp_path, "autotools")
+        assert "./buildconf" in recipe.steps[0].command
+
+    def test_clean_checkout_no_bootstrap_uses_autoreconf(self, tmp_path):
+        # No bootstrap script of any kind → fall back to
+        # canonical autoreconf -fi.
+        (tmp_path / "configure.ac").write_text("")
+        recipe = build_recipe(tmp_path, "autotools")
+        assert "autoreconf -fi" in recipe.steps[0].command
+
+    def test_configure_already_present_skips_bootstrap(self, tmp_path):
+        # If ./configure already exists (operator pulled a
+        # release tarball with generated artefacts, or ran
+        # autoreconf earlier), skip the bootstrap step entirely.
+        # Recipe is a single out-of-source build step.
+        (tmp_path / "configure.ac").write_text("")
+        (tmp_path / "configure").write_text("#!/bin/sh")
+        recipe = build_recipe(tmp_path, "autotools")
+        cmds = [s.command for s in recipe.steps]
+        # 1 step: combined out-of-source build.
+        assert len(recipe.steps) == 1
+        assert "mkdir -p build" in cmds[0]
+        assert "../configure" in cmds[0]
+        assert "make" in cmds[0]
+        # No bootstrap-related step.
+        assert not any(
+            "autoreconf" in c or "autogen" in c or "/bootstrap" in c
+            for c in cmds
+        )
+
+    def test_configure_present_skips_bootstrap_even_when_autogen_exists(
+        self, tmp_path,
+    ):
+        # Real shape: operator pulled a release tarball that
+        # ships BOTH configure (already generated) AND
+        # autogen.sh (kept for re-bootstrap). Recipe MUST skip
+        # the bootstrap step — running ./autogen.sh would
+        # regenerate configure unnecessarily and could break a
+        # subsequent ./configure run if autoconf is missing.
+        # Pre-fix a "if autogen.sh exists, always run it"
+        # regression would slip past the existing tests
+        # because each tested one bootstrap scenario in
+        # isolation.
+        #
+        # Post out-of-source refactor: recipe is a single
+        # combined step (``mkdir -p build && cd build &&
+        # ../configure && make``) when configure is present —
+        # no separate bootstrap step.
+        (tmp_path / "configure.ac").write_text("")
+        (tmp_path / "configure").write_text("#!/bin/sh")
+        (tmp_path / "autogen.sh").write_text("#!/bin/sh")
+        recipe = build_recipe(tmp_path, "autotools")
+        cmds = [s.command for s in recipe.steps]
+        assert len(recipe.steps) == 1, (
+            f"expected 1 combined out-of-source step (no "
+            f"bootstrap) when configure is present; got: {cmds}"
+        )
+        # The single step must NOT run autogen.sh / autoreconf /
+        # bootstrap.
+        assert not any("autogen" in c for c in cmds), (
+            f"autogen.sh must NOT run when configure exists; "
+            f"got: {cmds}"
+        )
+        assert not any("autoreconf" in c for c in cmds)
+        assert not any("/bootstrap" in c for c in cmds)
+        # And it MUST be the out-of-source shape.
+        assert "mkdir -p build" in cmds[0]
+        assert "../configure" in cmds[0]
+        assert "make" in cmds[0]
+
+    def test_bootstrap_preference_order(self, tmp_path):
+        # When MULTIPLE bootstrap scripts exist (rare but
+        # legal), autogen.sh wins per
+        # ``_AUTOTOOLS_BOOTSTRAP_CANDIDATES`` ordering — it's
+        # the most common modern convention.
+        (tmp_path / "configure.ac").write_text("")
+        (tmp_path / "autogen.sh").write_text("")
+        (tmp_path / "bootstrap").write_text("")
+        recipe = build_recipe(tmp_path, "autotools")
+        assert "./autogen.sh" in recipe.steps[0].command
+
+
+class TestCmakeRecipe:
+    def test_no_existing_build_dir_creates_one(self, tmp_path):
+        (tmp_path / "CMakeLists.txt").write_text("")
+        recipe = build_recipe(tmp_path, "cmake")
+        cmd = recipe.steps[0].command
+        assert "mkdir -p build" in cmd
+        assert "cmake .." in cmd
+        assert "make" in cmd
+
+    def test_existing_build_dir_reused(self, tmp_path):
+        (tmp_path / "CMakeLists.txt").write_text("")
+        (tmp_path / "build").mkdir()
+        recipe = build_recipe(tmp_path, "cmake")
+        cmd = recipe.steps[0].command
+        assert "build" in cmd
+        # Should NOT re-create the build dir.
+        assert "mkdir -p build" not in cmd
+
+    def test_underscore_build_dir_reused(self, tmp_path):
+        # Ninja / non-CMake-default convention.
+        (tmp_path / "_build").mkdir()
+        recipe = build_recipe(tmp_path, "cmake")
+        assert "_build" in recipe.steps[0].command
+        assert "mkdir" not in recipe.steps[0].command
+
+    def test_cmake_build_debug_dir_reused(self, tmp_path):
+        # CLion default — common in JetBrains workflows.
+        (tmp_path / "cmake-build-debug").mkdir()
+        recipe = build_recipe(tmp_path, "cmake")
+        assert "cmake-build-debug" in recipe.steps[0].command
+        assert "mkdir" not in recipe.steps[0].command
+
+
+class TestMakeRecipe:
+    def test_plain_make_one_step(self, tmp_path):
+        recipe = build_recipe(tmp_path, "make")
+        assert len(recipe.steps) == 1
+        assert recipe.steps[0].command == "cd <target> && make"
+
+
+class TestPipRecipe:
+    def test_pyproject_present_uses_editable_install(self, tmp_path):
+        (tmp_path / "pyproject.toml").write_text("")
+        recipe = build_recipe(tmp_path, "pip")
+        assert "pip install -e ." in recipe.steps[0].command
+
+    def test_setup_py_present_uses_editable_install(self, tmp_path):
+        (tmp_path / "setup.py").write_text("")
+        recipe = build_recipe(tmp_path, "pip")
+        assert "pip install -e ." in recipe.steps[0].command
+
+    def test_requirements_only_uses_requirements_install(self, tmp_path):
+        (tmp_path / "requirements.txt").write_text("")
+        recipe = build_recipe(tmp_path, "pip")
+        assert "pip install -r requirements.txt" in recipe.steps[0].command
+
+    def test_nothing_recognisable_falls_back_to_editable(self, tmp_path):
+        # No manifest → default to editable; pip will error
+        # with a clear message if there's nothing to install.
+        recipe = build_recipe(tmp_path, "pip")
+        assert "pip install -e ." in recipe.steps[0].command
+
+
+class TestOtherBuildSystems:
+    """Coverage of the smaller recipe builders."""
+
+    def test_cargo(self, tmp_path):
+        recipe = build_recipe(tmp_path, "cargo")
+        assert "cargo build" in recipe.steps[0].command
+
+    def test_go(self, tmp_path):
+        recipe = build_recipe(tmp_path, "go")
+        assert "go build" in recipe.steps[0].command
+
+    def test_meson(self, tmp_path):
+        recipe = build_recipe(tmp_path, "meson")
+        assert "meson setup" in recipe.steps[0].command
+
+    def test_maven(self, tmp_path):
+        recipe = build_recipe(tmp_path, "maven")
+        assert "mvn package" in recipe.steps[0].command
+
+    def test_gradle(self, tmp_path):
+        recipe = build_recipe(tmp_path, "gradle")
+        assert "gradlew" in recipe.steps[0].command
+
+
+class TestRecipeStepDataclass:
+    """Pin the RecipeStep shape — consumer renderers depend
+    on the field names."""
+
+    def test_default_values(self):
+        step = RecipeStep(command="make")
+        assert step.command == "make"
+        assert step.why is None
+        assert step.optional is False
+
+    def test_with_why_and_optional(self):
+        step = RecipeStep(
+            command="./bootstrap",
+            why="generates configure",
+            optional=True,
+        )
+        assert step.why == "generates configure"
+        assert step.optional is True

--- a/core/config/__init__.py
+++ b/core/config/__init__.py
@@ -99,7 +99,10 @@ class RaptorConfig:
         # to UNCERTAIN on most findings — informational-only axes
         # (axis 1 alias scan, axis 6 build flags, axis 8 validation-
         # after-overflow) still work via pure-Python paths.
-        "coccinelle":   {"binary": "spatch",    "severity": "degrades", "affects": "source_intel (axes 1-7 verdict-active)"},
+        # ``affects`` is operator-facing — names user commands ("/codeql,
+        # /agentic"), not internal subsystem axes. ``source_intel`` /
+        # ``verdict-active`` mean nothing to an operator reading /doctor.
+        "coccinelle":   {"binary": "spatch",    "severity": "degrades", "affects": "/codeql, /agentic (C/C++ semantic-patch verification)"},
         "gdb":          {"binary": "gdb",       "severity": "required", "affects": "/crash-analysis, /fuzz"},
         "rr":           {"binary": "rr",        "severity": "degrades", "affects": "/crash-analysis"},
         "semgrep":      {"binary": "semgrep",   "group": "scanner",     "affects": "/scan, /agentic"},

--- a/core/inventory/languages.py
+++ b/core/inventory/languages.py
@@ -7,6 +7,7 @@ LANGUAGE_MAP = {
     '.py': 'python',
     '.js': 'javascript',
     '.jsx': 'javascript',
+    '.mjs': 'javascript',
     '.ts': 'typescript',
     '.tsx': 'tsx',
     '.c': 'c',
@@ -15,6 +16,8 @@ LANGUAGE_MAP = {
     '.cc': 'cpp',
     '.cxx': 'cpp',
     '.hpp': 'cpp',
+    '.hh': 'cpp',
+    '.hxx': 'cpp',
     '.java': 'java',
     '.go': 'go',
     '.rs': 'rust',
@@ -23,6 +26,7 @@ LANGUAGE_MAP = {
     '.cs': 'csharp',
     '.swift': 'swift',
     '.kt': 'kotlin',
+    '.kts': 'kotlin',
     '.scala': 'scala',
 }
 
@@ -31,3 +35,46 @@ def detect_language(filepath: str) -> Optional[str]:
     """Detect language from file extension."""
     ext = Path(filepath).suffix.lower()
     return LANGUAGE_MAP.get(ext)
+
+
+# Semgrep-canonical language id → operator-display name.
+# Used by every consumer that prints language IDs to a human
+# (``/scan`` pack-applicability lines, ``/prepare`` target
+# analysis, future report renderers). Pinned here so a future
+# language addition lands in one place rather than fanning out
+# to every renderer.
+LANG_DISPLAY = {
+    "c": "C",
+    "cpp": "C++",
+    "python": "Python",
+    "go": "Go",
+    "rust": "Rust",
+    "javascript": "JavaScript",
+    "typescript": "TypeScript",
+    "java": "Java",
+    "ruby": "Ruby",
+    "php": "PHP",
+    "kotlin": "Kotlin",
+    "swift": "Swift",
+    "scala": "Scala",
+    "csharp": "C#",
+    "solidity": "Solidity",
+    "bash": "Bash",
+    "yaml": "YAML",
+    "json": "JSON",
+    "html": "HTML",
+    "lua": "Lua",
+}
+
+
+def display_lang(lang: str) -> str:
+    """Map a semgrep language id to its operator-display name.
+    Unknown id → pass through unchanged (caller renders the
+    raw id rather than guessing)."""
+    return LANG_DISPLAY.get(lang, lang)
+
+
+def display_langs(langs) -> str:
+    """Operator-readable joined list, e.g. ``["c", "cpp"]`` →
+    ``"C, C/C++"``."""
+    return ", ".join(display_lang(lang) for lang in langs)

--- a/core/license/detector.py
+++ b/core/license/detector.py
@@ -23,6 +23,7 @@ _OSS_SPDX_IDS = frozenset({
     "BlueOak-1.0.0",
     # Weak copyleft
     "MPL-2.0",
+    "LGPL-2.0", "LGPL-2.0-only", "LGPL-2.0-or-later",
     "LGPL-2.1", "LGPL-2.1-only", "LGPL-2.1-or-later",
     "LGPL-3.0", "LGPL-3.0-only", "LGPL-3.0-or-later",
     "EPL-2.0",
@@ -44,6 +45,14 @@ _LICENSE_FILENAME_PATTERNS = (
     # Dual-license: many projects ship `LICENSE-MIT` + `LICENSE-APACHE`
     # at the top level (Rust ecosystem convention).
     "LICENSE-*", "LICENCE-*",
+    # Per-license filename layout: vte ships ``COPYING.GPL3`` +
+    # ``COPYING.LGPL3``; systemd ships ``LICENSE.GPL2`` +
+    # ``LICENSE.LGPL2.1``. Common across systemd / GNOME /
+    # Linux kernel-adjacent projects. The ``.*`` glob matches
+    # any extension (fnmatch ``*`` includes dots), so this also
+    # subsumes the explicit ``LICENSE.txt`` / ``COPYING.txt``
+    # entries above — they're kept for documentation value.
+    "LICENSE.*", "LICENCE.*", "COPYING.*",
 )
 
 # Cap how many lines we read from each file. SPDX headers + standard
@@ -70,17 +79,52 @@ _PROPRIETARY_MARKERS = (
 # ``(spdx_id, marker_text)``; the first marker that hits wins.
 # Conservative — fingerprints picked from the canonical license
 # preamble, not generic phrases.
+# Non-GPL fingerprints — simple substring → SPDX mapping. GPL
+# family is handled separately because the version is essential
+# (GPL-2.0 vs GPL-3.0 is a material licensing distinction; we
+# can't conflate them to "GPL-3.0" the way we used to). BSD is
+# also handled separately because BSD-2 vs BSD-3 cannot be told
+# apart by a single substring (BSD-3 = BSD-2 + 'neither the
+# name of' clause); see ``_classify_bsd``.
 _TEXT_FINGERPRINTS = (
     ("MIT", "permission is hereby granted, free of charge"),
     ("Apache-2.0", "apache license"),
-    ("BSD-3-Clause", "neither the name of"),
-    ("BSD-2-Clause", "redistribution and use in source and binary forms"),
     ("ISC", "permission to use, copy, modify, and/or distribute"),
     ("MPL-2.0", "mozilla public license"),
-    ("GPL-3.0", "gnu general public license"),
-    ("LGPL-2.1", "gnu lesser general public license"),
-    ("AGPL-3.0", "gnu affero general public license"),
     ("Unlicense", "this is free and unencumbered software"),
+)
+
+# BSD discriminator. BSD-2 and BSD-3 both start with
+# "redistribution and use in source and binary forms" — the
+# distinguishing clause is BSD-3's "Neither the name of the
+# copyright holder nor the names of its contributors may be
+# used to endorse or promote". When the discriminator is
+# present → BSD-3; absent → BSD-2.
+_BSD_INTRO_MARKER = "redistribution and use in source and binary forms"
+_BSD3_DISCRIMINATOR = "neither the name of"
+
+# GPL-family fingerprints — order matters within this tuple:
+# more-specific names (Lesser / Library / Affero) MUST come
+# before the bare "GNU General Public License" since the bare
+# name appears INSIDE the LGPL/AGPL preamble text. Earliest-
+# position in _classify_text uses the index here only to break
+# pos ties.
+#
+# Each entry is (family_label, family_marker, default_version)
+# — version is filled in by ``_classify_gpl_version`` reading
+# the surrounding text for "Version X". Default is the most-
+# common version for that family if no version marker is found.
+_GPL_FAMILY_FINGERPRINTS = (
+    # Affero before "lesser" before "library" before bare GPL —
+    # AGPL preamble mentions GPL; LGPL preamble mentions GPL.
+    ("AGPL", "gnu affero general public license", "3.0"),
+    ("LGPL", "gnu lesser general public license", "2.1"),
+    # Pre-rename name: LGPL was called "Library GPL" before the
+    # rename in 1999 (LGPL v2 was "Library GPL"; v2.1 onwards
+    # was "Lesser GPL"). "Library" + Version 2 = LGPL-2.0;
+    # "Library" + Version 2.1 = unusual but possible.
+    ("LGPL", "gnu library general public license", "2.0"),
+    ("GPL", "gnu general public license", "2.0"),
 )
 
 _SPDX_HEADER_RE = re.compile(
@@ -139,19 +183,38 @@ class TargetLicense:
 def _find_license_files(target_dir: Path) -> List[Path]:
     """Return license-named files at the top level of ``target_dir``,
     case-insensitive. Glob first to keep IO bounded; then de-dupe.
-    Symlinks dropped defensively — a symlink to /etc/passwd via a
-    crafted LICENSE link shouldn't be read."""
+
+    Symlinks: accepted IF they resolve inside ``target_dir`` —
+    REUSE-compliant projects commonly ship ``COPYING`` as a
+    symlink into ``LICENSES/<SPDX>.txt`` (glib, NetworkManager
+    et al.). Refused when the symlink resolves outside the tree
+    (defence against ``LICENSE`` → ``/etc/passwd`` planted on a
+    crafted target). Broken symlinks (resolve fails) are
+    dropped.
+    """
     found: dict = {}  # name → Path (dedup case-insensitive)
     if not target_dir.is_dir():
         return []
     try:
         entries = list(target_dir.iterdir())
+        target_resolved = target_dir.resolve()
     except OSError:
         return []
     name_patterns_lower = [p.lower() for p in _LICENSE_FILENAME_PATTERNS]
     for entry in entries:
-        if not entry.is_file() or entry.is_symlink():
+        if not entry.is_file():
+            # is_file follows symlinks; True for symlinks pointing
+            # at regular files (including in-tree REUSE layouts).
+            # False for dangling links + non-regular targets.
             continue
+        if entry.is_symlink():
+            try:
+                resolved = entry.resolve()
+                # In-tree symlinks ok (REUSE layout). Out-of-tree
+                # ones refused (crafted-target defence).
+                resolved.relative_to(target_resolved)
+            except (OSError, ValueError):
+                continue
         name_lower = entry.name.lower()
         for pat in name_patterns_lower:
             # Match by fnmatch semantics for the wildcard cases
@@ -246,16 +309,98 @@ def _classify_text(text: str) -> tuple:
         # SPDX header present but not in our OSS allowlist (e.g. a
         # custom commercial identifier) — treat as proprietary.
         return spdx, "proprietary", "high"
-    # Fingerprint and marker checks are case-insensitive — license
-    # preambles vary on title-case vs upper-case across projects.
+    # Fingerprint matching: pick the EARLIEST hit in the text,
+    # not the first in registry order. Pre-fix Firefox's
+    # license.html (which contains both "Mozilla Public License"
+    # at the top and "permission is hereby granted" later in
+    # the bundled-lib aggregation section) classified as MIT
+    # because MIT was first in _TEXT_FINGERPRINTS. The earliest
+    # position is the signal an operator actually wants — the
+    # project's primary license is stated at the top of the
+    # file; bundled-lib notices follow it.
     lowered = text.lower()
+    earliest_pos: Optional[int] = None
+    earliest_spdx: Optional[str] = None
+    # Non-GPL fingerprints.
     for spdx, marker in _TEXT_FINGERPRINTS:
-        if marker in lowered:
-            return spdx, "oss", "medium"
+        pos = lowered.find(marker)
+        if pos == -1:
+            continue
+        if earliest_pos is None or pos < earliest_pos:
+            earliest_pos = pos
+            earliest_spdx = spdx
+    # BSD discriminator. Present at the BSD-intro position.
+    # BSD-3 wins over BSD-2 whenever the "neither the name of"
+    # clause is present anywhere in the text — it's strictly
+    # MORE restrictive than BSD-2 (extra clause), so if it
+    # applies, the license IS BSD-3 not BSD-2.
+    bsd_pos = lowered.find(_BSD_INTRO_MARKER)
+    if bsd_pos != -1:
+        spdx = (
+            "BSD-3-Clause"
+            if _BSD3_DISCRIMINATOR in lowered
+            else "BSD-2-Clause"
+        )
+        if earliest_pos is None or bsd_pos < earliest_pos:
+            earliest_pos = bsd_pos
+            earliest_spdx = spdx
+    # GPL-family fingerprints — version-disambiguated. The
+    # version is essential (GPL-2.0 vs GPL-3.0 is a material
+    # licensing distinction). Resolved by scanning the text near
+    # the family marker for ``Version X``.
+    for family, marker, default_ver in _GPL_FAMILY_FINGERPRINTS:
+        pos = lowered.find(marker)
+        if pos == -1:
+            continue
+        if earliest_pos is None or pos < earliest_pos:
+            spdx = _classify_gpl_version(text, family, pos, default_ver)
+            earliest_pos = pos
+            earliest_spdx = spdx
+    if earliest_spdx is not None:
+        return earliest_spdx, "oss", "medium"
     for marker in _PROPRIETARY_MARKERS:
         if marker in lowered:
             return None, "proprietary", "low"
     return None, "unknown", "low"
+
+
+# Version regex: "Version 2", "Version 2.1", "Version 3.0" —
+# common in GNU LICENSE preambles ("GNU GENERAL PUBLIC LICENSE
+# Version 3, 29 June 2007"). Captures the version number.
+_GPL_VERSION_RE = re.compile(
+    r"\bversion\s+(\d+(?:\.\d+)?)\b", re.IGNORECASE,
+)
+
+
+def _classify_gpl_version(
+    text: str, family: str, family_pos: int, default_version: str,
+) -> str:
+    """Resolve the GPL-family SPDX id by looking for a ``Version X``
+    marker near the family preamble. Searches a window starting
+    at the family-marker position so a project that mentions
+    multiple GPL versions doesn't get confused (the version
+    nearest the preamble is the one that classifies the file).
+    Falls back to the family's default version when no version
+    marker is found within the window.
+    """
+    # Window: ~500 chars after the family marker — enough to
+    # capture "Version X" on the line immediately after the
+    # title (every GNU preamble I've seen puts the version on
+    # line 2 or 3).
+    window = text[family_pos: family_pos + 500]
+    m = _GPL_VERSION_RE.search(window)
+    if m:
+        version = m.group(1)
+    else:
+        version = default_version
+    # SPDX normalises bare-integer versions to N.0 (the
+    # canonical id is "GPL-3.0", "AGPL-3.0", "LGPL-2.0" —
+    # never "GPL-3"). "LGPL-2.1" keeps its minor because it's
+    # a distinct license version (LGPL changed substantively
+    # from 2.0 → 2.1).
+    if "." not in version:
+        version = f"{version}.0"
+    return f"{family}-{version}"
 
 
 def detect_target_license(target_dir: Path) -> TargetLicense:
@@ -269,11 +414,19 @@ def detect_target_license(target_dir: Path) -> TargetLicense:
     favour of an SPDX header, then a text fingerprint, then
     anything else.
 
+    When the strongest top-level file is itself a redirect
+    (e.g. Firefox's ``LICENSE`` → "see toolkit/content/license.html"),
+    follow up to ``_INDIRECTION_DEPTH_LIMIT`` levels of file
+    references, re-classifying each, and adopt the strongest
+    classification found anywhere in the chain. Path-traversal
+    defended: referenced paths must resolve inside ``target_dir``.
+
     No-match cases:
       * No license files at top level → ``classification="missing"``
-      * Files present but none classifiable → ``classification="unknown"``
+      * Files present + indirection-followed but still no match →
+        ``classification="unknown"``
     """
-    target_dir = Path(target_dir)
+    target_dir = Path(target_dir).resolve()
     files = _find_license_files(target_dir)
     if not files:
         return TargetLicense(
@@ -281,7 +434,16 @@ def detect_target_license(target_dir: Path) -> TargetLicense:
             source_file=None, confidence="low",
         )
 
-    # Score each file by detection confidence to pick the strongest.
+    # Score each file by detection confidence; pick the
+    # strongest. Dual-license projects (e.g. libgcrypt ships
+    # ``COPYING`` GPL + ``COPYING.LIB`` LGPL; NetworkManager
+    # ships COPYING GPL + COPYING.LGPL) are inherently
+    # ambiguous — there's no general way to know which one is
+    # the operator's intended "project license." We report
+    # whichever has the highest-confidence detection (ties
+    # broken by alphabetical filename for determinism), and
+    # the ``additional_files`` field carries the rest so the
+    # operator can see the layout.
     _CONFIDENCE_RANK = {"high": 2, "medium": 1, "low": 0}
     best = None
     best_rank = -1
@@ -297,6 +459,33 @@ def detect_target_license(target_dir: Path) -> TargetLicense:
     additional = tuple(
         f.name for f in files if f != chosen_file
     )
+
+    # Follow LICENSE-file indirections ("see X" / "license is in X"
+    # / "refer to X") when the strongest top-level signal didn't
+    # classify. Common for projects whose root LICENSE points at
+    # a nested file (Firefox → toolkit/content/license.html;
+    # multi-license projects → LICENSES/<spdx>.txt). Returns the
+    # original TargetLicense unchanged when the chain doesn't
+    # improve confidence.
+    if classification == "unknown":
+        follow_result = _follow_license_indirection(
+            target_dir, chosen_file,
+        )
+        if follow_result is not None:
+            spdx, classification, confidence, chosen_path = follow_result
+            return TargetLicense(
+                spdx_id=spdx,
+                classification=classification,
+                # Render as a relative path so the operator can
+                # see the chain hop ("toolkit/content/license.html"
+                # rather than just "license.html").
+                source_file=str(
+                    chosen_path.relative_to(target_dir),
+                ),
+                confidence=confidence,
+                additional_files=additional,
+            )
+
     return TargetLicense(
         spdx_id=spdx,
         classification=classification,
@@ -304,6 +493,243 @@ def detect_target_license(target_dir: Path) -> TargetLicense:
         confidence=confidence,
         additional_files=additional,
     )
+
+
+# Indirection-follow tunables. Bounded recursion + path count
+# prevent a malicious / pathological LICENSE chain from making
+# detection allocate forever.
+_INDIRECTION_DEPTH_LIMIT = 2          # root LICENSE → linked → linked-of-linked
+_INDIRECTION_PATH_LIMIT = 8           # cap referenced paths per file
+_INDIRECTION_FILE_BYTES = 256 * 1024  # cap per-file read at 256 KB
+
+
+# Patterns we recognise as "this LICENSE file points elsewhere".
+# Case-insensitive; capture group 1 is the referenced path.
+# Conservative: only match patterns whose intent is unambiguous
+# ("see file X", "refer to X", "license is in X", "license can be
+# found at X"). Don't try to parse free-form prose like "X is the
+# license file" — false positives there are worse than a missed
+# follow.
+# Path shape recognised in "see X" patterns: either a common
+# file extension (txt/md/rst/html/htm), OR a license-naming
+# convention (LICENSE.<id> / LICENCE.<id> / COPYING.<id>) where
+# the suffix is the license id rather than a conventional
+# extension. tracker's COPYING says "See the file COPYING.LGPL"
+# — no .txt/.md/etc. but unambiguously a license-file reference.
+_INDIRECTION_PATH = (
+    r"(?:"
+    r"[A-Za-z0-9_./\-]+\.(?:txt|md|rst|html?|htm)"
+    r"|"
+    r"(?:[A-Za-z0-9_./\-]+/)?(?:LICENSE|LICENCE|COPYING)\.[A-Za-z0-9_\-]+"
+    r")"
+)
+_INDIRECTION_PATTERNS = [
+    re.compile(
+        r"(?:please\s+)?see\s+(?:the\s+file\s+)?(" + _INDIRECTION_PATH + r")",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        r"licens(?:e|ing)\s+(?:text\s+)?is\s+in\s+("
+        + _INDIRECTION_PATH + r")",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        r"refer\s+to\s+(" + _INDIRECTION_PATH + r")",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        r"licens(?:e|ing)\s+(?:can\s+be\s+|may\s+be\s+)?"
+        r"found\s+(?:at|in)\s+(" + _INDIRECTION_PATH + r")",
+        re.IGNORECASE,
+    ),
+    # Plain "see DIR/" pattern — referenced TARGET is a directory.
+    # We resolve to every license-named file inside that dir.
+    re.compile(
+        r"see\s+(?:the\s+)?([A-Za-z0-9_./\-]+/)\s+(?:directory|dir|folder)",
+        re.IGNORECASE,
+    ),
+]
+
+
+def _extract_indirection_paths(text: str) -> List[str]:
+    """Return referenced paths from a LICENSE body, capped at
+    ``_INDIRECTION_PATH_LIMIT`` so a malicious file with hundreds
+    of "see X" lines can't make the follow allocate forever."""
+    found: List[str] = []
+    seen: set = set()
+    for pat in _INDIRECTION_PATTERNS:
+        for m in pat.finditer(text):
+            ref = m.group(1)
+            if ref not in seen:
+                seen.add(ref)
+                found.append(ref)
+                if len(found) >= _INDIRECTION_PATH_LIMIT:
+                    return found
+    return found
+
+
+def _read_license_full(path: Path, byte_cap: int) -> str:
+    """Like ``_read_license_head`` but reads up to ``byte_cap``
+    bytes (for indirection-follow we may need the full body of
+    a linked file, not just the header). Best-effort: returns
+    "" on any IO / encoding error.
+
+    Uses ``O_NOFOLLOW`` defence-in-depth — the caller already
+    refuses symlinked indirection targets via is_symlink before
+    resolve, but a TOCTOU swap between the check and the open
+    could otherwise pivot us through a symlink. O_NOFOLLOW
+    refuses to open a symlink at the final path component.
+    """
+    import os
+    try:
+        fd = os.open(str(path), os.O_RDONLY | os.O_NOFOLLOW)
+    except OSError:
+        return ""
+    try:
+        with os.fdopen(fd, "rb") as f:
+            buf = f.read(byte_cap)
+        return buf.decode("utf-8", errors="replace")
+    except OSError:
+        return ""
+
+
+def _follow_license_indirection(
+    target_dir: Path, source_file: Path,
+):
+    """Recursively follow ``see X`` / ``license is in X`` /
+    ``refer to X`` references inside license files. Returns
+    ``(spdx, classification, confidence, resolved_path)`` for
+    the strongest classified file in the chain, or None when
+    the chain doesn't improve over the caller's unknown.
+
+    Path-traversal defended: every referenced path is resolved
+    relative to the file containing it, then checked to live
+    inside ``target_dir.resolve()``. Symlinks rejected outright
+    (a malicious LICENSE-redirect chain via symlinks could
+    otherwise escape the target tree).
+    """
+    target_dir = target_dir.resolve()
+    _CONFIDENCE_RANK = {"high": 2, "medium": 1, "low": 0}
+    best = None
+    best_rank = -1
+
+    # BFS over the chain so we visit every referenced file once,
+    # not depth-first into the first link. Queue entries are
+    # (file_path, depth, is_root) — is_root flags the original
+    # source_file we're trying to improve, so we don't re-
+    # classify it (caller already did that and got unknown).
+    queue: List[tuple] = [(source_file, 0, True)]
+    visited: set = set()
+    visited.add(source_file.resolve())
+
+    while queue:
+        current_file, depth, is_root = queue.pop(0)
+        if depth > _INDIRECTION_DEPTH_LIMIT:
+            continue
+
+        # Read the file ONCE — classify_text AND extract refs
+        # both consume the same body. Pre-fix this read each
+        # non-root file twice, doubling IO on the indirection
+        # path (which already includes a per-target walk).
+        text = _read_license_full(current_file, _INDIRECTION_FILE_BYTES)
+        if not text:
+            continue
+
+        # Classify the current file — unless it's the root
+        # (caller already classified it and found unknown).
+        # Earliest-position fingerprint matching in _classify_text
+        # handles multi-license aggregation files correctly
+        # (Firefox's license.html: MPL at top, bundled-lib
+        # notices later → picks MPL). No HTML-specific
+        # downgrade needed here; the position-based picker is
+        # the principled fix.
+        if not is_root:
+            spdx, classification, confidence = _classify_text(text)
+            rank = _CONFIDENCE_RANK[confidence]
+            if rank > best_rank:
+                best = (spdx, classification, confidence, current_file)
+                best_rank = rank
+
+        # Extract this file's own references and enqueue them
+        # for further follow.
+        refs = _extract_indirection_paths(text)
+
+        for ref in refs:
+            # Reject absolute-path refs and `~` expansion at
+            # the regex layer's blind spot — defence in depth
+            # before resolve() canonicalises.
+            if ref.startswith(("/", "~")):
+                continue
+            # Check is_symlink on the RAW (un-resolved) path
+            # FIRST. After .resolve() canonicalises, the result
+            # is the final target, and is_symlink() always
+            # returns False for it — so a post-resolve check
+            # would never fire. A LICENSE redirect via an
+            # in-tree symlink to e.g. ``.env`` would otherwise
+            # bypass our intent to "refuse symlink-pivoted
+            # indirection chains."
+            raw = current_file.parent / ref
+            try:
+                if raw.is_symlink():
+                    continue
+            except OSError:
+                continue
+            # Resolve relative to the file containing the ref,
+            # not the target root — references are usually
+            # written as paths relative to the operator's view
+            # of the repo (LICENSES/MIT.txt under the root,
+            # ./license.html in a nested file).
+            try:
+                candidate = raw.resolve()
+            except (OSError, ValueError):
+                continue
+            if candidate in visited:
+                continue
+            visited.add(candidate)
+
+            # Path-traversal defence: must live inside target_dir.
+            try:
+                candidate.relative_to(target_dir)
+            except ValueError:
+                continue
+
+            # Directory reference: enqueue every license-named
+            # file inside it. Same-depth, NOT depth+1 — the dir
+            # itself isn't being classified, just enumerated;
+            # each file inside is the same hop as if it had been
+            # referenced directly. Otherwise a real chain like
+            # "LICENSE → see LICENSES/ directory → MIT.txt" hits
+            # the depth limit at the contents step.
+            #
+            # Capped at ``_INDIRECTION_PATH_LIMIT`` children too —
+            # otherwise a hostile target with 10k files in
+            # LICENSES/ would enqueue all of them, blowing the
+            # per-file caps' intent.
+            if candidate.is_dir():
+                enqueued_from_dir = 0
+                try:
+                    for child in candidate.iterdir():
+                        if enqueued_from_dir >= _INDIRECTION_PATH_LIMIT:
+                            break
+                        if not child.is_file() or child.is_symlink():
+                            continue
+                        if child.suffix.lower() in (".txt", ".md", ".rst", ".html", ".htm") or "license" in child.name.lower() or "copying" in child.name.lower():
+                            if child.resolve() not in visited:
+                                visited.add(child.resolve())
+                                queue.append((child, depth + 1, False))
+                                enqueued_from_dir += 1
+                except OSError:
+                    pass
+                continue
+
+            if not candidate.is_file():
+                continue
+
+            queue.append((candidate, depth + 1, False))
+
+    if best is not None and best[1] != "unknown":
+        return best
+    return None
 
 
 def format_license_summary(lic: TargetLicense, *, command: str = "") -> str:

--- a/core/license/tests/test_detector.py
+++ b/core/license/tests/test_detector.py
@@ -159,6 +159,224 @@ class TestTextFingerprintDetection:
         assert lic.classification == "oss"
 
 
+class TestInTreeSymlinkLicenseFiles:
+    """REUSE-compliant projects ship ``COPYING`` as a symlink
+    into ``LICENSES/<SPDX>.txt`` (glib, NetworkManager, many
+    GNOME-era projects). _find_license_files now accepts
+    in-tree symlinks; out-of-tree ones still refused."""
+
+    def test_copying_symlinked_to_in_tree_license(self, tmp_path):
+        (tmp_path / "LICENSES").mkdir()
+        (tmp_path / "LICENSES" / "LGPL-2.1-or-later.txt").write_text(
+            "GNU LESSER GENERAL PUBLIC LICENSE\n"
+            "Version 2.1\n"
+        )
+        (tmp_path / "COPYING").symlink_to(
+            "LICENSES/LGPL-2.1-or-later.txt",
+        )
+        lic = detect_target_license(tmp_path)
+        assert lic.classification == "oss"
+        assert lic.spdx_id == "LGPL-2.1"
+
+    def test_license_symlinked_outside_tree_refused(self, tmp_path):
+        # Crafted-target defence: LICENSE → /etc/passwd-style
+        # symlink to host fs. Must be refused so we don't read
+        # host file contents and surface them as a license.
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        (outside / "definitely-not-a-license.txt").write_text(
+            "All Rights Reserved\n"
+        )
+        target = tmp_path / "target"
+        target.mkdir()
+        (target / "LICENSE").symlink_to(
+            outside / "definitely-not-a-license.txt",
+        )
+        lic = detect_target_license(target)
+        # Symlink out of tree refused; nothing left to detect.
+        assert lic.classification == "missing"
+
+
+class TestGplVersionDisambiguation:
+    """GPL family + version detected from the preamble. Without
+    this, every GPL/LGPL/AGPL file was classified as the family's
+    "default" version (categorically GPL-3.0), which mis-labelled
+    every GPL-2.0 project by a major version."""
+
+    def test_gpl_version_2_classified_as_gpl_2_0(self, tmp_path):
+        (tmp_path / "COPYING").write_text(
+            "                  GNU GENERAL PUBLIC LICENSE\n"
+            "                       Version 2, June 1991\n"
+        )
+        lic = detect_target_license(tmp_path)
+        assert lic.spdx_id == "GPL-2.0"
+
+    def test_gpl_version_3_classified_as_gpl_3_0(self, tmp_path):
+        (tmp_path / "COPYING").write_text(
+            "                  GNU GENERAL PUBLIC LICENSE\n"
+            "                  Version 3, 29 June 2007\n"
+        )
+        lic = detect_target_license(tmp_path)
+        assert lic.spdx_id == "GPL-3.0"
+
+    def test_lgpl_version_2_1_kept_as_minor(self, tmp_path):
+        # SPDX uses "LGPL-2.1" (with the .1) because 2.0 and 2.1
+        # are substantively different licenses. Normalisation
+        # rule: bare integer → .0; explicit minor → kept as-is.
+        (tmp_path / "COPYING").write_text(
+            "GNU LESSER GENERAL PUBLIC LICENSE\nVersion 2.1\n"
+        )
+        lic = detect_target_license(tmp_path)
+        assert lic.spdx_id == "LGPL-2.1"
+
+    def test_lgpl_version_3_classified_as_lgpl_3_0(self, tmp_path):
+        (tmp_path / "COPYING").write_text(
+            "GNU LESSER GENERAL PUBLIC LICENSE\nVersion 3, 29 June 2007\n"
+        )
+        lic = detect_target_license(tmp_path)
+        assert lic.spdx_id == "LGPL-3.0"
+
+    def test_agpl_version_3_classified_as_agpl_3_0(self, tmp_path):
+        (tmp_path / "COPYING").write_text(
+            "GNU AFFERO GENERAL PUBLIC LICENSE\nVersion 3, 19 November 2007\n"
+        )
+        lic = detect_target_license(tmp_path)
+        assert lic.spdx_id == "AGPL-3.0"
+
+
+class TestBsd2VsBsd3Discrimination:
+    """BSD-2 and BSD-3 share the same intro ("redistribution
+    and use in source and binary forms"). BSD-3 = BSD-2 + the
+    "Neither the name of" clause; presence of that clause
+    promotes the result to BSD-3."""
+
+    def test_bsd_3_clause_wins_when_neither_clause_present(self, tmp_path):
+        # libslirp-shape file: BSD-3 because the "neither the name
+        # of" clause is in the text. Pre-fix this got BSD-2 because
+        # earliest-position picked the shared intro.
+        (tmp_path / "LICENSE").write_text(
+            "Redistribution and use in source and binary forms, "
+            "with or without modification, are permitted provided "
+            "that the following conditions are met:\n"
+            "1. Redistributions of source code must retain ...\n"
+            "2. Redistributions in binary form must reproduce ...\n"
+            "3. Neither the name of the copyright holder nor "
+            "the names of its contributors may be used to endorse\n"
+        )
+        lic = detect_target_license(tmp_path)
+        assert lic.spdx_id == "BSD-3-Clause"
+
+    def test_bsd_2_clause_when_no_neither_clause(self, tmp_path):
+        (tmp_path / "LICENSE").write_text(
+            "Redistribution and use in source and binary forms, "
+            "with or without modification, are permitted provided "
+            "that the following conditions are met:\n"
+            "1. Redistributions of source code must retain ...\n"
+            "2. Redistributions in binary form must reproduce ...\n"
+        )
+        lic = detect_target_license(tmp_path)
+        assert lic.spdx_id == "BSD-2-Clause"
+
+
+class TestPreRenamedLgplFingerprint:
+    """Older GNOME-era projects (eds-data-server, others)
+    ship COPYING with the pre-1999 name 'GNU LIBRARY GENERAL
+    PUBLIC LICENSE' — same license, different title. Pin the
+    fingerprint so these don't silently fall through to
+    unknown."""
+
+    def test_library_gpl_version_2_classified_as_lgpl_2_0(self, tmp_path):
+        # "GNU LIBRARY GENERAL PUBLIC LICENSE Version 2" is
+        # the canonical LGPL-2.0 — the very first LGPL,
+        # before the 1999 rename to "Lesser" + version bump
+        # to 2.1. Pin the version-detection so this doesn't
+        # silently collapse to LGPL-2.1.
+        (tmp_path / "COPYING").write_text(
+            "GNU LIBRARY GENERAL PUBLIC LICENSE\n"
+            "Version 2, June 1991\n"
+        )
+        lic = detect_target_license(tmp_path)
+        assert lic.classification == "oss"
+        assert lic.spdx_id == "LGPL-2.0"
+
+
+class TestFingerprintPositionPriority:
+    """Earliest fingerprint in the text wins, not registry
+    order. Pre-fix _TEXT_FINGERPRINTS iterated in declaration
+    order (MIT first), so a multi-license aggregation file
+    that mentions MPL at the top but MIT later got classified
+    as MIT — wrong. The earliest position is the operator-
+    relevant signal: project's primary license is stated at
+    the top; bundled-lib notices follow."""
+
+    def test_earliest_match_wins_over_registry_order(self, tmp_path):
+        # MPL preamble at line 1, MIT preamble at line 3.
+        # Pre-fix: MIT wins (first in _TEXT_FINGERPRINTS).
+        # Post-fix: MPL wins (earliest in text).
+        (tmp_path / "LICENSE").write_text(
+            "Mozilla Public License — this is the primary license.\n"
+            "\n"
+            "Bundled library: Permission is hereby granted, "
+            "free of charge, to any person obtaining a copy.\n"
+        )
+        lic = detect_target_license(tmp_path)
+        assert lic.spdx_id == "MPL-2.0"
+
+    def test_lgpl_preamble_not_misclassified_as_gpl(self, tmp_path):
+        # LGPL boilerplate contains "GNU General Public License"
+        # deeper in the text (LGPL incorporates GPL terms by
+        # reference). Earliest-position correctly picks LGPL.
+        # Pre-fix the registry-order iteration mis-classified
+        # LGPL files as GPL-3.0.
+        (tmp_path / "LICENSE").write_text(
+            "GNU LESSER GENERAL PUBLIC LICENSE\nVersion 2.1\n"
+            "...this License incorporates the terms of the "
+            "GNU General Public License...\n"
+        )
+        lic = detect_target_license(tmp_path)
+        assert lic.spdx_id == "LGPL-2.1"
+
+    def test_agpl_preamble_not_misclassified_as_gpl(self, tmp_path):
+        # Same shape: AGPL preamble contains references to GPL.
+        (tmp_path / "LICENSE").write_text(
+            "GNU AFFERO GENERAL PUBLIC LICENSE\nVersion 3\n"
+            "...derived from the GNU General Public License...\n"
+        )
+        lic = detect_target_license(tmp_path)
+        assert lic.spdx_id == "AGPL-3.0"
+
+    def test_apache_notice_with_bundled_mpl_picks_apache(self, tmp_path):
+        # Apache NOTICE files frequently start with the Apache
+        # header then list third-party attributions including
+        # Mozilla / MIT / etc. Earliest-position picks Apache.
+        (tmp_path / "LICENSE").write_text(
+            "Apache License Version 2.0\n\n"
+            "Third-party notices:\n- foo: Mozilla Public License\n"
+        )
+        lic = detect_target_license(tmp_path)
+        assert lic.spdx_id == "Apache-2.0"
+
+    def test_spdx_header_still_overrides_position(self, tmp_path):
+        # The SPDX header takes precedence over fingerprint
+        # matching regardless of position. Pin so a future
+        # rework doesn't accidentally subordinate it.
+        (tmp_path / "LICENSE").write_text(
+            "Mozilla Public License preamble at top.\n"
+            "SPDX-License-Identifier: MIT\n"
+        )
+        lic = detect_target_license(tmp_path)
+        assert lic.spdx_id == "MIT"
+
+    def test_single_fingerprint_unchanged(self, tmp_path):
+        # Sanity: file with only one fingerprint still works.
+        (tmp_path / "LICENSE").write_text(
+            "Permission is hereby granted, free of charge, "
+            "to any person obtaining a copy of this software\n"
+        )
+        lic = detect_target_license(tmp_path)
+        assert lic.spdx_id == "MIT"
+
+
 class TestProprietaryDetection:
     """Common proprietary markers classify as proprietary even
     without an SPDX header."""
@@ -255,6 +473,214 @@ class TestFileNameCoverage:
         )
         lic = detect_target_license(tmp_path)
         assert lic.classification == "missing"
+
+
+class TestIndirectionFollow:
+    """Indirection-follow promotes ``classification=unknown``
+    when the top-level LICENSE is a pointer to a real license
+    file inside the target tree (Firefox, multi-license repos
+    with ``LICENSES/*.txt`` layouts)."""
+
+    def test_simple_text_indirection_follows(self, tmp_path):
+        # LICENSE redirect → LICENSE.txt with real MIT body.
+        (tmp_path / "LICENSE").write_text(
+            "Please see the file LICENSE.txt for the licence.\n"
+        )
+        (tmp_path / "LICENSE.txt").write_text(
+            "Permission is hereby granted, free of charge, "
+            "to any person obtaining a copy of this software "
+            "and associated documentation files (the Software)\n"
+        )
+        lic = detect_target_license(tmp_path)
+        assert lic.spdx_id == "MIT"
+        assert lic.classification == "oss"
+        # source_file is the relative path of the linked file,
+        # not the original LICENSE pointer.
+        assert lic.source_file == "LICENSE.txt"
+
+    def test_nested_subdir_indirection_follows(self, tmp_path):
+        # Multi-license layout: LICENSE → LICENSES/MIT.txt
+        (tmp_path / "LICENSE").write_text(
+            "license text is in LICENSES/MIT.txt\n"
+        )
+        (tmp_path / "LICENSES").mkdir()
+        (tmp_path / "LICENSES" / "MIT.txt").write_text(
+            "Permission is hereby granted, free of charge, "
+            "to any person obtaining a copy of this software\n"
+        )
+        lic = detect_target_license(tmp_path)
+        assert lic.spdx_id == "MIT"
+        assert lic.source_file == "LICENSES/MIT.txt"
+
+    def test_path_traversal_rejected(self, tmp_path):
+        # Adversarial: LICENSE redirect points outside the
+        # target tree via .. — defence must reject.
+        (tmp_path / "target").mkdir()
+        (tmp_path / "outside_license.txt").write_text(
+            "MIT License\n\n"
+            "Permission is hereby granted, free of charge\n"
+        )
+        (tmp_path / "target" / "LICENSE").write_text(
+            "See ../outside_license.txt for terms\n"
+        )
+        lic = detect_target_license(tmp_path / "target")
+        # Path traversal rejected → indirection didn't help →
+        # stays unknown with the original LICENSE as source.
+        assert lic.classification == "unknown"
+        assert lic.source_file == "LICENSE"
+
+    def test_symlinked_indirection_target_rejected(self, tmp_path):
+        # Adversarial: LICENSE → real_link.txt → /etc/passwd
+        # (symlink to host file). Symlink check refuses to
+        # follow.
+        (tmp_path / "LICENSE").write_text(
+            "see real_link.txt for the terms\n"
+        )
+        (tmp_path / "real_link.txt").symlink_to(
+            "/nonexistent/sensitive",
+        )
+        lic = detect_target_license(tmp_path)
+        # Symlinked target refused; stays unknown.
+        assert lic.classification == "unknown"
+        assert lic.source_file == "LICENSE"
+
+    def test_html_multi_license_aggregation_picks_primary(self, tmp_path):
+        # The Firefox case: LICENSE → license.html which
+        # contains MPL header + many bundled-lib license
+        # notices. _classify_text picks the EARLIEST fingerprint
+        # in the text, so the project's primary license (named
+        # at the top of the HTML) wins over the bundled-lib
+        # notices that appear later. Pre-fix the registry-order
+        # fingerprint iteration matched MIT (which appeared
+        # later, in the bundled-lib section) — wrong.
+        (tmp_path / "LICENSE").write_text(
+            "Please see the file legal/license.html for the "
+            "copyright licensing conditions.\n"
+        )
+        (tmp_path / "legal").mkdir()
+        (tmp_path / "legal" / "license.html").write_text(
+            "<html><body>\n"
+            "<h1>Project license: Mozilla Public License</h1>\n"
+            "<p>This project is licensed under the MPL-2.0.</p>\n"
+            "<h2>Bundled libraries</h2>\n"
+            "<pre>Permission is hereby granted, free of charge, "
+            "to any person obtaining a copy of this software</pre>\n"
+            "</body></html>\n"
+        )
+        lic = detect_target_license(tmp_path)
+        assert lic.classification == "oss"
+        assert lic.spdx_id == "MPL-2.0"
+        assert lic.source_file == "legal/license.html"
+
+    def test_in_tree_symlink_pivot_blocked(self, tmp_path):
+        # Adversarial: LICENSE redirect points to a file that's
+        # actually a symlink to another in-tree file (e.g.
+        # ``.env`` or any sensitive in-target file). Pre-fix the
+        # is_symlink check fired AFTER .resolve() — always
+        # returned False for the canonicalised target — so the
+        # symlink-pivot succeeded and we read the pivoted file's
+        # content for classification.
+        (tmp_path / ".env").write_text(
+            "API_KEY=secret-shouldnt-be-read\n"
+            "All Rights Reserved — proprietary\n"
+        )
+        (tmp_path / "shim.txt").symlink_to(".env")
+        (tmp_path / "LICENSE").write_text(
+            "see the file shim.txt for the terms\n"
+        )
+        lic = detect_target_license(tmp_path)
+        # Pivoted file NOT read; classification stays unknown.
+        # If it WERE read, the proprietary marker would fire
+        # and the result would be "proprietary" — pin against
+        # that regression.
+        assert lic.classification == "unknown"
+        assert lic.source_file == "LICENSE"
+
+    def test_absolute_path_ref_rejected(self, tmp_path):
+        # Defence-in-depth: ref starting with `/` rejected at
+        # the regex-blind-spot layer. relative_to(target_dir)
+        # would also catch this, but the early reject keeps
+        # the failure intent explicit.
+        (tmp_path / "LICENSE").write_text(
+            "see /etc/passwd.txt for the licence\n"
+        )
+        lic = detect_target_license(tmp_path)
+        assert lic.classification == "unknown"
+
+    def test_directory_enumeration_capped(self, tmp_path):
+        # A hostile LICENSES/ with hundreds of children — the
+        # cap caps enqueued children at _INDIRECTION_PATH_LIMIT
+        # (8) so the BFS doesn't blow up.
+        (tmp_path / "LICENSE").write_text(
+            "see the LICENSES/ directory\n"
+        )
+        (tmp_path / "LICENSES").mkdir()
+        # 50 files, only the first 8 should be enqueued.
+        # Make them all classifiable so we know the cap
+        # actually kicks in (otherwise non-classifiable
+        # children would silently exhaust).
+        for i in range(50):
+            (tmp_path / "LICENSES" / f"f{i:02d}.txt").write_text(
+                "MIT License\n\n"
+                "Permission is hereby granted, free of charge\n"
+            )
+        lic = detect_target_license(tmp_path)
+        # Should classify (cap doesn't prevent successful
+        # detection on small dirs); main concern is the cap
+        # doesn't break the legit case.
+        assert lic.classification == "oss"
+        assert lic.spdx_id == "MIT"
+
+    def test_cycle_terminates(self, tmp_path):
+        # A → B → A — the visited-set must prevent infinite
+        # loops. Pin so a future refactor doesn't accidentally
+        # drop the cycle-protection.
+        (tmp_path / "LICENSE").write_text(
+            "Some text. see A.txt for details\n"
+        )
+        (tmp_path / "A.txt").write_text(
+            "More text. see B.txt for the licence\n"
+        )
+        (tmp_path / "B.txt").write_text(
+            "Yet more text. see A.txt for the licence\n"
+        )
+        # No license-text fingerprint in any of them; the test
+        # is that this RETURNS (no infinite loop) — the
+        # classification stays unknown but the call completes.
+        lic = detect_target_license(tmp_path)
+        assert lic.classification == "unknown"
+
+    def test_depth_limit_blocks_deep_chains(self, tmp_path):
+        # _INDIRECTION_DEPTH_LIMIT=2 should prevent us
+        # following 3+ hops. Pin that a 4-hop chain doesn't
+        # reach the MIT text at the far end.
+        (tmp_path / "LICENSE").write_text("see A.txt for the licence\n")
+        (tmp_path / "A.txt").write_text("see B.txt for the licence\n")
+        (tmp_path / "B.txt").write_text("see C.txt for the licence\n")
+        (tmp_path / "C.txt").write_text("see D.txt for the licence\n")
+        (tmp_path / "D.txt").write_text(
+            "Permission is hereby granted, free of charge\n"
+        )
+        lic = detect_target_license(tmp_path)
+        # MIT text is 4 hops deep — beyond the depth limit;
+        # detector must NOT classify as MIT.
+        assert lic.spdx_id != "MIT"
+        assert lic.classification == "unknown"
+
+    def test_directory_reference_enumerated(self, tmp_path):
+        # Pattern: "see LICENSES/ directory" — should enumerate
+        # files inside and classify each.
+        (tmp_path / "LICENSE").write_text(
+            "see the LICENSES/ directory for all licenses\n"
+        )
+        (tmp_path / "LICENSES").mkdir()
+        (tmp_path / "LICENSES" / "MIT.txt").write_text(
+            "Permission is hereby granted, free of charge, "
+            "to any person obtaining a copy of this software\n"
+        )
+        lic = detect_target_license(tmp_path)
+        assert lic.classification == "oss"
+        assert lic.spdx_id == "MIT"
 
 
 class TestSecurityAndRobustness:

--- a/core/run/target_types/__init__.py
+++ b/core/run/target_types/__init__.py
@@ -288,15 +288,28 @@ def _score_entry(entry: CatalogEntry, paths: List[str]) -> Optional[float]:
     (broad, many entries claim ``.c``). Function-name matching when
     tree-sitter substrate exists earns a higher weight; not used
     in v1.
+
+    Specificity gate: if an entry declares ``file_globs`` (= it
+    requires specific framework markers) but ZERO matched, refuse
+    to count the extension hits — extensions alone don't validate
+    the specificity claim, and would otherwise let python.web-app
+    win on any project that has .py + .html files (security
+    frameworks, doc generators, library examples). Entries with
+    no file_globs declared (``generic``) skip the gate and score
+    via extensions as before.
     """
     # Negative signals are deal-breakers.
     if entry.negative_globs and _matches_any(paths, entry.negative_globs):
         return None
-    score = 0.0
-    score += 2.0 * _matches_any(paths, entry.file_globs)
-    score += 1.0 * _has_extension(paths, entry.file_extensions)
+    file_glob_score = 2.0 * _matches_any(paths, entry.file_globs)
+    ext_score = 1.0 * _has_extension(paths, entry.file_extensions)
+    if entry.file_globs and file_glob_score == 0:
+        # Specificity gate fired — entry claimed framework
+        # signals that aren't here. Fall through to the
+        # next-best entry (likely ``generic``).
+        return 0.0
     # function_names ignored in v1 (no tree-sitter dependency here).
-    return score
+    return file_glob_score + ext_score
 
 
 def detect(target_path: Path) -> List[Tuple[CatalogEntry, float]]:

--- a/core/run/target_types/python.web-app.yml
+++ b/core/run/target_types/python.web-app.yml
@@ -7,28 +7,47 @@ description: |
   and python.library (no application boundary).
 
 detection:
+  # Tightening rationale: this catalog entry previously included
+  # generic Python manifests (pyproject.toml, setup.py,
+  # requirements.txt, Pipfile, poetry.lock) AND generic entry
+  # files (app.py, main.py) AND containerisation markers
+  # (Dockerfile, docker-compose.yml). Every Python project hits
+  # several of those, so python.web-app won by score against
+  # ``generic`` for ANY Python codebase — including RAPTOR itself,
+  # which is a security framework not a web app.
+  #
+  # Keep only FRAMEWORK-DISTINCTIVE markers — files that exist
+  # almost exclusively in web-app codebases. Pure Python libraries
+  # / CLI tools / security frameworks land in ``generic`` instead.
+  # Under-matching a real web app is better than false-matching a
+  # library: an operator can override via #18 smart-create
+  # ``--require-target-type python.web-app`` if needed.
   file_globs:
-    # Project / dep manifests.
-    - "pyproject.toml"
-    - "setup.py"
-    - "setup.cfg"
-    - "requirements.txt"
-    - "requirements-*.txt"
-    - "Pipfile"
-    - "poetry.lock"
-    # Framework-distinctive entry / config files.
-    - "manage.py"          # Django
-    - "wsgi.py"            # Django / generic WSGI
-    - "asgi.py"            # Django / generic ASGI
-    - "app.py"             # Flask / FastAPI common
-    - "main.py"            # FastAPI common
-    - "settings.py"        # Django
-    - "urls.py"            # Django
+    # Django — very strong signal.
+    - "manage.py"
+    - "wsgi.py"
+    - "asgi.py"
+    - "urls.py"
+    - "settings.py"
+    # Templating — Jinja2 / Django templates / etc.
     - "**/templates/**/*.html"
-    # Container shape often paired with web apps.
-    - "Dockerfile"
-    - "docker-compose.yml"
-    - "docker-compose.yaml"
+    # Flask blueprint shape — also strong (less common than
+    # Django's manage.py but unambiguous when paired with .py).
+    - "**/blueprints/**/*.py"
+    #
+    # KNOWN UNDER-MATCH: A pure FastAPI app with only
+    # ``main.py`` + ``pyproject.toml`` won't match here. The
+    # alternative — listing ``main.py`` — over-matched every
+    # Python project (RAPTOR itself, library examples, doc
+    # generators) so we tightened to framework-distinctive
+    # markers only. Operators with a FastAPI app that lands in
+    # ``generic`` can override via ``raptor project create
+    # --target <path> --require-target-type python.web-app``
+    # (QoL #18 smart-create gate). When more FastAPI-shaped
+    # globs prove distinctive (e.g. specific dependency
+    # patterns from pyproject.toml), add them here. Don't
+    # weaken with ``main.py`` / ``app.py`` / ``pyproject.toml``
+    # without re-validating against the false-match corpus.
   file_extensions:
     - .py
     - .html

--- a/core/run/target_types/tests/test_target_types.py
+++ b/core/run/target_types/tests/test_target_types.py
@@ -169,6 +169,62 @@ class TestDetect:
         assert ranked
         assert ranked[0][0].name == "python.web-app"
 
+    def test_specificity_gate_extensions_alone_dont_score(self, tmp_path):
+        # Regression: a Python codebase with .py + .html files but
+        # NO framework markers (no manage.py / wsgi.py / urls.py /
+        # settings.py / templates/) must NOT match python.web-app.
+        # Pre-fix the catalog scorer counted file_extension hits
+        # even when no specific file_glob matched; RAPTOR-itself
+        # got false-classified as python.web-app for this reason.
+        _build_tree(tmp_path, {
+            "lib/util.py": "",
+            "lib/core.py": "",
+            "lib/tests.py": "",
+            "docs/index.html": "",
+            "README.md": "# Just a Python library",
+        })
+        winner = load(tmp_path)
+        assert winner is not None
+        # Must fall through to generic — no framework signals
+        # validate the python.web-app specificity claim.
+        assert winner.name == "generic", (
+            f"expected generic for Python-library-shaped tree; "
+            f"got {winner.name!r} — specificity gate regression"
+        )
+
+    def test_specificity_gate_still_matches_real_django(self, tmp_path):
+        # Counter-check: a tree WITH framework markers still
+        # matches python.web-app via the gate.
+        _build_tree(tmp_path, {
+            "manage.py": "",
+            "settings.py": "",
+            "urls.py": "",
+            "app/views.py": "",
+        })
+        winner = load(tmp_path)
+        assert winner.name == "python.web-app"
+
+    def test_specificity_gate_boundary_single_framework_file_wins(self, tmp_path):
+        # Boundary case: a tree with EXACTLY ONE framework file
+        # match (the minimum the gate requires) should still
+        # match the catalog entry. Pins the gate semantic at
+        # the lowest passing edge — a future refactor that
+        # raised the threshold (e.g. "require ≥2 file_globs")
+        # would silently drop borderline real web apps. This
+        # test fails loudly when that happens.
+        _build_tree(tmp_path, {
+            # Only manage.py — a minimal Django-shaped tree.
+            "manage.py": "",
+            "app/handler.py": "",
+        })
+        winner = load(tmp_path)
+        assert winner.name == "python.web-app", (
+            f"single-framework-file match should still win "
+            f"the specificity gate; got {winner.name}. The "
+            f"gate is 'at least one file_glob match', not "
+            f"'multiple file_glob matches'."
+        )
+
     def test_negative_signal_disqualifies(self, tmp_path):
         # Tree LOOKS like an autotools daemon but has a Kconfig at
         # top — that's a Linux-kernel-module shape, c.userspace-daemon

--- a/core/startup/doctor.py
+++ b/core/startup/doctor.py
@@ -14,13 +14,18 @@ Differences from the banner:
   * Non-zero exit on real failure (``--strict`` also fails on
     warnings) so CI / shell scripts can gate on a clean state.
 
+Install advice (PM-aware): each missing-tool warning is enriched
+with an install-hint continuation line via
+``packages.describe.package_manager.format_install_advice``. The
+historic "no hints" stance was driven by the wrong-by-construction
+``apt install`` everywhere — install_advice fixes that: per-tool
+policy dispatches to the right shape for each install kind
+(distro PM with PM-correct package name, pipx for CLI tools,
+static URL for codeql, "Linux-only" for rr off Linux). The hints
+are correct or honestly absent — they're never patronising.
+
 Deliberately NOT in scope:
 
-  * Install advice for missing binaries. RAPTOR's audience is
-    technical operators — saying ``apt install rr`` is patronising
-    and often wrong (rr is Linux-only, the operator may build from
-    source for newer kernels, etc.). Doctor reports what's missing
-    and which features degrade; the operator picks how to install.
   * Performance benchmarks, network reachability beyond what
     ``check_llm`` already does, test runs.
 
@@ -51,6 +56,51 @@ _USAGE = (
     "  --strict     non-zero exit on warnings too (CI gate)\n"
     "  --verbose    include passing checks in the output\n"
 )
+
+
+def _build_install_hints(missing_tool_names: List[str]) -> dict:
+    """For each missing TOOL_DEPS name, look up its binary and
+    format install advice via packages.describe.package_manager.
+
+    Returns ``{binary_name: hint_line}``. Lookup keys are the
+    ``binary`` field from RaptorConfig.TOOL_DEPS, not the
+    user-facing tool name — warnings include the binary name
+    (e.g. ``spatch not found`` for coccinelle).
+    """
+    try:
+        from core.config import RaptorConfig
+        from packages.describe.package_manager import format_install_advice
+    except Exception:  # noqa: BLE001
+        return {}
+    out: dict = {}
+    for name in missing_tool_names:
+        dep = RaptorConfig.TOOL_DEPS.get(name)
+        if not dep:
+            continue
+        binary = dep.get("binary")
+        if not binary:
+            continue
+        try:
+            out[binary] = format_install_advice(binary)
+        except Exception:  # noqa: BLE001
+            continue
+    return out
+
+
+def _hint_for_warning(warning: str, install_hints: dict) -> Optional[str]:
+    """Match a warning string to one of the install hints. The
+    warnings produced by check_tools look like ``"… <binary>
+    not found"`` (single-tool case) or ``"… (afl-fuzz or
+    semgrep)"`` (group case). Match against the binary names
+    in ``install_hints``; first match wins.
+    """
+    for binary, hint in install_hints.items():
+        # Bounded by spaces / parentheses so a binary like "go"
+        # doesn't accidentally match inside "/agentic".
+        for needle in (f" {binary} ", f"({binary} ", f" {binary})", f" {binary}.", f"{binary} not found"):
+            if needle in warning:
+                return hint
+    return None
 
 
 def _gather() -> Tuple[
@@ -130,8 +180,30 @@ def _render(
         # need to re-format from tool_results here. tool_warnings
         # also carries group-level entries (e.g. "no scanner").
         pass
+    # Build a lookup of "binary name → install advice" for every
+    # tool that's missing so we can enrich the upstream warnings.
+    # Pre-fix /doctor printed "rr not found" with no hint — the
+    # historic concern was hints being patronising/wrong; with PM-
+    # aware advice they're correct-by-construction (or honest
+    # about Linux-only when off Linux).
+    install_hints = _build_install_hints(missing)
     for w in tool_warnings:
+        # Enrich the warning with an install hint when the
+        # missing tool's binary name appears in the warning. The
+        # warning strings look like "/crash-analysis limited — rr
+        # not found"; match by " <name> not found" so a future
+        # warning shape can extend without re-coding the
+        # detection.
         warnings.append(w)
+        hint = _hint_for_warning(w, install_hints)
+        if hint:
+            # Tuple-marker: the renderer below routes (hint, str)
+            # tuples to a continuation prefix instead of the
+            # warning bullet. Parallel structure rather than an
+            # in-band sentinel — eliminates the collision surface
+            # if a future warning string starts with an attacker-
+            # influenced LLM error message.
+            warnings.append(("hint", hint))
 
     # LLM — banner's ``check_llm`` is informational; entries describe
     # which provider is configured. Warnings stand alone.
@@ -189,7 +261,16 @@ def _render(
         out.append("")
         out.append("WARNINGS:")
         for w in warnings:
-            out.append(f"  ! {escape_nonprintable(w)}")
+            # Tuple-marked continuation lines (currently just
+            # install hints) get a continuation prefix instead of
+            # the warning bullet, so the operator reads them as a
+            # follow-up to the prior warning.
+            if isinstance(w, tuple) and len(w) == 2 and w[0] == "hint":
+                out.append(
+                    f"      hint: {escape_nonprintable(w[1])}"
+                )
+            else:
+                out.append(f"  ! {escape_nonprintable(w)}")
 
     if verbose and passes:
         out.append("")
@@ -203,12 +284,18 @@ def _render(
                    "(--verbose for detail.)")
 
     out.append("")
+    # Continuation entries (install-hint tuples) don't count as
+    # warnings — only the real warning bullets do.
+    real_warnings = sum(
+        1 for w in warnings
+        if not (isinstance(w, tuple) and w and w[0] == "hint")
+    )
     out.append(
         f"Summary: {len(failures)} failure(s), "
-        f"{len(warnings)} warning(s), {len(passes)} passed."
+        f"{real_warnings} warning(s), {len(passes)} passed."
     )
 
-    return "\n".join(out), len(failures), len(warnings)
+    return "\n".join(out), len(failures), real_warnings
 
 
 def main(argv: Optional[List[str]] = None) -> int:

--- a/core/startup/tests/test_doctor.py
+++ b/core/startup/tests/test_doctor.py
@@ -274,6 +274,66 @@ class TestOutputShape:
         warn_idx = out.index("WARNINGS:")
         assert fail_idx < warn_idx
 
+    def test_install_hint_attached_to_missing_tool_warning(
+        self, capsys, monkeypatch,
+    ):
+        # Missing rr → warning carries the PM-aware install hint
+        # on a continuation line. Shared substrate with /describe.
+        from packages.describe.package_manager import (
+            detect_package_manager,
+        )
+        detect_package_manager.cache_clear()
+        monkeypatch.setattr(
+            "shutil.which",
+            lambda cmd: "/usr/bin/apt" if cmd == "apt" else None,
+        )
+        monkeypatch.setattr(
+            doctor, "_gather",
+            lambda: _gather_stub(
+                tool_results=[("rr", False), ("gdb", True)],
+                tool_warnings=[
+                    "/crash-analysis limited — rr not found",
+                ],
+            ),
+        )
+        main([])
+        out = capsys.readouterr().out
+        # Warning + install hint on its own continuation line.
+        assert "rr not found" in out
+        assert "hint: sudo apt install rr" in out
+        # Summary count uses real-warning count (1), not 1+hint=2.
+        assert "1 warning(s)" in out
+
+    def test_install_hint_for_codeql_uses_static_url(
+        self, capsys, monkeypatch,
+    ):
+        # codeql isn't in any distro repo → install_advice
+        # dispatches to a static GH-Releases URL instead of a
+        # bogus ``apt install codeql``.
+        from packages.describe.package_manager import (
+            detect_package_manager,
+        )
+        detect_package_manager.cache_clear()
+        monkeypatch.setattr(
+            "shutil.which",
+            lambda cmd: "/usr/bin/apt" if cmd == "apt" else None,
+        )
+        monkeypatch.setattr(
+            doctor, "_gather",
+            lambda: _gather_stub(
+                tool_results=[("codeql", False)],
+                tool_warnings=[
+                    "/codeql, /agentic limited — codeql not found",
+                ],
+            ),
+        )
+        main([])
+        out = capsys.readouterr().out
+        # Static-URL kind: NO "apt install codeql" (would be
+        # wrong — package doesn't exist in distro repos).
+        assert "apt install codeql" not in out
+        assert "github.com/github/codeql-cli-binaries" in out
+
     def test_specific_paths_present_in_env_warnings(
         self, capsys, monkeypatch,
     ):

--- a/libexec/raptor-describe
+++ b/libexec/raptor-describe
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Pre-flight inspection: target type, tool readiness, recommended
+pipeline, and cost estimate. No LLM cost; no side effects.
+
+Usage:
+  raptor-describe --target <path>          Operator-facing text block
+  raptor-describe --target <path> --json   Machine-readable JSON
+
+Mirrors ``raptor.py prepare`` — this libexec form is what the
+``/describe`` slash-command invokes; operators typically use
+``bin/raptor describe --target <path>``.
+"""
+
+import argparse
+import sys
+from pathlib import Path
+
+# ─── trust-marker check (do not import; inline by design) ───
+import os
+if not (os.environ.get("CLAUDECODE")
+        or os.environ.get("_RAPTOR_TRUSTED")):
+    sys.stderr.write(
+        f"{sys.argv[0]}: internal dispatch script.\n"
+        "  Run via 'bin/raptor' instead.\n"
+        "  Tests / power users: set _RAPTOR_TRUSTED=1 to bypass.\n"
+    )
+    sys.exit(2)
+# ─── end trust-marker check ─────────────────────────────────
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(
+        prog="raptor-describe",
+        description=(
+            "Pre-flight inspection: target type, tool readiness, "
+            "recommended pipeline, cost estimate."
+        ),
+    )
+    parser.add_argument(
+        "--target", default=None, metavar="<path>",
+        help=(
+            "Path to the target codebase (directory OR archive: "
+            "tar.gz / zip / …). Optional — falls back to the "
+            "active project's target, then $RAPTOR_CALLER_DIR, "
+            "per CLAUDE.md DEFAULT TARGET DIRECTORY."
+        ),
+    )
+    parser.add_argument(
+        "--json", action="store_true",
+        help="Emit machine-readable JSON instead of the text block",
+    )
+    args = parser.parse_args(argv)
+
+    from packages.describe.cli import describe_main
+    return describe_main(args.target, args.json)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/packages/codeql/build_detector.py
+++ b/packages/codeql/build_detector.py
@@ -149,27 +149,51 @@ class BuildDetector:
             },
         },
         "cpp": {
+            # Priority ordering rationale (lower = picked first
+            # via ``min()``): source-of-truth build descriptions
+            # win over generated artefacts. An autotools project
+            # ships ``configure.ac`` AND a generated ``Makefile``
+            # AND a generated ``configure`` — picking "make"
+            # because Makefile is present would tell the operator
+            # to run ``make`` on a clean checkout, which fails
+            # because Makefile carries host-specific paths that
+            # ``./configure`` would have populated. The
+            # source-of-truth markers (CMakeLists.txt /
+            # configure.ac / meson.build) are HAND-AUTHORED;
+            # everything else can be regenerated from them.
+            # ``make`` is the fallback when ONLY a Makefile
+            # exists (no higher-level source) — that's a real
+            # case (hand-written Makefile projects) but rare;
+            # losing the false positive on autotools projects is
+            # a much bigger win.
             "cmake": {
                 "files": ["CMakeLists.txt"],
                 "command": "cmake . && make",
                 "env_vars": {},
                 "priority": 1,
             },
-            "make": {
-                "files": ["Makefile", "makefile"],
-                "command": "make",
-                "env_vars": {},
-                "priority": 2,
-            },
             "autotools": {
-                "files": ["configure", "configure.ac"],
+                "files": ["configure.ac", "configure.in", "Makefile.am"],
                 "command": "./configure && make",
                 "env_vars": {},
-                "priority": 3,
+                "priority": 2,
             },
             "meson": {
                 "files": ["meson.build"],
                 "command": "meson setup builddir && meson compile -C builddir",
+                "env_vars": {},
+                "priority": 3,
+            },
+            "make": {
+                # Last-resort: a hand-written Makefile with no
+                # higher-level source. Generated Makefiles (from
+                # autotools / cmake / meson) get classified by
+                # those entries above instead. Note we DON'T
+                # include ``configure`` here — its presence
+                # implies autotools regardless of which file is
+                # source vs generated.
+                "files": ["Makefile", "makefile"],
+                "command": "make",
                 "env_vars": {},
                 "priority": 4,
             },

--- a/packages/describe/cli.py
+++ b/packages/describe/cli.py
@@ -1,0 +1,231 @@
+"""Shared CLI driver for /describe.
+
+Both invocation paths — ``raptor.py describe`` (the dispatcher
+mode) and ``libexec/raptor-describe`` (the slash-command shim)
+— call into ``describe_main`` here, so target resolution,
+archive handling, building the report, and rendering live in
+exactly one place. Pre-fix the two paths each had their own
+copy of the same logic, which silently drifted (e.g. archive
+support landing in only one).
+
+Archive handling reuses ``core.archive`` (the same substrate
+that ``raptor.py:_unpack_archive_target`` uses for /scan and
+/agentic). Cache hit first: if a prior /scan run already
+extracted the same archive into the active project's shared
+``_sources/<safe-name>-<sha>/`` cache, /describe uses that
+directly — no re-extraction. Cache miss: extract into a temp
+directory we own, describe, clean up at the end.
+
+The operator sees one extra line in the render
+("Source: archive foo.tar.gz") so the result is unambiguous;
+they don't have to wonder whether RAPTOR somehow described a
+binary blob.
+"""
+
+from __future__ import annotations
+
+import shutil
+import sys
+import tempfile
+from pathlib import Path
+from typing import Optional, Tuple
+
+
+def describe_main(
+    target_arg: Optional[str],
+    json_output: bool,
+    stderr=sys.stderr,
+    stdout=sys.stdout,
+) -> int:
+    """Resolve target → (optionally extract archive) → build
+    report → render. Returns an exit code.
+
+    ``stderr`` / ``stdout`` are injectable for testing; defaults
+    use the real streams.
+    """
+    from core.run.output import resolve_default_target
+
+    target_arg = target_arg or resolve_default_target()
+    if target_arg is None:
+        stderr.write(
+            "✗ --target required (and no active project / "
+            "RAPTOR_CALLER_DIR set). "
+            "Run: raptor describe --target <path>\n"
+        )
+        return 1
+
+    raw_path = Path(target_arg).expanduser().resolve()
+    if not raw_path.exists():
+        stderr.write(
+            f"✗ target path does not exist: {raw_path}\n"
+        )
+        return 1
+
+    # Branch on directory vs file. Archive (file + recognised
+    # format) — cache hit reuses an existing extraction; cache
+    # miss extracts into a tmp dir we own and clean up.
+    tmp_extract_root: Optional[Path] = None
+    archive_label: Optional[str] = None
+    try:
+        if raw_path.is_dir():
+            target_path = raw_path
+        else:
+            resolved = _resolve_archive(raw_path, stderr)
+            if resolved is None:
+                return 1
+            target_path, tmp_extract_root, archive_label = resolved
+
+        from packages.describe.report import (
+            build_describe_report, format_json, format_text,
+        )
+        report = build_describe_report(
+            target_path, archive_label=archive_label,
+        )
+        if json_output:
+            stdout.write(format_json(report))
+            stdout.write("\n")
+        else:
+            stdout.write(format_text(report))
+            stdout.write("\n")
+        return 0
+    finally:
+        if tmp_extract_root is not None:
+            shutil.rmtree(tmp_extract_root, ignore_errors=True)
+
+
+def _resolve_archive(
+    raw_path: Path, stderr,
+) -> Optional[Tuple[Path, Optional[Path], str]]:
+    """Turn an archive ``raw_path`` into a describable directory.
+
+    Returns ``(target_path, tmp_extract_root, archive_label)``:
+
+    * ``target_path`` — the directory to describe (may be a
+      cache hit, a one-shot tmp extract, or a single-subdir
+      descent of either).
+    * ``tmp_extract_root`` — the tmp dir we own and must clean
+      up, or None for cache hits / failed cases.
+    * ``archive_label`` — original archive basename, for the
+      report header.
+
+    Returns None on any error; writes an operator-actionable
+    message to ``stderr``.
+    """
+    try:
+        from core.archive import (
+            extract_to_dir, is_archive, safe_cache_name,
+        )
+    except Exception:  # noqa: BLE001
+        stderr.write(
+            f"✗ target is not a directory and the archive "
+            f"substrate is unavailable: {raw_path}\n"
+        )
+        return None
+
+    if not is_archive(raw_path):
+        stderr.write(
+            f"✗ target is a file but not a recognised archive "
+            f"(tar, zip, gz, bz2, xz, zst): {raw_path}\n"
+        )
+        return None
+
+    archive_label = raw_path.name
+
+    # Cache-hit check FIRST: if a prior /scan / /agentic run on
+    # the same archive (in the same active project) already
+    # extracted to ``<project_output_dir>/_sources/<name>-<sha>/``,
+    # describe that — no re-extraction.
+    cache_hit = _find_cached_extraction(
+        raw_path, safe_cache_name,
+    )
+    if cache_hit is not None:
+        return (_descend_single_subdir(cache_hit), None, archive_label)
+
+    # Miss: one-shot extract to tmp. /describe stays read-only
+    # w.r.t. the project — does NOT write into ``_sources/`` (the
+    # cache is /scan's to populate; describing alone shouldn't
+    # create persistent project state).
+    tmp_extract_root = Path(tempfile.mkdtemp(prefix="raptor-describe-"))
+    try:
+        extract_to_dir(raw_path, tmp_extract_root)
+    except Exception as e:  # noqa: BLE001
+        # Broad on purpose: extraction runs on attacker-controlled
+        # input. ArchiveError, OSError, ValueError, MemoryError
+        # on oversized archives — any of them must fail gracefully
+        # rather than crash /describe.
+        stderr.write(
+            f"✗ archive extraction failed for {raw_path}: {e}\n"
+        )
+        shutil.rmtree(tmp_extract_root, ignore_errors=True)
+        return None
+
+    return (
+        _descend_single_subdir(tmp_extract_root),
+        tmp_extract_root,
+        archive_label,
+    )
+
+
+def _find_cached_extraction(
+    archive_path: Path, safe_cache_name_fn,
+) -> Optional[Path]:
+    """Return the cached extraction dir for ``archive_path``
+    under the active project's ``_sources/<name>-<sha>/``, or
+    None on no active project / no cache hit / snapshot
+    failure.
+
+    Mirrors ``raptor.py:_unpack_archive_target``'s cache
+    layout: ``<project_output_dir>/_sources/<safe-name>-<sha>``.
+    """
+    try:
+        from core.run.output import _resolve_active_project
+        from core.run.provenance import archive_snapshot
+    except Exception:  # noqa: BLE001
+        return None
+
+    active = _resolve_active_project()
+    if active is None:
+        return None
+    project_output_dir = active[0]
+
+    snap = archive_snapshot(archive_path)
+    if snap is None:
+        return None
+
+    cache_name = safe_cache_name_fn(snap["archive_name"], snap["archive_sha256"])
+    candidate = Path(project_output_dir) / "_sources" / cache_name
+    if candidate.is_dir():
+        return candidate
+    return None
+
+
+def _descend_single_subdir(root: Path) -> Path:
+    """When an extracted archive has the common single-top-level-
+    subdir layout (``tar czf proj.tgz proj/`` → extract gives
+    ``<root>/proj/<contents>``), descend into that subdir so the
+    catalog scorer + build detector see the project's top-level
+    markers (configure.ac, package.json, …) where they actually
+    are. No-op when the root has multiple entries, none, or when
+    the single entry is a symlink (a symlinked single entry could
+    escape the extract dir and retarget /describe at host paths;
+    refuse to follow).
+    """
+    try:
+        entries = [p for p in root.iterdir() if not p.name.startswith(".")]
+    except OSError:
+        return root
+    if len(entries) != 1:
+        return root
+    only = entries[0]
+    # is_symlink() guard before is_dir() — is_dir() follows
+    # symlinks, so a malicious archive with a single entry
+    # ``proj`` symlinking to ``/`` would otherwise retarget the
+    # whole /describe run at the host filesystem.
+    if only.is_symlink():
+        return root
+    if only.is_dir():
+        return only
+    return root
+
+
+__all__ = ["describe_main"]

--- a/packages/describe/deps.py
+++ b/packages/describe/deps.py
@@ -1,0 +1,98 @@
+"""Dependency-count snapshot for /describe.
+
+Reuses ``packages/sca`` substrate: ``find_manifests`` walks the
+target for known manifest files, ``parse_manifest`` extracts
+:class:`Dependency` rows. We count direct deps per ecosystem
+(skipping lockfiles, which would inflate the count with
+transitive deps — operator wants "20 direct npm deps" not
+"180 transitive").
+
+Materially useful as a handoff signal: "180 npm + 12 pypi deps
+detected → /sca is the natural next step before /agentic."
+
+Best-effort throughout. /sca isn't available, manifest parsing
+fails, target isn't a directory — all degrade silently to an
+empty result so /describe doesn't crash on unusual targets.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict
+
+
+# Cap on manifests we parse. /describe should be sub-second on
+# normal repos; a monorepo with hundreds of package.json files
+# would otherwise dominate the runtime. The cap is on parsing
+# work, not on discovery — discovery is fast even at scale.
+_MAX_MANIFESTS_TO_PARSE = 50
+
+
+@dataclass(frozen=True)
+class DependencyCounts:
+    """Per-ecosystem direct-dep count + a truncation flag when
+    we hit the parser cap."""
+    by_ecosystem: Dict[str, int] = field(default_factory=dict)
+    truncated: bool = False
+
+
+def detect_dependency_counts(target_path: Path) -> DependencyCounts:
+    """Walk the target for manifests, count direct deps per
+    ecosystem (npm / pypi / cargo / gomod / …). Lockfiles
+    excluded — they inflate the count with transitive deps.
+
+    Silences /sca's ``sca.discovery`` / ``sca.parsers`` INFO
+    logs for the duration — they'd otherwise leak the
+    "found N manifest candidates" / "no parser for path"
+    chatter into /describe's operator-facing block.
+    """
+    import logging
+
+    try:
+        from packages.sca.discovery import find_manifests
+        from packages.sca.parsers import parse_manifest
+    except Exception:  # noqa: BLE001
+        return DependencyCounts()
+
+    # Logger names follow __name__ in /sca's modules → fully
+    # qualified as "packages.sca.discovery" / "packages.sca.parsers".
+    discovery_logger = logging.getLogger("packages.sca.discovery")
+    parsers_logger = logging.getLogger("packages.sca.parsers")
+    prev_disc = discovery_logger.level
+    prev_parse = parsers_logger.level
+    discovery_logger.setLevel(logging.WARNING)
+    parsers_logger.setLevel(logging.WARNING)
+    try:
+        manifests = find_manifests(target_path)
+    except Exception:  # noqa: BLE001
+        discovery_logger.setLevel(prev_disc)
+        parsers_logger.setLevel(prev_parse)
+        return DependencyCounts()
+
+    # Drop lockfiles (transitive view); keep direct-manifest
+    # files where the operator wrote their dep list.
+    direct = [m for m in manifests if not m.is_lockfile]
+    truncated = len(direct) > _MAX_MANIFESTS_TO_PARSE
+    if truncated:
+        direct = direct[:_MAX_MANIFESTS_TO_PARSE]
+
+    counts: Dict[str, int] = {}
+    try:
+        for manifest in direct:
+            try:
+                deps = parse_manifest(manifest)
+            except Exception:  # noqa: BLE001
+                continue
+            if not deps:
+                continue
+            eco = manifest.ecosystem or "unknown"
+            counts[eco] = counts.get(eco, 0) + len(deps)
+    finally:
+        discovery_logger.setLevel(prev_disc)
+        parsers_logger.setLevel(prev_parse)
+
+    return DependencyCounts(by_ecosystem=counts, truncated=truncated)
+
+
+__all__ = ["DependencyCounts", "detect_dependency_counts"]

--- a/packages/describe/git_provenance.py
+++ b/packages/describe/git_provenance.py
@@ -1,0 +1,84 @@
+"""Git provenance for /describe — branch / commit / dirty /
+last-commit-date for the SCANNED TARGET.
+
+Distinct from ``core/run/provenance.py`` which snapshots the
+*framework*'s own checkout (the RAPTOR repo that produced a
+run). Here the target is attacker-controlled (we're describing
+an unknown codebase), so every git call goes through the
+shared ``_git`` helper with ``untrusted=True`` — that layers
+``safe_git_command``'s per-invocation overrides which
+neutralise hostile ``.git/config`` vectors
+(``core.fsmonitor`` / ``core.hooksPath`` / CVE-2024-32002
+family).
+
+Best-effort throughout: a non-git target, a missing git
+binary, a timeout, or any individual command failure yields
+``None`` for the affected field rather than failing the
+inference. /describe's render shows a "Git: none detected"
+line in the all-None case, otherwise renders the fields it
+got.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+
+@dataclass(frozen=True)
+class GitProvenance:
+    """Point-in-time git facts for the target tree. All
+    fields ``None`` when the target isn't a git checkout (or
+    git is unavailable, or every call timed out)."""
+    branch: Optional[str]           # current branch name; None when detached HEAD
+    commit_short: Optional[str]     # 7-12 char SHA
+    dirty: Optional[bool]           # True/False, or None when status couldn't be read
+    last_commit_date: Optional[str]  # ISO 8601 (e.g. "2026-05-30T14:22:11+00:00")
+
+
+def detect_git_provenance(target_path: Path) -> GitProvenance:
+    """Snapshot the target's git state. Reuses
+    ``core.run.provenance._git`` with ``untrusted=True`` for
+    the hostile-.git/config defense.
+    """
+    try:
+        from core.run.provenance import _git
+    except Exception:  # noqa: BLE001
+        return GitProvenance(None, None, None, None)
+
+    # rev-parse --short = "is this a git checkout AND give me the SHA". A
+    # None result means "not a git tree" — short-circuit the rest.
+    sha = _git(target_path, "rev-parse", "--short", "HEAD", untrusted=True)
+    if sha is None:
+        return GitProvenance(None, None, None, None)
+
+    # symbolic-ref returns the branch name; detached HEAD returns None.
+    # "main" / "master" / "develop" etc.
+    branch = _git(
+        target_path, "symbolic-ref", "--short", "HEAD", untrusted=True,
+    )
+
+    # status --porcelain is empty on clean. Distinguish "couldn't read" (None)
+    # from "clean" (empty) from "dirty" (non-empty).
+    status = _git(target_path, "status", "--porcelain", untrusted=True)
+    if status is None:
+        dirty: Optional[bool] = None
+    else:
+        dirty = bool(status)
+
+    # %cI = strict ISO 8601 committer date. Parseable by every datetime
+    # library; readable by humans.
+    last_commit = _git(
+        target_path, "log", "-1", "--format=%cI", "HEAD", untrusted=True,
+    )
+
+    return GitProvenance(
+        branch=branch,
+        commit_short=sha,
+        dirty=dirty,
+        last_commit_date=last_commit,
+    )
+
+
+__all__ = ["GitProvenance", "detect_git_provenance"]

--- a/packages/describe/package_manager.py
+++ b/packages/describe/package_manager.py
@@ -1,0 +1,428 @@
+"""Package-manager-aware install advice.
+
+Two layers:
+
+1. **PM detection + raw install-command formatting**
+   (``detect_package_manager`` + ``format_install_hint``) —
+   the primitive. Operator's PM detected from PATH; install
+   verb formatted for that PM (apt / dnf / pacman / apk /
+   zypper / brew). Pre-fix every hint hardcoded
+   ``sudo apt install …``, wrong-by-construction off
+   Debian/Ubuntu.
+
+2. **Per-tool install advice**
+   (``InstallAdvice`` + ``format_install_advice``) — the
+   policy layer. Different tools install different ways:
+
+   * distro-PM (autoconf, automake, libtoolize, spatch, gdb)
+   * pipx (semgrep — CLI tool, isolated env)
+   * static URL (codeql — not in distro repos; GH Releases)
+   * platform-restricted (rr — Linux-only; no brew)
+   * per-PM package-name override (afl-fuzz — apt: afl++,
+     dnf: american-fuzzy-lop, brew: afl-fuzz)
+
+   ``format_install_advice("rr")`` knows rr is Linux-only and
+   surfaces the project URL instead of a wrong ``brew install
+   rr`` on macOS. ``format_install_advice("semgrep")`` knows
+   it's not in distro repos and surfaces ``pipx install
+   semgrep``. Both /describe and /doctor consume this surface.
+"""
+
+from __future__ import annotations
+
+import functools
+import os
+import platform as _platform
+import shutil
+from dataclasses import dataclass
+from typing import Dict, List, Optional
+
+
+# Package managers we recognise, in detection order. Order is
+# significant for the "first wins" rule — if a system has both
+# (e.g. brew installed on a Linux box), the Linux native PM
+# leads because system-level tool dependencies typically come
+# from there, not the user-local PM.
+_KNOWN_PMS = (
+    "apt", "dnf", "yum", "pacman", "apk", "zypper", "brew",
+)
+
+
+# Per-PM package-name overrides for binaries whose package
+# name differs across distros. Empty today — every binary
+# /describe currently checks (autoconf / automake / libtool /
+# libtoolize / coccinelle) has the same package name on
+# apt / dnf / pacman / apk / zypper / brew. Extend with
+# ``{"binary": {"pm": "package-name"}}`` when a divergent case
+# materialises.
+_PER_PM_PKG_OVERRIDES: dict = {}
+
+
+@functools.lru_cache(maxsize=1)
+def detect_package_manager() -> Optional[str]:
+    """Return the first installed PM from ``_KNOWN_PMS``, or
+    None when no recognised PM is on PATH. Cached per-process
+    since the answer doesn't change mid-run.
+    """
+    for pm in _KNOWN_PMS:
+        if shutil.which(pm):
+            return pm
+    return None
+
+
+def _sudo_prefix() -> str:
+    """``"sudo "`` for a normal-user invocation, empty string
+    when already root. Docker base images (slim/distroless)
+    often run as root with no ``sudo`` binary installed; a
+    pastable ``sudo apt install foo`` line then fails with
+    ``sudo: command not found``. ``os.geteuid() == 0`` covers
+    Linux/macOS root; on Windows ``geteuid`` doesn't exist and
+    we degrade to "sudo" prefix (incorrect on Windows but
+    Windows isn't a supported RAPTOR host anyway)."""
+    try:
+        if os.geteuid() == 0:  # type: ignore[attr-defined]
+            return ""
+    except AttributeError:
+        pass
+    return "sudo "
+
+
+def format_install_hint(packages: List[str]) -> str:
+    """Return an operator-pastable install command for the
+    detected PM, or a generic message when no PM is found.
+
+    Examples::
+
+        format_install_hint(["libtool"])
+        → "sudo apt install libtool"      (Debian/Ubuntu)
+        → "sudo dnf install libtool"      (Fedora/RHEL)
+        → "sudo pacman -S libtool"        (Arch)
+        → "brew install libtool"          (macOS)
+        → "apt install libtool"           (root in container, no sudo)
+        → "install libtool via your system package manager"
+                                          (no recognised PM)
+    """
+    pm = detect_package_manager()
+    pkgs = " ".join(_resolve_pkg(p, pm) for p in packages)
+    sudo = _sudo_prefix()
+
+    if pm == "apt":
+        return f"{sudo}apt install {pkgs}"
+    if pm in ("dnf", "yum"):
+        return f"{sudo}{pm} install {pkgs}"
+    if pm == "pacman":
+        return f"{sudo}pacman -S {pkgs}"
+    if pm == "zypper":
+        return f"{sudo}zypper install {pkgs}"
+    if pm == "apk":
+        return f"{sudo}apk add {pkgs}"
+    if pm == "brew":
+        # brew refuses to run as root regardless; no sudo
+        # prefix needed even when EUID==0 (brew itself errors
+        # in that case, which is the right surface).
+        return f"brew install {pkgs}"
+    return f"install {pkgs} via your system package manager"
+
+
+def _resolve_pkg(pkg: str, pm: Optional[str]) -> str:
+    """Look up the per-PM override for ``pkg`` if one exists,
+    else pass through unchanged."""
+    overrides = _PER_PM_PKG_OVERRIDES.get(pkg)
+    if overrides and pm and pm in overrides:
+        return overrides[pm]
+    return pkg
+
+
+# ---------------------------------------------------------------------------
+# Python-environment-aware install path for the ``pipx`` / ``pip`` kinds
+# ---------------------------------------------------------------------------
+
+# Pipx install command per PM, used when pipx itself isn't on PATH.
+# Names match what each PM ships in current releases:
+#   apt  — Ubuntu 23.04+ / Debian 12+ ship ``pipx`` as the package name.
+#          Older releases require ``python3 -m pip install --user pipx``
+#          (we leave that case to the operator — they'll see the apt
+#          error and Google for two seconds).
+#   pacman — package is namespaced as ``python-pipx`` per Arch convention.
+#   everything else — bare ``pipx``.
+# Pipx package name per PM (some distros namespace differently).
+# The install command is built at call time via format_install_hint
+# so the EUID==0 / no-sudo path is honoured uniformly.
+_PIPX_PKG_PER_PM: Dict[str, str] = {
+    "apt": "pipx",
+    "dnf": "pipx",
+    "yum": "pipx",
+    "pacman": "python-pipx",
+    "apk": "pipx",
+    "zypper": "pipx",
+    "brew": "pipx",
+}
+
+
+def _format_python_cli_install(package: str) -> str:
+    """Render an install command for a Python CLI tool (``semgrep``
+    et al.), preferring whatever Python environment the operator
+    is actually in:
+
+    1. **Active venv** (``VIRTUAL_ENV`` set) — ``pip install pkg``
+       works inside a venv with no PEP 668 issue.
+    2. **Active conda env** (``CONDA_DEFAULT_ENV`` set) — ``conda
+       install -c conda-forge pkg``.
+    3. **uv on PATH** — ``uv tool install pkg`` (the equivalent of
+       ``pipx install`` for the uv toolchain).
+    4. **pipx on PATH** — ``pipx install pkg``.
+    5. **pipx NOT on PATH** — chain the bootstrap:
+       ``<pm-install-pipx> && pipx ensurepath && pipx install pkg``.
+       ``ensurepath`` is included because a fresh pipx install
+       requires it to put ``~/.local/bin`` on PATH; new operators
+       forget this and the next command fails with "command not
+       found: <tool>" until they re-login.
+    6. **No PM, no env** — generic fallback message.
+
+    The detection order matches what an operator would actually
+    want: their currently-activated env wins over a globally
+    available tool. Each branch is correct on PEP 668 systems —
+    we never suggest a path that the OS-managed Python would
+    block.
+    """
+    # 1. Active venv — pip works inside the venv even on PEP 668
+    #    systems because the venv's pip writes to the venv, not the
+    #    system site-packages. Pre-fix the hint blindly said pipx
+    #    even when the operator was in a venv where pip would work.
+    if os.environ.get("VIRTUAL_ENV"):
+        return f"pip install {package}"
+
+    # 2. Active conda env. conda-forge is the canonical channel for
+    #    third-party tools; conda's default channel often lacks
+    #    them (semgrep isn't in defaults at this time).
+    if os.environ.get("CONDA_DEFAULT_ENV"):
+        return f"conda install -c conda-forge {package}"
+
+    # 3. uv — modern (2024+) replacement for pipx/venv. If the
+    #    operator has it, they want the uv command (consistent
+    #    toolchain).
+    if shutil.which("uv"):
+        return f"uv tool install {package}"
+
+    # 4. pipx already installed → straightforward.
+    if shutil.which("pipx"):
+        return f"pipx install {package}"
+
+    # 5. pipx missing → bootstrap chain. format_install_hint
+    #    handles per-PM verb + EUID==0 sudo suppression
+    #    (Docker root images don't have sudo).
+    pm = detect_package_manager()
+    pipx_pkg = _PIPX_PKG_PER_PM.get(pm or "") if pm else None
+    if pipx_pkg:
+        pipx_install = format_install_hint([pipx_pkg])
+        return (
+            f"{pipx_install} && pipx ensurepath && pipx install {package}"
+        )
+
+    # 6. No PM and no env — the operator's setup is non-standard;
+    #    point them at the canonical pipx docs and let them choose
+    #    their poison (venv / pip --user / pyenv etc).
+    return (
+        f"install pipx first (see https://pipx.pypa.io/stable/installation/), "
+        f"then: pipx install {package}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Per-tool install advice — kind-dispatched policy layer
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class InstallAdvice:
+    """How to install a tool.
+
+    ``kind`` dispatches the formatter:
+
+    * ``distro_pm`` — distro package manager. ``pm_packages`` is an
+      optional per-PM override map; when None, the binary name is
+      used as the package name on every PM. When a single PM's
+      override exists but the operator's PM isn't in the map, the
+      formatter falls back to the binary name (best-effort).
+    * ``pipx`` — pipx install (preferred over pip for CLI tools so
+      the install lands in an isolated venv).
+    * ``pip`` — pip install (for libraries / when pipx is overkill).
+    * ``static_url`` — not in any distro / language PM; operator
+      installs from a project URL. Used for codeql (GH Releases).
+    * ``linux_only`` — Linux-only tool. On Linux falls back to
+      ``distro_pm`` semantics; off Linux surfaces an unavailable
+      message + ``docs_url``.
+
+    ``docs_url`` is rendered after the install command as a
+    parenthetical pointer ("see https://…") for the operator who
+    wants build-from-source instructions or version-specific advice.
+
+    ``mac_caveat`` is appended ONLY when running on macOS — for
+    tools whose install command works but whose runtime has a
+    Mac-specific gotcha (gdb's codesigning rabbit hole; afl-fuzz's
+    incomplete Apple Silicon support). Pre-fix the install hint
+    rendered the same on every platform; an operator on macOS hit
+    the gotcha after the install succeeded, wasting Google time.
+    """
+    kind: str    # "distro_pm" | "pipx" | "pip" | "static_url" | "linux_only"
+    pm_packages: Optional[Dict[str, str]] = None
+    package: Optional[str] = None
+    static_url: Optional[str] = None
+    docs_url: Optional[str] = None
+    mac_caveat: Optional[str] = None
+
+
+# Registry — binary name → InstallAdvice. Binary names match what
+# ``shutil.which`` (and ``RaptorConfig.TOOL_DEPS[*]['binary']``)
+# checks for, so callers pass the same name they probed with.
+_INSTALL_ADVICE: Dict[str, InstallAdvice] = {
+    # --- autotools chain (consumed by tool_readiness) ---
+    "autoreconf": InstallAdvice(
+        kind="distro_pm",
+        pm_packages={
+            "apt": "autoconf", "dnf": "autoconf", "yum": "autoconf",
+            "pacman": "autoconf", "apk": "autoconf",
+            "zypper": "autoconf", "brew": "autoconf",
+        },
+    ),
+    "automake": InstallAdvice(kind="distro_pm"),
+    "libtoolize": InstallAdvice(
+        kind="distro_pm",
+        # Binary ships in the ``libtool`` package on every PM.
+        pm_packages={
+            "apt": "libtool", "dnf": "libtool", "yum": "libtool",
+            "pacman": "libtool", "apk": "libtool",
+            "zypper": "libtool", "brew": "libtool",
+        },
+    ),
+    # --- /doctor-checked binaries ---
+    "gdb": InstallAdvice(
+        kind="distro_pm",
+        mac_caveat=(
+            "macOS: gdb needs codesigning to control processes — "
+            "consider lldb instead (`xcrun lldb`)"
+        ),
+    ),
+    "spatch": InstallAdvice(
+        kind="distro_pm",
+        pm_packages={
+            "apt": "coccinelle", "dnf": "coccinelle",
+            "yum": "coccinelle", "pacman": "coccinelle",
+            "apk": "coccinelle", "zypper": "coccinelle",
+            "brew": "coccinelle",
+        },
+        docs_url="https://coccinelle.gitlabpages.inria.fr/website/",
+    ),
+    "rr": InstallAdvice(
+        kind="linux_only",
+        # Linux package names: apt: rr ✓ / dnf: rr ✓ / pacman: rr (AUR)
+        pm_packages={"apt": "rr", "dnf": "rr", "pacman": "rr"},
+        docs_url="https://rr-project.org/",
+    ),
+    "afl-fuzz": InstallAdvice(
+        kind="distro_pm",
+        # Genuinely divergent package names per PM.
+        pm_packages={
+            "apt": "afl++", "dnf": "american-fuzzy-lop",
+            "pacman": "afl++", "brew": "afl-fuzz",
+        },
+        docs_url="https://aflplus.plus/",
+        mac_caveat=(
+            "macOS: incomplete Apple Silicon support upstream; "
+            "x86_64 Macs work, M-series degraded"
+        ),
+    ),
+    "codeql": InstallAdvice(
+        kind="static_url",
+        static_url=(
+            "https://github.com/github/codeql-cli-binaries/releases"
+        ),
+    ),
+    "semgrep": InstallAdvice(
+        kind="pipx",
+        package="semgrep",
+        docs_url="https://semgrep.dev/docs/getting-started/quickstart",
+    ),
+}
+
+
+def format_install_advice(binary: str) -> str:
+    """Operator-actionable install line for ``binary``. Falls
+    back to the generic "install via your system package
+    manager" message when the binary isn't in the registry.
+
+    Examples::
+
+        format_install_advice("libtoolize")
+            → "sudo apt install libtool"      (Ubuntu)
+            → "sudo dnf install libtool"      (Fedora)
+            → "brew install libtool"          (macOS)
+
+        format_install_advice("semgrep")
+            → "pipx install semgrep
+               (see https://semgrep.dev/docs/getting-started/quickstart)"
+
+        format_install_advice("codeql")
+            → "see https://github.com/github/codeql-cli-binaries/releases"
+
+        format_install_advice("rr")  on Linux
+            → "sudo apt install rr (see https://rr-project.org/)"
+        format_install_advice("rr")  on macOS
+            → "rr is Linux-only (see https://rr-project.org/)"
+    """
+    advice = _INSTALL_ADVICE.get(binary)
+    if advice is None:
+        # Unknown tool — generic fallback through the primitive.
+        return format_install_hint([binary])
+
+    docs_suffix = (
+        f" (see {advice.docs_url})" if advice.docs_url else ""
+    )
+    # Mac-specific caveat appended only on macOS. Suppresses on
+    # Linux even when set, so tools with mac_caveat data don't
+    # noise up the more-common Linux operator surface. Goes
+    # before docs_suffix so the order reads "install command —
+    # caveat — see-also URL".
+    mac_suffix = (
+        f" — {advice.mac_caveat}"
+        if advice.mac_caveat and _platform.system() == "Darwin"
+        else ""
+    )
+
+    if advice.kind == "distro_pm":
+        pm = detect_package_manager()
+        pkg = (advice.pm_packages or {}).get(pm or "", binary)
+        return f"{format_install_hint([pkg])}{mac_suffix}{docs_suffix}"
+
+    if advice.kind == "pipx":
+        cmd = _format_python_cli_install(advice.package or binary)
+        return f"{cmd}{mac_suffix}{docs_suffix}"
+
+    if advice.kind == "pip":
+        # Same env-aware path as pipx — a library install in a
+        # PEP 668 system is the same problem as a CLI install:
+        # need a venv/conda/uv/--user-via-pipx context for pip to
+        # actually work.
+        cmd = _format_python_cli_install(advice.package or binary)
+        return f"{cmd}{mac_suffix}{docs_suffix}"
+
+    if advice.kind == "static_url":
+        return f"see {advice.static_url}{mac_suffix}{docs_suffix}"
+
+    if advice.kind == "linux_only":
+        if _platform.system() == "Linux":
+            pm = detect_package_manager()
+            pkg = (advice.pm_packages or {}).get(pm or "", binary)
+            return f"{format_install_hint([pkg])}{docs_suffix}"
+        return f"{binary} is Linux-only{docs_suffix}"
+
+    # Unknown kind — degrade to the generic primitive.
+    return format_install_hint([binary])
+
+
+__all__ = [
+    "InstallAdvice",
+    "detect_package_manager",
+    "format_install_advice",
+    "format_install_hint",
+]

--- a/packages/describe/recommendations.py
+++ b/packages/describe/recommendations.py
@@ -1,0 +1,93 @@
+"""Signal-based "Recommended next:" picks for /describe.
+
+Augments the catalog's static ``pipeline_recommended`` defaults
+(rendered as "Pipeline: scan → agentic" by the matched target
+type) with picks derived from what we actually detected on this
+target: dep counts, build system, CI scanners already running,
+license, …
+
+Two-layer rendering is deliberate. The catalog line is the
+template ("for a project of this type, these commands by
+default"); the signal-based line is informed by today's tree
+("these commands are particularly applicable given what's
+actually here"). Operator sees both — the template recommends
+broad coverage, the signals refine.
+
+Recommendations are RAPTOR commands only (sandboxed,
+operator-typed-free). No raw shell commands; no operator-typed
+build steps. Same security rationale as the /describe scope
+(see ``report.py`` module docstring).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List
+
+from packages.describe.target_shape import TargetShape
+
+
+@dataclass(frozen=True)
+class Recommendation:
+    """One signal-derived recommendation: which RAPTOR command
+    to consider next + the one-line reason (so operator can
+    judge whether it applies)."""
+    command: str   # "/sca", "/codeql", "/agentic", …
+    reason: str    # one-line WHY, derived from signals
+
+
+def recommend_next(shape: TargetShape) -> List[Recommendation]:
+    """Pick RAPTOR commands likely to add value for THIS target.
+
+    Order is significant — high-signal picks first (per-target
+    specifics), broad always-applicable picks last. Operator
+    reads top-down.
+    """
+    out: List[Recommendation] = []
+
+    # /sca — dep counts present. The strongest signal for "you
+    # have a dep tree worth scanning".
+    if shape.deps is not None and shape.deps.by_ecosystem:
+        eco_blurb = ", ".join(
+            f"{count} {eco}"
+            for eco, count in sorted(
+                shape.deps.by_ecosystem.items(), key=lambda x: -x[1],
+            )[:3]   # top 3 ecosystems by count, avoid wrapping
+        )
+        out.append(Recommendation(
+            command="/sca",
+            reason=f"{eco_blurb} dep manifests detected",
+        ))
+
+    # /codeql — build system available. (We don't check whether
+    # CodeQL is already running in CI: RAPTOR's /codeql does
+    # different work than a generic CI codeql scan — different
+    # queries, different suites, different IRIS Tier 1 dataflow
+    # — and "duplicate effort" is bad advice for a security
+    # framework where defensive scanning is additive.)
+    has_build = bool(shape.primary_language and shape.build_systems.get(
+        shape.primary_language,
+    ))
+    if has_build:
+        bs = shape.build_systems[shape.primary_language]
+        out.append(Recommendation(
+            command="/codeql",
+            reason=f"{bs} build available",
+        ))
+
+    # /agentic — broad LLM-driven analysis. Only surface when
+    # there are no signal-driven picks AND when it'd actually
+    # add value; otherwise the "always applicable" line is
+    # marketing noise that crowds the real recommendations.
+    # When other recs are present, the operator already knows
+    # /agentic exists from the catalog Pipeline line above.
+    if not out:
+        out.append(Recommendation(
+            command="/agentic",
+            reason="LLM-driven analysis — applicable to any target",
+        ))
+
+    return out
+
+
+__all__ = ["Recommendation", "recommend_next"]

--- a/packages/describe/report.py
+++ b/packages/describe/report.py
@@ -1,0 +1,496 @@
+"""Top-level ``/describe`` report — composes target shape +
+tool readiness + catalog defaults preview + cost estimate
+into a single operator-facing description (``DescribeReport``)
+plus renderers (text + JSON).
+
+**Scope contract — read-only describe, no execution.**
+
+/describe deliberately does NOT recommend operator-typed shell
+commands (``./configure``, ``make``, ``apt install``). The
+earlier ``recommended_pipeline`` section did, and that
+conflated RAPTOR's sandboxed execution (``raptor.py X``) with
+operator-typed arbitrary code execution of the target's
+Makefile / configure script. A Makefile can do ``rm -rf /``,
+exfiltrate data, run anything — recommending the operator
+type ``make`` is a security boundary RAPTOR shouldn't cross.
+
+What /describe DOES surface:
+
+* Target shape — language mix, build system, size, catalog
+  target type
+* Target-type defaults preview — what packs, what preferred
+  dirs, what RAPTOR pipeline names the catalog will apply
+  when the operator runs analysis. NO runnable commands.
+* Target-specific tool gaps — CodeQL build deps, coccinelle
+  language applicability, binary-oracle artefact presence.
+  Per-target. Host-level checks live in /doctor.
+* Cost estimate — from #21 estimator.
+
+When the operator is ready to act, they run ``raptor.py
+agentic`` / ``codeql`` / ``scan`` etc. — those commands have
+their own lifecycles and (when builds are needed) run them
+inside RAPTOR's sandbox. The dangerous-build problem belongs
+where building actually happens (in /codeql's DB step,
+specifically), not in a "here, type these into your shell"
+recommendation surface.
+
+``core/build/recipe.py`` is still here as the build-command
+substrate — /codeql will consume it when it gains sandboxed
+build (separate arc).
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from packages.describe.recommendations import recommend_next
+from packages.describe.target_shape import TargetShape, infer_target_shape
+from packages.describe.tool_readiness import ToolCheck, check_tool_readiness
+
+
+@dataclass(frozen=True)
+class TargetTypeDefaults:
+    """What the matched catalog entry will drive when the
+    operator runs analysis. Read-only preview — no
+    runnable commands, just data.
+
+    Empty fields are dropped from the renderer (target with
+    no specific catalog defaults shows nothing here)."""
+    semgrep_packs: List[str]
+    high_priority_dirs: List[str]
+    pipeline_names: List[str]   # catalog-label names, not runnable commands
+
+
+@dataclass(frozen=True)
+class DescribeReport:
+    """Top-level ``/describe`` result. Pure data; renderers
+    consume this. Crucially does NOT contain runnable
+    operator-typed commands — see module docstring for the
+    scope rationale."""
+    target_shape: TargetShape
+    tool_checks: List[ToolCheck]
+    target_type_defaults: Optional[TargetTypeDefaults]
+    estimate_summary: Optional[str]  # one-line "$X-Y, N-M min" or None
+    # Original archive basename when the operator pointed at a
+    # tarball/zip (extracted on the fly into a temp dir before
+    # inference). None when the target was a plain directory.
+    archive_label: Optional[str] = None
+
+
+def build_describe_report(
+    target_path: Path,
+    archive_label: Optional[str] = None,
+) -> DescribeReport:
+    """Compose the substrates: target shape (#17 catalog +
+    language/build detectors), tool readiness, catalog
+    defaults preview, cost estimate.
+
+    ``archive_label`` is the original archive basename when the
+    caller extracted an archive to ``target_path`` before
+    calling here. None for plain-directory targets.
+    """
+    shape = infer_target_shape(target_path)
+    checks = check_tool_readiness(shape)
+    preview = _target_type_defaults(shape)
+    estimate = _estimate_summary(target_path)
+    return DescribeReport(
+        target_shape=shape,
+        tool_checks=checks,
+        target_type_defaults=preview,
+        estimate_summary=estimate,
+        archive_label=archive_label,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Target-type defaults preview — read-only data, no commands
+# ---------------------------------------------------------------------------
+
+
+def _target_type_defaults(
+    shape: TargetShape,
+) -> Optional[TargetTypeDefaults]:
+    """Read the matched target-type entry and surface what it'll
+    apply at analysis time. None when no matched entry OR when
+    all preview fields are empty (no useful defaults to show —
+    today the ``generic`` fallback has empty arrays for all
+    three fields, but the check is field-based not name-based
+    so a future generic entry that gains real defaults would
+    surface here automatically)."""
+    if not shape.target_type:
+        return None
+    try:
+        from core.run.target_types import load_by_name
+        entry = load_by_name(shape.target_type)
+    except Exception:  # noqa: BLE001
+        return None
+    if entry is None:
+        return None
+    packs = list(entry.semgrep_packs_default)
+    dirs = list(entry.attack_surface_high)
+    pipeline = list(entry.pipeline_recommended)
+    # Suppress preview when EVERY field is empty — nothing
+    # useful to show. A future entry with any non-empty field
+    # will surface (even if it's only the pipeline list, etc).
+    if not packs and not dirs and not pipeline:
+        return None
+    return TargetTypeDefaults(
+        semgrep_packs=packs,
+        high_priority_dirs=dirs,
+        pipeline_names=pipeline,
+    )
+
+
+def _estimate_summary(target_path: Path) -> Optional[str]:
+    """One-line cost+time estimate from the existing #21
+    estimator. None when no catalog match / estimator data."""
+    try:
+        from core.run.estimator import estimate_run, format_estimate
+        est = estimate_run(target_path)
+        if est is None:
+            return None
+        full = format_estimate(est)
+        if not full:
+            return None
+        # Strip the estimator's "Expected: " prefix and "(target
+        # type: ...)" suffix — the /describe renderer wraps the
+        # value in "Cost estimate: ..." and the target type is
+        # already named in the header.
+        full = full.removeprefix("Expected: ")
+        return full.split(" (target type:", 1)[0]
+    except Exception:  # noqa: BLE001
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Renderers — text (operator-facing) + JSON (machine-readable)
+# ---------------------------------------------------------------------------
+
+
+_STATUS_SYMBOL = {"ok": "✓", "warn": "⚠", "fail": "✗", "unknown": "?"}
+
+
+# Shared with packages/static-analysis/scanner.py — single
+# source of truth lives in core.inventory.languages.
+from core.inventory.languages import display_lang as _display_lang  # noqa: E402
+
+
+def format_text(report: DescribeReport) -> str:
+    """Operator-facing block. Single source of truth for what a
+    human sees when they run ``raptor describe``."""
+    s = report.target_shape
+    lines: List[str] = ["Target analysis:"]
+
+    # Pre-flight: when /describe extracted an archive on the
+    # fly, surface that fact first so the operator knows the
+    # rest of the block describes the extracted tree (not a
+    # mystery binary blob).
+    if report.archive_label:
+        lines.append(f"  Source: archive {report.archive_label}")
+
+    # Languages — "C++ (95%, 47k LOC), Python (5%, 2k LOC)".
+    # File-share % alone over-represents languages with many
+    # tiny files (Java's one-class-per-file convention can
+    # dwarf a much larger C++ kernel by file count alone), so
+    # we surface per-language LOC alongside the share.
+    if s.language_breakdown:
+        sorted_langs = sorted(
+            s.language_breakdown.items(), key=lambda x: -x[1],
+        )
+        parts = []
+        for lang, pct in sorted_langs:
+            loc = s.language_lines.get(lang)
+            if loc is None or loc <= 0:
+                parts.append(f"{_display_lang(lang)} ({pct:g}%)")
+            else:
+                parts.append(
+                    f"{_display_lang(lang)} ({pct:g}%, "
+                    f"{_short_int(loc)} LOC)"
+                )
+        lines.append(f"  Languages: {', '.join(parts)}")
+    else:
+        # "none detected" rather than "unknown": we DID run the
+        # language detector and it returned no signal. Whether
+        # that's "really no source files" or "source files we
+        # don't recognise" is something the operator can
+        # distinguish by looking at the tree — we honestly
+        # report what the detector saw.
+        lines.append("  Languages: none detected")
+
+    # Build system from primary language. Same "none detected"
+    # vs "unknown" reasoning: BuildDetector ran and reported
+    # no match. Could be "no build system at all" (loose source
+    # collection, header-only library) OR "build system we
+    # don't recognise" (custom build script, Bazel before we
+    # added it, etc.). "none detected" is the honest report;
+    # operator can investigate if surprised.
+    if s.primary_language and s.primary_language in s.build_systems:
+        lines.append(f"  Build system: {s.build_systems[s.primary_language]}")
+    else:
+        lines.append("  Build system: none detected")
+
+    # Size.
+    if s.total_files > 0:
+        lines.append(
+            f"  Size: ~{_short_int(s.total_lines)} LOC, "
+            f"{s.total_files} source file"
+            f"{'s' if s.total_files != 1 else ''}"
+        )
+
+    if s.target_type:
+        lines.append(f"  Detected type: {s.target_type}")
+
+    # License — from core.license (same detector that fires at
+    # run lifecycle start). Surfaces SPDX id when known
+    # ("MIT", "Apache-2.0"), classification only when SPDX
+    # missing ("oss" / "proprietary"). "missing" → "License:
+    # none detected" so the operator sees we DID look. We
+    # never gate on the result — operator may have a CodeQL
+    # commercial license, may be authorised on first-party
+    # code, etc.
+    if s.license is not None:
+        if s.license.classification == "missing":
+            lines.append("  License: none detected")
+        elif s.license.spdx_id:
+            line = f"  License: {s.license.spdx_id}"
+            # Surface additional license files when present —
+            # dual-licensed projects (libgcrypt: COPYING +
+            # COPYING.LIB; NetworkManager: COPYING +
+            # COPYING.LGPL; many GNU projects) carry meaningful
+            # secondary licenses the operator should know about.
+            # Keep the list short (≤3 file names) so the line
+            # stays compact; truncate with "+N more" otherwise.
+            if s.license.additional_files:
+                names = list(s.license.additional_files)
+                shown = names[:3]
+                suffix = (
+                    f", +{len(names) - 3} more"
+                    if len(names) > 3 else ""
+                )
+                line += (
+                    f"  (also: {', '.join(shown)}{suffix})"
+                )
+            lines.append(line)
+        elif s.license.source_file:
+            # "unknown" classification + a source file means the
+            # detector found a LICENSE-named file but couldn't
+            # classify the content (Firefox's LICENSE is a 7-line
+            # pointer to toolkit/content/license.html, not the
+            # actual MPL text). Be explicit so the operator
+            # doesn't read "License: unknown" as "no license".
+            lines.append(
+                f"  License: present in {s.license.source_file} "
+                f"(couldn't classify — check manually)"
+            )
+        else:
+            lines.append(f"  License: {s.license.classification}")
+
+    # Direct-dep counts per ecosystem. Lockfiles excluded —
+    # this is the "what is the operator on the hook for
+    # maintaining" view, not the transitive-tree size.
+    # /sca is the natural next command when this is non-empty.
+    if s.deps is not None and s.deps.by_ecosystem:
+        # Sort by count desc so the dominant ecosystem leads.
+        parts = [
+            f"{count} {eco}"
+            for eco, count in sorted(
+                s.deps.by_ecosystem.items(), key=lambda x: -x[1],
+            )
+        ]
+        suffix = " (parser cap hit; counts partial)" if s.deps.truncated else ""
+        lines.append(f"  Dependencies: {', '.join(parts)}{suffix}")
+
+    # Git provenance — branch / commit / dirty / last commit date.
+    # All-None GitProvenance is "not a git checkout" — render
+    # "Git: none detected" for honesty (we DID look). Partial
+    # state (e.g. detached HEAD: branch=None but commit set)
+    # renders what we got.
+    if s.git is not None:
+        if s.git.commit_short is None:
+            lines.append("  Git: none detected")
+        else:
+            parts = []
+            if s.git.branch:
+                parts.append(s.git.branch)
+            parts.append(f"@ {s.git.commit_short}")
+            tail = []
+            if s.git.dirty is True:
+                tail.append("dirty")
+            elif s.git.dirty is False:
+                tail.append("clean")
+            if s.git.last_commit_date:
+                # Strip TZ for compact render — operator can
+                # read the JSON if they need millisecond
+                # precision. Date portion is the action-changer
+                # ("is this code from yesterday or 2017?").
+                tail.append(f"last commit {s.git.last_commit_date[:10]}")
+            if tail:
+                parts.append(f"({', '.join(tail)})")
+            lines.append(f"  Git: {' '.join(parts)}")
+
+    # Target-type defaults preview — data, not commands.
+    if report.target_type_defaults is not None:
+        cp = report.target_type_defaults
+        lines.append("")
+        lines.append("Defaults for this target type:")
+        if cp.semgrep_packs:
+            lines.append(
+                f"  /scan baseline packs: {', '.join(cp.semgrep_packs)}"
+            )
+        if cp.high_priority_dirs:
+            lines.append(
+                f"  /agentic preferred dirs: "
+                f"{', '.join(cp.high_priority_dirs)}"
+            )
+        if cp.pipeline_names:
+            lines.append(
+                f"  Pipeline: {' → '.join(cp.pipeline_names)}"
+            )
+
+    # Signal-based "Recommended next:" — augments the catalog's
+    # static Pipeline line above with picks derived from what
+    # we actually detected on this tree (dep counts, build
+    # system, CI scanners already running). Two-layer: catalog
+    # template + signal refinement.
+    recs = recommend_next(s)
+    if recs:
+        lines.append("")
+        lines.append("Recommended next (based on signals):")
+        cmd_w = max(len(r.command) for r in recs)
+        for r in recs:
+            lines.append(f"  {r.command:<{cmd_w}}  — {r.reason}")
+
+    # Tool applicability — target-level signals only. Host-level
+    # checks (binary presence, LLM keys, env) live in /doctor.
+    # Header says ``checks`` not ``gaps`` because the section
+    # surfaces both ok and warn lines; "gaps" misled operators
+    # who saw ✓ entries here and thought they were problems.
+    lines.append("")
+    lines.append("Target-specific checks:")
+    if not report.tool_checks:
+        lines.append("  (no target-specific checks ran)")
+    else:
+        name_w = max(len(c.name) for c in report.tool_checks)
+        for c in report.tool_checks:
+            sym = _STATUS_SYMBOL.get(c.status, "?")
+            ver = f" ({c.version})" if c.version else ""
+            head = f"  {sym} {c.name:<{name_w}}{ver}"
+            lines.append(f"{head:<40} — {c.detail}")
+            if c.hint:
+                lines.append(f"      hint: {c.hint}")
+
+    # Cost estimate.
+    if report.estimate_summary:
+        lines.append("")
+        lines.append(
+            f"Cost estimate (when running /agentic): "
+            f"{report.estimate_summary}"
+        )
+
+    # Pointers — explicitly NO runnable build/install commands.
+    # ``--repo`` value substituted with the resolved target path
+    # so operators can copy the line directly (rather than the
+    # pre-fix ``<target>`` placeholder which forced them to
+    # substitute by hand).
+    lines.append("")
+    lines.append("For host-level setup, run `raptor doctor`.")
+    lines.append(
+        f"To start analysis, run `raptor.py agentic --repo "
+        f"{s.target_path}` (prints same estimate at start; "
+        f"runs sandboxed)."
+    )
+
+    return "\n".join(lines)
+
+
+def format_json(report: DescribeReport) -> str:
+    """Machine-readable serialisation — for CI / dashboards /
+    downstream tools. Field names match the dataclass shape so
+    consumers can mirror the schema."""
+    s = report.target_shape
+    doc: Dict[str, Any] = {
+        "target_path": str(s.target_path),
+        "languages": s.languages,
+        "language_breakdown": s.language_breakdown,
+        "primary_language": s.primary_language,
+        "build_systems": s.build_systems,
+        "target_type": s.target_type,
+        "total_files": s.total_files,
+        "total_lines": s.total_lines,
+        "file_extensions": s.file_extensions,
+        "language_lines": s.language_lines,
+        "git": (
+            None if s.git is None or s.git.commit_short is None else {
+                "branch": s.git.branch,
+                "commit_short": s.git.commit_short,
+                "dirty": s.git.dirty,
+                "last_commit_date": s.git.last_commit_date,
+            }
+        ),
+        # Dep counts per ecosystem. None when detection didn't
+        # run; empty by_ecosystem when no manifests / nothing
+        # parseable. truncated=True flags the parser cap was hit.
+        "deps": (
+            None if s.deps is None else {
+                "by_ecosystem": s.deps.by_ecosystem,
+                "truncated": s.deps.truncated,
+            }
+        ),
+        # License from core.license — serialise the full TargetLicense
+        # shape (.to_dict() preserves it) so JSON consumers get the
+        # SPDX id + classification + source file + confidence + any
+        # additional dual-license files. None when detection failed.
+        "license": (
+            None if s.license is None else s.license.to_dict()
+        ),
+        "tool_checks": [
+            {
+                "name": c.name,
+                "status": c.status,
+                "version": c.version,
+                "detail": c.detail,
+                "hint": c.hint,
+            }
+            for c in report.tool_checks
+        ],
+        "target_type_defaults": (
+            None if report.target_type_defaults is None else {
+                "semgrep_packs": report.target_type_defaults.semgrep_packs,
+                "high_priority_dirs": report.target_type_defaults.high_priority_dirs,
+                "pipeline_names": report.target_type_defaults.pipeline_names,
+            }
+        ),
+        "estimate_summary": report.estimate_summary,
+        "archive_label": report.archive_label,
+        # Signal-based recommendations — sibling to the catalog's
+        # static "pipeline_names" (in target_type_defaults) but
+        # derived from THIS tree's detected signals. RAPTOR
+        # commands only (sandboxed) — never shell commands; the
+        # scope guardrail in this module's docstring still holds.
+        "recommended_next": [
+            {"command": r.command, "reason": r.reason}
+            for r in recommend_next(s)
+        ],
+    }
+    return json.dumps(doc, indent=2)
+
+
+def _short_int(n: int) -> str:
+    """52000 → '52k'; 1500000 → '1.5M'."""
+    if n >= 1_000_000:
+        return f"{n / 1_000_000:.1f}M"
+    if n >= 1_000:
+        return f"{n // 1_000}k"
+    return str(n)
+
+
+__all__ = [
+    "TargetTypeDefaults",
+    "DescribeReport",
+    "build_describe_report",
+    "format_text",
+    "format_json",
+]

--- a/packages/describe/start_line.py
+++ b/packages/describe/start_line.py
@@ -1,0 +1,127 @@
+"""Start-line target summary for /scan, /agentic, /codeql.
+
+A single line emitted at run START — operator gets confirmation
+RAPTOR understood the target shape BEFORE any LLM cost or
+analysis time burns. Pre-fix the start surfaced only the
+catalog cost estimate ("Expected: $25-$50, 40-75 min …") which
+told the operator NOTHING about whether RAPTOR detected the
+right languages, build system, target type. The richer line
+closes that loop.
+
+Format::
+
+    Analyzing C++ (95%, 47k LOC), autotools, c.userspace-daemon —
+    $25-$50, 40-75 min estimated
+
+* Primary language + share + LOC (the dominant signal — answers
+  "did RAPTOR think this is C++?")
+* Build system (answers "did the build detector recognise the
+  manifest?")
+* Catalog target type (answers "did the catalog match? was it
+  the right type?")
+* Cost + time estimate (the existing surface, preserved as a
+  tail clause so the budget gate's information stays surfaced)
+
+Any missing piece is omitted rather than rendered as "unknown" —
+keep the line compact when signals are sparse, since the
+operator can run /describe for the full breakdown.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+
+def format_start_line(target_path: Path) -> Optional[str]:
+    """Compose a one-line start-of-run target summary. Returns
+    None when /describe substrate is unavailable (caller falls
+    back to the bare cost estimate).
+    """
+    try:
+        from packages.describe.target_shape import infer_target_shape
+        from core.inventory.languages import display_lang
+    except Exception:  # noqa: BLE001
+        return None
+
+    try:
+        shape = infer_target_shape(target_path)
+    except Exception:  # noqa: BLE001
+        return None
+
+    parts: list = []
+
+    # Primary language + share + LOC.
+    primary = shape.primary_language
+    if primary and shape.language_breakdown:
+        pct = shape.language_breakdown.get(primary)
+        loc = shape.language_lines.get(primary) if shape.language_lines else None
+        head = display_lang(primary)
+        if pct is not None:
+            head = f"{head} ({pct:g}%"
+            if loc:
+                head += f", {_short_loc(loc)} LOC"
+            head += ")"
+        parts.append(head)
+
+    # Build system (primary language's).
+    if primary and shape.build_systems and primary in shape.build_systems:
+        parts.append(shape.build_systems[primary])
+
+    # Catalog target type (skip the bland "generic" default —
+    # adds noise to the line when no real type matched).
+    if shape.target_type and shape.target_type != "generic":
+        parts.append(shape.target_type)
+
+    head_str = ", ".join(parts) if parts else None
+
+    # Cost estimate — preserve the existing format so the budget
+    # gate's "Expected" framing is recognisable; "estimated" tail
+    # word ties it to the new richer head.
+    estimate_str = _format_compact_estimate(target_path)
+
+    # "Target:" not "Analyzing": this line emits at run start,
+    # BEFORE any tool actually runs. "Analyzing" implies the
+    # LLM is already burning tokens which is misleading; "Target:"
+    # accurately frames it as the operator-facing shape RAPTOR
+    # detected before kicking off the work.
+    if head_str and estimate_str:
+        return f"Target: {head_str} — {estimate_str} estimated"
+    if head_str:
+        return f"Target: {head_str}"
+    if estimate_str:
+        return f"Expected: {estimate_str}"
+    return None
+
+
+def _short_loc(n: int) -> str:
+    """52000 → '52k'; 1500000 → '1.5M'."""
+    if n >= 1_000_000:
+        return f"{n / 1_000_000:.1f}M"
+    if n >= 1_000:
+        return f"{n // 1_000}k"
+    return str(n)
+
+
+def _format_compact_estimate(target_path: Path) -> Optional[str]:
+    """Compact "$25-$50, 40-75 min" form — drops the "Expected:"
+    prefix + the "(target type: …)" suffix that
+    ``core.run.estimator.format_estimate`` adds (we already
+    name the target type in the head clause). None on
+    estimator failure / no catalog match.
+    """
+    try:
+        from core.run.estimator import estimate_run, format_estimate
+        est = estimate_run(target_path)
+        if est is None:
+            return None
+        full = format_estimate(est)
+        if not full:
+            return None
+        full = full.removeprefix("Expected: ")
+        return full.split(" (target type:", 1)[0]
+    except Exception:  # noqa: BLE001
+        return None
+
+
+__all__ = ["format_start_line"]

--- a/packages/describe/target_shape.py
+++ b/packages/describe/target_shape.py
@@ -1,0 +1,403 @@
+"""Target-shape inference for the ``/describe`` command (QoL #14).
+
+Composes existing substrates rather than introducing new
+detectors:
+
+* ``core/inventory/languages.py:LANGUAGE_MAP`` — extension →
+  language id (single source of truth). Counted directly here
+  rather than via ``codeql.LanguageDetector`` because the
+  latter applies a ``min_files=3`` floor for codeql's DB-build
+  use case and silently drops languages with few files —
+  wrong for /describe's "what's actually in this tree"
+  question.
+* ``packages/codeql/build_detector.py:BuildDetector`` — per-
+  language build system (autotools / cmake / poetry / npm / …)
+* ``core/run/target_types`` — catalog entry (#17 substrate)
+
+The output is a ``TargetShape`` dataclass the renderer turns
+into the operator-facing block::
+
+    Target analysis:
+      Languages: C (95%), Python (5%)
+      Build system: autotools
+      Size: ~52k LOC, 189 source files
+      Detected type: c.userspace-daemon
+
+``TargetShape`` is deliberately a passive data container — all
+field derivation happens in ``infer_target_shape`` so consumers
+(the text renderer, the JSON renderer, downstream tools) read
+the same shape without re-running detection.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from packages.describe.deps import (
+    DependencyCounts,
+    detect_dependency_counts,
+)
+from packages.describe.git_provenance import (
+    GitProvenance,
+    detect_git_provenance,
+)
+
+
+@dataclass(frozen=True)
+class TargetShape:
+    """Inferred shape of a target codebase. All fields are
+    derived from ``infer_target_shape``; consumers treat this
+    as read-only.
+
+    ``languages`` maps language id to file count (cpp, python,
+    go, …). Ids match the codeql/catalog convention: C and C++
+    extensions both roll up to ``cpp``. ``language_breakdown``
+    is the same map normalised to percentages (sum to 100.0)
+    so the renderer can show "C (95%), Python (5%)" without
+    recomputing.
+
+    ``build_systems`` maps language → build-system type ("autotools",
+    "cmake", "poetry", …). May be empty when no build manifests
+    matched (header-only library, script collection, …); the
+    renderer treats absent build system as "unknown".
+
+    ``target_type`` is the matched ``core/run/target_types``
+    entry name, or "generic" when nothing more specific matched.
+    ``None`` only when the catalog substrate failed to load —
+    defensive against future catalog substrate bugs.
+    """
+    target_path: Path
+    languages: Dict[str, int]
+    language_breakdown: Dict[str, float]
+    primary_language: Optional[str]
+    build_systems: Dict[str, str]
+    target_type: Optional[str]
+    total_files: int
+    total_lines: int
+    file_extensions: Dict[str, int] = field(default_factory=dict)
+    # Per-language LOC, e.g. {"cpp": 8000, "python": 1200}.
+    # Sums to ``total_lines``. Lets the renderer show where the
+    # mass of a mixed-language tree actually sits — file-count
+    # share over-represents languages with many tiny files
+    # (Java's one-class-per-file convention can dwarf a much
+    # larger C++ kernel by file count alone).
+    language_lines: Dict[str, int] = field(default_factory=dict)
+    # Git provenance for the target tree. All-None when the
+    # target isn't a git checkout — render shows "Git: none
+    # detected". Distinct from RAPTOR's own framework
+    # provenance (core/run/provenance.py).
+    git: Optional[GitProvenance] = None
+    # Target's own license (LICENSE / COPYING etc. at the repo
+    # root). Reused from ``core.license`` so /describe and the
+    # run-lifecycle license warning share a single detector.
+    # ``Any`` typed here to avoid an unconditional import at
+    # module load — keeps target_shape importable when
+    # core.license is unavailable (defence in depth).
+    license: Optional[Any] = None
+    # Direct-dep counts per ecosystem (npm / pypi / cargo /
+    # gomod / …). Lockfiles excluded (those inflate to
+    # transitive). Sourced from packages.sca substrate; empty
+    # when no manifests / parser failure / /sca unavailable.
+    deps: Optional[DependencyCounts] = None
+
+
+def infer_target_shape(target_path: Path) -> TargetShape:
+    """Walk ``target_path`` and compose language / build-system /
+    catalog signals into a ``TargetShape``.
+
+    All sub-detectors are best-effort: a missing dependency or
+    sub-detector exception yields an empty value in the
+    corresponding field rather than failing the whole inference.
+    The operator-facing renderer can degrade gracefully — "Build
+    system: unknown" is better than no output at all when only
+    the build detector failed.
+    """
+    target_path = Path(target_path).resolve()
+
+    # Single tree walk; per-extension counts feed both the
+    # inventory (size, file_extensions) AND the per-language
+    # rollup. Detection lives in core.inventory.languages
+    # (LANGUAGE_MAP) — single source of truth, shared with
+    # other RAPTOR consumers.
+    total_files, total_lines, ext_counts, ext_lines = _scan_inventory(
+        target_path,
+    )
+    languages = _per_language_counts(ext_counts)
+    language_lines = _per_language_counts(ext_lines)
+    breakdown = _compute_breakdown(languages)
+    primary = _pick_primary(breakdown)
+    build_systems = _detect_build_systems(target_path, languages)
+    target_type = _detect_target_type(target_path)
+    git = detect_git_provenance(target_path)
+    license_obj = _detect_license(target_path)
+    deps = detect_dependency_counts(target_path)
+
+    return TargetShape(
+        target_path=target_path,
+        languages=languages,
+        language_breakdown=breakdown,
+        primary_language=primary,
+        build_systems=build_systems,
+        target_type=target_type,
+        total_files=total_files,
+        total_lines=total_lines,
+        file_extensions=ext_counts,
+        language_lines=language_lines,
+        git=git,
+        license=license_obj,
+        deps=deps,
+    )
+
+
+def _per_language_counts(ext_amounts: Dict[str, int]) -> Dict[str, int]:
+    """Aggregate per-extension integer amounts into per-language
+    integer amounts. Used twice in ``infer_target_shape``:
+    once for file-counts, once for LOC. Same rollup rule for
+    both because the language-id mapping (LANGUAGE_MAP) is the
+    same operation either way.
+
+    Languages with multiple extensions (e.g. C++ owns .cpp /
+    .cc / .cxx / .hpp / .hh / .hxx) sum across them. C and C++
+    extensions both map to "cpp" here — matching what the
+    rest of the codebase uses (codeql LanguageDetector merges
+    them into a single ``cpp`` id; catalog file_extensions
+    use the same), so downstream consumers see a consistent
+    language id whether they came in through /describe or
+    through /codeql.
+    """
+    from core.inventory.languages import LANGUAGE_MAP
+    out: Dict[str, int] = {}
+    for ext, amount in ext_amounts.items():
+        lang = LANGUAGE_MAP.get(ext)
+        if lang is None:
+            continue
+        # Merge bare-C into cpp for consistency with the rest
+        # of the codebase. LANGUAGE_MAP has .c→"c" and .cpp→
+        # "cpp"; we want both extensions under one language
+        # id ("cpp") because that's the codeql convention and
+        # what the catalog file_extensions enumerate.
+        if lang == "c":
+            lang = "cpp"
+        out[lang] = out.get(lang, 0) + amount
+    return out
+
+
+def _compute_breakdown(languages: Dict[str, int]) -> Dict[str, float]:
+    """Normalise file counts to percentages. Empty input → empty
+    output (renderer skips the breakdown line)."""
+    total = sum(languages.values())
+    if total == 0:
+        return {}
+    return {
+        lang: round((count / total) * 100.0, 1)
+        for lang, count in languages.items()
+    }
+
+
+def _pick_primary(breakdown: Dict[str, float]) -> Optional[str]:
+    """Language with the largest share. None when no languages
+    detected. Ties broken by alphabetical name (deterministic)."""
+    if not breakdown:
+        return None
+    return max(breakdown.items(), key=lambda x: (x[1], -ord(x[0][0])))[0]
+
+
+def _detect_build_systems(
+    target_path: Path, languages: Dict[str, int],
+) -> Dict[str, str]:
+    """Per-language build-system type. Skips languages the
+    BuildDetector can't classify (returns None).
+
+    Silences ``BuildDetector``'s INFO / WARNING log lines for
+    the duration of detection — its "Detecting … / No build
+    system detected …" output is noise in /describe's
+    operator-facing block (one INFO + one WARNING per language
+    we probe, which on multi-language targets dominates the
+    actual report). Probe outcome already shown in the
+    "Build system: …" line of the report.
+    """
+    out: Dict[str, str] = {}
+    if not languages:
+        return out
+    try:
+        import logging
+        from packages.codeql.build_detector import BuildDetector
+
+        # Drop the per-language probe chatter from the report.
+        # BuildDetector uses ``get_logger()`` (no name), which
+        # resolves to the shared "raptor" logger — so we can't
+        # silence by logger name without quieting unrelated
+        # modules. Instead install a record-content filter for
+        # the duration of probing: drops ONLY the "Detecting …"
+        # / "No build system detected …" probe lines, leaves
+        # every other log record alone.
+        class _ProbeNoiseFilter(logging.Filter):
+            def filter(self, record: logging.LogRecord) -> bool:
+                msg = record.getMessage()
+                return not (
+                    msg.startswith("Detecting build system for ")
+                    or msg.startswith("No build system detected for ")
+                    or msg.startswith("✓ Detected ")
+                    or msg.startswith("  Command: ")
+                )
+
+        raptor_logger = logging.getLogger("raptor")
+        noise_filter = _ProbeNoiseFilter()
+        raptor_logger.addFilter(noise_filter)
+        try:
+            detector = BuildDetector(target_path)
+            for lang in languages:
+                try:
+                    bs = detector.detect_build_system(lang)
+                    if bs is not None:
+                        out[lang] = bs.type
+                except Exception:  # noqa: BLE001
+                    continue
+        finally:
+            raptor_logger.removeFilter(noise_filter)
+    except Exception:  # noqa: BLE001
+        return out
+    return out
+
+
+def _detect_license(target_path: Path):
+    """Reuse ``core.license.detect_target_license`` — same
+    substrate that fires at every run lifecycle's start. None
+    on substrate failure (defensive against import / missing-
+    deps; render falls back to "License: none detected")."""
+    try:
+        from core.license import detect_target_license
+        return detect_target_license(target_path)
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def _detect_target_type(target_path: Path) -> Optional[str]:
+    """Matched target-type entry name via the existing
+    ``core/run/target_types`` substrate. None on substrate
+    failure (the catalog is best-effort throughout RAPTOR)."""
+    try:
+        from core.run.target_types import load
+        entry = load(target_path)
+        return entry.name if entry is not None else None
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def _scan_inventory(
+    target_path: Path,
+) -> tuple[int, int, Dict[str, int], Dict[str, int]]:
+    """Total source file count + LOC + per-extension file count
+    + per-extension LOC. Walks the tree once and counts every
+    file whose extension is in ``LANGUAGE_MAP`` (i.e. a
+    recognised source language).
+
+    Two parallel per-extension dicts (file count + LOC) instead
+    of one dict-of-tuples because both feed the same per-
+    language rollup helper, and a separate LOC dict keeps the
+    JSON serialisation simple.
+
+    Skips hidden + common build / vendored dirs (node_modules,
+    vendor, build, dist, target, __pycache__, out) — those
+    exclusions are the real bound on the walk size. No file
+    cap: pre-fix this scanned at most 50k files, which silently
+    truncated real targets (Linux kernel ~80k .c+.h, Chromium
+    larger) and produced wrong totals. The dir-exclusions
+    contain pathological inputs in practice, and an honest
+    high count is more useful than a silently-clamped one.
+
+    No language-filter argument: previous version took a
+    pre-detected language set and only counted its extensions,
+    which double-walked and missed languages the upstream
+    detector dropped (e.g. Java + JS with <3 files filtered
+    out by codeql's ``min_files``). The unconditional walk
+    over LANGUAGE_MAP extensions catches every present
+    language for /describe's "what's in this tree" purpose.
+    """
+    from core.inventory.languages import LANGUAGE_MAP
+    counted_exts = set(LANGUAGE_MAP.keys())
+
+    total_files = 0
+    total_lines = 0
+    ext_counts: Dict[str, int] = {}
+    ext_lines: Dict[str, int] = {}
+    # Per-file LOC read budget. Hostile targets can include a
+    # huge text file (10s of GB) to make line counting allocate
+    # forever; cap at 20 MB per file (covers every legitimate
+    # source file, including auto-generated lexers).
+    _MAX_FILE_BYTES_FOR_LOC = 20 * 1024 * 1024
+    try:
+        import os
+        # ``followlinks=False`` (the default, but stated explicitly)
+        # — a symlinked directory inside the target would otherwise
+        # let an attacker make /describe walk arbitrary host paths.
+        # We also skip individual symlinked FILES below: opening
+        # them resolves to whatever they point at (possibly
+        # /etc/shadow), and reading the LOC count from a host path
+        # gives an attacker a sandbox-side-channel probe.
+        for root, dirs, files in os.walk(target_path, followlinks=False):
+            # Skip hidden + common build/vendored dirs.
+            dirs[:] = [
+                d for d in dirs
+                if not d.startswith(".")
+                and d not in {
+                    "node_modules", "vendor", "build", "dist",
+                    "target", "__pycache__", "out",
+                }
+            ]
+            for f in files:
+                ext = "." + f.rsplit(".", 1)[-1].lower() if "." in f else ""
+                if ext not in counted_exts:
+                    continue
+                fp = Path(root) / f
+                try:
+                    st = fp.lstat()
+                except OSError:
+                    continue
+                # Refuse symlinks: their target may be outside the
+                # tree and reading it leaks host-fs state into LOC.
+                import stat as _stat
+                if _stat.S_ISLNK(st.st_mode):
+                    continue
+                # Refuse non-regular files (FIFOs, sockets, devices)
+                # — opening them can block or be a probe primitive.
+                if not _stat.S_ISREG(st.st_mode):
+                    continue
+                total_files += 1
+                ext_counts[ext] = ext_counts.get(ext, 0) + 1
+                # Cap the read at _MAX_FILE_BYTES_FOR_LOC; on a
+                # truly huge file we count the bytes we read and
+                # skip the rest (the file count still ticks; the
+                # LOC contribution is bounded).
+                try:
+                    # O_NOFOLLOW: defence in depth — even though we
+                    # already ruled out symlinks via lstat, between
+                    # lstat and open a TOCTOU swap could substitute
+                    # a symlink. O_NOFOLLOW refuses to open one.
+                    fd = os.open(
+                        str(fp), os.O_RDONLY | os.O_NOFOLLOW,
+                    )
+                    try:
+                        with os.fdopen(fd, "rb") as fh:
+                            n = 0
+                            remaining = _MAX_FILE_BYTES_FOR_LOC
+                            while remaining > 0:
+                                chunk = fh.read(min(remaining, 65536))
+                                if not chunk:
+                                    break
+                                n += chunk.count(b"\n")
+                                remaining -= len(chunk)
+                    except Exception:  # noqa: BLE001
+                        continue
+                    total_lines += n
+                    ext_lines[ext] = ext_lines.get(ext, 0) + n
+                except OSError:
+                    continue
+    except OSError:
+        return (0, 0, {}, {})
+    return (total_files, total_lines, ext_counts, ext_lines)
+
+
+__all__ = ["TargetShape", "infer_target_shape"]

--- a/packages/describe/tests/test_cli.py
+++ b/packages/describe/tests/test_cli.py
@@ -1,0 +1,189 @@
+"""CLI-level smoke tests for /describe — runs the actual
+``raptor.py describe`` mode dispatcher AND ``libexec/raptor-describe``
+shim against a synthetic target.
+
+These tests exercise the wiring (argparse → resolve → build →
+render → exit code) that the unit tests for substrate
+(target_shape / tool_readiness / report) don't cover. A bug
+where the mode handler doesn't pass ``--json`` through, or the
+libexec shim panics on missing target, would slip past the
+unit tests but get caught here.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+_RAPTOR_ROOT = Path(__file__).resolve().parents[3]
+
+
+def _c_daemon_target(tmp_path: Path) -> Path:
+    """Synthesise a c.userspace-daemon shape that exercises both
+    the language detector and the catalog match."""
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    (tmp_path / "configure.ac").write_text("")
+    (tmp_path / "Makefile.am").write_text("")
+    src = tmp_path / "src"
+    src.mkdir()
+    for i in range(5):
+        (src / f"f{i}.c").write_text("int main(){return 0;}")
+    return tmp_path
+
+
+def _run(cmd_args: list, *, env_extra: dict | None = None,
+         timeout: int = 30) -> subprocess.CompletedProcess:
+    env = os.environ.copy()
+    env["CLAUDECODE"] = "1"
+    env["RAPTOR_DIR"] = str(_RAPTOR_ROOT)
+    if env_extra:
+        env.update(env_extra)
+    return subprocess.run(
+        cmd_args, capture_output=True, text=True,
+        env=env, timeout=timeout,
+    )
+
+
+class TestRaptorPrepareMode:
+    """``python3 raptor.py describe ...`` — the operator-facing
+    dispatcher path."""
+
+    def test_text_output_against_c_daemon_target(self, tmp_path):
+        target = _c_daemon_target(tmp_path / "t")
+        result = _run([
+            sys.executable, str(_RAPTOR_ROOT / "raptor.py"),
+            "describe", "--target", str(target),
+        ])
+        assert result.returncode == 0
+        out = result.stdout
+        assert "Target analysis:" in out
+        assert "Detected type: c.userspace-daemon" in out
+        assert "Target-specific checks:" in out
+        assert "raptor doctor" in out  # doctor-deferral footer
+        # /describe is read-only — target-type preview is data,
+        # not commands. No "Recommended pipeline" with numbered
+        # steps (that would imply operator should run them).
+        assert "Defaults for this target type" in out
+        assert "Recommended pipeline:" not in out
+        # Footer substitutes the resolved target path (no
+        # <target> placeholder). Operator can copy the line
+        # directly.
+        assert "<target>" not in out, (
+            "footer should substitute the resolved target path; "
+            "<target> placeholder forces operators to hand-edit"
+        )
+        assert str(target) in out
+
+    def test_json_output_parses_and_has_expected_keys(self, tmp_path):
+        target = _c_daemon_target(tmp_path / "t")
+        result = _run([
+            sys.executable, str(_RAPTOR_ROOT / "raptor.py"),
+            "describe", "--target", str(target), "--json",
+        ])
+        assert result.returncode == 0
+        doc = json.loads(result.stdout)
+        # Pin the top-level schema operators / CI consumers
+        # will rely on.
+        assert doc["primary_language"] == "cpp"
+        assert doc["target_type"] == "c.userspace-daemon"
+        assert doc["build_systems"] == {"cpp": "autotools"}
+        assert "tool_checks" in doc
+        # Catalog preview present + populated for a matched entry.
+        assert doc["target_type_defaults"] is not None
+        assert (
+            "security-audit" in doc["target_type_defaults"]["semgrep_packs"]
+        )
+        # SCOPE GUARDRAIL (read-only describe): JSON output
+        # must not contain runnable-command lists — see
+        # report.py docstring + test_no_runnable_build_commands
+        # for the security rationale.
+        forbidden = {"pipeline", "setup_steps", "analysis_steps"}
+        assert forbidden.isdisjoint(doc.keys()), (
+            f"JSON must not include runnable-command lists; "
+            f"intersection: {doc.keys() & forbidden}"
+        )
+
+    def test_missing_target_path_exits_nonzero(self, tmp_path):
+        # --target points at a path that doesn't exist; clean
+        # error message + non-zero exit (operator script doesn't
+        # silently proceed).
+        result = _run([
+            sys.executable, str(_RAPTOR_ROOT / "raptor.py"),
+            "describe", "--target", "/nonexistent/raptor-describe-test",
+        ])
+        assert result.returncode != 0
+        assert "does not exist" in result.stderr
+
+    def test_no_target_no_active_project_exits_nonzero(self, tmp_path):
+        # Single expected outcome: refusal with non-zero exit
+        # AND operator-actionable stderr. Pre-fix the test
+        # accepted either refusal OR active-project leak; that
+        # passed for the wrong reason whenever the developer's
+        # worktree had an active project pointing somewhere
+        # real. Now: HOME is a tmp dir (no ~/.raptor/projects/.active)
+        # and RAPTOR_CALLER_DIR is empty → resolver MUST return
+        # None → /describe MUST refuse.
+        env = os.environ.copy()
+        env["CLAUDECODE"] = "1"
+        env["RAPTOR_DIR"] = str(_RAPTOR_ROOT)
+        env["HOME"] = str(tmp_path)  # no ~/.raptor/projects/.active
+        env.pop("RAPTOR_CALLER_DIR", None)
+        result = subprocess.run(
+            [sys.executable, str(_RAPTOR_ROOT / "raptor.py"), "describe"],
+            capture_output=True, text=True,
+            env=env, cwd=str(tmp_path), timeout=30,
+        )
+        assert result.returncode != 0, (
+            f"expected refusal; got success. stdout:\n{result.stdout}"
+        )
+        assert "--target required" in result.stderr, (
+            f"expected explicit '--target required' refusal; "
+            f"stderr was:\n{result.stderr}"
+        )
+
+
+class TestLibexecRaptorPrepare:
+    """``libexec/raptor-describe`` — the slash-command surface
+    invoked from Claude Code sessions."""
+
+    def test_libexec_text_output(self, tmp_path):
+        target = _c_daemon_target(tmp_path / "t")
+        result = _run([
+            sys.executable,
+            str(_RAPTOR_ROOT / "libexec" / "raptor-describe"),
+            "--target", str(target),
+        ])
+        assert result.returncode == 0
+        assert "Target analysis:" in result.stdout
+        assert "Detected type: c.userspace-daemon" in result.stdout
+
+    def test_libexec_json_output(self, tmp_path):
+        target = _c_daemon_target(tmp_path / "t")
+        result = _run([
+            sys.executable,
+            str(_RAPTOR_ROOT / "libexec" / "raptor-describe"),
+            "--target", str(target), "--json",
+        ])
+        assert result.returncode == 0
+        doc = json.loads(result.stdout)
+        assert doc["target_type"] == "c.userspace-daemon"
+
+    def test_libexec_trust_marker_required(self, tmp_path):
+        # The libexec script gates on CLAUDECODE / _RAPTOR_TRUSTED.
+        # Without them, exit 2 + stderr advice.
+        env = os.environ.copy()
+        env.pop("CLAUDECODE", None)
+        env.pop("_RAPTOR_TRUSTED", None)
+        target = _c_daemon_target(tmp_path / "t")
+        result = subprocess.run(
+            [sys.executable,
+             str(_RAPTOR_ROOT / "libexec" / "raptor-describe"),
+             "--target", str(target)],
+            capture_output=True, text=True,
+            env=env, timeout=15,
+        )
+        assert result.returncode == 2
+        assert "Run via" in result.stderr  # the trust-marker hint

--- a/packages/describe/tests/test_cli_archive.py
+++ b/packages/describe/tests/test_cli_archive.py
@@ -1,0 +1,293 @@
+"""Tests for ``packages/describe/cli.py`` — shared driver
+covering archive handling.
+
+End-to-end coverage:
+* directory target — happy path (the existing tests already
+  exercise this; here we cover the archive branches)
+* tarball / zip targets — extracted on the fly, described,
+  temp dir cleaned up
+* non-archive binary file — refused with operator-actionable
+  stderr
+* JSON output preserves ``archive_label``
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import subprocess
+import tarfile
+import zipfile
+from pathlib import Path
+
+
+from packages.describe.cli import describe_main
+
+
+def _make_c_daemon_source(d: Path) -> None:
+    """Synthesise a c.userspace-daemon shape inside ``d``."""
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "configure.ac").write_text("")
+    (d / "Makefile.am").write_text("")
+    src = d / "src"
+    src.mkdir()
+    for i in range(5):
+        (src / f"f{i}.c").write_text("int main(){return 0;}")
+
+
+def _make_tarball(src_dir: Path, dest_archive: Path) -> None:
+    with tarfile.open(dest_archive, "w:gz") as tf:
+        tf.add(src_dir, arcname=src_dir.name)
+
+
+def _make_zip(src_dir: Path, dest_archive: Path) -> None:
+    with zipfile.ZipFile(dest_archive, "w") as zf:
+        for p in src_dir.rglob("*"):
+            zf.write(p, arcname=p.relative_to(src_dir.parent))
+
+
+class TestArchiveHandling:
+    def test_tarball_extracted_and_described(self, tmp_path):
+        src = tmp_path / "proj"
+        _make_c_daemon_source(src)
+        archive = tmp_path / "proj.tar.gz"
+        _make_tarball(src, archive)
+
+        out_buf = io.StringIO()
+        err_buf = io.StringIO()
+        rc = describe_main(
+            str(archive), json_output=False,
+            stdout=out_buf, stderr=err_buf,
+        )
+        assert rc == 0, err_buf.getvalue()
+        out = out_buf.getvalue()
+        # Operator sees "Source: archive ..." so they know
+        # the rest of the block describes the extracted tree.
+        assert "Source: archive proj.tar.gz" in out
+        # Catalog match still triggers on the extracted tree.
+        assert "Detected type: c.userspace-daemon" in out
+        assert "autotools" in out
+
+    def test_zip_extracted_and_described(self, tmp_path):
+        src = tmp_path / "proj"
+        _make_c_daemon_source(src)
+        archive = tmp_path / "proj.zip"
+        _make_zip(src, archive)
+
+        out_buf = io.StringIO()
+        err_buf = io.StringIO()
+        rc = describe_main(
+            str(archive), json_output=False,
+            stdout=out_buf, stderr=err_buf,
+        )
+        assert rc == 0, err_buf.getvalue()
+        assert "Source: archive proj.zip" in out_buf.getvalue()
+
+    def test_non_archive_binary_refused(self, tmp_path):
+        # Random binary blob (not a recognised archive format).
+        blob = tmp_path / "mystery.bin"
+        blob.write_bytes(b"\x00\x01\x02RANDOMBYTES\xff" * 100)
+
+        out_buf = io.StringIO()
+        err_buf = io.StringIO()
+        rc = describe_main(
+            str(blob), json_output=False,
+            stdout=out_buf, stderr=err_buf,
+        )
+        assert rc == 1
+        err = err_buf.getvalue()
+        assert "not a recognised archive" in err
+
+    def test_nonexistent_target_refused(self, tmp_path):
+        out_buf = io.StringIO()
+        err_buf = io.StringIO()
+        rc = describe_main(
+            str(tmp_path / "does-not-exist"), json_output=False,
+            stdout=out_buf, stderr=err_buf,
+        )
+        assert rc == 1
+        assert "does not exist" in err_buf.getvalue()
+
+    def test_archive_label_surfaces_in_json(self, tmp_path):
+        src = tmp_path / "proj"
+        _make_c_daemon_source(src)
+        archive = tmp_path / "proj.tar.gz"
+        _make_tarball(src, archive)
+
+        out_buf = io.StringIO()
+        err_buf = io.StringIO()
+        rc = describe_main(
+            str(archive), json_output=True,
+            stdout=out_buf, stderr=err_buf,
+        )
+        assert rc == 0, err_buf.getvalue()
+        doc = json.loads(out_buf.getvalue())
+        assert doc["archive_label"] == "proj.tar.gz"
+
+    def test_directory_target_archive_label_is_null(self, tmp_path):
+        src = tmp_path / "proj"
+        _make_c_daemon_source(src)
+        out_buf = io.StringIO()
+        err_buf = io.StringIO()
+        rc = describe_main(
+            str(src), json_output=True,
+            stdout=out_buf, stderr=err_buf,
+        )
+        assert rc == 0, err_buf.getvalue()
+        doc = json.loads(out_buf.getvalue())
+        assert doc["archive_label"] is None
+
+    def test_temp_dir_cleaned_up_after_archive_describe(self, tmp_path):
+        # After a successful archive-describe, no raptor-describe-*
+        # temp dirs should remain under the system tmp.
+        import tempfile as _tmp
+        src = tmp_path / "proj"
+        _make_c_daemon_source(src)
+        archive = tmp_path / "proj.tar.gz"
+        _make_tarball(src, archive)
+
+        sys_tmp = Path(_tmp.gettempdir())
+        before = set(sys_tmp.glob("raptor-describe-*"))
+
+        out_buf = io.StringIO()
+        err_buf = io.StringIO()
+        rc = describe_main(
+            str(archive), json_output=False,
+            stdout=out_buf, stderr=err_buf,
+        )
+        assert rc == 0, err_buf.getvalue()
+
+        after = set(sys_tmp.glob("raptor-describe-*"))
+        assert after == before, (
+            f"temp extract dirs leaked: {after - before}"
+        )
+
+
+class TestSymlinkDefences:
+    """Adversarial-fixture pins for the symlink-safety
+    refactor in cli.py."""
+
+    def test_single_subdir_symlink_not_followed(self, tmp_path):
+        # Pre-fix: a tarball whose only top-level entry is a
+        # symlink named ``proj`` pointing at ``/`` would make
+        # /describe retarget at the host filesystem root.
+        from packages.describe.cli import _descend_single_subdir
+        extract_root = tmp_path / "extract"
+        extract_root.mkdir()
+        (extract_root / "proj").symlink_to("/etc")
+        # Symlink-only entry → no descent; describe stays at root.
+        assert _descend_single_subdir(extract_root) == extract_root
+
+
+class TestArchiveCacheHit:
+    """Pins the cache-reuse contract: when a prior /scan or
+    /agentic on the same archive (same active project) has
+    already extracted to ``<project_out>/_sources/<name>-<sha>``,
+    /describe MUST use that path — not re-extract.
+    """
+
+    def _set_active_project(
+        self, monkeypatch, home: Path, project_out: Path,
+    ) -> None:
+        # Stand up a minimal project.json + .active symlink so
+        # ``_resolve_active_project`` finds it.
+        proj_dir = home / ".raptor" / "projects"
+        proj_dir.mkdir(parents=True, exist_ok=True)
+        import json as _json
+        (proj_dir / "_t.json").write_text(_json.dumps({
+            "name": "_t",
+            "target": "/tmp",
+            "output_dir": str(project_out),
+        }))
+        active = proj_dir / ".active"
+        if active.is_symlink() or active.exists():
+            active.unlink()
+        active.symlink_to("_t.json")
+        monkeypatch.setenv("HOME", str(home))
+
+    def test_cache_hit_skips_extraction(
+        self, tmp_path, monkeypatch,
+    ):
+        # 1. Create a real archive + its content sha + cache
+        #    name (mirroring how /scan would have populated
+        #    the cache via _unpack_archive_target).
+        src = tmp_path / "proj"
+        _make_c_daemon_source(src)
+        archive = tmp_path / "proj.tar.gz"
+        _make_tarball(src, archive)
+
+        from core.archive import safe_cache_name
+        from core.run.provenance import archive_snapshot
+        snap = archive_snapshot(archive)
+        assert snap is not None
+        cache_name = safe_cache_name(
+            snap["archive_name"], snap["archive_sha256"],
+        )
+
+        # 2. Pre-populate the cache dir with the same shape
+        #    /scan would have left there (extracted tree).
+        project_out = tmp_path / "project_out"
+        cache_dir = project_out / "_sources" / cache_name
+        cache_dir.mkdir(parents=True)
+        # Mark the cached tree so we can detect /describe used IT
+        # rather than a fresh extract. Catalog content is the same
+        # shape as the source so c.userspace-daemon still matches.
+        _make_c_daemon_source(cache_dir / "proj")
+        (cache_dir / "proj" / "CACHE-MARKER").write_text(
+            "from-cache",
+        )
+
+        # 3. Stand up an active project pointing at project_out.
+        self._set_active_project(
+            monkeypatch, tmp_path / "fakehome", project_out,
+        )
+
+        # 4. Run describe. Expect cache hit → no tmp extract dir
+        #    created (verify with /tmp tally) + content reflects
+        #    the cached tree.
+        import tempfile as _tmp
+        sys_tmp = Path(_tmp.gettempdir())
+        before = set(sys_tmp.glob("raptor-describe-*"))
+
+        out_buf = io.StringIO()
+        err_buf = io.StringIO()
+        rc = describe_main(
+            str(archive), json_output=False,
+            stdout=out_buf, stderr=err_buf,
+        )
+        assert rc == 0, err_buf.getvalue()
+
+        after = set(sys_tmp.glob("raptor-describe-*"))
+        assert after == before, (
+            "cache hit must NOT create a tmp extract dir; "
+            f"new tmp dirs: {after - before}"
+        )
+        assert "Source: archive proj.tar.gz" in out_buf.getvalue()
+        assert "c.userspace-daemon" in out_buf.getvalue()
+
+
+class TestRaptorDescribeArchiveE2E:
+    """End-to-end through ``raptor.py describe`` with the
+    real subprocess + argparse path, to confirm the
+    mode_describe → describe_main wiring works."""
+
+    def test_subprocess_invocation_on_archive(self, tmp_path):
+        import os
+        import sys as _sys
+
+        src = tmp_path / "proj"
+        _make_c_daemon_source(src)
+        archive = tmp_path / "proj.tar.gz"
+        _make_tarball(src, archive)
+
+        repo = Path(__file__).resolve().parents[3]
+        env = os.environ.copy()
+        env["CLAUDECODE"] = "1"
+        env["RAPTOR_DIR"] = str(repo)
+        result = subprocess.run(
+            [_sys.executable, str(repo / "raptor.py"),
+             "describe", "--target", str(archive)],
+            capture_output=True, text=True, env=env, timeout=30,
+        )
+        assert result.returncode == 0, result.stderr
+        assert "Source: archive proj.tar.gz" in result.stdout

--- a/packages/describe/tests/test_deps.py
+++ b/packages/describe/tests/test_deps.py
@@ -1,0 +1,94 @@
+"""Tests for ``packages/describe/deps.py``."""
+
+from __future__ import annotations
+
+from packages.describe.deps import (
+    DependencyCounts,
+    detect_dependency_counts,
+)
+
+
+class TestDetectDependencyCounts:
+    def test_empty_tree_returns_empty(self, tmp_path):
+        result = detect_dependency_counts(tmp_path)
+        assert result == DependencyCounts(by_ecosystem={}, truncated=False)
+
+    def test_npm_direct_deps_counted(self, tmp_path):
+        (tmp_path / "package.json").write_text(
+            '{"name": "demo", "version": "1.0.0",'
+            '"dependencies": {'
+            '  "react": "^18.0.0",'
+            '  "lodash": "^4.17.21",'
+            '  "express": "^4.18.0"'
+            '},'
+            '"devDependencies": {'
+            '  "jest": "^29.0.0"'
+            '}'
+            '}'
+        )
+        result = detect_dependency_counts(tmp_path)
+        # 3 prod + 1 dev = 4 direct deps. /sca's npm parser
+        # counts both dependencies + devDependencies as direct.
+        assert result.by_ecosystem.get("npm", 0) == 4
+
+    def test_gomod_direct_deps_counted(self, tmp_path):
+        # /sca's gomod parser uses ecosystem id "Go" (matches its
+        # registry name, not the manifest filename).
+        (tmp_path / "go.mod").write_text(
+            "module example.com/demo\n\n"
+            "go 1.21\n\n"
+            "require (\n"
+            "    github.com/gin-gonic/gin v1.9.1\n"
+            "    github.com/sirupsen/logrus v1.9.3\n"
+            ")\n"
+        )
+        result = detect_dependency_counts(tmp_path)
+        assert result.by_ecosystem.get("Go", 0) >= 2
+
+    def test_cargo_direct_deps_counted(self, tmp_path):
+        # /sca's cargo parser uses ecosystem id "Cargo".
+        (tmp_path / "Cargo.toml").write_text(
+            '[package]\n'
+            'name = "demo"\n'
+            'version = "0.1.0"\n'
+            'edition = "2021"\n\n'
+            '[dependencies]\n'
+            'tokio = "1"\n'
+            'serde = "1"\n'
+        )
+        result = detect_dependency_counts(tmp_path)
+        assert result.by_ecosystem.get("Cargo", 0) >= 2
+
+    def test_multiple_ecosystems_counted_independently(self, tmp_path):
+        # Ecosystem ids come from /sca parsers verbatim:
+        # package_json → "npm", gomod → "Go".
+        (tmp_path / "package.json").write_text(
+            '{"name": "d", "version": "0.1.0",'
+            '"dependencies": {"react": "^18.0.0"}}'
+        )
+        (tmp_path / "go.mod").write_text(
+            "module demo\n\n"
+            "go 1.21\n\n"
+            "require github.com/gin-gonic/gin v1.9.1\n"
+        )
+        result = detect_dependency_counts(tmp_path)
+        assert result.by_ecosystem.get("npm", 0) >= 1
+        assert result.by_ecosystem.get("Go", 0) >= 1
+
+    def test_lockfile_alone_does_not_inflate_count(self, tmp_path):
+        # No package.json — just a lockfile. Lockfile is_lockfile=True
+        # so the count stays 0 (avoids reporting transitive-dep counts
+        # as direct).
+        (tmp_path / "package-lock.json").write_text(
+            '{"name": "d", "lockfileVersion": 3, "packages": {'
+            '  "": {"name": "d"},'
+            '  "node_modules/a": {"version": "1.0.0"},'
+            '  "node_modules/b": {"version": "1.0.0"},'
+            '  "node_modules/c": {"version": "1.0.0"}'
+            '}}'
+        )
+        result = detect_dependency_counts(tmp_path)
+        # Even with 3 transitive packages in the lockfile,
+        # by_ecosystem stays empty because is_lockfile=True
+        # manifests are skipped.
+        assert "npm" not in result.by_ecosystem

--- a/packages/describe/tests/test_git_provenance.py
+++ b/packages/describe/tests/test_git_provenance.py
@@ -1,0 +1,80 @@
+"""Tests for ``packages/describe/git_provenance.py``."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from packages.describe.git_provenance import (
+    GitProvenance,
+    detect_git_provenance,
+)
+
+
+def _git(repo: Path, *args: str) -> None:
+    subprocess.run(
+        ["git", "-C", str(repo), *args],
+        check=True, capture_output=True,
+        env={
+            "PATH": "/usr/bin:/bin",
+            "GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@t",
+            "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@t",
+            "GIT_CONFIG_GLOBAL": "/dev/null",
+            "GIT_CONFIG_SYSTEM": "/dev/null",
+        },
+    )
+
+
+def _init_repo(repo: Path) -> None:
+    repo.mkdir(parents=True, exist_ok=True)
+    _git(repo, "init", "-b", "main")
+    (repo / "f.txt").write_text("hello\n")
+    _git(repo, "add", "f.txt")
+    _git(repo, "commit", "-m", "first")
+
+
+class TestDetectGitProvenance:
+    def test_non_git_tree_returns_all_none(self, tmp_path):
+        result = detect_git_provenance(tmp_path)
+        assert result == GitProvenance(None, None, None, None)
+
+    def test_clean_repo_populates_fields(self, tmp_path):
+        _init_repo(tmp_path)
+        result = detect_git_provenance(tmp_path)
+        assert result.branch == "main"
+        assert result.commit_short is not None
+        assert 7 <= len(result.commit_short) <= 12
+        assert result.dirty is False
+        assert result.last_commit_date is not None
+        # ISO 8601: "2026-05-30T14:22:11+00:00" — accept any timezone.
+        assert "T" in result.last_commit_date
+
+    def test_dirty_tree_flips_dirty(self, tmp_path):
+        _init_repo(tmp_path)
+        (tmp_path / "f.txt").write_text("changed\n")
+        result = detect_git_provenance(tmp_path)
+        assert result.dirty is True
+
+    def test_untracked_file_counts_as_dirty(self, tmp_path):
+        _init_repo(tmp_path)
+        (tmp_path / "new.txt").write_text("untracked\n")
+        result = detect_git_provenance(tmp_path)
+        assert result.dirty is True
+
+    def test_detached_head_branch_is_none(self, tmp_path):
+        _init_repo(tmp_path)
+        # Add a second commit so we have something to detach to
+        (tmp_path / "f.txt").write_text("v2\n")
+        _git(tmp_path, "add", "f.txt")
+        _git(tmp_path, "commit", "-m", "second")
+        sha = subprocess.run(
+            ["git", "-C", str(tmp_path), "rev-parse", "HEAD"],
+            check=True, capture_output=True, text=True,
+        ).stdout.strip()
+        _git(tmp_path, "checkout", sha)
+        result = detect_git_provenance(tmp_path)
+        # Detached: symbolic-ref returns None → branch=None
+        assert result.branch is None
+        # But commit + dirty still readable
+        assert result.commit_short is not None
+        assert result.dirty is False

--- a/packages/describe/tests/test_package_manager.py
+++ b/packages/describe/tests/test_package_manager.py
@@ -267,7 +267,12 @@ class TestFormatInstallHint:
         monkeypatch.delenv("CONDA_DEFAULT_ENV", raising=False)
         with patch("shutil.which", side_effect=_which_only(set())):
             hint = format_install_advice("semgrep")
-        assert "pipx.pypa.io" in hint
+        # Operator-readable prose check rather than a hostname
+        # fragment — ``py/incomplete-url-substring-sanitization``
+        # false-positives on assertions like ``"pypa.io" in hint``
+        # because the substring looks like a URL-allowlist check.
+        # Same FP class as the trusted→short_circuit rename.
+        assert "install pipx first" in hint
         assert "pipx install semgrep" in hint
 
     def test_venv_wins_over_conda(self, monkeypatch):

--- a/packages/describe/tests/test_package_manager.py
+++ b/packages/describe/tests/test_package_manager.py
@@ -1,0 +1,327 @@
+"""Tests for ``packages/describe/package_manager.py``."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from packages.describe import package_manager as pm_mod
+from packages.describe.package_manager import (
+    detect_package_manager,
+    format_install_hint,
+)
+
+
+def _which_only(present_pms):
+    """Return a shutil.which mock that finds the given PMs and
+    nothing else."""
+    def _which(cmd):
+        return "/usr/bin/" + cmd if cmd in present_pms else None
+    return _which
+
+
+class TestDetectPackageManager:
+    def setup_method(self):
+        # Cached at module level — reset between tests.
+        detect_package_manager.cache_clear()
+
+    def test_apt_detected(self):
+        with patch("shutil.which", side_effect=_which_only({"apt"})):
+            assert detect_package_manager() == "apt"
+
+    def test_dnf_detected(self):
+        with patch("shutil.which", side_effect=_which_only({"dnf"})):
+            assert detect_package_manager() == "dnf"
+
+    def test_pacman_detected(self):
+        with patch("shutil.which", side_effect=_which_only({"pacman"})):
+            assert detect_package_manager() == "pacman"
+
+    def test_brew_detected(self):
+        with patch("shutil.which", side_effect=_which_only({"brew"})):
+            assert detect_package_manager() == "brew"
+
+    def test_first_wins_when_multiple_pms_present(self):
+        # System with both apt + brew installed (e.g. Homebrew on
+        # Linux). Order in _KNOWN_PMS places apt first because
+        # system tool deps typically come from the native PM,
+        # not the user-local one.
+        with patch("shutil.which", side_effect=_which_only({"apt", "brew"})):
+            assert detect_package_manager() == "apt"
+
+    def test_no_pm_returns_none(self):
+        with patch("shutil.which", side_effect=_which_only(set())):
+            assert detect_package_manager() is None
+
+
+class TestFormatInstallHint:
+    def setup_method(self):
+        detect_package_manager.cache_clear()
+
+    def test_apt_hint(self):
+        with patch("shutil.which", side_effect=_which_only({"apt"})):
+            assert format_install_hint(["libtool"]) == "sudo apt install libtool"
+
+    def test_dnf_hint(self):
+        with patch("shutil.which", side_effect=_which_only({"dnf"})):
+            assert format_install_hint(["libtool"]) == "sudo dnf install libtool"
+
+    def test_yum_hint_uses_yum(self):
+        with patch("shutil.which", side_effect=_which_only({"yum"})):
+            assert format_install_hint(["libtool"]) == "sudo yum install libtool"
+
+    def test_pacman_hint(self):
+        with patch("shutil.which", side_effect=_which_only({"pacman"})):
+            assert format_install_hint(["libtool"]) == "sudo pacman -S libtool"
+
+    def test_zypper_hint(self):
+        with patch("shutil.which", side_effect=_which_only({"zypper"})):
+            assert (
+                format_install_hint(["libtool"])
+                == "sudo zypper install libtool"
+            )
+
+    def test_apk_hint(self):
+        with patch("shutil.which", side_effect=_which_only({"apk"})):
+            assert format_install_hint(["libtool"]) == "sudo apk add libtool"
+
+    def test_brew_hint_omits_sudo(self):
+        # brew runs as the calling user — sudo would actually
+        # cause problems with permissions on the cellar.
+        with patch("shutil.which", side_effect=_which_only({"brew"})):
+            assert format_install_hint(["libtool"]) == "brew install libtool"
+
+    def test_multi_package_install(self):
+        with patch("shutil.which", side_effect=_which_only({"apt"})):
+            assert (
+                format_install_hint(["autoconf", "automake", "libtool"])
+                == "sudo apt install autoconf automake libtool"
+            )
+
+    def test_no_pm_generic_fallback(self):
+        with patch("shutil.which", side_effect=_which_only(set())):
+            hint = format_install_hint(["libtool"])
+            assert "libtool" in hint
+            assert "system package manager" in hint
+
+    def test_mac_caveat_appended_on_darwin(self, monkeypatch):
+        # gdb on macOS: install command works (brew install gdb)
+        # but the runtime needs codesigning. The caveat appears
+        # only on Darwin; Linux operators (the more common case)
+        # don't see the noise.
+        from packages.describe.package_manager import (
+            format_install_advice,
+        )
+        detect_package_manager.cache_clear()
+        with patch(
+            "packages.describe.package_manager._platform.system",
+            return_value="Darwin",
+        ):
+            with patch(
+                "shutil.which",
+                side_effect=_which_only({"brew"}),
+            ):
+                hint = format_install_advice("gdb")
+        assert "brew install gdb" in hint
+        assert "codesigning" in hint
+        assert "lldb" in hint
+
+    def test_mac_caveat_suppressed_on_linux(self, monkeypatch):
+        from packages.describe.package_manager import (
+            format_install_advice,
+        )
+        detect_package_manager.cache_clear()
+        with patch(
+            "packages.describe.package_manager._platform.system",
+            return_value="Linux",
+        ):
+            with patch(
+                "shutil.which",
+                side_effect=_which_only({"apt"}),
+            ):
+                hint = format_install_advice("gdb")
+        assert "apt install gdb" in hint
+        # No mac caveat noise for Linux operators.
+        assert "codesigning" not in hint
+        assert "macOS" not in hint
+
+    def test_afl_fuzz_mac_caveat_for_apple_silicon(self, monkeypatch):
+        from packages.describe.package_manager import (
+            format_install_advice,
+        )
+        detect_package_manager.cache_clear()
+        with patch(
+            "packages.describe.package_manager._platform.system",
+            return_value="Darwin",
+        ):
+            with patch(
+                "shutil.which",
+                side_effect=_which_only({"brew"}),
+            ):
+                hint = format_install_advice("afl-fuzz")
+        assert "brew install afl-fuzz" in hint
+        assert "Apple Silicon" in hint
+
+    def test_pipx_in_active_venv_uses_pip(self, monkeypatch):
+        # In a venv, pip install works (no PEP 668 issue inside
+        # the venv's site-packages). Operator gets the actually-
+        # working command, not a pipx detour.
+        from packages.describe.package_manager import (
+            format_install_advice,
+        )
+        detect_package_manager.cache_clear()
+        monkeypatch.setenv("VIRTUAL_ENV", "/tmp/myvenv")
+        monkeypatch.delenv("CONDA_DEFAULT_ENV", raising=False)
+        with patch("shutil.which", side_effect=_which_only({"apt"})):
+            hint = format_install_advice("semgrep")
+        assert hint.startswith("pip install semgrep")
+
+    def test_pipx_in_active_conda_env_uses_conda(self, monkeypatch):
+        from packages.describe.package_manager import (
+            format_install_advice,
+        )
+        detect_package_manager.cache_clear()
+        monkeypatch.delenv("VIRTUAL_ENV", raising=False)
+        monkeypatch.setenv("CONDA_DEFAULT_ENV", "myenv")
+        with patch("shutil.which", side_effect=_which_only({"apt"})):
+            hint = format_install_advice("semgrep")
+        assert "conda install -c conda-forge semgrep" in hint
+
+    def test_pipx_with_uv_present_uses_uv(self, monkeypatch):
+        from packages.describe.package_manager import (
+            format_install_advice,
+        )
+        detect_package_manager.cache_clear()
+        monkeypatch.delenv("VIRTUAL_ENV", raising=False)
+        monkeypatch.delenv("CONDA_DEFAULT_ENV", raising=False)
+        with patch("shutil.which", side_effect=_which_only({"uv", "apt"})):
+            hint = format_install_advice("semgrep")
+        assert hint.startswith("uv tool install semgrep")
+
+    def test_pipx_present_uses_pipx(self, monkeypatch):
+        from packages.describe.package_manager import (
+            format_install_advice,
+        )
+        detect_package_manager.cache_clear()
+        monkeypatch.delenv("VIRTUAL_ENV", raising=False)
+        monkeypatch.delenv("CONDA_DEFAULT_ENV", raising=False)
+        with patch("shutil.which", side_effect=_which_only({"pipx", "apt"})):
+            hint = format_install_advice("semgrep")
+        assert hint.startswith("pipx install semgrep")
+
+    def test_pipx_missing_chains_bootstrap_for_apt(self, monkeypatch):
+        # Most-common Linux operator case: pipx not installed,
+        # apt is the PM. Hint must chain the bootstrap with
+        # ensurepath so the next command finds the binary.
+        from packages.describe.package_manager import (
+            format_install_advice,
+        )
+        detect_package_manager.cache_clear()
+        monkeypatch.delenv("VIRTUAL_ENV", raising=False)
+        monkeypatch.delenv("CONDA_DEFAULT_ENV", raising=False)
+        with patch("shutil.which", side_effect=_which_only({"apt"})):
+            hint = format_install_advice("semgrep")
+        assert "sudo apt install pipx" in hint
+        assert "pipx ensurepath" in hint
+        assert "pipx install semgrep" in hint
+        # Chain order: install pipx → ensurepath → install pkg.
+        assert (
+            hint.index("apt install pipx")
+            < hint.index("pipx ensurepath")
+            < hint.index("pipx install semgrep")
+        )
+
+    def test_pipx_missing_chains_bootstrap_for_brew(self, monkeypatch):
+        from packages.describe.package_manager import (
+            format_install_advice,
+        )
+        detect_package_manager.cache_clear()
+        monkeypatch.delenv("VIRTUAL_ENV", raising=False)
+        monkeypatch.delenv("CONDA_DEFAULT_ENV", raising=False)
+        with patch("shutil.which", side_effect=_which_only({"brew"})):
+            hint = format_install_advice("semgrep")
+        assert "brew install pipx" in hint
+        assert "pipx install semgrep" in hint
+
+    def test_pipx_missing_pacman_uses_python_pipx_package_name(
+        self, monkeypatch,
+    ):
+        # Arch namespaces python packages under ``python-X``. Pin
+        # the package name so a future PM-mapping change doesn't
+        # accidentally suggest the non-existent bare ``pipx``.
+        from packages.describe.package_manager import (
+            format_install_advice,
+        )
+        detect_package_manager.cache_clear()
+        monkeypatch.delenv("VIRTUAL_ENV", raising=False)
+        monkeypatch.delenv("CONDA_DEFAULT_ENV", raising=False)
+        with patch("shutil.which", side_effect=_which_only({"pacman"})):
+            hint = format_install_advice("semgrep")
+        assert "sudo pacman -S python-pipx" in hint
+
+    def test_pipx_no_pm_no_env_points_to_pipx_docs(self, monkeypatch):
+        from packages.describe.package_manager import (
+            format_install_advice,
+        )
+        detect_package_manager.cache_clear()
+        monkeypatch.delenv("VIRTUAL_ENV", raising=False)
+        monkeypatch.delenv("CONDA_DEFAULT_ENV", raising=False)
+        with patch("shutil.which", side_effect=_which_only(set())):
+            hint = format_install_advice("semgrep")
+        assert "pipx.pypa.io" in hint
+        assert "pipx install semgrep" in hint
+
+    def test_venv_wins_over_conda(self, monkeypatch):
+        # Both set (operator activated a venv inside a conda env).
+        # VIRTUAL_ENV wins because it's the more-immediate active
+        # context.
+        from packages.describe.package_manager import (
+            format_install_advice,
+        )
+        detect_package_manager.cache_clear()
+        monkeypatch.setenv("VIRTUAL_ENV", "/tmp/v")
+        monkeypatch.setenv("CONDA_DEFAULT_ENV", "myenv")
+        with patch("shutil.which", side_effect=_which_only({"apt"})):
+            hint = format_install_advice("semgrep")
+        assert hint.startswith("pip install semgrep")
+
+    def test_tool_without_mac_caveat_renders_normally_on_mac(self, monkeypatch):
+        # libtoolize has no mac_caveat — should render plain on
+        # macOS too (no spurious dash-clause appears).
+        from packages.describe.package_manager import (
+            format_install_advice,
+        )
+        detect_package_manager.cache_clear()
+        with patch(
+            "packages.describe.package_manager._platform.system",
+            return_value="Darwin",
+        ):
+            with patch(
+                "shutil.which",
+                side_effect=_which_only({"brew"}),
+            ):
+                hint = format_install_advice("libtoolize")
+        assert hint == "brew install libtool"
+        assert "macOS" not in hint
+
+    def test_per_pm_override_applies(self, monkeypatch):
+        # Synthetic per-PM override → resolves the binary to a
+        # different package name on a specific PM.
+        monkeypatch.setattr(
+            pm_mod, "_PER_PM_PKG_OVERRIDES",
+            {"libtool": {"dnf": "libtool-special"}},
+        )
+        with patch("shutil.which", side_effect=_which_only({"dnf"})):
+            assert (
+                format_install_hint(["libtool"])
+                == "sudo dnf install libtool-special"
+            )
+        # And on a different PM, the override doesn't apply.
+        # Cache cleared because the prior detection inside this
+        # test pinned "dnf"; otherwise the lru_cache would
+        # return dnf again.
+        detect_package_manager.cache_clear()
+        with patch("shutil.which", side_effect=_which_only({"apt"})):
+            assert (
+                format_install_hint(["libtool"])
+                == "sudo apt install libtool"
+            )

--- a/packages/describe/tests/test_recommendations.py
+++ b/packages/describe/tests/test_recommendations.py
@@ -1,0 +1,101 @@
+"""Tests for ``packages/describe/recommendations.py``."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from packages.describe.deps import DependencyCounts
+from packages.describe.recommendations import (
+    Recommendation,
+    recommend_next,
+)
+from packages.describe.target_shape import TargetShape
+
+
+def _shape(**overrides) -> TargetShape:
+    base = dict(
+        target_path=Path("/tmp"),
+        languages={},
+        language_breakdown={},
+        primary_language=None,
+        build_systems={},
+        target_type=None,
+        total_files=0,
+        total_lines=0,
+    )
+    base.update(overrides)
+    return TargetShape(**base)
+
+
+class TestRecommendNext:
+    def test_minimal_shape_recommends_agentic(self):
+        # No deps, no build, no CI. /agentic is the only
+        # rec — applies to any target as the catch-all.
+        recs = recommend_next(_shape())
+        assert len(recs) == 1
+        assert recs[0].command == "/agentic"
+        assert "any target" in recs[0].reason
+
+    def test_deps_present_recommends_sca(self):
+        recs = recommend_next(_shape(
+            deps=DependencyCounts(by_ecosystem={"npm": 180}),
+        ))
+        sca = next(r for r in recs if r.command == "/sca")
+        assert "180 npm" in sca.reason
+
+    def test_build_present_recommends_codeql(self):
+        # /codeql recommended whenever a build system is
+        # detected. We deliberately DON'T check CI state — RAPTOR
+        # /codeql does different work than a generic CI codeql
+        # scan (different queries / suites / IRIS Tier 1
+        # dataflow), and "skip because it's in CI" is bad
+        # advice for a security framework where defensive
+        # scanning should be additive.
+        recs = recommend_next(_shape(
+            primary_language="cpp",
+            build_systems={"cpp": "autotools"},
+        ))
+        codeql = next(r for r in recs if r.command == "/codeql")
+        assert "autotools" in codeql.reason
+
+    def test_no_build_system_omits_codeql(self):
+        # Header-only library, script collection, etc. — no
+        # build, /codeql doesn't apply.
+        recs = recommend_next(_shape(
+            primary_language="python",
+            build_systems={},  # no build detected
+        ))
+        assert not any(r.command == "/codeql" for r in recs)
+
+    def test_agentic_dropped_when_other_recs_present(self):
+        # /agentic is the catch-all — when signal-driven picks
+        # exist, the catalog Pipeline line above already names
+        # /agentic, so we don't repeat it. Pre-fix surfaced an
+        # always-on row that read like marketing copy.
+        recs = recommend_next(_shape(
+            deps=DependencyCounts(by_ecosystem={"npm": 10}),
+            primary_language="cpp",
+            build_systems={"cpp": "cmake"},
+        ))
+        commands = [r.command for r in recs]
+        assert "/agentic" not in commands
+
+    def test_recommendation_is_immutable(self):
+        rec = Recommendation(command="/sca", reason="x")
+        import pytest
+        with pytest.raises(Exception):  # FrozenInstanceError
+            rec.command = "/agentic"  # type: ignore[misc]
+
+    def test_full_signal_set_orders_correctly(self):
+        # Realistic: a C++ daemon with deps + autotools.
+        # /agentic dropped when other recs present (catalog
+        # Pipeline line already names it).
+        recs = recommend_next(_shape(
+            primary_language="cpp",
+            build_systems={"cpp": "autotools"},
+            deps=DependencyCounts(
+                by_ecosystem={"PyPI": 12, "OCI": 3},
+            ),
+        ))
+        commands = [r.command for r in recs]
+        assert commands == ["/sca", "/codeql"]

--- a/packages/describe/tests/test_report.py
+++ b/packages/describe/tests/test_report.py
@@ -1,0 +1,357 @@
+"""Tests for ``packages/describe/report.py`` — top-level
+report build + text/JSON renderers.
+
+Scope guardrails: /describe is READ-ONLY by design. These
+tests pin that no runnable operator-typed commands appear in
+the output. See report.py module docstring for the security
+rationale (Makefile can do anything; we don't recommend it)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from packages.describe.report import (
+    TargetTypeDefaults,
+    DescribeReport,
+    _short_int,
+    build_describe_report,
+    format_json,
+    format_text,
+)
+from packages.describe.target_shape import TargetShape
+from packages.describe.tool_readiness import ToolCheck
+
+
+def _shape(**overrides) -> TargetShape:
+    base = {
+        "target_path": Path("/tmp/test"),
+        "languages": {"cpp": 100},
+        "language_breakdown": {"cpp": 100.0},
+        "primary_language": "cpp",
+        "build_systems": {"cpp": "autotools"},
+        "target_type": "c.userspace-daemon",
+        "total_files": 189,
+        "total_lines": 52_000,
+        "language_lines": {},
+    }
+    base.update(overrides)
+    return TargetShape(**base)
+
+
+def _report(
+    shape=None, checks=None, preview=None, est=None,
+) -> DescribeReport:
+    return DescribeReport(
+        target_shape=shape if shape is not None else _shape(),
+        tool_checks=checks if checks is not None else [],
+        target_type_defaults=preview,
+        estimate_summary=est,
+    )
+
+
+class TestShortInt:
+    def test_thousands(self):
+        assert _short_int(52_000) == "52k"
+        assert _short_int(1_500) == "1k"  # truncates
+
+    def test_millions(self):
+        assert _short_int(1_500_000) == "1.5M"
+
+    def test_small(self):
+        assert _short_int(42) == "42"
+
+
+class TestFormatText:
+    """Operator-facing text renderer."""
+
+    def test_full_shape_renders_describe_block(self):
+        shape = _shape()
+        checks = [
+            ToolCheck("CodeQL", "warn", "2.18.4",
+                      "DB build needs autoreconf for autotools build system",
+                      hint="sudo apt install autoconf"),
+            ToolCheck("Binary oracle", "warn", None,
+                      "no build artefacts found — will activate after build"),
+        ]
+        preview = TargetTypeDefaults(
+            semgrep_packs=["security-audit", "command-injection"],
+            high_priority_dirs=["src/http", "src/net"],
+            pipeline_names=["understand-map", "scan", "agentic"],
+        )
+        out = format_text(_report(shape, checks, preview, "$25-$50, 40-75 min"))
+        # Target analysis section
+        assert "Target analysis:" in out
+        assert "Languages: C++ (100%)" in out
+        assert "Build system: autotools" in out
+        assert "Size: ~52k LOC, 189 source files" in out
+        assert "Detected type: c.userspace-daemon" in out
+        # Target-type defaults preview
+        assert "Defaults for this target type:" in out
+        assert "security-audit, command-injection" in out
+        assert "src/http, src/net" in out
+        assert "understand-map → scan → agentic" in out
+        # Target-specific checks section (header avoids "gaps"
+        # because ✓ ok entries land here too — pre-fix "gaps"
+        # misled operators into reading ok lines as problems).
+        assert "Target-specific checks:" in out
+        assert "Target-specific tool gaps:" not in out
+        assert "⚠" in out and "CodeQL" in out
+        assert "hint: sudo apt install autoconf" in out
+        # Estimate
+        assert "Cost estimate (when running /agentic): $25-$50, 40-75 min" in out
+        # Doctor-deferral footer
+        assert "raptor doctor" in out
+        # Sandboxed-analysis pointer with resolved target path
+        # (operator can copy the line; no <target> placeholder
+        # forcing manual substitution).
+        assert "raptor.py agentic" in out
+        assert "<target>" not in out, (
+            "footer should substitute the resolved target path; "
+            "the <target> placeholder forces operators to hand-edit"
+        )
+        # The resolved path appears in the footer.
+        assert str(shape.target_path) in out
+
+    def test_no_runnable_build_commands_in_output(self):
+        # SCOPE GUARDRAIL: /describe must NEVER recommend
+        # operator-typed shell commands that execute target
+        # code. ``./configure``, ``make``, ``apt install`` are
+        # the markers — none should appear in the output's
+        # main command list.
+        shape = _shape()
+        checks = [
+            ToolCheck("CodeQL", "warn", "2.18.4",
+                      "DB build needs autoreconf",
+                      hint="sudo apt install autoconf"),
+        ]
+        out = format_text(_report(shape, checks, est="$25-$50"))
+        # No numbered instruction list — would imply
+        # "run these in order" and cross the sandbox boundary.
+        assert "1. " not in out
+        # No shell command sequences that execute target code.
+        assert "./configure" not in out
+        assert "./bootstrap" not in out
+        assert "./autogen.sh" not in out
+        assert "autoreconf -fi" not in out
+        assert "&& make" not in out
+        # Hint lines CAN say "apt install" (those are
+        # operator-readable advice, not a numbered command
+        # list to follow).
+
+    def test_no_languages_renders_unknown(self):
+        out = format_text(_report(_shape(
+            languages={}, language_breakdown={},
+            primary_language=None, build_systems={},
+            target_type=None, total_files=0,
+            total_lines=0,
+        )))
+        # "none detected" rather than "unknown" — we ran the
+        # detectors and they reported no signal; honest about
+        # what the run actually saw vs claiming we couldn't
+        # tell.
+        assert "Languages: none detected" in out
+        assert "Build system: none detected" in out
+
+    def test_no_target_type_defaults_omits_section(self):
+        out = format_text(_report(preview=None))
+        assert "Defaults for this target type" not in out
+
+    def test_estimate_omitted_when_none(self):
+        out = format_text(_report(est=None))
+        assert "Cost estimate" not in out
+
+    def test_multi_language_breakdown_sorted(self):
+        out = format_text(_report(_shape(
+            languages={"python": 5, "cpp": 95},
+            language_breakdown={"python": 5.0, "cpp": 95.0},
+            primary_language="cpp",
+        )))
+        c_idx = out.find("C++")
+        py_idx = out.find("Python")
+        assert c_idx < py_idx
+        assert "C++ (95%)" in out
+        assert "Python (5%)" in out
+
+    def test_language_loc_rendered_when_present(self):
+        # Per-language LOC surfaces alongside file-share %.
+        # Pins the contrast with file-share alone, which over-
+        # represents languages with many tiny files (Java's
+        # one-class-per-file convention can dwarf a much larger
+        # C++ kernel by file count alone).
+        out = format_text(_report(_shape(
+            languages={"java": 60, "cpp": 40},
+            language_breakdown={"java": 60.0, "cpp": 40.0},
+            primary_language="java",
+            language_lines={"java": 5_000, "cpp": 47_000},
+        )))
+        assert "Java (60%, 5k LOC)" in out
+        assert "C++ (40%, 47k LOC)" in out
+
+    def test_language_loc_omitted_when_zero_or_absent(self):
+        # Mixed: cpp has LOC, python doesn't (zero / missing).
+        # Pins the omission contract per-language.
+        out = format_text(_report(_shape(
+            languages={"cpp": 95, "python": 5},
+            language_breakdown={"cpp": 95.0, "python": 5.0},
+            primary_language="cpp",
+            language_lines={"cpp": 50_000, "python": 0},
+        )))
+        assert "C++ (95%, 50k LOC)" in out
+        assert "Python (5%)" in out
+        assert "Python (5%, 0" not in out
+
+
+class TestFormatJson:
+    """JSON renderer — machine consumers."""
+
+    def test_round_trip_structure(self):
+        preview = TargetTypeDefaults(
+            semgrep_packs=["security-audit"],
+            high_priority_dirs=["src/http"],
+            pipeline_names=["scan", "agentic"],
+        )
+        report = _report(
+            _shape(),
+            checks=[ToolCheck("CodeQL", "warn", "2.18.4",
+                              "needs libtool", "apt install libtool")],
+            preview=preview,
+            est="$25-$50, 40-75 min",
+        )
+        doc = json.loads(format_json(report))
+        assert doc["primary_language"] == "cpp"
+        assert doc["target_type"] == "c.userspace-daemon"
+        assert doc["total_files"] == 189
+        assert doc["build_systems"] == {"cpp": "autotools"}
+        assert len(doc["tool_checks"]) == 1
+        assert doc["tool_checks"][0]["status"] == "warn"
+        assert doc["target_type_defaults"]["semgrep_packs"] == ["security-audit"]
+        assert doc["target_type_defaults"]["pipeline_names"] == ["scan", "agentic"]
+        assert doc["estimate_summary"] == "$25-$50, 40-75 min"
+        # Per-language LOC surfaces as its own key (sums to
+        # ``total_lines`` in real shapes; here it's the default
+        # empty dict since _shape() doesn't override it).
+        assert "language_lines" in doc
+        # SCOPE GUARDRAIL: no runnable-command lists exported.
+        forbidden_keys = {
+            "pipeline", "setup_steps", "analysis_steps",
+            "recommended_pipeline",
+        }
+        assert forbidden_keys.isdisjoint(doc.keys()), (
+            f"JSON schema must not include runnable-command "
+            f"lists; got intersection: "
+            f"{doc.keys() & forbidden_keys}"
+        )
+
+    def test_no_target_type_defaults_serialises_null(self):
+        report = _report(preview=None)
+        doc = json.loads(format_json(report))
+        assert doc["target_type_defaults"] is None
+
+    def test_paths_serialised_as_strings(self):
+        report = _report(_shape(target_path=Path("/home/raptor/targets/monit")))
+        doc = json.loads(format_json(report))
+        assert doc["target_path"] == "/home/raptor/targets/monit"
+
+
+class TestBuildDescribeReport:
+    """End-to-end — composes shape + checks + catalog preview
+    + estimate against a real catalog-matching target tree."""
+
+    def test_c_userspace_daemon_target_end_to_end(self, tmp_path):
+        (tmp_path / "configure.ac").write_text("")
+        (tmp_path / "Makefile.am").write_text("")
+        src = tmp_path / "src"
+        src.mkdir()
+        for i in range(5):
+            (src / f"f{i}.c").write_text("int main(){return 0;}")
+
+        report = build_describe_report(tmp_path)
+        assert report.target_shape.target_type == "c.userspace-daemon"
+        assert report.target_shape.primary_language == "cpp"
+        assert report.tool_checks
+        # Catalog preview present + populated for a known entry.
+        assert report.target_type_defaults is not None
+        assert "security-audit" in report.target_type_defaults.semgrep_packs
+        assert report.estimate_summary is not None
+
+    def test_unmatched_target_surfaces_generic_defaults(self, tmp_path):
+        # Empty tree → falls back to ``generic``. The generic
+        # entry SHIPS with non-empty defaults today
+        # (security-audit + owasp-top-ten packs + scan/agentic
+        # pipeline) — operators get those defaults even on
+        # unmatched targets. Pre-fix this was suppressed by a
+        # hardcoded ``name == 'generic'`` check; the
+        # field-emptiness gate correctly surfaces them now.
+        report = build_describe_report(tmp_path)
+        assert report.target_type_defaults is not None
+        assert "security-audit" in report.target_type_defaults.semgrep_packs
+        # Empty preferred-dirs is fine — generic doesn't
+        # narrow attack surface by directory.
+        assert report.target_type_defaults.high_priority_dirs == []
+
+    def test_target_type_with_all_empty_fields_skips_preview(
+        self, tmp_path, monkeypatch,
+    ):
+        # Counter-test: a target-type entry with ALL preview
+        # fields empty still gets suppressed. Pins the
+        # field-emptiness contract.
+        import core.run.target_types as tt
+        empty_entry = tt.CatalogEntry(name="hollow")
+        monkeypatch.setattr(
+            tt, "load_by_name", lambda _name: empty_entry,
+        )
+        from packages.describe.report import (
+            _target_type_defaults as _ttd,
+        )
+        from packages.describe.target_shape import TargetShape
+        from pathlib import Path as _Path
+        shape = TargetShape(
+            target_path=_Path("/tmp"),
+            languages={"python": 10},
+            language_breakdown={"python": 100.0},
+            primary_language="python",
+            build_systems={},
+            target_type="hollow",
+            total_files=10,
+            total_lines=200,
+        )
+        assert _ttd(shape) is None
+
+    def test_target_type_with_partial_defaults_renders(
+        self, tmp_path, monkeypatch,
+    ):
+        # Pin the field-emptiness path: an entry with ANY
+        # non-empty preview field surfaces (pre-fix the
+        # suppression hardcoded ``name == 'generic'`` and would
+        # have dropped this entry if it had been named generic).
+        import core.run.target_types as tt
+        synth_entry = tt.CatalogEntry(
+            name="exotic",
+            # Only semgrep_packs populated; dirs + pipeline empty.
+            semgrep_packs_default=("security-audit",),
+        )
+        monkeypatch.setattr(
+            tt, "load_by_name",
+            lambda name: synth_entry if name == "exotic" else None,
+        )
+        from packages.describe.report import (
+            _target_type_defaults as _ttd,
+        )
+        from packages.describe.target_shape import TargetShape
+        from pathlib import Path as _Path
+        shape = TargetShape(
+            target_path=_Path("/tmp"),
+            languages={"python": 10},
+            language_breakdown={"python": 100.0},
+            primary_language="python",
+            build_systems={},
+            target_type="exotic",
+            total_files=10,
+            total_lines=200,
+        )
+        preview = _ttd(shape)
+        assert preview is not None
+        assert preview.semgrep_packs == ["security-audit"]
+        assert preview.high_priority_dirs == []
+        assert preview.pipeline_names == []

--- a/packages/describe/tests/test_start_line.py
+++ b/packages/describe/tests/test_start_line.py
@@ -1,0 +1,64 @@
+"""Tests for ``packages/describe/start_line.py`` — single-line
+target summary emitted at /scan / /agentic / /codeql startup."""
+
+from __future__ import annotations
+
+from packages.describe.start_line import format_start_line
+
+
+def _c_daemon(tmp_path):
+    (tmp_path / "configure.ac").write_text("")
+    (tmp_path / "Makefile.am").write_text("")
+    src = tmp_path / "src"
+    src.mkdir()
+    for i in range(10):
+        (src / f"f{i}.c").write_text("int main(){return 0;}\n")
+    return tmp_path
+
+
+class TestFormatStartLine:
+    def test_full_signal_set_renders_compact_line(self, tmp_path):
+        target = _c_daemon(tmp_path)
+        line = format_start_line(target)
+        assert line is not None
+        assert "C++" in line
+        assert "autotools" in line
+        assert "c.userspace-daemon" in line
+        # Cost estimate appears as tail clause (the existing
+        # surface — preserved so the budget gate's "$N-M"
+        # framing stays recognisable).
+        assert "estimated" in line
+        # One line only — operator visibility, not a wall of
+        # text at run start.
+        assert "\n" not in line
+
+    def test_omits_generic_target_type(self, tmp_path):
+        # "generic" is the catalog's bland fallback — adding it
+        # to the start line is noise. Omit, keep the line tight.
+        (tmp_path / "f.py").write_text("pass\n")
+        line = format_start_line(tmp_path)
+        assert line is not None
+        assert "generic" not in line
+
+    def test_empty_target_returns_none(self, tmp_path):
+        # No languages → infer_target_shape still works but the
+        # line has nothing useful to render and no estimate
+        # either. Return None so the caller surfaces nothing
+        # rather than an empty header.
+        line = format_start_line(tmp_path)
+        # The estimate for an empty tree may yield None; if so,
+        # line is None. If the estimator yields a generic line
+        # we'd still want the line to be informative.
+        # Either way, we don't render a header with nothing.
+        if line is not None:
+            assert "Analyzing" not in line or "(" in line  # has content
+
+    def test_loc_renders_compactly(self, tmp_path):
+        # Synthetic large repo — assert k/M abbreviation kicks in.
+        for i in range(100):
+            (tmp_path / f"f{i}.c").write_text("\n" * 600)  # 600 lines each
+        line = format_start_line(tmp_path)
+        assert line is not None
+        # 100 files * 600 lines = 60000 LOC → "60k LOC"
+        assert "LOC" in line
+        assert "60k" in line or "59k" in line  # boundary tolerance

--- a/packages/describe/tests/test_target_shape.py
+++ b/packages/describe/tests/test_target_shape.py
@@ -1,0 +1,251 @@
+"""Tests for ``packages/describe/target_shape.py`` — target-shape
+inference for the /describe command."""
+
+from __future__ import annotations
+
+from packages.describe.target_shape import (
+    TargetShape,
+    _compute_breakdown,
+    _pick_primary,
+    infer_target_shape,
+)
+
+
+class TestComputeBreakdown:
+    """Normalisation of per-language file counts to percentages."""
+
+    def test_single_language(self):
+        result = _compute_breakdown({"c": 10})
+        assert result == {"c": 100.0}
+
+    def test_two_languages_share_correctly(self):
+        result = _compute_breakdown({"c": 95, "python": 5})
+        assert result == {"c": 95.0, "python": 5.0}
+
+    def test_rounds_to_one_decimal(self):
+        # 7/3 should round to one decimal.
+        result = _compute_breakdown({"c": 7, "python": 3})
+        assert result == {"c": 70.0, "python": 30.0}
+
+    def test_empty_input_returns_empty(self):
+        assert _compute_breakdown({}) == {}
+
+    def test_zero_total_returns_empty(self):
+        # All-zero counts (pathological) → empty rather than
+        # ZeroDivisionError.
+        assert _compute_breakdown({"c": 0, "python": 0}) == {}
+
+
+class TestPickPrimary:
+    """Picks the language with the largest share. None on empty.
+    Deterministic on ties."""
+
+    def test_largest_wins(self):
+        assert _pick_primary({"c": 95.0, "python": 5.0}) == "c"
+
+    def test_empty_returns_none(self):
+        assert _pick_primary({}) is None
+
+    def test_single_language_returned(self):
+        assert _pick_primary({"rust": 100.0}) == "rust"
+
+
+class TestInferTargetShape:
+    """End-to-end inference on synthetic target trees."""
+
+    def test_c_userspace_daemon_shape(self, tmp_path):
+        # Build a tree the codeql detector + catalog both recognise.
+        (tmp_path / "configure.ac").write_text("")
+        (tmp_path / "Makefile.am").write_text("")
+        src = tmp_path / "src"
+        src.mkdir()
+        for i in range(10):
+            (src / f"file{i}.c").write_text(
+                f"// file {i}\nint main() {{ return 0; }}\n"
+            )
+        (src / "header.h").write_text("// hdr\nvoid f();\n")
+
+        shape = infer_target_shape(tmp_path)
+
+        assert shape.target_path == tmp_path.resolve()
+        # codeql language detector merges C + C++ into "cpp"
+        # (single CodeQL database). The .c/.h files land under
+        # this id; ``file_extensions`` keeps the raw extension
+        # breakdown for renderers that want strict-C numbers.
+        assert "cpp" in shape.languages
+        assert shape.primary_language == "cpp"
+        # 100% C/C++ since no other language.
+        assert shape.language_breakdown["cpp"] == 100.0
+        # Catalog matched c.userspace-daemon (autotools markers).
+        assert shape.target_type == "c.userspace-daemon"
+        # File count + lines populated.
+        assert shape.total_files >= 11  # 10 .c + 1 .h
+        assert shape.total_lines > 0
+        # Per-extension counts preserve the C/C++ split.
+        assert shape.file_extensions.get(".c", 0) == 10
+        assert shape.file_extensions.get(".h", 0) == 1
+        # Per-language LOC populated + sums to total_lines (.c
+        # and .h both roll up under "cpp", matching the codeql /
+        # catalog merge convention).
+        assert shape.language_lines.get("cpp", 0) > 0
+        assert sum(shape.language_lines.values()) == shape.total_lines
+
+    def test_python_target_shape(self, tmp_path):
+        # python web app shape.
+        (tmp_path / "manage.py").write_text("# django manage")
+        (tmp_path / "settings.py").write_text("# settings")
+        (tmp_path / "urls.py").write_text("# urls")
+        for i in range(5):
+            (tmp_path / f"view{i}.py").write_text(f"def view{i}(): pass\n")
+
+        shape = infer_target_shape(tmp_path)
+        assert shape.primary_language == "python"
+        assert "python" in shape.languages
+        assert shape.target_type == "python.web-app"
+
+    def test_empty_target_returns_minimal_shape(self, tmp_path):
+        # Empty tree → no languages detected → renderer can still
+        # show "Languages: unknown" without crashing.
+        shape = infer_target_shape(tmp_path)
+        assert shape.languages == {}
+        assert shape.primary_language is None
+        assert shape.language_breakdown == {}
+        assert shape.total_files == 0
+        # Catalog falls back to "generic" rather than None.
+        assert shape.target_type == "generic"
+
+    def test_symlinked_source_file_is_skipped(self, tmp_path):
+        # Adversarial fixture: a symlinked "source file" points at
+        # /etc/shadow (or any host path). Pre-fix the LOC walk
+        # opened it and read line count → leak primitive into
+        # the JSON output. Post-fix lstat + S_ISLNK guard skips
+        # symlinks entirely.
+        (tmp_path / "real.c").write_text("int main(){return 0;}\n")
+        # Symlink target doesn't have to exist for lstat to
+        # detect the symlink itself; use a definitely-not-here
+        # path so the test doesn't depend on host /etc state.
+        (tmp_path / "evil.c").symlink_to("/nonexistent/sensitive-data")
+        shape = infer_target_shape(tmp_path)
+        # real.c is the only counted file; evil.c is skipped.
+        assert shape.total_files == 1
+        # Single counted .c → ≥1 LOC; the symlink contributes 0.
+        assert shape.total_lines >= 1
+        assert shape.file_extensions.get(".c", 0) == 1
+
+    def test_symlinked_dir_inside_tree_not_followed(self, tmp_path):
+        # os.walk(followlinks=False) — a symlinked dir within
+        # the target shouldn't be descended into. Otherwise an
+        # attacker could plant ``vendor`` -> ``/`` and we'd
+        # try to walk the whole host filesystem.
+        (tmp_path / "real.c").write_text("int x;\n")
+        (tmp_path / "evil_dir").symlink_to("/etc")
+        shape = infer_target_shape(tmp_path)
+        # Just the one legitimate file — the symlinked dir is
+        # listed as a "file" by os.walk (because followlinks
+        # defaults False; symlinked dirs surface as entries but
+        # aren't recursed), and our file path is lstat-guarded
+        # so the symlink isn't opened either.
+        assert shape.total_files == 1
+
+    def test_license_detected_when_license_file_present(self, tmp_path):
+        # MIT LICENSE at repo root → license.spdx_id="MIT".
+        # Pins the reuse contract with core.license: /describe
+        # gets the same detector the run-lifecycle license
+        # warning uses, no parallel implementation.
+        (tmp_path / "LICENSE").write_text(
+            "MIT License\n\n"
+            "Permission is hereby granted, free of charge, to any "
+            "person obtaining a copy of this software\n"
+        )
+        (tmp_path / "f.py").write_text("pass\n")
+        shape = infer_target_shape(tmp_path)
+        assert shape.license is not None
+        assert shape.license.spdx_id == "MIT"
+        assert shape.license.classification == "oss"
+
+    def test_license_missing_when_no_license_file(self, tmp_path):
+        (tmp_path / "f.py").write_text("pass\n")
+        shape = infer_target_shape(tmp_path)
+        assert shape.license is not None
+        assert shape.license.classification == "missing"
+        assert shape.license.spdx_id is None
+
+    def test_small_language_surface_not_dropped(self, tmp_path):
+        # /describe walks LANGUAGE_MAP extensions directly — NO
+        # ``min_files`` floor. Pins the contrast with codeql's
+        # LanguageDetector (which would drop these 2-file
+        # languages under its DB-build min_files=3 threshold).
+        # Mixed corpus: 3 C, 2 Python, 2 Java, 2 JS — Java + JS
+        # below codeql's floor; /describe MUST report all four.
+        for i in range(3):
+            (tmp_path / f"c{i}.c").write_text("int main(){return 0;}")
+        for i in range(2):
+            (tmp_path / f"p{i}.py").write_text("pass\n")
+        for i in range(2):
+            (tmp_path / f"J{i}.java").write_text(
+                f"class J{i} {{}}\n"
+            )
+        for i in range(2):
+            (tmp_path / f"j{i}.js").write_text("var x;\n")
+
+        shape = infer_target_shape(tmp_path)
+        # Every language present in the tree appears, regardless
+        # of how few files it has — this is the bug the
+        # codeql-based detector caused on /tmp/vulns.
+        assert "cpp" in shape.languages
+        assert "python" in shape.languages
+        assert "java" in shape.languages
+        assert "javascript" in shape.languages
+
+    def test_catalog_failure_returns_none(self, monkeypatch, tmp_path):
+        # Catalog load raises → target_type is None
+        # (defensive against future catalog substrate bugs).
+        import core.run.target_types as tt
+        monkeypatch.setattr(
+            tt, "load",
+            lambda _p: (_ for _ in ()).throw(RuntimeError("boom")),
+        )
+        shape = infer_target_shape(tmp_path)
+        assert shape.target_type is None
+
+    def test_build_system_detected_for_cpp_autotools(self, tmp_path):
+        # autotools markers should yield a build_system entry.
+        # Indexed under "cpp" because the language detector merges
+        # C/C++ into that single language id.
+        (tmp_path / "configure.ac").write_text("")
+        (tmp_path / "Makefile.am").write_text("")
+        src = tmp_path / "src"
+        src.mkdir()
+        for i in range(5):
+            (src / f"f{i}.c").write_text("int main(){return 0;}")
+
+        shape = infer_target_shape(tmp_path)
+        assert "cpp" in shape.build_systems
+        assert shape.build_systems["cpp"] == "autotools"
+
+    def test_returns_frozen_dataclass(self, tmp_path):
+        # TargetShape is frozen — caller can't mutate.
+        shape = infer_target_shape(tmp_path)
+        import pytest
+        with pytest.raises(Exception):  # FrozenInstanceError
+            shape.total_files = 999  # type: ignore[misc]
+
+
+class TestTargetShapeDataclass:
+    """Direct dataclass construction shape — used by JSON
+    serialisation / consumer tests."""
+
+    def test_minimal_construction(self, tmp_path):
+        shape = TargetShape(
+            target_path=tmp_path,
+            languages={},
+            language_breakdown={},
+            primary_language=None,
+            build_systems={},
+            target_type=None,
+            total_files=0,
+            total_lines=0,
+        )
+        # file_extensions has a default factory; constructible
+        # without specifying it.
+        assert shape.file_extensions == {}

--- a/packages/describe/tests/test_tool_readiness.py
+++ b/packages/describe/tests/test_tool_readiness.py
@@ -1,0 +1,281 @@
+"""Tests for ``packages/describe/tool_readiness.py`` — per-tool
+readiness checks tailored to a target."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+from packages.describe.target_shape import TargetShape
+from packages.describe.tool_readiness import (
+    ToolCheck,
+    _check_binary_oracle,
+    _check_codeql,
+    _check_coccinelle,
+    check_tool_readiness,
+)
+
+
+def _shape(**overrides) -> TargetShape:
+    """Build a minimal TargetShape for tests; caller overrides
+    fields relevant to the check under test."""
+    base = {
+        "target_path": Path("/tmp/test"),
+        "languages": {"cpp": 100},
+        "language_breakdown": {"cpp": 100.0},
+        "primary_language": "cpp",
+        "build_systems": {"cpp": "autotools"},
+        "target_type": "c.userspace-daemon",
+        "total_files": 100,
+        "total_lines": 5000,
+    }
+    base.update(overrides)
+    return TargetShape(**base)
+
+
+# ---------------------------------------------------------------------------
+# _check_codeql — target-specific build-deps check (host-level
+# presence defers to /doctor).
+# ---------------------------------------------------------------------------
+
+
+class TestCheckCodeql:
+    def test_missing_binary_defers_to_doctor(self):
+        # Per the /describe scope boundary: host-level facts
+        # belong in /doctor. /describe emits a deferral rather
+        # than re-implementing install hints.
+        with patch("shutil.which", return_value=None):
+            result = _check_codeql(_shape())
+        assert result.name == "CodeQL"
+        assert result.status == "unknown"
+        assert "deferred" in result.detail
+        assert result.hint and "raptor doctor" in result.hint
+
+    def test_present_binary_with_all_build_deps_returns_ok(self):
+        def _which(cmd):
+            # codeql + every autotools dep present.
+            return "/usr/bin/" + cmd
+        with patch("shutil.which", side_effect=_which):
+            with patch(
+                "packages.describe.tool_readiness._bin_version",
+                return_value="2.18.4",
+            ):
+                result = _check_codeql(_shape())
+        assert result.status == "ok"
+        assert result.version == "2.18.4"
+        assert "build deps ok" in result.detail
+
+    def test_present_binary_missing_autoreconf_warns(self):
+        def _which(cmd):
+            if cmd == "autoreconf":
+                return None
+            # Pretend apt is the installed PM (the test
+            # machine's actual PM is irrelevant — we're pinning
+            # the hint shape, not the host's PM).
+            if cmd == "apt":
+                return "/usr/bin/apt"
+            return "/usr/bin/" + cmd
+        from packages.describe.package_manager import (
+            detect_package_manager,
+        )
+        detect_package_manager.cache_clear()
+        with patch("shutil.which", side_effect=_which):
+            with patch(
+                "packages.describe.tool_readiness._bin_version",
+                return_value="2.18.4",
+            ):
+                result = _check_codeql(_shape())
+        assert result.status == "warn"
+        # Operator-actionable: names the missing dep + the build
+        # system that needs it.
+        assert "autoreconf" in result.detail
+        assert "autotools" in result.detail
+        # Hint includes the install verb + the apt package name.
+        assert result.hint and "apt install" in result.hint
+        assert "autoconf" in result.hint  # apt package name
+
+    def test_check_uses_libtoolize_not_libtool(self):
+        # Pin the libtoolize-vs-libtool fix. The Debian
+        # ``libtool`` package ships ``libtoolize`` as the
+        # bootstrap binary autoreconf actually invokes; a bare
+        # ``libtool`` command isn't always present even when
+        # the package is fully installed. Pre-fix the check
+        # spuriously warned "DB build needs libtool" on
+        # systems where the package was installed but the bare
+        # ``libtool`` binary wasn't.
+        from packages.describe.tool_readiness import _BUILD_SYSTEM_DEPS
+        assert "libtoolize" in _BUILD_SYSTEM_DEPS["autotools"]
+        assert "libtool" not in _BUILD_SYSTEM_DEPS["autotools"]
+        # Install-advice registry resolves libtoolize → ``libtool``
+        # package on every PM (that's what ships libtoolize).
+        from packages.describe.package_manager import _INSTALL_ADVICE
+        adv = _INSTALL_ADVICE["libtoolize"]
+        assert adv.pm_packages
+        assert adv.pm_packages.get("apt") == "libtool"
+        assert adv.pm_packages.get("dnf") == "libtool"
+        assert adv.pm_packages.get("brew") == "libtool"
+
+
+# ---------------------------------------------------------------------------
+# _check_coccinelle
+# ---------------------------------------------------------------------------
+
+
+class TestCheckCoccinelle:
+    def test_missing_binary_defers_to_doctor(self):
+        with patch("shutil.which", return_value=None):
+            result = _check_coccinelle(_shape())
+        assert result.status == "unknown"
+        assert "deferred" in result.detail
+        assert result.hint and "raptor doctor" in result.hint
+
+    def test_c_target_returns_ok(self):
+        with patch("shutil.which", return_value="/usr/bin/spatch"):
+            with patch(
+                "packages.describe.tool_readiness._bin_version",
+                return_value="1.3.0",
+            ):
+                result = _check_coccinelle(_shape(primary_language="cpp"))
+        assert result.status == "ok"
+        assert "applicable" in result.detail
+
+    def test_python_target_warns_about_zero_fire(self):
+        # Cocci's shipped rule pack is C-only — honest "will
+        # 0-fire" warning instead of pretending it works.
+        with patch("shutil.which", return_value="/usr/bin/spatch"):
+            with patch(
+                "packages.describe.tool_readiness._bin_version",
+                return_value="1.3.0",
+            ):
+                result = _check_coccinelle(
+                    _shape(primary_language="python"),
+                )
+        assert result.status == "warn"
+        assert "C-only" in result.detail
+        assert "0 rules" in result.detail
+
+
+# ---------------------------------------------------------------------------
+# _check_binary_oracle — native-only, build-artefact-aware
+# ---------------------------------------------------------------------------
+
+
+class TestCheckBinaryOracle:
+    def test_python_target_returns_none(self):
+        # Binary oracle doesn't apply to managed-runtime languages.
+        result = _check_binary_oracle(_shape(primary_language="python"))
+        assert result is None
+
+    def test_native_target_no_artefacts_warns(self, tmp_path):
+        shape = _shape(target_path=tmp_path, primary_language="cpp")
+        result = _check_binary_oracle(shape)
+        assert result is not None
+        assert result.status == "warn"
+        assert "after build" in result.detail
+
+    def test_native_target_with_build_dir_ok(self, tmp_path):
+        (tmp_path / "build").mkdir()
+        shape = _shape(target_path=tmp_path, primary_language="cpp")
+        result = _check_binary_oracle(shape)
+        assert result is not None
+        assert result.status == "ok"
+        assert "build artefacts" in result.detail
+
+
+# ---------------------------------------------------------------------------
+# Scope boundary: /describe does NOT check LLM configuration
+# (host-level — /doctor's domain). Test that the helper is gone
+# so a future drift back into this scope fails loudly.
+# ---------------------------------------------------------------------------
+
+
+class TestNoLlmCheckByDesign:
+    def test_no_check_llm_function_exported(self):
+        # /describe and /doctor have separate concerns; LLM
+        # configuration is host-level and belongs in /doctor.
+        # If a future change re-introduces an LLM check here,
+        # update this test consciously.
+        from packages.describe import tool_readiness as tr
+        assert not hasattr(tr, "_check_llm"), (
+            "tool_readiness._check_llm was reinstated. LLM "
+            "config is host-level; /doctor owns it. Update "
+            "the test only if the scope boundary changed."
+        )
+
+    def test_top_level_checks_exclude_llm(self):
+        # The aggregate check list should NOT include any
+        # "LLM dispatcher" entry — /describe focuses on target-
+        # applicability only.
+        with patch("shutil.which", return_value="/usr/bin/mock"):
+            with patch(
+                "packages.describe.tool_readiness._bin_version",
+                return_value="1.0",
+            ):
+                checks = check_tool_readiness(_shape())
+        names = [c.name for c in checks]
+        assert "LLM dispatcher" not in names
+
+
+# ---------------------------------------------------------------------------
+# check_tool_readiness — top-level integration
+# ---------------------------------------------------------------------------
+
+
+class TestStatusEnum:
+    """Pin the ``status`` enum + renderer symbol-map alignment
+    so a new status added in one place fails loudly if the
+    other isn't updated. Downstream JSON consumers will rely
+    on the set membership."""
+
+    def test_renderer_symbol_map_covers_every_status(self):
+        # If a new status is added to the contract, the renderer's
+        # symbol map in packages/describe/report.py:_STATUS_SYMBOL
+        # needs an entry too. This test fails loudly when they
+        # drift.
+        from packages.describe.report import _STATUS_SYMBOL
+        known = {"ok", "warn", "fail", "unknown"}
+        assert set(_STATUS_SYMBOL.keys()) == known, (
+            f"_STATUS_SYMBOL keys drifted from the status enum. "
+            f"Expected {known}; got {set(_STATUS_SYMBOL.keys())}."
+        )
+
+
+class TestCheckToolReadiness:
+    def test_returns_list_of_tool_checks(self):
+        # Smoke: top-level helper returns a non-empty list of
+        # ToolCheck instances covering the target-applicability
+        # surface (codeql build-deps + cocci language + binary
+        # oracle). Per-tool semantics covered above.
+        with patch("shutil.which", return_value="/usr/bin/mock"):
+            with patch(
+                "packages.describe.tool_readiness._bin_version",
+                return_value="1.0",
+            ):
+                checks = check_tool_readiness(_shape())
+        # Three target-applicability checks (codeql + cocci +
+        # binary-oracle for native targets).
+        assert len(checks) == 3
+        assert all(isinstance(c, ToolCheck) for c in checks)
+        for c in checks:
+            assert c.name
+            assert c.status in ("ok", "warn", "fail", "unknown")
+        # Host-level checks (LLM dispatcher) MUST NOT appear here.
+        names = [c.name for c in checks]
+        assert "LLM dispatcher" not in names
+
+    def test_python_target_omits_binary_oracle(self):
+        # Binary oracle returns None for managed-runtime targets;
+        # caller filters it out.
+        with patch("shutil.which", return_value="/usr/bin/mock"):
+            with patch(
+                "packages.describe.tool_readiness._bin_version",
+                return_value="1.0",
+            ):
+                checks = check_tool_readiness(
+                    _shape(primary_language="python",
+                           languages={"python": 50},
+                           language_breakdown={"python": 100.0},
+                           build_systems={"python": "poetry"}),
+                )
+        names = [c.name for c in checks]
+        assert "Binary oracle" not in names

--- a/packages/describe/tool_readiness.py
+++ b/packages/describe/tool_readiness.py
@@ -1,0 +1,320 @@
+"""Target-applicability checks for /describe (QoL #14c).
+
+**Scope boundary with /doctor:** /doctor answers "is RAPTOR set
+up on this host" — tool binaries on PATH, API keys present,
+output dir writable. /describe answers "given THIS target, will
+the tools find anything and what will the run look like."
+These should not duplicate. When a host-level prerequisite is
+absent (binary missing, no LLM config), /describe reports it as
+"deferred to ``raptor doctor``" rather than rendering its own
+parallel diagnostic.
+
+Checks here focus on target-applicability:
+
+* CodeQL — IF binary present, are the build-system deps
+  installed for the target's detected build system? A CodeQL
+  DB build for an autotools target fails when ``autoreconf`` /
+  ``libtool`` are missing; /describe names them up-front.
+* Coccinelle — would the shipped rule pack fire on the target?
+  (cocci's rules are C-specific; honest "will 0-fire on a
+  Python target" warning beats silent uselessness.)
+* Binary oracle — does the target have build artefacts the
+  oracle would consume (after build), or will it activate
+  post-build?
+
+LLM-dispatcher configuration + bare tool presence are NOT
+checked here — those are /doctor's domain. When a tool is
+missing entirely we render a single deferral line pointing at
+/doctor rather than re-implementing host diagnostics.
+"""
+
+from __future__ import annotations
+
+import shutil
+from dataclasses import dataclass
+from typing import List, Optional
+
+from packages.describe.target_shape import TargetShape
+
+
+@dataclass(frozen=True)
+class ToolCheck:
+    """One per-tool readiness signal. ``status`` drives the
+    renderer's symbol (✓ / ⚠ / ✗ / ?) and the overall pass/fail
+    rollup. ``hint`` is operator-actionable text shown only when
+    status is not ``ok``.
+
+    Status values:
+      * ``ok``    — tool is present and applicable to the target
+      * ``warn``  — present but limited (missing build dep, wrong
+                    rule pack for the language, no build artefacts
+                    yet, etc.)
+      * ``fail``  — required tool absent
+      * ``unknown`` — check couldn't determine state (probe
+                    raised, ambiguous signals, etc.); honest
+                    "we don't know" rather than a falsely-cheerful
+                    default. Operator sees ``?`` and a hint to
+                    run ``raptor doctor`` for deeper inspection.
+    """
+    name: str
+    status: str  # "ok" | "warn" | "fail" | "unknown"
+    version: Optional[str]
+    detail: str
+    hint: Optional[str] = None
+
+
+# Build-system → list of binaries the target's build will need.
+# Drives the CodeQL DB-build readiness check: if the target's
+# build system is autotools and ``autoreconf`` isn't on PATH,
+# the operator gets a specific install hint instead of "CodeQL
+# might fail" hand-waving.
+_BUILD_SYSTEM_DEPS = {
+    # ``libtoolize`` not ``libtool``: the Debian ``libtool``
+    # package ships ``libtoolize`` (the binary autoreconf
+    # actually invokes during bootstrap) but doesn't always
+    # ship a bare ``libtool`` command. Checking ``libtool``
+    # gave false-positive "missing" warnings on systems with
+    # the package fully installed.
+    "autotools": ["autoreconf", "automake", "libtoolize"],
+    "cmake": ["cmake"],
+    "meson": ["meson", "ninja"],
+    "make": ["make"],
+    "maven": ["mvn"],
+    "gradle": ["gradle"],
+    "poetry": ["poetry"],
+    "pip": ["pip"],
+    "npm": ["npm"],
+    "yarn": ["yarn"],
+    "cargo": ["cargo"],
+    "go": ["go"],
+}
+
+def _format_build_deps_hint(missing_deps: List[str]) -> str:
+    """Group missing build deps by their per-PM package name +
+    install verb so the operator gets ONE pastable install
+    command per shared install path (rather than N sudo prompts
+    for three packages in the same PM).
+
+    Three autotools deps missing on Ubuntu render as:
+
+        sudo apt install autoconf automake libtool
+
+    Same three on macOS:
+
+        brew install autoconf automake libtool
+
+    Mixed install kinds (e.g. one is pipx, two are distro_pm)
+    fall back to per-binary advice joined with "; ".
+    """
+    from packages.describe.package_manager import (
+        _INSTALL_ADVICE, detect_package_manager, format_install_advice,
+        format_install_hint,
+    )
+
+    # Group by (kind, pm) so distro_pm deps for the same PM
+    # collapse into one install command; everything else falls
+    # through per-binary.
+    pm = detect_package_manager()
+    distro_pkgs: List[str] = []
+    other_hints: List[str] = []
+    for dep in missing_deps:
+        adv = _INSTALL_ADVICE.get(dep)
+        if adv and adv.kind == "distro_pm":
+            pkg = (adv.pm_packages or {}).get(pm or "", dep)
+            distro_pkgs.append(pkg)
+        else:
+            other_hints.append(format_install_advice(dep))
+
+    parts: List[str] = []
+    if distro_pkgs:
+        # De-dupe pkg names — multiple binaries (autoreconf +
+        # automake share no package, but autoreconf is from
+        # ``autoconf`` and any future dep mapping the same way
+        # wouldn't double-print).
+        seen = set()
+        dedup_pkgs = [
+            p for p in distro_pkgs
+            if not (p in seen or seen.add(p))
+        ]
+        parts.append(format_install_hint(dedup_pkgs))
+    parts.extend(other_hints)
+    return "; ".join(parts)
+
+
+def check_tool_readiness(shape: TargetShape) -> List[ToolCheck]:
+    """Return target-applicability checks for ``shape``.
+    Per-tool helpers may return None when the check doesn't
+    apply (binary oracle on header-only library, cocci on
+    Python target where we don't surface the binary-missing
+    case because /doctor owns it); those are filtered out.
+
+    Host-level checks (LLM dispatcher, raw binary presence)
+    are NOT included — those live in ``raptor doctor``. The
+    renderer adds a footer pointing the operator there."""
+    checks: List[Optional[ToolCheck]] = [
+        _check_codeql(shape),
+        _check_coccinelle(shape),
+        _check_binary_oracle(shape),
+    ]
+    return [c for c in checks if c is not None]
+
+
+# ---------------------------------------------------------------------------
+# Per-tool checks
+# ---------------------------------------------------------------------------
+
+
+def _doctor_deferral(tool_name: str) -> ToolCheck:
+    """Render the standard 'host-level — see /doctor' line for a
+    tool that's not on PATH. /describe doesn't duplicate /doctor's
+    install hints; one short pointer is enough."""
+    return ToolCheck(
+        name=tool_name,
+        status="unknown",
+        version=None,
+        detail="host check deferred",
+        hint="run `raptor doctor` to diagnose host setup",
+    )
+
+
+def _check_codeql(shape: TargetShape) -> Optional[ToolCheck]:
+    """Target-applicability for CodeQL: given that the binary
+    exists, will the target's detected build system actually
+    build under codeql's database step? Names the missing dep
+    and the install command up-front.
+
+    When the binary is absent we defer to /doctor (host-level)
+    rather than render install instructions here."""
+    if not shutil.which("codeql"):
+        return _doctor_deferral("CodeQL")
+    version = _bin_version("codeql")
+    # Build-deps check for the target's primary-language build.
+    missing_deps: List[str] = []
+    if shape.primary_language and shape.primary_language in shape.build_systems:
+        bs = shape.build_systems[shape.primary_language]
+        required = _BUILD_SYSTEM_DEPS.get(bs, [])
+        for dep in required:
+            if not shutil.which(dep):
+                missing_deps.append(dep)
+        if missing_deps:
+            hint = _format_build_deps_hint(missing_deps)
+            return ToolCheck(
+                name="CodeQL",
+                status="warn",
+                version=version,
+                detail=(
+                    f"DB build needs {', '.join(missing_deps)} for "
+                    f"{bs} build system"
+                ),
+                hint=hint,
+            )
+    return ToolCheck(
+        name="CodeQL",
+        status="ok",
+        version=version,
+        detail=(
+            f"build deps ok for {shape.build_systems.get(shape.primary_language or '', 'this target')}"
+        ),
+    )
+
+
+def _check_coccinelle(shape: TargetShape) -> Optional[ToolCheck]:
+    """Target-applicability for Coccinelle: will the shipped
+    rule pack actually fire? Cocci's rules are C-specific —
+    honest "will 0-fire on Python" warning beats silent
+    uselessness.
+
+    Binary absence defers to /doctor (host-level)."""
+    if not shutil.which("spatch"):
+        return _doctor_deferral("Coccinelle")
+    version = _bin_version("spatch")
+    # Cocci is C-only today. If primary language isn't C/C++,
+    # warn that it'll run but find nothing.
+    if shape.primary_language not in (None, "cpp"):
+        return ToolCheck(
+            name="Coccinelle",
+            status="warn",
+            version=version,
+            detail=(
+                f"rule pack is C-only — will run on "
+                f"{shape.primary_language} target but fire 0 rules"
+            ),
+            hint=None,
+        )
+    return ToolCheck(
+        name="Coccinelle",
+        status="ok",
+        version=version,
+        detail="C rule pack applicable to target",
+    )
+
+
+def _check_binary_oracle(shape: TargetShape) -> Optional[ToolCheck]:
+    """Binary-oracle reachability is opt-out on /agentic / /codeql.
+    Check whether the target has build artefacts in the
+    auto-detect dirs — if not, the oracle will be inactive
+    unless the operator builds first."""
+    # Native languages only — Python / JS / Go-build targets
+    # don't produce the ELF artefacts the oracle parses.
+    if shape.primary_language not in ("cpp", "rust", "go"):
+        return None
+    target = shape.target_path
+    common_build_dirs = (
+        "build", "target/release", "target/debug",
+        "bazel-bin", "cmake-build-debug", "cmake-build-release",
+    )
+    has_artefacts = any(
+        (target / d).exists() for d in common_build_dirs
+    )
+    if has_artefacts:
+        return ToolCheck(
+            name="Binary oracle",
+            status="ok",
+            version=None,
+            detail="build artefacts present in common locations",
+        )
+    return ToolCheck(
+        name="Binary oracle",
+        status="warn",
+        version=None,
+        detail="no build artefacts found — will activate after build",
+        hint=None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _bin_version(binary: str) -> Optional[str]:
+    """Best-effort ``--version`` extraction. Returns None on
+    binary missing / non-zero exit / parse failure — caller
+    renders without a version suffix."""
+    if not shutil.which(binary):
+        return None
+    import subprocess
+    for flag in ("--version", "-V", "version"):
+        try:
+            res = subprocess.run(
+                [binary, flag],
+                capture_output=True, text=True, timeout=5,
+            )
+            if res.returncode == 0 and res.stdout:
+                # First line; strip whitespace + leading tool name.
+                first = res.stdout.splitlines()[0].strip()
+                # Extract just the version token if the line is
+                # "tool-name X.Y.Z [other stuff]". Strip
+                # trailing punctuation so "2.23.8." (CodeQL's
+                # release-line shape) renders as "2.23.8".
+                parts = first.split()
+                for tok in parts:
+                    if tok and tok[0].isdigit():
+                        return tok.rstrip(".,;:")
+                return first[:60].rstrip(".,;:")
+        except (subprocess.TimeoutExpired, OSError):
+            continue
+    return None
+
+
+__all__ = ["ToolCheck", "check_tool_readiness"]

--- a/packages/static-analysis/scanner.py
+++ b/packages/static-analysis/scanner.py
@@ -201,43 +201,16 @@ _SEMGREP_LANG_ALIASES: Dict[str, set] = {
 }
 
 
-# Semgrep internal language id → operator-facing display name.
-# Used purely for rendered text — internal sets / counts continue
-# to use the canonical lowercased ids. Unmapped ids render as-is
-# (lowercased) so a missing entry doesn't break the line.
-_LANG_DISPLAY: Dict[str, str] = {
-    "c": "C",
-    "cpp": "C++",
-    "python": "Python",
-    "go": "Go",
-    "rust": "Rust",
-    "javascript": "JavaScript",
-    "typescript": "TypeScript",
-    "java": "Java",
-    "ruby": "Ruby",
-    "php": "PHP",
-    "kotlin": "Kotlin",
-    "swift": "Swift",
-    "scala": "Scala",
-    "csharp": "C#",
-    "solidity": "Solidity",
-    "bash": "Bash",
-    "yaml": "YAML",
-    "json": "JSON",
-    "html": "HTML",
-    "lua": "Lua",
-}
-
-
-def _display_lang(lang: str) -> str:
-    """Map a semgrep language id to its operator-facing display
-    name; pass through unchanged if no mapping exists."""
-    return _LANG_DISPLAY.get(lang, lang)
-
-
-def _display_langs(langs: List[str]) -> str:
-    """Operator-readable joined list, e.g. ``[c, cpp]`` → ``C, C++``."""
-    return ", ".join(_display_lang(lang) for lang in langs)
+# Operator-facing display names live in
+# ``core.inventory.languages`` so /prepare and any future
+# renderer share the single source of truth. Re-exported with
+# underscore prefix here for back-compat with internal callers
+# (e.g. tests) that imported from this module.
+from core.inventory.languages import (  # noqa: E402, F401
+    LANG_DISPLAY as _LANG_DISPLAY,        # tests reference via _scanner._LANG_DISPLAY
+    display_lang as _display_lang,        # tests reference via _scanner._display_lang
+    display_langs as _display_langs,      # used by call sites below
+)
 
 
 def _expand_language_aliases(langs: List[str]) -> set:
@@ -1825,7 +1798,7 @@ def main():
                 _tt_name = "unknown"
             _names = [n for n, _ in resolved_baseline]
             logger.info(
-                f"Semgrep baseline packs from target-type catalog "
+                f"Semgrep baseline packs for target type "
                 f"'{_tt_name}': {_names}"
             )
         # Per-pack language applicability (QoL #16a). Tells the

--- a/raptor.py
+++ b/raptor.py
@@ -154,19 +154,13 @@ def _rewrite_target_arg(args: list, old: str, new: str) -> list:
     return out
 
 
-_CACHE_NAME_ALLOWED = frozenset(
-    "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789._-")
-
-
-def _safe_cache_name(archive_name: str, sha: str) -> str:
-    """Content-cache dir name: ``<sanitised archive name>-<sha>`` — readable
-    *and* collision-free. The archive name is attacker-influenced, so it's
-    reduced to a safe charset, stripped of leading separators, and length-capped
-    before the sha (which alone guarantees uniqueness) is appended.
-    """
-    base = "".join(c if c in _CACHE_NAME_ALLOWED else "_" for c in archive_name)
-    base = base.strip("._-")[:64] or "archive"
-    return f"{base}-{sha}"
+# Cache-name helper lives in core.archive (shared with
+# packages/describe/cli.py — extracts opportunistically into
+# the same cache so /describe + /scan don't re-extract the
+# same archive). Re-exported here under the old private name
+# for backward compatibility with anything in this module that
+# still references _safe_cache_name.
+from core.archive import safe_cache_name as _safe_cache_name  # noqa: E402
 
 
 def _unpack_archive_target(target: str, args: list, out_dir: Path):
@@ -374,9 +368,22 @@ def _run_with_lifecycle(command: str, script_path: Path, args: list,
         try:
             from core.run.estimator import estimate_run, format_estimate
             _est = estimate_run(Path(target))
-            _est_line = format_estimate(_est)
-            if _est_line:
-                print(_est_line, flush=True)
+            # Richer start line: primary language + LOC + build
+            # system + target type + cost estimate, all in one
+            # line. Falls back to the bare estimate if /describe
+            # substrate is unavailable so the budget gate still
+            # surfaces.
+            try:
+                from packages.describe.start_line import format_start_line
+                _start_line = format_start_line(Path(target))
+            except Exception:  # noqa: BLE001
+                _start_line = None
+            if _start_line:
+                print(_start_line, flush=True)
+            else:
+                _est_line = format_estimate(_est)
+                if _est_line:
+                    print(_est_line, flush=True)
             if (
                 max_cost_usd is not None
                 and _est is not None
@@ -922,6 +929,48 @@ def mode_llm_analysis(args: list) -> int:
     return _run_script(llm_script, args)
 
 
+def mode_describe(args: list) -> int:
+    """``raptor describe --target <path>`` — show target analysis,
+    tool readiness, and recommended pipeline BEFORE running any
+    analysis. No LLM cost, no side effects beyond stdout.
+
+    Composes ``packages/describe`` substrates: target-shape
+    inference + tool readiness + catalog defaults + cost
+    estimate. JSON form via ``--json`` for CI / dashboards;
+    text form (default) for human reading. Archive targets
+    (.tar.gz / .zip / …) extracted on the fly via
+    ``core.archive`` and described.
+    """
+    import argparse as _ap
+    parser = _ap.ArgumentParser(
+        prog="raptor describe",
+        description=(
+            "Pre-flight inspection: target type, tool readiness, "
+            "recommended pipeline, and cost estimate. No LLM cost."
+        ),
+    )
+    parser.add_argument(
+        "--target", default=None, metavar="<path>",
+        help=(
+            "Path to the target codebase (directory OR archive: "
+            "tar.gz / zip / …). Optional — falls back to the "
+            "active project's target, then $RAPTOR_CALLER_DIR, "
+            "per CLAUDE.md DEFAULT TARGET DIRECTORY."
+        ),
+    )
+    parser.add_argument(
+        "--json", action="store_true",
+        help="Emit machine-readable JSON instead of the text block",
+    )
+    try:
+        parsed = parser.parse_args(args)
+    except SystemExit as e:
+        return int(e.code or 0)
+
+    from packages.describe.cli import describe_main
+    return describe_main(parsed.target, parsed.json)
+
+
 def mode_doctor(args: list) -> int:
     """Run the on-demand status report.
 
@@ -1164,6 +1213,7 @@ def main():
         'codeql': mode_codeql,
         'analyze': mode_llm_analysis,
         'doctor': mode_doctor,
+        'describe': mode_describe,
     }
     
     if mode not in mode_handlers:


### PR DESCRIPTION
Adds /describe — read-only target inspection (languages with file-share % + LOC, build system, catalog type, git provenance, license, dep counts, tool readiness, cost estimate) plus signal-based "Recommended next:" picks. Handles archive inputs via core.archive (cache-hit reuses /scan's content-addressed extraction). Adds a "Target: ..." start-line at /scan, /agentic, /codeql startup so operators see what RAPTOR detected before LLM cost incurs.

PM-aware install advice substrate: apt/dnf/yum/pacman/apk/zypper/brew with EUID==0 sudo suppression, per-tool advice registry covering distro PM, pipx (env-aware: VIRTUAL_ENV / CONDA_DEFAULT_ENV / uv / pipx-missing bootstrap chain), static-URL (codeql), Linux-only (rr), macOS runtime caveats (gdb codesigning, afl-fuzz Apple Silicon). Same substrate enriches /doctor's tool-missing warnings.

core.license overhaul:
* LICENSE-file indirection-follow (see X / see DIR/, bounded depth+refs, path-traversal + symlink defended)
* REUSE-compliant in-tree symlinks accepted (glib's COPYING → LICENSES/<spdx>.txt); out-of-tree refused
* Earliest-position fingerprint matching (Firefox's multi-license HTML now correctly classifies as MPL-2.0, not MIT)
* Version-aware GPL/LGPL/AGPL — pre-fix mapped everything to v3.0 categorically, mis-labelling every GPL-2.0 project
* BSD-2 vs BSD-3 discriminated by "Neither the name of" clause
* Pre-rename "Library GPL Version 2" → LGPL-2.0 support
* Filename patterns: LICENSE.* / COPYING.* (systemd, vte, etc.)
* Dual-license disclosure via additional_files render

Misc: operator-language for coccinelle's "affects" string; inventory/languages adds .mjs/.hh/.hxx/.kts; core.archive extracts safe_cache_name for shared use.