### PR TITLE
fix(sandbox): env-overridable default profile for rootless podman/distrobox

### DIFF
--- a/bin/raptor
+++ b/bin/raptor
@@ -170,6 +170,19 @@ export RAPTOR_DIR
 # and resolved RAPTOR_DIR; mark this invocation as trusted.
 export _RAPTOR_TRUSTED=1
 
+# Rootless podman / distrobox cannot engage mount-ns + Landlock, so the
+# default 'full' sandbox half-engages and the semgrep/codeql scanners emit
+# empty output. Inside the dedicated `raptor` distrobox, default the sandbox
+# profile to 'none' (the container itself is the isolation boundary). Only a
+# default — an explicit `export RAPTOR_SANDBOX=...` or `--sandbox <profile>`
+# still wins. Scoped via CONTAINER_ID so host / other distroboxes are
+# unaffected. RAPTOR_SANDBOX is allowlisted in core.config so it survives
+# into the scanner subprocess.
+if [ "${CONTAINER_ID:-}" = "raptor" ]; then
+    : "${RAPTOR_SANDBOX:=none}"
+    export RAPTOR_SANDBOX
+fi
+
 # Parse RAPTOR-specific args, collect Claude args
 STARTUP_ARGS=("--caller-dir" "$RAPTOR_CALLER_DIR")
 CLAUDE_ARGS=("-n" "RAPTOR")

--- a/core/config/__init__.py
+++ b/core/config/__init__.py
@@ -403,6 +403,20 @@ class RaptorConfig:
         #                    read as an enum (any other value → auto); no
         #                    injection surface.
         "RAPTOR_TARGET_KIND",
+        #   RAPTOR_SANDBOX   operator's default sandbox-profile override
+        #                    (full|debug|network-only|none), read by
+        #                    core/sandbox/profiles._resolve_default_profile().
+        #                    Must survive the subprocess boundary: the
+        #                    scanner runs as a __main__ subprocess with a
+        #                    get_safe_env() environment, and without this
+        #                    in the allowlist the child re-resolves
+        #                    DEFAULT_PROFILE to "full" — silently ignoring
+        #                    the operator's choice (e.g. "none" on rootless
+        #                    podman/distrobox where mount-ns + Landlock
+        #                    cannot engage). Read only as a PROFILES enum
+        #                    key (any other value → "full"); no injection
+        #                    surface, identical to passing --sandbox.
+        "RAPTOR_SANDBOX",
     })
 
     # Name prefixes — any variable whose name starts with one of these is

--- a/core/sandbox/context.py
+++ b/core/sandbox/context.py
@@ -683,6 +683,19 @@ def sandbox(block_network: bool = False, target: str = None, output: str = None,
         effectively_disabled = disabled or state._cli_sandbox_disabled
         if effectively_disabled:
             profile = "none"
+        elif profile is None and DEFAULT_PROFILE != "full":
+            # No explicit caller profile and no CLI --sandbox flag: when the
+            # operator has set a non-default DEFAULT_PROFILE (via
+            # RAPTOR_SANDBOX), honour it across ALL isolation layers, not
+            # just the seccomp default seeded at function top. Without this,
+            # `RAPTOR_SANDBOX=none` disabled seccomp but left Landlock +
+            # network-block engaged — which breaks the semgrep scanner on
+            # rootless podman / distrobox, where mount-ns + Landlock cannot
+            # operate and the half-engaged sandbox yields empty output.
+            # Scoped to `!= "full"` so the stock default path is byte-for-
+            # byte unchanged: only an explicit operator downgrade takes it.
+            profile = DEFAULT_PROFILE
+            effectively_disabled = (profile == "none")
     if profile is not None:
         if profile not in PROFILES:
             raise ValueError(

--- a/core/sandbox/profiles.py
+++ b/core/sandbox/profiles.py
@@ -12,6 +12,7 @@ a plain dict would let an external caller mutate `PROFILES["full"]
 sandbox() invocation in the process.
 """
 
+import os
 import types
 
 # Profile definitions
@@ -46,7 +47,24 @@ PROFILES = types.MappingProxyType({
     "network-only": types.MappingProxyType({"block_network": True,  "use_landlock": False, "seccomp": ""}),
     "none":         types.MappingProxyType({"block_network": False, "use_landlock": False, "seccomp": ""}),
 })
-DEFAULT_PROFILE = "full"
+def _resolve_default_profile() -> str:
+    """Default sandbox profile, overridable via ``RAPTOR_SANDBOX``.
+
+    Hardened default stays ``full`` (network blocked + Landlock +
+    seccomp). Environments where the kernel-isolation layers cannot
+    engage — notably **rootless podman / distrobox**, where mount-ns
+    spawn and Landlock are unavailable and the sandbox would otherwise
+    fall back to a half-broken path that yields empty scanner output —
+    can export ``RAPTOR_SANDBOX=none`` (or any valid profile name) to
+    set a coherent default without passing ``--sandbox`` on every call.
+    Unknown / empty values fall back to ``full`` so a typo never
+    silently downgrades isolation.
+    """
+    env = os.environ.get("RAPTOR_SANDBOX", "").strip().lower()
+    return env if env in PROFILES else "full"
+
+
+DEFAULT_PROFILE = _resolve_default_profile()
 
 
 # Kwargs that configure isolation. Callers must not pass these to


### PR DESCRIPTION
## Problem

On rootless podman / distrobox, the sandbox's kernel-isolation layers (mount-ns spawn, Landlock) cannot engage. With the default `full` profile, the sandbox half-engages and falls back to a broken path: `semgrep`/`codeql` produce **empty output**, and `raptor scan` silently reports **0 findings in 0 files** instead of failing loudly. The result looks like a clean scan when nothing actually ran.

There's no way to set a coherent default profile for such an environment short of passing `--sandbox none` on every single invocation.

## Fix

Make the default sandbox profile overridable via a `RAPTOR_SANDBOX` env var, so environments that can't run the kernel layers can opt into a coherent profile once:

- **`core/sandbox/profiles.py`** — `DEFAULT_PROFILE` is now resolved by `_resolve_default_profile()` from `RAPTOR_SANDBOX`. Unknown/empty values fall back to `"full"`, so a typo can never silently downgrade isolation.
- **`core/config/__init__.py`** — allowlist `RAPTOR_SANDBOX` in `SAFE_ENV_ALLOWLIST` so the operator's choice survives into the `scanner` `__main__` subprocess (otherwise the child re-resolves `DEFAULT_PROFILE` to `"full"` and the override is silently lost). Read only as a `PROFILES` enum key → no injection surface, identical in effect to passing `--sandbox`.
- **`core/sandbox/context.py`** — when no caller `profile=` and no CLI `--sandbox` flag, fall back to `DEFAULT_PROFILE` across **all** isolation layers, not just the seccomp default seeded at function top. Scoped to `DEFAULT_PROFILE != "full"` so the **stock hardened default path is byte-for-byte unchanged** — only an explicit operator downgrade takes the new branch.
- **`bin/raptor`** — inside a distrobox named `raptor` (guarded by `CONTAINER_ID`), default `RAPTOR_SANDBOX=none`, since the container is itself the isolation boundary. An explicit `RAPTOR_SANDBOX` / `--sandbox` still wins.

## Safety / scope

- Default behaviour with no env var set is unchanged: `DEFAULT_PROFILE == "full"`.
- Does **not** touch the deliberate `PYTHONUSERBASE` strip in `DANGEROUS_ENV_VARS`. A HOME-independent `semgrep` install (system / venv / pipx) remains required — a `pip --user` install breaks under the sandbox's `HOME` redirect regardless of this change.

## Testing

- `core/sandbox/tests/test_audit_cli_flags.py`, `test_context_backend_dispatch.py`, and `core/config/tests/test_config.py` all pass (35 + 39).
- Full run: **920 passed**, 25 skipped. The 55 failures are confined to `test_spawn_mount_ns.py`, `test_spawn_audit.py`, and `test_fingerprint_e2e.py` — they require mount-ns/Landlock/ptrace and fail identically on unmodified `main` in a rootless container (verified by checking out `main` and re-running). They are environmental, not introduced by this change. `test_tracer.py` fails to collect under Python 3.11 (3.12+ nested-quote f-string) — also pre-existing and unrelated.
- End-to-end: with `RAPTOR_SANDBOX=none`, `raptor scan` returns real findings again (was 0).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
