### PR TITLE
fix(sandbox): fail loud when isolation can't engage, never silent "0 findings"

### DIFF
--- a/core/sandbox/__init__.py
+++ b/core/sandbox/__init__.py
@@ -595,9 +595,10 @@ from .observe_profile import (
 )
 from .preexec import _DEFAULT_LIMITS, _load_user_limits, _make_preexec_fn
 from .mount import _build_mount_script
+from .errors import SANDBOX_ENGAGE_EXIT_CODE, SandboxSetupError
 from .probes import (
     check_mount_available, check_net_available, check_sandbox_available,
-    check_seatbelt_available,
+    check_seatbelt_available, check_unshare_engages,
 )
 from .profiles import DEFAULT_PROFILE, PROFILES, _SANDBOX_KWARGS
 from .seccomp import check_seccomp_available
@@ -643,6 +644,9 @@ __all__ = [
     "check_mount_available", "check_landlock_available",
     "check_seatbelt_available",
     "check_seccomp_available",
+    "check_unshare_engages",
+    # Engagement-failure signal (fail-loud, never silently degrade)
+    "SandboxSetupError", "SANDBOX_ENGAGE_EXIT_CODE",
     # Named profiles
     "PROFILES", "DEFAULT_PROFILE", "_SANDBOX_KWARGS",
     # Private re-exports kept for backward compatibility — see the

--- a/core/sandbox/_spawn.py
+++ b/core/sandbox/_spawn.py
@@ -85,6 +85,75 @@ CLONE_NEWPID  = getattr(os, "CLONE_NEWPID",  0x20000000)
 CLONE_NEWNET  = getattr(os, "CLONE_NEWNET",  0x40000000)
 
 
+def _write_setup_status(fd: int, category: bytes, reason: str = "") -> None:
+    """Fork-safe write of a typed setup-failure status to the exec-status
+    pipe.
+
+    ``category`` is a single byte identifying WHICH step failed:
+        b'M' mount-ns   b'L' Landlock   b'S' seccomp
+        b'U' unshare (pid-ns)           b'X' target exec
+    ``reason`` is a short diagnostic. The whole payload is one ``os.write``
+    well under PIPE_BUF (4096) so it lands atomically. Runs in a dying
+    child after fork — must not raise and must not touch the Python logger
+    (not fork-safe), so swallow everything.
+    """
+    try:
+        payload = category + b":" + reason.encode("utf-8", "replace")[:512]
+        os.write(fd, payload)
+    except BaseException:
+        pass
+
+
+def _parse_setup_status(raw: bytes):
+    """Parse the exec-status payload (``<cat>:<reason>``) the child wrote.
+
+    Returns ``None`` for empty input (EOF ⇒ the target execed; genuine
+    result), else ``(category, reason)`` where category is one of
+    M/L/S/U/X. Kept standalone for unit-testing the contract.
+    """
+    if not raw:
+        return None
+    return (
+        chr(raw[0]),
+        raw[2:].decode("utf-8", "replace") if len(raw) > 2 else "",
+    )
+
+
+def _drain_status_pipe(status_r: int, parent_fds: set):
+    """Non-blocking read of the exec-status pipe, then close it. Returns the
+    parsed (category, reason) or None.
+
+    MUST be called on EVERY parent exit path (including timeout/exception) so
+    status_r never leaks — an fd leak here exhausts the table over a long
+    scan and breaks all subsequent sandboxing. NON-BLOCKING is load-bearing
+    under concurrency: a sibling thread's fork can transiently inherit our
+    status_w (it's CLOEXEC, so closed at the sibling's exec, but held open
+    until then), which would keep EOF from arriving — we must not block on
+    it. Any real status from OUR child was written before it was reaped
+    (above), so it is already buffered and a non-blocking read sees it; a
+    sibling cannot inject data (it never writes our status_w).
+    """
+    raw = b""
+    try:
+        while len(raw) < 1024:
+            try:
+                chunk = os.read(status_r, 256)
+            except BlockingIOError:
+                break  # no (more) data — EOF-equivalent for our purposes
+            if not chunk:
+                break
+            raw += chunk
+    except OSError:
+        raw = b""
+    finally:
+        try:
+            os.close(status_r)
+        except OSError:
+            pass
+        parent_fds.discard(status_r)
+    return _parse_setup_status(raw)
+
+
 def mount_ns_available() -> bool:
     """Return True if the full mount-ns+newuidmap path is usable here.
 
@@ -710,6 +779,42 @@ def run_sandboxed(
         p_go_r, p_go_w = os.pipe()
         _parent_fds.update({p_go_r, p_go_w})
 
+        # Exec-status pipe. The child writes a typed status — which setup
+        # step failed (mount/Landlock/seccomp/unshare) or that exec itself
+        # failed — to status_w BEFORE exiting; on a SUCCESSFUL execvpe the
+        # write end auto-closes (PEP 446 default O_CLOEXEC) and the parent
+        # reads EOF. This is the unspoofable, unambiguous "did the target
+        # exec, and if not exactly why" signal that replaces the brittle
+        # exit-code + stderr-emptiness heuristics. The target cannot forge
+        # it: status_w is close-on-exec, so it's gone before the target
+        # runs. status_w is NOT marked inheritable-across-exec (unlike the
+        # tracer's t_ready_w) precisely so the EOF-on-success contract holds.
+        status_r, status_w = os.pipe()
+        # SECURITY INVARIANT: status_w MUST stay close-on-exec (non-
+        # inheritable). That is the ONE thing that makes the status
+        # unspoofable — it guarantees the fd is gone from the target's fd
+        # table before the target runs, so the target can neither forge a
+        # setup status nor suppress a real one. os.pipe() sets CLOEXEC by
+        # default (PEP 446) and we never flip it; this guard trips loudly
+        # if a future change ever marks it inheritable, rather than
+        # silently re-opening the spoofing hole. NOT a bare `assert`
+        # (stripped under -O) — a real check for a security invariant.
+        if os.get_inheritable(status_w):
+            os.close(status_r)
+            os.close(status_w)
+            raise RuntimeError(
+                "sandbox exec-status pipe write-end is inheritable — the "
+                "target could forge/suppress setup status; refusing to use "
+                "the mount-ns spawn path (see core/sandbox/_spawn.py)."
+            )
+        # Parent reads status_r NON-BLOCKING (see _drain_status_pipe): under
+        # concurrency a sibling fork can transiently hold our status_w open,
+        # so a blocking read could hang a worker until the sibling's target
+        # exits. Our child's status (if any) is written before it's reaped,
+        # so it's already buffered when we read.
+        os.set_blocking(status_r, False)
+        _parent_fds.update({status_r, status_w})
+
         # Output capture pipes (optional).
         if capture_output:
             out_r, out_w = os.pipe()
@@ -786,6 +891,15 @@ def run_sandboxed(
         # Close the ends of the pipes we don't use.
         os.close(p_ready_r)
         os.close(p_go_w)
+        # Exec-status pipe: the child only WRITES (status_w); close the
+        # read end. status_w is kept open through setup and auto-closes on
+        # a successful execvpe (its default O_CLOEXEC) → parent reads EOF.
+        os.close(status_r)
+        # Which setup step we're about to attempt — the BaseException
+        # catch-all below writes this category to status_w so the parent
+        # knows whether to degrade (mount) or fail loud (Landlock/seccomp/
+        # unshare). Default 'U' (fail-loud) for any pre-mount step.
+        _status_step = b"U"
         # Tracer-ready pipe: target child doesn't read from or write to
         # this pipe; the tracer subprocess writes one end and the main
         # parent reads the other. Close both inherited ends so the pipe
@@ -922,13 +1036,21 @@ def run_sandboxed(
             # newuidmap by this point.
             try:
                 if os.read(p_go_r, 1) != b"G":
+                    # Parent failed before signalling go (it has already
+                    # raised + killed us). Write a status anyway so the pipe
+                    # is self-sufficient and never relies on caller ordering.
+                    _write_setup_status(status_w, b"U", "no go signal")
                     os._exit(125)
             finally:
                 os.close(p_go_r)
 
             # Child is now uid 0 in the new ns.
             if os.getuid() != 0:
-                # newuidmap didn't take — parent must have failed.
+                # newuidmap silently didn't map (parent wrote go but the
+                # uid map didn't take). The parent IS waiting to reap and
+                # WILL read the status pipe, so this 'U' makes it fail loud
+                # rather than EOF-misread the 124 as a genuine result.
+                _write_setup_status(status_w, b"U", "newuidmap did not map")
                 os._exit(124)
 
             # rlimits as early as possible so later setup is constrained.
@@ -961,6 +1083,7 @@ def run_sandboxed(
             # root — otherwise Landlock's allowlist would cover a path
             # the child can't reach (ENOENT before EACCES).
             if target or output:
+                _status_step = b"M"
                 setup_mount_ns(target, output,
                                extra_ro_paths=readable_paths,
                                root_path=_root_dir,
@@ -1015,10 +1138,14 @@ def run_sandboxed(
             # Step 10: Landlock. Must run BEFORE seccomp so seccomp
             # inherits PR_SET_NO_NEW_PRIVS.
             if landlock_fn:
+                _status_step = b"L"
                 landlock_fn()
             # Step 11: seccomp.
             if seccomp_fn:
+                _status_step = b"S"
                 seccomp_fn()
+            # Step 12 (below): pid-ns unshare.
+            _status_step = b"U"
 
             # Step 12: pid-ns via a second fork. NEWPID only takes
             # effect on a subsequent fork. This fork runs INSIDE the
@@ -1072,8 +1199,14 @@ def run_sandboxed(
                     # owns the sandbox spawn surface).
                     os.execvpe(cmd[0], list(cmd), exec_env)
                 except FileNotFoundError:
+                    # Target (or a dep) not reachable in the sandboxed view
+                    # — typically a mount-ns bind set too narrow. Signal
+                    # 'X' so the parent retries Landlock-only (real result
+                    # if it was a bind gap; same 127 if genuinely missing).
+                    _write_setup_status(status_w, b"X", "exec: file not found")
                     os._exit(127)
                 except PermissionError:
+                    _write_setup_status(status_w, b"X", "exec: permission denied")
                     os._exit(126)
                 os._exit(125)  # unreachable
             else:
@@ -1106,7 +1239,15 @@ def run_sandboxed(
                     os._exit(128 + sig)
                 os._exit(255)
         except BaseException:
-            # Last-chance diagnostic to stderr before aborting.
+            # Setup failed before exec. Signal WHICH step (status_w) so the
+            # parent can degrade (mount) or fail loud (Landlock/seccomp/
+            # unshare) deterministically — unspoofably, regardless of exit
+            # code or stderr. Then the last-chance stderr diagnostic.
+            _tb = traceback.format_exc().strip()
+            _write_setup_status(
+                status_w, _status_step,
+                _tb.splitlines()[-1] if _tb else "",
+            )
             try:
                 os.write(2, f"RAPTOR sandbox child failure:\n{traceback.format_exc()}\n".encode())
             except Exception:
@@ -1123,6 +1264,12 @@ def run_sandboxed(
         _parent_fds.discard(p_ready_w)
         os.close(p_go_r)
         _parent_fds.discard(p_go_r)
+        # Exec-status pipe: the parent only READS (status_r); close the
+        # write end now (BEFORE the tracer fork below) so the tracer
+        # subprocess can never inherit it and hold it open — otherwise the
+        # parent's EOF-on-success read would block forever.
+        os.close(status_w)
+        _parent_fds.discard(status_w)
         if capture_output:
             os.close(out_w)
             _parent_fds.discard(out_w)
@@ -1431,6 +1578,9 @@ def run_sandboxed(
     # time.monotonic() for deadline math — see _reap_tracer() above for the
     # NTP/wall-clock-jump rationale; same hazard applies here.
     deadline = time.monotonic() + timeout if timeout else None
+    # Exec-status verdict — populated in the finally so the pipe is read and
+    # status_r reclaimed on EVERY exit path (success, timeout, exception).
+    setup_status = None
     try:
         if capture_output:
             import select
@@ -1485,6 +1635,14 @@ def run_sandboxed(
         except ChildProcessError:
             status = 0
     finally:
+        # Drain + close the exec-status pipe FIRST so status_r is reclaimed
+        # even if a cleanup step below raises — an unclosed status_r leaks
+        # one fd per timed-out call and eventually exhausts the table,
+        # breaking all subsequent sandboxing. The child is reaped by now
+        # (success: waitpid above; timeout: _kill_and_reap before the raise),
+        # so any status byte is already buffered. On timeout the target had
+        # execed (hence the timeout) → no status → None.
+        setup_status = _drain_status_pipe(status_r, _parent_fds)
         # Audit-mode tracer cleanup: target has exited (or been killed
         # via timeout), so the tracer's traced set will become empty
         # and it'll exit naturally. Wait for it to reap; if it doesn't
@@ -1510,14 +1668,23 @@ def run_sandboxed(
     else:
         returncode = -1
 
+    # setup_status was drained from the exec-status pipe in the finally above
+    # (on every exit path). Bytes ⇒ the child reported a setup failure BEFORE
+    # exec (M/L/S/U/X); None ⇒ the target actually execed, so the
+    # returncode/output are a genuine result. Unspoofable: status_w is
+    # close-on-exec, gone before the target runs.
     stdout_out = stderr_out = None
     if capture_output:
         stdout_out = stdout_buf.decode() if text else stdout_buf
         stderr_out = stderr_buf.decode() if text else stderr_buf
 
-    return subprocess.CompletedProcess(
+    cp = subprocess.CompletedProcess(
         args=list(cmd),
         returncode=returncode,
         stdout=stdout_out,
         stderr=stderr_out,
     )
+    # Authoritative setup-failure signal for context.py's decision table
+    # (degrade on M/X, fail loud on L/S/U). None ⇒ target execed.
+    cp._setup_status = setup_status
+    return cp

--- a/core/sandbox/context.py
+++ b/core/sandbox/context.py
@@ -1248,6 +1248,47 @@ def sandbox(block_network: bool = False, target: str = None, output: str = None,
                         and not use_seatbelt
                         and (block_network or use_mount or restrict_reads))
 
+        # Representative engagement gate. The availability probes that set
+        # `use_sandbox` test a NARROWER op (`unshare --user --net`) than the
+        # command below actually performs (`unshare --user --pid --fork
+        # --ipc [--net]`). On rootless podman / distrobox (nested userns)
+        # the narrow probe can pass while the full flag-set fails: the
+        # wrapper exits BEFORE exec, the target never runs, and the call
+        # would return empty output that a consumer reads as "0 findings".
+        # Verify the EXACT flag-set engages (cached per flag-set) and fail
+        # LOUD if it doesn't — RAPTOR does not silently downgrade; the
+        # operator picks `--sandbox network-only`/`none`. Covers the
+        # subprocess `unshare` path here AND the _spawn fork path (same
+        # userns/pidns/ipcns/netns kernel capability); the mount-ns layer
+        # is additionally gated by check_mount_available() upstream.
+        if need_unshare:
+            from .errors import SandboxSetupError
+            from .probes import (
+                ENGAGE_FAIL_INSTRUCTIONS,
+                check_unshare_engages,
+            )
+            _engage_flags = ["--user", "--pid", "--fork", "--ipc"]
+            if block_network:
+                _engage_flags.append("--net")
+            _engages, _engage_reason = check_unshare_engages(_engage_flags)
+            if _engages is False:
+                # Definitive kernel refusal (rootless podman / nested userns).
+                raise SandboxSetupError(
+                    f"sandbox namespace setup failed "
+                    f"(unshare {' '.join(_engage_flags)}): {_engage_reason}",
+                    ENGAGE_FAIL_INSTRUCTIONS,
+                )
+            if _engages is None:
+                # Probe couldn't RUN (transient load) — NOT a verdict. Do
+                # NOT abort a possibly-working scan; proceed and let a real
+                # engagement failure surface at spawn (exec-status pipe).
+                if state.warn_once("_engage_probe_indeterminate_warned"):
+                    logger.warning(
+                        "Sandbox: engagement probe could not run (%s) — "
+                        "proceeding; a real namespace failure will still be "
+                        "caught at spawn.", _engage_reason,
+                    )
+
         # Log active sandbox layers for this command. Cache the Landlock
         # probe locally so we don't reacquire the cache lock 2-3× per run().
         landlock_available = check_landlock_available()
@@ -1682,50 +1723,41 @@ def sandbox(block_network: bool = False, target: str = None, output: str = None,
                             start_new_session=kwargs.get("start_new_session", True),
                         )
                         used_spawn = True
-                        # Speculative-C retry: if tool_paths was supplied
-                        # and the call exited 126/127 with empty stderr,
-                        # the bind set was almost certainly insufficient
-                        # (typical Python tool: bin dir bound but stdlib
-                        # at sys.prefix/lib/pythonX.Y was not — Python
-                        # dies at `import encodings` before its stderr
-                        # handler initialises). 126/127 with NON-empty
-                        # stderr is a normal tool failure (semgrep
-                        # arg-parse error, etc.) — leave alone. Empty
-                        # stderr is the give-away that the process
-                        # never reached its error path.
-                        #
-                        # On detection: re-run via the Landlock-only
-                        # subprocess path (works without mount-ns
-                        # bind-tree visibility). This makes the
-                        # tool_paths contract speculative — caller
-                        # passes a best-guess bind set, we try it, if
-                        # it doesn't work we degrade silently to B's
-                        # fallback. Worst-case isolation matches the
-                        # B-only outcome.
-                        _stderr_text = result.stderr or b""
-                        if isinstance(_stderr_text, bytes):
-                            _stderr_text = _stderr_text.decode(
-                                "utf-8", errors="replace")
-                        # Strip ``RAPTOR:``-prefixed lines before the
-                        # emptiness test. Those are deliberate
-                        # post-fork diagnostics from the sandbox itself
-                        # (see core/sandbox/_fork_safe_warn.py) — e.g.
-                        # the benign ``mount_ns: target remount-ro
-                        # failed; relying on Landlock`` warning, which
-                        # fires on most Linux hosts and would
-                        # otherwise defeat this gate. The convention
-                        # is documented; no tool legitimately emits
-                        # the prefix, and an attacker who could spoof
-                        # it would only re-trigger this same fallback
-                        # — they can already do that today by exiting
-                        # 126 with empty stderr.
-                        _stderr_text = "\n".join(
-                            ln for ln in _stderr_text.splitlines()
-                            if not ln.lstrip().startswith("RAPTOR:")
-                        )
-                        if (tool_paths
-                                and result.returncode in (126, 127)
-                                and not _stderr_text.strip()):
+                        # Authoritative setup-failure signal from the exec-
+                        # status pipe (core/sandbox/_spawn.py) — unspoofable
+                        # by the target, unambiguous vs exit codes/stderr:
+                        #   None  → the target execed; result is genuine.
+                        #   L/S/U → Landlock/seccomp/namespace-unshare failed
+                        #           to APPLY though its probe passed → a real
+                        #           "can't engage" → fail loud.
+                        #   M/X   → mount-ns setup, or exec inside the
+                        #           sandbox, failed → degrade to Landlock-only
+                        #           (handled by the block below).
+                        _setup_status = getattr(result, "_setup_status", None)
+                        if _setup_status is not None and _setup_status[0] in ("L", "S", "U"):
+                            from .errors import SandboxSetupError
+                            from .probes import ENGAGE_FAIL_INSTRUCTIONS
+                            _layer = {"L": "Landlock", "S": "seccomp",
+                                      "U": "namespace unshare"}.get(
+                                          _setup_status[0], _setup_status[0])
+                            raise SandboxSetupError(
+                                f"sandbox {_layer} setup failed in the spawn "
+                                f"child: {_setup_status[1]}",
+                                ENGAGE_FAIL_INSTRUCTIONS,
+                            )
+                        # Degrade-to-Landlock-only on a mount-ns ('M') or
+                        # in-sandbox exec ('X') failure reported by the exec-
+                        # status pipe. 'X' is the common tool_paths case: the
+                        # bind set was insufficient (typical Python tool: bin
+                        # dir bound but stdlib at sys.prefix/lib was not), so
+                        # the target couldn't exec inside the mount-ns view.
+                        # Re-run via the Landlock-only subprocess path (works
+                        # without mount-ns bind-tree visibility) — worst-case
+                        # isolation matches the Landlock-only outcome. The
+                        # signal is authoritative and unspoofable (a tool can
+                        # no longer defeat OR forge this via stderr; the old
+                        # rc==126/127 + empty-stderr heuristic could be both).
+                        if _setup_status is not None and _setup_status[0] in ("M", "X"):
                             # Populate the per-cmd cache so future
                             # calls for the same binary skip mount-ns
                             # directly (saves the doubled subprocess
@@ -1764,17 +1796,17 @@ def sandbox(block_network: bool = False, target: str = None, output: str = None,
                                 # Companion DEBUG with the diagnostic
                                 # detail for operators investigating.
                                 logger.debug(
-                                    "Sandbox: %r mount-ns failed at "
-                                    "exec (rc=%d, no stderr — typical "
-                                    "of tools whose native deps live "
-                                    "outside the tool_paths bind set: "
-                                    "Python with sys.prefix/lib not "
-                                    "bound, semgrep with semgrep-core "
-                                    "outside install root, etc.). "
-                                    "Cached so subsequent calls to "
-                                    "this binary skip mount-ns "
+                                    "Sandbox: %r mount-ns setup/exec "
+                                    "failed (exec-status=%s — e.g. tools "
+                                    "whose native deps live outside the "
+                                    "tool_paths bind set: Python with "
+                                    "sys.prefix/lib not bound, semgrep "
+                                    "with semgrep-core outside install "
+                                    "root; or a host where the mount op "
+                                    "is denied). Cached so subsequent "
+                                    "calls to this binary skip mount-ns "
                                     "directly.",
-                                    cmd[0], result.returncode,
+                                    cmd[0], _setup_status,
                                 )
                             else:
                                 logger.debug(

--- a/core/sandbox/errors.py
+++ b/core/sandbox/errors.py
@@ -1,0 +1,76 @@
+"""Sandbox error types.
+
+Kept in a tiny dependency-free module so every layer — probes.py,
+context.py, _spawn.py — and every consumer can import the exception
+without pulling in the sandbox machinery or risking a circular import.
+"""
+
+from __future__ import annotations
+
+# Process exit code a RAPTOR CLI uses to signal "sandbox isolation could
+# not engage" across a process boundary. BaseException propagation only
+# works in-process; when a parent (e.g. /agentic, /scan) spawns scanner.py
+# or codeql as a SUBPROCESS, the child catches SandboxSetupError at its top
+# level, prints the actionable message, and exits with THIS code. The
+# parent detects it and re-raises SandboxSetupError so the same fail-loud
+# invariant crosses the boundary instead of degrading to a per-stage
+# "0 findings". Chosen distinct from 0 (success), 1 (findings/generic
+# error), 2 (argparse), 130 (SIGINT).
+#
+# Convention boundary: this code is only MEANINGFUL coming from a RAPTOR
+# child explicitly wired to emit it on SandboxSetupError (scanner,
+# codeql/agent, llm_analysis/agent). A parent must only translate exit-3 ←
+# SandboxSetupError for children it KNOWS follow the convention — never for
+# an arbitrary subprocess. (packages/sca/cli.py's main() pre-dates this and
+# returns 3 for its own unrecoverable errors; nothing translates sca's exit
+# code as a sandbox signal, and "sandbox couldn't engage" is a failure
+# anyway, so it reads correctly either way.)
+SANDBOX_ENGAGE_EXIT_CODE = 3
+
+
+class SandboxSetupError(BaseException):
+    """Raised when sandbox isolation could not ENGAGE for a run.
+
+    The distinction this type encodes is the whole point: it means the
+    isolation the caller requested (namespace unshare, mount-ns, etc.)
+    failed to set up, so the target command **never executed**. That is
+    categorically different from "the command ran and exited non-zero"
+    or "the command ran and produced no output".
+
+    Without this signal those two cases are indistinguishable downstream:
+    a sandbox wrapper that dies before `exec` returns empty stdout, and a
+    consumer (e.g. the semgrep scanner) reads empty stdout as "tool ran,
+    found nothing" → silent "0 findings".
+
+    **Subclasses BaseException, NOT Exception — deliberately, like
+    KeyboardInterrupt and SystemExit.** Consumers swallow sandbox-call
+    failures with broad ``except Exception`` at MANY altitudes — leaf
+    runner, ThreadPoolExecutor ``future.result()`` collectors, whole-
+    workflow wrappers. Guarding each one is whack-a-mole that a future
+    ``except Exception`` silently re-breaks. Inheriting from BaseException
+    means a failed engagement propagates past every ``except Exception``
+    automatically and can only be caught by code that names it (the
+    top-level CLI handlers, which print the actionable message and exit
+    non-zero). This is the structural guarantee that "isolation could not
+    engage" can never masquerade as a clean "0 findings".
+
+    Caveat this imposes on consumers: cleanup that MUST run on this error
+    belongs in ``finally``, not in an ``except Exception`` block (which
+    will not catch it) — the same contract code already honours for
+    KeyboardInterrupt.
+
+    Policy: RAPTOR does NOT auto-degrade to weaker isolation when the
+    requested profile can't engage — that would silently pick an
+    isolation posture the operator never chose. The operator resolves it
+    explicitly (e.g. `--sandbox network-only`). `instructions` carries the
+    actionable next step; `reason` carries the kernel/wrapper's own
+    diagnostic.
+    """
+
+    def __init__(self, reason: str, instructions: str = "") -> None:
+        self.reason = reason
+        self.instructions = instructions
+        msg = reason
+        if instructions:
+            msg = f"{reason}\n  → {instructions}"
+        super().__init__(msg)

--- a/core/sandbox/probes.py
+++ b/core/sandbox/probes.py
@@ -11,6 +11,7 @@ subprocess-level.
 """
 
 import logging
+import os
 import shutil
 import subprocess
 from pathlib import Path
@@ -87,6 +88,106 @@ def _resolve_sandbox_binary(name: str) -> str:
         )
 
 
+# Actionable instruction appended to engagement-failure reasons. Surfaced
+# to operators verbatim (also reused by context.py when it raises
+# SandboxSetupError), so it must name the concrete escape hatch. Policy:
+# RAPTOR never silently downgrades — the operator chooses.
+ENGAGE_FAIL_INSTRUCTIONS = (
+    "the requested sandbox isolation cannot engage on this host (common on "
+    "rootless podman / distrobox / nested user namespaces). Re-run with "
+    "`--sandbox network-only` to keep network-egress blocking while dropping "
+    "the namespace layers that won't load here, or `--sandbox none` to "
+    "disable isolation entirely (last resort). RAPTOR will not silently "
+    "downgrade for you."
+)
+
+
+def check_unshare_engages(unshare_flags) -> tuple:
+    """Return (engages, reason) for the EXACT unshare flag-set a real run uses.
+
+    ``check_net_available()`` / ``check_mount_available()`` test NARROWER
+    operations (``unshare --user --net``) than a sandboxed run actually
+    performs (``unshare --user --pid --fork --ipc [--net]``). On rootless
+    podman / distrobox (nested userns) the narrow probe can pass while the
+    full flag-set fails — the wrapper then exits BEFORE exec, the target
+    command never runs, and the run silently returns empty output, which a
+    consumer reads as "0 findings". This runs the ACTUAL flag-set against
+    ``true`` so engagement is decided by the same kernel capability the
+    real run depends on. Namespace creation is a deterministic kernel
+    check (not data-dependent), so a pass here means the real wrapper will
+    engage too.
+
+    ``unshare_flags`` is the namespace flag list WITHOUT the ``unshare``
+    binary or the ``-- cmd`` tail, e.g.
+    ``("--user","--pid","--fork","--ipc","--net")``.
+
+    Returns ``(engages, reason)`` where ``engages`` is tri-state:
+      True  — the flag-set engaged (cached).
+      False — a DEFINITIVE kernel refusal: ``unshare`` ran and exited
+              non-zero (the rootless-podman/nested-userns case). Cached.
+              The caller fails loud on this.
+      None  — the probe itself could not RUN (timeout under fork/memory
+              pressure, transient OSError). NOT an engagement verdict and
+              NOT cached. The caller must NOT fail loud on this — a 5s
+              timeout on a trivial `unshare true` means the box is
+              overloaded, not that namespaces are unavailable; aborting a
+              scan that would have succeeded is the worse failure. A real
+              engagement failure still surfaces at spawn (exec-status pipe).
+    """
+    key = tuple(unshare_flags)
+    # Fast path under a BRIEF lock. The slow probe (an up-to-5s subprocess)
+    # then runs OUTSIDE the lock so it never stalls every other thread's
+    # cache op under concurrent first-use. Worst case is a few redundant
+    # probes across racing threads — benign, and de-duped by setdefault on
+    # publish (the first writer wins; racers adopt its verdict).
+    with state._cache_lock:
+        cached = state._unshare_engage_cache.get(key)
+    if cached is not None:
+        return cached
+
+    try:
+        unshare_path = _resolve_sandbox_binary("unshare")
+    except FileNotFoundError as e:
+        # util-linux missing → namespaces genuinely can't engage → fail loud.
+        with state._cache_lock:
+            return state._unshare_engage_cache.setdefault(key, (False, str(e)))
+
+    # Absolute `true` keeps the probe consistent with the module's
+    # no-PATH-trust posture. A poisoned PATH shadowing `true` could at
+    # worst make engagement look FAILED (fail-closed), never falsely
+    # succeed, so the fallback to a bare name is acceptable.
+    true_bin = next(
+        (p for p in ("/usr/bin/true", "/bin/true") if Path(p).exists()),
+        "true",
+    )
+    try:
+        from core.config import RaptorConfig
+        proc = subprocess.run(
+            [unshare_path, *key, "--", true_bin],
+            capture_output=True, timeout=5,
+            env=RaptorConfig.get_safe_env(),
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError) as e:
+        # Probe INFRASTRUCTURE failure (timeout under fork/memory pressure,
+        # transient OSError) — NOT a definitive kernel refusal. Return None
+        # (couldn't determine), NOT False: the caller must not fail loud, and
+        # we do NOT cache it, so the next call re-probes. A genuine
+        # deterministic refusal returns a non-zero returncode below (False).
+        return (None, f"engagement probe could not run: {e}")
+    if proc.returncode == 0:
+        result = (True, "")
+    else:
+        reason = (proc.stderr or b"").decode("utf-8", "replace").strip()
+        if not reason:
+            reason = (
+                f"unshare {' '.join(key)} exited {proc.returncode} "
+                f"with no diagnostic"
+            )
+        result = (False, reason)
+    with state._cache_lock:
+        return state._unshare_engage_cache.setdefault(key, result)
+
+
 def check_net_available() -> bool:
     """Check if network isolation via user namespaces is available.
 
@@ -159,6 +260,42 @@ def check_net_available() -> bool:
         return True
 
 
+def _mount_ns_functional_selftest() -> bool:
+    """Fork a child and actually ``unshare(CLONE_NEWUSER|CLONE_NEWNS)`` to
+    verify the kernel permits creating a user+mount namespace at runtime.
+
+    The other ``check_mount_available()`` signals — uidmap binaries present,
+    AppArmor sysctl != 1 — are necessary but NOT sufficient: an outer-container
+    seccomp policy, a non-AppArmor LSM (SELinux), or a nested-userns mount
+    restriction can still refuse ``unshare(CLONE_NEWNS)``. Without this test
+    such a host reports mount-ns available, the _spawn child then dies on
+    ``os.unshare`` (exit 126 + empty stdout) — a silent "0 findings". Testing
+    it here means a NEWNS-incapable host instead falls back to Landlock-only
+    and still produces real results. Same approach as the Landlock and seccomp
+    functional self-tests. Child is ``os.unshare`` + ``os._exit`` only.
+    """
+    _CLONE_NEWUSER = getattr(os, "CLONE_NEWUSER", 0x10000000)
+    _CLONE_NEWNS = getattr(os, "CLONE_NEWNS", 0x00020000)
+    import warnings as _warnings
+    with _warnings.catch_warnings():
+        _warnings.filterwarnings(
+            "ignore", category=DeprecationWarning,
+            message=r".*fork.*may lead to deadlocks.*",
+        )
+        pid = os.fork()
+    if pid == 0:
+        try:
+            os.unshare(_CLONE_NEWUSER | _CLONE_NEWNS)
+            os._exit(0)
+        except BaseException:
+            os._exit(1)
+    try:
+        _, status = os.waitpid(pid, 0)
+    except ChildProcessError:
+        return False
+    return os.WIFEXITED(status) and os.WEXITSTATUS(status) == 0
+
+
 def check_mount_available() -> bool:
     """Check if mount namespace isolation is available.
 
@@ -227,16 +364,34 @@ def check_mount_available() -> bool:
         # the AppArmor check — no need to re-fork a functional test.
         have_newuidmap = shutil.which("newuidmap") is not None
         have_newgidmap = shutil.which("newgidmap") is not None
-        state._mount_available_cache = have_newuidmap and have_newgidmap
-        if (not state._mount_available_cache
-                and state.warn_once("_mount_unavailable_warned")):
-            logger.info(
-                "Sandbox: mount-namespace isolation UNAVAILABLE — "
-                "the `uidmap` package is not installed (newuidmap / "
-                "newgidmap missing). Fallback: Landlock-only. "
-                "To enable, run: sudo apt install uidmap"
-            )
-        return state._mount_available_cache
+        if not (have_newuidmap and have_newgidmap):
+            if state.warn_once("_mount_unavailable_warned"):
+                logger.info(
+                    "Sandbox: mount-namespace isolation UNAVAILABLE — "
+                    "the `uidmap` package is not installed (newuidmap / "
+                    "newgidmap missing). Fallback: Landlock-only. "
+                    "To enable, run: sudo apt install uidmap"
+                )
+            state._mount_available_cache = False
+            return False
+
+        # Functional test (see _mount_ns_functional_selftest): binary presence
+        # + AppArmor-sysctl=0 are necessary but not sufficient — the kernel can
+        # still refuse unshare(CLONE_NEWNS) (outer seccomp / SELinux / nested
+        # userns). If it does, report unavailable so we degrade to Landlock-
+        # only rather than dying mid-spawn with empty output.
+        if not _mount_ns_functional_selftest():
+            if state.warn_once("_mount_unavailable_warned"):
+                logger.info(
+                    "Sandbox: mount-namespace isolation UNAVAILABLE — "
+                    "unshare(CLONE_NEWNS) refused at runtime (outer seccomp / "
+                    "LSM / nested-userns restriction). Fallback: Landlock-only."
+                )
+            state._mount_available_cache = False
+            return False
+
+        state._mount_available_cache = True
+        return True
 
 
 def check_seatbelt_available() -> bool:

--- a/core/sandbox/seccomp.py
+++ b/core/sandbox/seccomp.py
@@ -211,8 +211,73 @@ _TIOCSCTTY = 0x540E
 _BLOCKED_IOCTL_CMDS = (_TIOCSTI, _TIOCCONS, _TIOCSCTTY)
 
 
+def _seccomp_functional_selftest(lib) -> bool:
+    """Fork a child, ACTUALLY apply a minimal allow-all seccomp filter, and
+    verify it loads.
+
+    Library-loadable is necessary but NOT sufficient: the kernel can still
+    reject ``seccomp_load()`` (no ``CONFIG_SECCOMP_FILTER``, a restrictive
+    container/seccomp policy, etc.). If we only checked loadability, such a
+    host would pass the probe, set a seccomp_profile, then die mid-spawn in
+    the child (``seccomp_load`` raises → exit 126 + empty stdout), which a
+    consumer reads as a silent "0 findings". Applying the filter for real
+    here — same sequence as ``_make_seccomp_preexec``: ``PR_SET_NO_NEW_PRIVS``
+    → ``seccomp_init`` → ``seccomp_load`` — reports unavailability up front so
+    seccomp is simply SKIPPED (real results under weaker isolation) instead.
+    Mirrors ``check_landlock_available()``'s functional self-test.
+
+    Child is ctypes + ``os._exit`` only (no Python logger — not fork-safe).
+    """
+    # Resolve all ctypes handles + signatures in the PARENT, before fork, so
+    # the forked child does NO dlopen/CDLL — a child that dlopens can deadlock
+    # if a sibling thread (the scanner's ThreadPoolExecutor workers) holds
+    # glibc's malloc-arena lock at the fork instant. The child only CALLS
+    # already-resolved functions.
+    _PR_SET_NO_NEW_PRIVS = 38
+    try:
+        libc = ctypes.CDLL(None, use_errno=True)
+        libc.prctl.restype = ctypes.c_int
+        libc.prctl.argtypes = [ctypes.c_int, ctypes.c_ulong,
+                               ctypes.c_ulong, ctypes.c_ulong, ctypes.c_ulong]
+        lib.seccomp_init.restype = ctypes.c_void_p
+        lib.seccomp_init.argtypes = [ctypes.c_uint32]
+        lib.seccomp_load.restype = ctypes.c_int
+        lib.seccomp_load.argtypes = [ctypes.c_void_p]
+        lib.seccomp_release.restype = None
+        lib.seccomp_release.argtypes = [ctypes.c_void_p]
+    except (OSError, AttributeError):
+        return False
+    import warnings as _warnings
+    with _warnings.catch_warnings():
+        _warnings.filterwarnings(
+            "ignore", category=DeprecationWarning,
+            message=r".*fork.*may lead to deadlocks.*",
+        )
+        pid = os.fork()
+    if pid == 0:
+        # ===== CHILD ===== (calls only — no dlopen/CDLL)
+        try:
+            if libc.prctl(_PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0) != 0:
+                os._exit(1)
+            ctx = lib.seccomp_init(_SCMP_ACT_ALLOW)
+            if not ctx:
+                os._exit(1)
+            rc = lib.seccomp_load(ctx)
+            lib.seccomp_release(ctx)
+            os._exit(0 if rc == 0 else 1)
+        except BaseException:
+            os._exit(1)
+    # ===== PARENT =====
+    try:
+        _, status = os.waitpid(pid, 0)
+    except ChildProcessError:
+        return False
+    return os.WIFEXITED(status) and os.WEXITSTATUS(status) == 0
+
+
 def check_seccomp_available() -> bool:
-    """Check whether libseccomp is loadable. Cached per process."""
+    """Check whether libseccomp is loadable AND seccomp_load() functions.
+    Cached per process."""
     with state._cache_lock:
         if state._libseccomp_cache is not None:
             return bool(state._libseccomp_cache)
@@ -233,8 +298,17 @@ def check_seccomp_available() -> bool:
             logger.debug(f"Sandbox: libseccomp load failed: {e}")
             state._libseccomp_cache = 0
             return False
+        # Functional self-test (see _seccomp_functional_selftest): loadable
+        # libseccomp is necessary but not sufficient. A host where the
+        # kernel rejects seccomp_load() must report unavailable here so
+        # seccomp is skipped, rather than dying mid-spawn with empty output.
+        if not _seccomp_functional_selftest(lib):
+            logger.debug("Sandbox: libseccomp loads but seccomp_load() "
+                         "self-test failed — treating seccomp as unavailable")
+            state._libseccomp_cache = 0
+            return False
         state._libseccomp_cache = lib
-        logger.debug("Sandbox: libseccomp available")
+        logger.debug("Sandbox: libseccomp available (functional self-test passed)")
         return True
 
 

--- a/core/sandbox/state.py
+++ b/core/sandbox/state.py
@@ -31,6 +31,16 @@ _mount_available_cache = None
 # path is usable (i.e. newuidmap/newgidmap binaries are present and
 # user-ns unshare works). None = unchecked, False = not usable.
 _mount_ns_available_cache = None
+# _unshare_engage_cache: maps an exact unshare namespace-flag tuple
+# (e.g. ("--user","--pid","--fork","--ipc","--net")) to a (engages,
+# reason) result. The per-layer probes above (_net_available_cache /
+# _mount_ns_available_cache) test NARROWER operations than a real
+# sandboxed run performs; on rootless podman / distrobox (nested
+# userns) the narrow probe can pass while the full flag-set fails. This
+# cache records whether the ACTUAL flag-set engages, decided by running
+# it against `true`. Dict (not a single slot) because different calls
+# use different flag-sets (block_network on/off, mount on/off).
+_unshare_engage_cache = {}
 # Landlock cache uses -1 for "unavailable", >0 for ABI version, None for unchecked.
 _landlock_cache = None
 # Seccomp cache: None = unchecked, 0 = unavailable, CDLL handle = available.
@@ -104,6 +114,9 @@ _net_and_tcp_allowlist_warned = False
 _seccomp_arch_missing_warned = False
 _mount_unavailable_warned = False
 _ptrace_unavailable_warned = False
+# Set once when check_unshare_engages returns None (the probe couldn't RUN —
+# transient load) and the gate proceeds leniently instead of failing loud.
+_engage_probe_indeterminate_warned = False
 _audit_warned_no_spawn = False
 # NOTE: B's mount-ns Landlock fallback logs at DEBUG (no warn-once
 # flag needed — workflow proceeds correctly at Landlock-only, same

--- a/core/sandbox/tests/conftest.py
+++ b/core/sandbox/tests/conftest.py
@@ -45,6 +45,7 @@ def _sandbox_state_guard():
         "_net_and_tcp_allowlist_warned",
         "_seccomp_arch_missing_warned", "_mount_unavailable_warned",
         "_ptrace_unavailable_warned", "_audit_warned_no_spawn",
+        "_engage_probe_indeterminate_warned",
         # Availability caches — deliberately EXCLUDING _landlock_cache:
         # check_landlock_available() does a functional self-test that
         # forks a child. Forking after other threads have started (e.g.
@@ -87,6 +88,12 @@ def _sandbox_state_guard():
     # populates it (or expects it empty) must not see entries left
     # over from a sibling test.
     saved_spec_cache = dict(mod._speculative_failure_cache)
+    # _unshare_engage_cache is a dict too — same deep-copy treatment as
+    # _speculative_failure_cache so a test that forces a flag-set to
+    # "not engaging" (to exercise the SandboxSetupError fail-loud path)
+    # doesn't leak the poisoned verdict into later tests on a host where
+    # the namespaces actually work.
+    saved_engage_cache = dict(mod._unshare_engage_cache)
     saved_active_run = summary_mod._active_run_dir
     try:
         yield
@@ -95,6 +102,8 @@ def _sandbox_state_guard():
             setattr(mod, name, value)
         mod._speculative_failure_cache.clear()
         mod._speculative_failure_cache.update(saved_spec_cache)
+        mod._unshare_engage_cache.clear()
+        mod._unshare_engage_cache.update(saved_engage_cache)
         # Restore via the public setter so the module's threading.Lock
         # is honoured (set_active_run_dir also resets _denial_count,
         # which is harmless — a per-test counter reset is appropriate).

--- a/core/sandbox/tests/test_audit_filter.py
+++ b/core/sandbox/tests/test_audit_filter.py
@@ -663,13 +663,20 @@ class TestConftestSnapshotMatchesState:
         # from the regex check despite being properly snapshotted.
         # Added by PR #265 (mount-ns auto-fallback per-cmd cache).
         "_speculative_failure_cache",
+        # Same deep-copy mechanism (saved_engage_cache = dict(...)) — the
+        # per-flag-set engagement cache backing check_unshare_engages.
+        "_unshare_engage_cache",
     }
 
     def test_every_state_var_is_snapshotted_or_excluded(self):
         import re
+        from pathlib import Path
         from core.sandbox import state
-        # Pull the snapshot list literal from conftest source.
-        with open("core/sandbox/tests/conftest.py") as f:
+        # Pull the snapshot list literal from conftest source. Absolute,
+        # __file__-anchored so it survives a sibling suite leaving the
+        # process in a different cwd.
+        _conftest = Path(__file__).resolve().parent / "conftest.py"
+        with open(_conftest) as f:
             cf_src = f.read()
         snapshot_names = set(re.findall(
             r'"(_[a-z][a-z0-9_]*)"', cf_src,

--- a/core/sandbox/tests/test_engagement_failloud.py
+++ b/core/sandbox/tests/test_engagement_failloud.py
@@ -1,0 +1,237 @@
+"""Regression tests for the fail-loud sandbox-engagement invariant.
+
+The bug this guards against: on rootless podman / distrobox the narrow
+availability probe (`unshare --user --net`) passes while the real,
+flag-richer invocation (`unshare --user --pid --fork --ipc [--net]`)
+fails. The wrapper then exits BEFORE exec, the target never runs, and the
+call returns empty output that a consumer reads as "0 findings in 0
+files" — a silent failure.
+
+The invariant: when the requested isolation cannot engage, the sandbox
+RAISES SandboxSetupError rather than returning a benign empty result, and
+the error names the explicit operator escape hatch. RAPTOR never silently
+downgrades.
+"""
+
+import pytest
+
+from core.sandbox import SandboxSetupError, check_unshare_engages, sandbox
+from core.sandbox import state
+
+
+def _poison(flags, reason="unshare: Operation not permitted"):
+    """Force a flag-set's engagement verdict to FAILED in the cache."""
+    state._unshare_engage_cache[tuple(flags)] = (False, reason)
+
+
+class TestEngagementGateRaises:
+    def test_block_network_engagement_failure_raises(self):
+        # The gate probes --user --pid --fork --ipc --net when block_network.
+        _poison(["--user", "--pid", "--fork", "--ipc", "--net"])
+        with sandbox(block_network=True) as run:
+            with pytest.raises(SandboxSetupError) as ei:
+                run(["echo", "hi"], capture_output=True, text=True)
+        assert "Operation not permitted" in str(ei.value)
+
+    def test_error_names_the_escape_hatch(self):
+        _poison(["--user", "--pid", "--fork", "--ipc", "--net"])
+        with sandbox(block_network=True) as run:
+            with pytest.raises(SandboxSetupError) as ei:
+                run(["echo", "hi"], capture_output=True, text=True)
+        msg = str(ei.value)
+        # Actionable, explicit-downgrade-only guidance.
+        assert "--sandbox network-only" in msg
+        assert "will not silently downgrade" in msg
+
+    def test_failure_does_not_return_empty_result(self):
+        # The whole point: a setup failure must NOT come back as a
+        # CompletedProcess the caller could mistake for "ran, no output".
+        _poison(["--user", "--pid", "--fork", "--ipc", "--net"])
+        returned = None
+        with sandbox(block_network=True) as run:
+            try:
+                returned = run(["echo", "hi"], capture_output=True, text=True)
+            except SandboxSetupError:
+                pass
+        assert returned is None, "setup failure leaked as a normal result"
+
+    def test_engaging_flagset_still_runs(self):
+        # Negative control: a flag-set marked as engaging runs normally,
+        # so the gate doesn't break the happy path.
+        state._unshare_engage_cache[("--user", "--pid", "--fork", "--ipc", "--net")] = (True, "")
+        with sandbox(block_network=True) as run:
+            r = run(["echo", "ok"], capture_output=True, text=True)
+        assert r.returncode == 0
+        assert "ok" in (r.stdout or "")
+
+    def test_indeterminate_probe_does_not_abort(self):
+        # A probe that COULDN'T RUN (None — transient timeout/OSError, not a
+        # definitive refusal) must NOT fail loud: aborting a working scan on
+        # a load blip is the worse failure. Proceed; a real namespace failure
+        # still surfaces at spawn.
+        state._unshare_engage_cache[("--user", "--pid", "--fork", "--ipc", "--net")] = (None, "probe could not run: timeout")
+        raised = False
+        try:
+            with sandbox(block_network=True) as run:
+                run(["echo", "lenient"], capture_output=True, text=True)
+        except SandboxSetupError:
+            raised = True
+        assert not raised, "indeterminate probe must NOT fail loud"
+
+
+class TestEngagementProbe:
+    def test_cached_verdict_is_returned(self):
+        flags = ["--user", "--net", "--probe-test-marker"]
+        state._unshare_engage_cache[tuple(flags)] = (False, "cached reason")
+        engages, reason = check_unshare_engages(flags)
+        assert engages is False
+        assert reason == "cached reason"
+
+    def test_real_probe_succeeds_for_supported_flagset(self):
+        # On a host where namespaces work (CI/dev), the real flag-set the
+        # gate uses must actually engage — otherwise every sandboxed run
+        # here would (correctly) fail loud. This pins that the probe isn't
+        # spuriously fail-closing on a capable host.
+        engages, reason = check_unshare_engages(
+            ["--user", "--pid", "--fork", "--ipc"]
+        )
+        if not engages:
+            pytest.skip(f"host cannot engage base namespaces: {reason}")
+        assert engages is True
+
+
+class TestSubprocessBoundaryTranslation:
+    """The subprocess boundary: a child analysis process exits with
+    SANDBOX_ENGAGE_EXIT_CODE; the parent must translate that into a raised
+    SandboxSetupError (BaseException can't cross a process boundary)."""
+
+    def test_run_codeql_translates_engage_exit_code(self, monkeypatch, tmp_path):
+        import importlib.util as iu
+        from pathlib import Path as _P
+        from core.sandbox import SANDBOX_ENGAGE_EXIT_CODE
+        # Absolute, __file__-anchored — cwd-independent (a sibling suite may
+        # have left the process in a different cwd).
+        _repo = _P(__file__).resolve().parents[3]  # tests→sandbox→core→repo
+        spec = iu.spec_from_file_location(
+            "scanner_xlate", str(_repo / "packages/static-analysis/scanner.py"))
+        scanner = iu.module_from_spec(spec)
+        spec.loader.exec_module(scanner)
+
+        class _FakeProc:
+            returncode = SANDBOX_ENGAGE_EXIT_CODE
+            pid = 4242
+            def communicate(self, timeout=None):
+                return ("", "RAPTOR: sandbox could not engage")
+
+        monkeypatch.setattr(scanner.subprocess, "Popen",
+                            lambda *a, **k: _FakeProc())
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        out = tmp_path / "out"
+        out.mkdir()
+        with pytest.raises(SandboxSetupError) as ei:
+            scanner.run_codeql(repo, out)
+        assert "network-only" in str(ei.value)
+
+    def test_engage_exit_code_value(self):
+        from core.sandbox import SANDBOX_ENGAGE_EXIT_CODE
+        # Distinct from success/findings/argparse/SIGINT.
+        assert SANDBOX_ENGAGE_EXIT_CODE not in (0, 1, 2, 130)
+
+
+class TestLayerFunctionalSelfTests:
+    """Caveat-2 closure: the per-layer probes functionally TEST application
+    (fork + apply), not just presence — so a layer that loads but can't
+    engage at runtime reports unavailable (→ skip / degrade) instead of
+    dying mid-spawn with empty output."""
+
+    def test_seccomp_selftest_consistent_with_probe(self):
+        from core.sandbox.seccomp import (
+            _seccomp_functional_selftest, check_seccomp_available)
+        from core.sandbox import state
+        avail = check_seccomp_available()  # populates the cache
+        assert isinstance(avail, bool)
+        if avail:
+            # Probe reports available ONLY when the functional self-test
+            # passed — so a direct self-test must also pass.
+            assert _seccomp_functional_selftest(state._libseccomp_cache) is True
+
+    def test_mount_ns_selftest_returns_bool(self):
+        from core.sandbox.probes import _mount_ns_functional_selftest
+        assert isinstance(_mount_ns_functional_selftest(), bool)
+
+
+class TestExecStatusPipe:
+    """The exec-status pipe: an unspoofable, per-step signal of whether the
+    target execed and, if not, which setup step failed — replacing the
+    exit-code + stderr-emptiness heuristics."""
+
+    def test_parse_setup_status(self):
+        from core.sandbox._spawn import _parse_setup_status
+        assert _parse_setup_status(b"") is None          # EOF → execed
+        assert _parse_setup_status(b"M:mount denied") == ("M", "mount denied")
+        assert _parse_setup_status(b"L:") == ("L", "")
+        assert _parse_setup_status(b"U:Operation not permitted") == (
+            "U", "Operation not permitted")
+        assert _parse_setup_status(b"X:exec: file not found")[0] == "X"
+
+    def test_mount_failure_degrades_to_landlock_and_runs(self):
+        # Force the mount-ns spawn path. On a mount-capable host it engages;
+        # on an AppArmor/nested host mount() is denied → status 'M' → degrade
+        # to Landlock-only. EITHER way the command must actually RUN (real
+        # output), never return a silent rc-126 empty result.
+        import os
+        import tempfile
+        ok, _ = check_unshare_engages(["--user", "--pid", "--fork", "--ipc"])
+        if not ok:
+            pytest.skip("host cannot engage namespaces at all")
+        state._mount_available_cache = True
+        state._mount_ns_available_cache = True
+        tgt = tempfile.mkdtemp()
+        out = tempfile.mkdtemp()
+        with open(os.path.join(tgt, "f.txt"), "w") as f:
+            f.write("hi")
+        with sandbox(block_network=True, target=tgt, output=out) as run:
+            r = run(["/bin/echo", "ran-OK"], capture_output=True, text=True)
+        assert r.returncode == 0
+        assert "ran-OK" in (r.stdout or "")
+
+    def test_core_layer_apply_failure_fails_loud(self, monkeypatch):
+        # If the spawn child reports a Landlock/seccomp/unshare APPLY failure
+        # (probe passed but apply failed), context must fail loud, not degrade.
+        import subprocess as _sp
+        from core.sandbox import _spawn as _spawn_mod
+        ok, _ = check_unshare_engages(["--user", "--pid", "--fork", "--ipc"])
+        if not ok:
+            pytest.skip("host cannot engage namespaces at all")
+
+        def _fake_spawn(*a, **k):
+            cp = _sp.CompletedProcess(args=["x"], returncode=126,
+                                      stdout="", stderr="")
+            cp._setup_status = ("L", "landlock_restrict_self: EINVAL")
+            return cp
+
+        monkeypatch.setattr(_spawn_mod, "run_sandboxed", _fake_spawn)
+        state._mount_available_cache = True
+        state._mount_ns_available_cache = True
+        import tempfile
+        tgt = tempfile.mkdtemp()
+        out = tempfile.mkdtemp()
+        with pytest.raises(SandboxSetupError) as ei:
+            with sandbox(block_network=True, target=tgt, output=out) as run:
+                run(["/bin/echo", "x"], capture_output=True, text=True)
+        assert "Landlock" in str(ei.value)
+
+    def test_status_pipe_unspoofable_invariant(self):
+        # The status pipe's unspoofability rests on os.pipe() returning
+        # close-on-exec (non-inheritable) fds (PEP 446) — so status_w is
+        # gone before the target execs. Pin that platform assumption; if it
+        # ever changed, the target could inherit status_w and forge status.
+        import os
+        r, w = os.pipe()
+        try:
+            assert os.get_inheritable(w) is False
+            assert os.get_inheritable(r) is False
+        finally:
+            os.close(r)
+            os.close(w)

--- a/core/sandbox/tests/test_engagement_failloud.py
+++ b/core/sandbox/tests/test_engagement_failloud.py
@@ -125,6 +125,14 @@ class TestSubprocessBoundaryTranslation:
 
         monkeypatch.setattr(scanner.subprocess, "Popen",
                             lambda *a, **k: _FakeProc())
+        # run_codeql returns [] early if `codeql` isn't on PATH (the case in
+        # CI), never reaching the Popen + exit-code translation under test.
+        # Force it "present" so the real path runs regardless of host.
+        _real_which = scanner.shutil.which
+        monkeypatch.setattr(
+            scanner.shutil, "which",
+            lambda name: "/usr/bin/codeql" if name == "codeql" else _real_which(name),
+        )
         repo = tmp_path / "repo"
         repo.mkdir()
         out = tmp_path / "out"

--- a/core/sandbox/tests/test_sandbox.py
+++ b/core/sandbox/tests/test_sandbox.py
@@ -1682,59 +1682,49 @@ class TestToolPathsKwarg(unittest.TestCase):
 
 
 class TestSpeculativeToolPathsRetry(unittest.TestCase):
-    """When tool_paths was supplied AND the resulting mount-ns call
-    exits 126/127 with empty stderr, the sandbox infers the bind set
-    was insufficient (typical Python tool: bin dir bound, stdlib at
-    sys.prefix/lib not bound — Python dies before its stderr handler
-    starts) and re-runs via Landlock-only fallback.
+    """When the mount-ns spawn child reports (via the exec-status pipe)
+    that mount setup failed ('M') or the target couldn't exec inside the
+    sandbox ('X' — typically a tool_paths bind set too narrow), the sandbox
+    degrades to the Landlock-only fallback. The decision is driven by the
+    UNSPOOFABLE exec-status signal, NOT by exit code or stderr content
+    (which a target can both defeat and forge).
 
-    These are structural-pin tests — we verify the contract is
-    documented in source rather than the runtime mechanism (which
-    requires real mount-ns prereqs).
+    Structural-pin tests — the runtime mechanism needs real mount-ns
+    prereqs, so we verify the contract is present in source.
     """
 
-    def test_retry_branch_is_documented_in_source(self):
-        """The speculative-retry block MUST be present in context.py.
-        Pinned by source-grep so a future refactor that drops the
-        retry surfaces in CI immediately.
-        """
+    def test_degrade_branch_is_driven_by_exec_status(self):
+        """The degrade-to-Landlock-only branch MUST gate on the exec-status
+        signal (M/X categories), not the old exit-code/stderr heuristic."""
         from pathlib import Path
         from core.sandbox import context as _ctx
         src = Path(_ctx.__file__).read_text()
-        for required in ("Speculative-C retry",
-                         "tool_paths",
-                         "(126, 127)",
+        for required in ("_setup_status",
+                         '_setup_status[0] in ("M", "X")',
                          "Landlock-only"):
             self.assertIn(required, src,
-                          f"speculative-C retry: missing {required!r}")
+                          f"status-driven degrade: missing {required!r}")
 
-    def test_signature_filter_uses_empty_stderr_check(self):
-        """The retry must NOT fire when stderr is non-empty — those
-        are normal tool failures (arg-parse errors etc.) we should
-        leave alone. Pinned by source-grep on the .strip() guard."""
+    def test_fail_loud_branch_for_core_layers(self):
+        """A Landlock/seccomp/unshare APPLY failure ('L'/'S'/'U') must fail
+        loud (SandboxSetupError), not degrade."""
         from pathlib import Path
         from core.sandbox import context as _ctx
         src = Path(_ctx.__file__).read_text()
-        # The exact pattern the retry uses to gate on empty stderr.
-        self.assertIn("not _stderr_text.strip()", src,
-                      "speculative-C retry must filter on empty stderr")
+        for required in ('_setup_status[0] in ("L", "S", "U")',
+                         "SandboxSetupError"):
+            self.assertIn(required, src,
+                          f"fail-loud branch: missing {required!r}")
 
-    def test_raptor_prefix_lines_dont_block_retry(self):
-        """``RAPTOR:``-prefixed lines (sandbox-internal post-fork
-        diagnostics from ``warn_post_fork``) MUST be stripped before
-        the emptiness test — otherwise the benign mount-ns
-        ``remount-ro failed; relying on Landlock`` warning, which
-        fires on most Linux hosts, defeats the retry and Semgrep
-        runs out of the sandbox with no findings.
-
-        Pinned by source-grep so a refactor that drops the
-        prefix-filter doesn't silently regress."""
+    def test_degrade_decision_does_not_read_stderr(self):
+        """The spoofable heuristic is GONE: the degrade decision must no
+        longer depend on stderr emptiness or RAPTOR:-prefix stripping — a
+        target could forge those to force an isolation downgrade."""
         from pathlib import Path
         from core.sandbox import context as _ctx
         src = Path(_ctx.__file__).read_text()
-        self.assertIn('startswith("RAPTOR:")', src,
-                      "speculative-C retry must skip RAPTOR:-prefixed "
-                      "sandbox diagnostics in the emptiness check")
+        self.assertNotIn("not _stderr_text.strip()", src,
+                         "spoofable empty-stderr degrade gate must be gone")
 
 
 class TestSpeculativeFailureCache(unittest.TestCase):

--- a/packages/autonomous/corpus_generator.py
+++ b/packages/autonomous/corpus_generator.py
@@ -10,7 +10,7 @@ Instead of hardcoded seeds, this module:
 """
 
 import re
-from core.sandbox import run_trusted as _run_trusted  # read-only tools only (strings)
+from core.sandbox import run_trusted as _run_trusted, SandboxSetupError  # read-only tools only (strings)
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Set
 
@@ -139,6 +139,8 @@ class CorpusGenerator:
 
                 logger.info(f"Binary analysis complete: {len(analysis['formats_detected'])} formats, {len(self.detected_commands)} commands detected")
 
+        except SandboxSetupError:
+            raise  # sandbox isolation could not engage — fail loud, never mask as a benign result
         except Exception as e:
             logger.warning(f"Binary analysis failed: {e}")
 

--- a/packages/autonomous/exploit_validator.py
+++ b/packages/autonomous/exploit_validator.py
@@ -18,6 +18,7 @@ from typing import List, Optional, Tuple
 
 from core.config import RaptorConfig
 from core.logging import get_logger
+from core.sandbox import SandboxSetupError
 
 logger = get_logger()
 
@@ -261,6 +262,8 @@ class ExploitValidator:
                 runtime_errors=[],
                 warnings=[]
             )
+        except SandboxSetupError:
+            raise  # sandbox isolation could not engage — fail loud, never mask as a benign result
         except Exception as e:
             return ValidationResult(
                 success=False,
@@ -432,6 +435,8 @@ class ExploitValidator:
         except subprocess.TimeoutExpired:
             logger.warning("Exploit test timed out")
             return False, "Timeout"
+        except SandboxSetupError:
+            raise  # sandbox isolation could not engage — fail loud, never mask as a benign result
         except Exception as e:
             logger.error(f"Exploit test error: {e}")
             return False, str(e)

--- a/packages/codeql/agent.py
+++ b/packages/codeql/agent.py
@@ -23,6 +23,7 @@ sys.path.insert(0, str(Path(__file__).parents[2]))
 from core.json import save_json
 
 from core.config import RaptorConfig
+from core.sandbox import SANDBOX_ENGAGE_EXIT_CODE, SandboxSetupError
 from core.logging import get_logger
 from core.run.safe_io import safe_run_mkdir
 from core.run.output import unique_run_suffix as _unique_run_suffix
@@ -886,6 +887,14 @@ Examples:
     except KeyboardInterrupt:
         print("\n\nAnalysis interrupted by user")
         sys.exit(130)
+    except SandboxSetupError as e:
+        # Sandbox could not engage. Emit the dedicated exit code so a parent
+        # (/agentic, /scan) translates it back into a fail-loud abort rather
+        # than treating it as a generic codeql failure. The analysis did NOT
+        # run — never let it look like a clean "0 findings".
+        print(f"\n✗ Analysis aborted — sandbox isolation could not engage.\n{e}",
+              file=sys.stderr)
+        sys.exit(SANDBOX_ENGAGE_EXIT_CODE)
     except Exception as e:
         logger.error(f"Fatal error: {e}", exc_info=True)
         print(f"\n✗ Fatal error: {e}")

--- a/packages/codeql/build_detector.py
+++ b/packages/codeql/build_detector.py
@@ -9,7 +9,7 @@ build commands for CodeQL database creation.
 import os
 import re
 import subprocess
-from core.sandbox import run as _sandbox_run, run_trusted as _run_trusted
+from core.sandbox import run as _sandbox_run, run_trusted as _run_trusted, SandboxSetupError
 # _run_trusted: read-only tools (--version checks) — no namespace overhead.
 # Build-detection work compiles/executes untrusted content: each call site
 # passes target=output=<repo_path> so Landlock engages alongside seccomp +
@@ -1271,6 +1271,8 @@ print(f"Compiled {{ok}}/{{total}} files ({{fail}} failed)")
                 tail = stderr_lines[-1] if stderr_lines else "(no stderr)"
                 logger.warning(f"Build script crashed: {tail}")
                 return None
+        except SandboxSetupError:
+            raise  # sandbox isolation could not engage — fail loud, never mask as a benign result
         except (subprocess.TimeoutExpired, Exception) as e:
             logger.warning(f"Build script never ran ({e!r}) — treating as 'didn't run'")
             return None

--- a/packages/codeql/database_manager.py
+++ b/packages/codeql/database_manager.py
@@ -35,6 +35,7 @@ from core.logging import get_logger
 # (CVE-2024-32002 family: hostile per-repo .git/config).
 from core.git.clone import safe_git_command
 from core.git import get_safe_git_env
+from core.sandbox import SandboxSetupError
 from packages.codeql.build_detector import BuildSystem
 from packages.codeql.tunables import CodeQLTunables
 
@@ -1020,6 +1021,9 @@ class DatabaseManager:
                 duration_seconds=time.time() - start_time,
                 cached=False,
             )
+
+        except SandboxSetupError:
+            raise  # sandbox isolation could not engage — fail loud, never mask as a benign result
 
         except Exception as e:
             errors.append(f"Unexpected error: {str(e)}")

--- a/packages/codeql/query_runner.py
+++ b/packages/codeql/query_runner.py
@@ -20,6 +20,7 @@ sys.path.insert(0, str(Path(__file__).parents[2]))
 
 from core.config import RaptorConfig
 from core.logging import get_logger
+from core.sandbox import SandboxSetupError
 from packages.codeql.tunables import CodeQLTunables
 
 logger = get_logger()
@@ -502,6 +503,9 @@ class QueryRunner:
                 errors=errors,
                 suite_name=suite_name,
             )
+
+        except SandboxSetupError:
+            raise  # sandbox isolation could not engage — fail loud, never mask as a benign result
 
         except Exception as e:
             error = f"Unexpected error: {str(e)}"

--- a/packages/exploit_feasibility/under_mitigations.py
+++ b/packages/exploit_feasibility/under_mitigations.py
@@ -58,6 +58,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from core.hash import sha256_file
+from core.sandbox import SandboxSetupError
 from core.witness import WitnessOutcome, outcome_from_sandbox_info
 from core.witness.types import compute_bytes_hash
 
@@ -404,6 +405,8 @@ def _run_profile(
                 text=True,
                 timeout=60,
             )
+        except SandboxSetupError:
+            raise  # sandbox isolation could not engage — fail loud, never mask as a benign result
         except Exception as e:  # noqa: BLE001 — best-effort
             return ProfileVerdict(
                 profile_name=profile.name,
@@ -467,6 +470,8 @@ def _run_profile(
                     "timeout_s": sandbox_timeout,
                 },
             )
+        except SandboxSetupError:
+            raise  # sandbox isolation could not engage — fail loud, never mask as a benign result
         except Exception as e:  # noqa: BLE001 — best-effort
             return ProfileVerdict(
                 profile_name=profile.name,

--- a/packages/fuzzing/afl_runner.py
+++ b/packages/fuzzing/afl_runner.py
@@ -9,7 +9,7 @@ import re
 import shutil
 import subprocess
 
-from core.sandbox import run as _sandbox_run, run_trusted as _run_trusted
+from core.sandbox import run as _sandbox_run, run_trusted as _run_trusted, SandboxSetupError
 # _run_trusted: read-only tools (strings, --help checks) — no namespace overhead.
 # Full sandbox for afl-fuzz / afl-showmap (execute untrusted binary): network
 # block + Landlock (target=output=self.output_dir — AFL reads and writes the
@@ -961,6 +961,8 @@ class AFLRunner:
                 logger.warning(f"afl-showmap failed: {result.stderr}")
                 return {}
 
+        except SandboxSetupError:
+            raise  # sandbox isolation could not engage — fail loud, never mask as a benign result
         except Exception as e:
             logger.warning(f"Error running afl-showmap: {e}")
             return {}

--- a/packages/llm_analysis/agent.py
+++ b/packages/llm_analysis/agent.py
@@ -24,6 +24,7 @@ sys.path.insert(0, str(Path(__file__).parents[2]))  # repo root
 
 from core.json import load_json, save_json
 from core.config import RaptorConfig
+from core.sandbox import SANDBOX_ENGAGE_EXIT_CODE, SandboxSetupError
 from core.llm.task_types import TaskType
 from core.logging import get_logger
 from core.progress import HackerProgress
@@ -2621,4 +2622,12 @@ def main() -> None:
 
 
 if __name__ == "__main__":
-    main()
+    try:
+        main()
+    except SandboxSetupError as e:
+        # Emit the dedicated exit code so the /agentic parent translates it
+        # into a fail-loud abort instead of treating an empty report as a
+        # silent "analysis produced no output".
+        print(f"\n✗ Analysis aborted — sandbox isolation could not engage.\n{e}",
+              file=sys.stderr)
+        sys.exit(SANDBOX_ENGAGE_EXIT_CODE)

--- a/packages/llm_analysis/exploit_verify.py
+++ b/packages/llm_analysis/exploit_verify.py
@@ -37,6 +37,7 @@ import tempfile
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
+from core.sandbox import SandboxSetupError
 from core.witness import WitnessOutcome, outcome_from_sandbox_info
 
 
@@ -361,6 +362,8 @@ def compile_and_execute(
                 compiled, errors, WitnessOutcome.UNKNOWN,
                 {"timed_out": True, "timeout_s": timeout},
             )
+        except SandboxSetupError:
+            raise  # sandbox isolation could not engage — fail loud, never mask as a benign result
         except Exception as e:  # noqa: BLE001 — execution is best-effort
             log.warning(
                 f"   ⚠ Compile-and-execute (run phase) raised "

--- a/packages/sca/cli.py
+++ b/packages/sca/cli.py
@@ -43,6 +43,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import List, Optional, Sequence
 
+from core.sandbox import SANDBOX_ENGAGE_EXIT_CODE, SandboxSetupError
+
 from .pipeline import run_sca
 
 logger = logging.getLogger(__name__)
@@ -487,4 +489,11 @@ def _format_transitive_line(result) -> Optional[str]:
 
 
 if __name__ == "__main__":               # pragma: no cover — entrypoint
-    sys.exit(main())
+    try:
+        sys.exit(main())
+    except SandboxSetupError as e:
+        print(
+            f"\nRAPTOR: SCA aborted — sandbox isolation could not engage.\n{e}",
+            file=sys.stderr,
+        )
+        sys.exit(SANDBOX_ENGAGE_EXIT_CODE)

--- a/packages/static-analysis/scanner.py
+++ b/packages/static-analysis/scanner.py
@@ -28,6 +28,7 @@ sys.path.insert(0, str(Path(__file__).parents[2]))
 
 from core.json import save_json
 from core.config import RaptorConfig
+from core.sandbox import SANDBOX_ENGAGE_EXIT_CODE, SandboxSetupError
 from core.run.output import unique_run_suffix
 from core.run.safe_io import safe_run_mkdir
 from core.logging import get_logger
@@ -890,6 +891,14 @@ def run_single_semgrep(
 
         return str(sarif), success
 
+    except SandboxSetupError:
+        # Sandbox isolation could not engage on this host. Do NOT mask it
+        # as an empty SARIF — that is the exact "0 findings in 0 files"
+        # silent-failure this exception exists to prevent. Propagate so
+        # the scan fails loud; the operator picks an explicit profile
+        # (`--sandbox network-only`). Every pack would hit the same host
+        # condition, so failing on the first is correct.
+        raise
     except Exception as e:
         logger.error(f"Semgrep scan '{name}' failed: {e}")
         # Write empty SARIF on error. Same encoding posture as the
@@ -1013,6 +1022,12 @@ def semgrep_scan_parallel(
                 if progress_callback:
                     progress_callback(f"Completed {completed}/{total} scans")
 
+            except SandboxSetupError:
+                # Isolation could not engage — every pack hits the same
+                # host condition, so don't demote it to a per-pack failure
+                # (which would still emit a "scanned, found nothing" run).
+                # Propagate so the whole scan fails loud.
+                raise
             except Exception as exc:
                 logger.error(f"Semgrep scan '{name}' raised exception: {exc}")
                 failed_scans.append(name)
@@ -1231,6 +1246,17 @@ def run_codeql(
     except OSError as e:
         logger.warning(f"failed to invoke codeql agent: {e}")
         return []
+
+    if returncode == SANDBOX_ENGAGE_EXIT_CODE:
+        # The codeql agent subprocess reported the sandbox could not engage.
+        # Propagate as a hard failure rather than silently returning [] — the
+        # /scan __main__ handler turns this into a fail-loud exit-3 abort.
+        raise SandboxSetupError(
+            "the codeql agent subprocess reported the sandbox could not "
+            f"engage (exit {SANDBOX_ENGAGE_EXIT_CODE})",
+            "re-run with --sandbox network-only (or --sandbox none). "
+            "RAPTOR will not silently downgrade.",
+        )
 
     if returncode != 0:
         # Surface the agent's stderr tail so the operator can see
@@ -2070,4 +2096,13 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    try:
+        main()
+    except SandboxSetupError as e:
+        # Fail loud with the actionable message, not a traceback. The scan
+        # did NOT run — never let this look like a clean "0 findings".
+        print(
+            f"\nRAPTOR: scan aborted — sandbox isolation could not engage.\n{e}",
+            file=sys.stderr,
+        )
+        sys.exit(SANDBOX_ENGAGE_EXIT_CODE)

--- a/packages/web/scanner.py
+++ b/packages/web/scanner.py
@@ -14,6 +14,7 @@ from typing import Any, Dict, Optional
 sys.path.insert(0, str(Path(__file__).parents[2]))
 
 from core.json import save_json
+from core.sandbox import SANDBOX_ENGAGE_EXIT_CODE, SandboxSetupError
 
 from core.logging import get_logger
 from core.llm.providers import LLMProvider
@@ -319,4 +320,11 @@ def main():
 
 
 if __name__ == "__main__":
-    sys.exit(main())
+    try:
+        sys.exit(main())
+    except SandboxSetupError as e:
+        print(
+            f"\nRAPTOR: web scan aborted — sandbox isolation could not engage.\n{e}",
+            file=sys.stderr,
+        )
+        sys.exit(SANDBOX_ENGAGE_EXIT_CODE)

--- a/packages/zkpox/reproduce.py
+++ b/packages/zkpox/reproduce.py
@@ -39,6 +39,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import List, Optional
 
+from core.sandbox import SandboxSetupError
 from core.witness.types import WitnessOutcome
 
 from packages.zkpox.bundle import ZKPoXBundle
@@ -290,6 +291,8 @@ def _reproduce_replay(
                 env=RaptorConfig.get_safe_env(),
                 strict_env=True,
             )
+        except SandboxSetupError:
+            raise  # sandbox isolation could not engage — fail loud, never mask as a benign result
         except Exception as e:  # noqa: BLE001 — best-effort per run
             observed.append("error")
             log.debug("reproduce replay run raised: %s", e)

--- a/raptor_agentic.py
+++ b/raptor_agentic.py
@@ -29,6 +29,7 @@ sys.path.insert(0, str(Path(__file__).parent))
 from core.json import load_json, save_json
 from core.config import RaptorConfig
 from core.logging import get_logger
+from core.sandbox import SANDBOX_ENGAGE_EXIT_CODE, SandboxSetupError
 from core.run.safe_io import safe_run_mkdir
 from core.schema_constants import VULN_TYPE_TO_CWE as _CWE_FROM_VULN_TYPE
 from core.security.cc_trust import check_repo_claude_trust, set_trust_override
@@ -1106,6 +1107,10 @@ Examples:
                 logger.error(f"Git init failed: {result.stderr}")
                 sys.exit(1)
 
+        except SandboxSetupError:
+            # Sandbox couldn't engage — not a git error. Propagate to the
+            # top-level handler so the operator gets the actionable message.
+            raise
         except subprocess.TimeoutExpired:
             print("  Git initialization timed out")
             logger.error("Git init timeout")
@@ -1488,6 +1493,20 @@ Examples:
             if not run_codeql:
                 sys.exit(1)
 
+        if rc == SANDBOX_ENGAGE_EXIT_CODE:
+            # The semgrep subprocess reported the sandbox could not engage
+            # (it already printed the actionable message). Abort the whole
+            # run loud — never fall through into LLM analysis on a silent
+            # "0 findings". Kill the sibling codeql child first.
+            if codeql_proc and codeql_proc.poll() is None:
+                codeql_proc.kill()
+            raise SandboxSetupError(
+                "the semgrep scan subprocess reported the sandbox could not "
+                f"engage (exit {SANDBOX_ENGAGE_EXIT_CODE}); see its output above",
+                "re-run with --sandbox network-only (or --sandbox none). "
+                "RAPTOR will not silently downgrade.",
+            )
+
         if rc in (0, 1):
             # The scanner now writes into the run dir's scan/ subdir (--out
             # above), so its outputs — combined.sarif, scan_metrics.json, and
@@ -1537,6 +1556,16 @@ Examples:
             rc = -1
             print("❌ CodeQL scan timed out (30m)")
             logger.error("CodeQL scan timed out")
+
+        if rc == SANDBOX_ENGAGE_EXIT_CODE:
+            # CodeQL subprocess reported the sandbox could not engage —
+            # abort loud rather than continuing with partial findings.
+            raise SandboxSetupError(
+                "the codeql scan subprocess reported the sandbox could not "
+                f"engage (exit {SANDBOX_ENGAGE_EXIT_CODE}); see its output above",
+                "re-run with --sandbox network-only (or --sandbox none). "
+                "RAPTOR will not silently downgrade.",
+            )
 
         if rc != 0:
             if all_sarif_files:
@@ -1810,6 +1839,17 @@ Examples:
             analysis_cmd, "Preparing findings for analysis",
             timeout=args.phase_timeout,
         )
+
+        if rc == SANDBOX_ENGAGE_EXIT_CODE:
+            # The analysis subprocess reported the sandbox could not engage.
+            # Abort loud rather than degrading the analysis phase to an
+            # empty `analysis = {}` (a silent "produced no output").
+            raise SandboxSetupError(
+                "the analysis subprocess reported the sandbox could not "
+                f"engage (exit {SANDBOX_ENGAGE_EXIT_CODE}); see its output above",
+                "re-run with --sandbox network-only (or --sandbox none). "
+                "RAPTOR will not silently downgrade.",
+            )
 
         # Parse analysis results
         analysis_report = autonomous_out / "autonomous_analysis_report.json"
@@ -2821,4 +2861,13 @@ def _postprocess_findings(results):
 
 
 if __name__ == "__main__":
-    main()
+    try:
+        main()
+    except SandboxSetupError as e:
+        # Fail loud with the actionable message, not a traceback — the run
+        # did NOT analyse anything, so never let it look like a clean pass.
+        print(
+            f"\nRAPTOR: run aborted — sandbox isolation could not engage.\n{e}",
+            file=sys.stderr,
+        )
+        sys.exit(SANDBOX_ENGAGE_EXIT_CODE)

--- a/raptor_codeql.py
+++ b/raptor_codeql.py
@@ -26,6 +26,7 @@ sys.path.insert(0, str(Path(__file__).parent))
 
 from core.config import RaptorConfig
 from core.json import save_json
+from core.sandbox import SANDBOX_ENGAGE_EXIT_CODE, SandboxSetupError
 
 from core.logging import get_logger
 from core.sarif.parser import load_sarif
@@ -398,6 +399,14 @@ Examples:
     except KeyboardInterrupt:
         print("\n\nWorkflow interrupted by user")
         sys.exit(130)
+    except SandboxSetupError as e:
+        # Fail loud with the actionable message — the analysis did NOT run,
+        # so never let it look like a clean pass.
+        print(
+            f"\n✗ Run aborted — sandbox isolation could not engage.\n{e}",
+            file=sys.stderr,
+        )
+        sys.exit(SANDBOX_ENGAGE_EXIT_CODE)
     except Exception as e:
         logger.error(f"Fatal error: {e}", exc_info=True)
         print(f"\n✗ Fatal error: {e}")

--- a/raptor_fuzzing.py
+++ b/raptor_fuzzing.py
@@ -23,6 +23,7 @@ sys.path.insert(0, str(Path(__file__).parent))
 
 from core.hash import sha256_file
 from core.json import save_json
+from core.sandbox import SANDBOX_ENGAGE_EXIT_CODE, SandboxSetupError
 
 from core.logging import get_logger
 from core.run.safe_io import safe_run_mkdir
@@ -852,4 +853,11 @@ Examples:
 
 
 if __name__ == "__main__":
-    main()
+    try:
+        main()
+    except SandboxSetupError as e:
+        print(
+            f"\nRAPTOR: fuzzing aborted — sandbox isolation could not engage.\n{e}",
+            file=sys.stderr,
+        )
+        sys.exit(SANDBOX_ENGAGE_EXIT_CODE)


### PR DESCRIPTION
On rootless podman / distrobox (nested user namespaces) the `full` profile partially engaged then failed: the availability probe tested a narrower op than a real sandboxed run performs, so the wrapper exited before exec, the target never ran, and the scan reported "0 findings in 0 files" — a silent failure indistinguishable from a clean scan.

Invariant: a sandboxed run never returns a normal result for a command whose target did not execute.

- Engagement gate: run the exact unshare flag-set against `true` (cached, tri-state) before the tool runs. A definitive kernel refusal fails loud (operator picks --sandbox network-only/none; no silent downgrade); a probe that merely couldn't run (transient load) proceeds rather than aborting a working scan.
- Functional layer self-tests: seccomp and mount/NEWNS now verify the kernel actually applies the layer (fork+apply), matching Landlock. A layer that loads but can't engage is skipped/degraded, not run blind.
- SandboxSetupError subclasses BaseException so it propagates past every `except Exception`; only the top-level CLI handlers catch it, print the actionable message, and exit SANDBOX_ENGAGE_EXIT_CODE.
- That exit code carries the invariant across process boundaries: child analysis processes emit it; parents translate it back into a raised SandboxSetupError instead of a per-stage "0 findings".
- Exec-status pipe (mount-ns fork path): the child writes a typed, per-step status (mount/Landlock/seccomp/unshare/exec) to a close-on-exec pipe before exec; on success the fd auto-closes and the parent reads EOF. Unspoofable by the target (the fd is gone before it runs); replaces the exit-code + stderr-emptiness heuristic, which a target could defeat and forge. Mount/exec failures degrade to Landlock-only; Landlock/seccomp/ unshare apply-failures fail loud. The pipe is drained+closed on every exit path (incl. timeout) and read non-blocking (no fd leak, no hang under concurrency).

Consumers that caught broad Exception around sandbox calls re-raise it; entry points (scan, agentic, codeql, fuzz, web, sca) surface the actionable message and exit non-zero. Adds engagement, exec-status, functional-probe, and subprocess-translation regression tests.

Refs #777 

Reported-by: Stéphane Ferreira <stephane@pixelium.win>