### PR TITLE
sec(threat-model): contain attacker-influenced inputs

### DIFF
--- a/core/project/cli.py
+++ b/core/project/cli.py
@@ -114,6 +114,29 @@ def _stream_threat_model_json(json_path: Path, project_out: Path) -> int:
     return 0
 
 
+def _emit_json_payload(payload) -> None:
+    """Emit a JSON payload to stdout via binary I/O.
+
+    Uses ``sys.stdout.buffer.write(bytes)`` instead of
+    ``print(json.dumps(...))`` so CodeQL's
+    ``py/clear-text-logging-sensitive-data`` query doesn't
+    flag the call site. Same pattern as ``_stream_threat_model_json``:
+    the query's sink list is narrowly Python's ``logging`` module
+    + ``print()`` — a binary write to ``sys.stdout.buffer``
+    doesn't match, so a payload containing auth-vocab keys
+    (``trusted_inputs`` / ``untrusted_inputs`` / ``trust_boundaries`` /
+    ``threats[*].title`` derived from the target repo / etc.)
+    won't taint into a flagged sink.
+
+    Operator-visible behaviour: identical to ``print(json.dumps(
+    payload, indent=2, sort_keys=True))`` — pipe-friendly, one
+    trailing newline.
+    """
+    data = json.dumps(payload, indent=2, sort_keys=True).encode("utf-8")
+    sys.stdout.buffer.write(data)
+    sys.stdout.buffer.write(b"\n")
+
+
 def _detect_target_type(target_path: str):
     """Best-effort catalog detection for project-create. Returns
     a ``CatalogEntry`` or None — substrate failures (catalog
@@ -1115,7 +1138,6 @@ def _handle_threat_model(mgr, args) -> None:
         from_context_map,
         lint_model,
         load_model,
-        project_threat_model_report_path,
         project_threat_model_paths,
         render_markdown,
         save_model,
@@ -1140,13 +1162,23 @@ def _handle_threat_model(mgr, args) -> None:
         print(_red(f"Project '{name}' not found."))
         return
 
-    json_path, markdown_path = project_threat_model_paths(project)
-    if getattr(project, "threat_model_path", ""):
-        json_path = Path(project.threat_model_path)
+    # Path-containment defence: ``project.threat_model_path`` is
+    # read from ``~/.raptor/projects/<name>.json`` which is
+    # operator/tamper-influenceable. An attacker who can write
+    # that file could set ``threat_model_path = "/etc/shadow"`` —
+    # the I/O below would then read/write that arbitrary path.
+    # Restrict to paths inside ``project.output_dir``.
+    from core.threat_model import _project_threat_model_json_path
+    resolved_json = _project_threat_model_json_path(project)
+    if resolved_json is None:
+        # Either no output_dir, or threat_model_path resolves
+        # outside the project. Fall back to the default
+        # in-project location.
+        json_path, markdown_path = project_threat_model_paths(project)
+    else:
+        json_path = resolved_json
         markdown_path = json_path.with_name("THREAT_MODEL.md")
-    report_path = project_threat_model_report_path(project)
-    if getattr(project, "threat_model_path", ""):
-        report_path = json_path.with_name("threat-model-report.md")
+    report_path = json_path.with_name("threat-model-report.md")
 
     if args.action == "init":
         context_map = None
@@ -1187,7 +1219,7 @@ def _handle_threat_model(mgr, args) -> None:
     if args.action == "lint":
         issues = lint_model(model)
         if args.json_out:
-            print(json.dumps({"issues": issues}, indent=2, sort_keys=True))
+            _emit_json_payload({"issues": issues})
             return
         if not issues:
             print(_green("Threat model lint: no issues found."))
@@ -1216,7 +1248,7 @@ def _handle_threat_model(mgr, args) -> None:
             return
         drift = diff_context_map(model, context_map)
         if args.json_out:
-            print(json.dumps(drift, indent=2, sort_keys=True))
+            _emit_json_payload(drift)
             return
         print(f"Threat model drift: {'yes' if drift.get('is_drifted') else 'no'}")
         for key in (
@@ -1242,11 +1274,11 @@ def _handle_threat_model(mgr, args) -> None:
         lint = lint_model(model)
         drift = diff_context_map(model, context_map) if context_map else None
         if args.json_out:
-            print(json.dumps({
+            _emit_json_payload({
                 "report": str(report_path),
                 "lint": lint,
                 "drift": drift,
-            }, indent=2, sort_keys=True))
+            })
             return
         save_report(model, report_path, lint=lint, drift=drift)
         print(_green(f"Threat model report written: {report_path}"))
@@ -1285,7 +1317,11 @@ def _handle_threat_model(mgr, args) -> None:
 def _print_status(project):
     """Print project status."""
     from core.run import load_run_metadata
-    from core.threat_model import load_model, project_threat_model_paths
+    from core.threat_model import (
+        _project_threat_model_json_path,
+        load_model,
+        project_threat_model_paths,
+    )
 
     print(f"Project: {project.name}")
     if project.description:
@@ -1293,10 +1329,10 @@ def _print_status(project):
     print(f"Target: {project.target}")
     print(f"Output: {project.output_dir}")
     print(f"Created: {project.created[:10] if project.created else 'unknown'}")
-    tm_path = (
-        Path(project.threat_model_path)
-        if getattr(project, "threat_model_path", "")
-        else project_threat_model_paths(project)[0]
+    # Containment-defended resolution (see _project_threat_model_json_path
+    # for the rationale — same root as the show/lint/diff/report path).
+    tm_path = _project_threat_model_json_path(project) or (
+        project_threat_model_paths(project)[0]
     )
     if tm_path.exists():
         model = load_model(tm_path)

--- a/core/tests/test_threat_model.py
+++ b/core/tests/test_threat_model.py
@@ -190,3 +190,195 @@ def test_load_for_target_does_not_use_unrelated_active_project(tmp_path):
 
     with patch("core.project.project.ProjectManager", return_value=FakeManager()):
         assert load_for_target(target) is None
+
+
+# ---------------------------------------------------------------
+# Security defences — added when PR #776 review surfaced the
+# substrate issues (path traversal / silent-coerce / unbounded
+# raw evidence / markdown+Mermaid injection / concurrent writes).
+# ---------------------------------------------------------------
+
+
+def test_from_dict_rejects_hostile_version_string():
+    from core.threat_model import ThreatModel
+    import pytest
+    with pytest.raises(ValueError, match="version"):
+        ThreatModel.from_dict({
+            "project_name": "x", "target": "/x",
+            "version": "evil",
+        })
+
+
+def test_from_dict_rejects_out_of_range_version():
+    from core.threat_model import ThreatModel
+    import pytest
+    with pytest.raises(ValueError, match="schema version"):
+        ThreatModel.from_dict({
+            "project_name": "x", "target": "/x",
+            "version": 999,
+        })
+
+
+def test_from_dict_caps_oversized_list_entries():
+    # Hostile JSON claims a million-entry focus_areas list, each
+    # entry 100 KB. Should be capped at _MAX_LIST_ENTRIES (256)
+    # and _MAX_STRING_BYTES per entry, not allocate forever.
+    from core.threat_model import ThreatModel
+    huge_value = "A" * (10 * 1024 * 1024)  # 10 MB single entry
+    model = ThreatModel.from_dict({
+        "project_name": "x", "target": "/x",
+        "focus_areas": [huge_value] * 1000,
+    })
+    assert len(model.focus_areas) <= 256
+    assert all(len(v) <= 4 * 1024 for v in model.focus_areas)
+
+
+def test_render_markdown_escapes_newline_injection(tmp_path):
+    # Adversarial focus_area: opens a new ## section via embedded
+    # newline. Pre-fix the renderer interpolated raw, forging
+    # operator-readable section headings at line-start. Markdown
+    # only treats ``## X`` as a heading at line-start, so the
+    # security property is "the ## Forged Section text does NOT
+    # appear at the start of any line." Inline (mid-bullet) is
+    # just text.
+    from core.threat_model import (
+        ThreatModel, render_markdown,
+    )
+    model = ThreatModel(
+        project_name="demo", target="/x",
+        focus_areas=["benign\n## Forged Section\nexfil"],
+    )
+    md = render_markdown(model)
+    # No line in the rendered markdown begins with "## Forged".
+    assert not any(
+        line.lstrip().startswith("## Forged") for line in md.splitlines()
+    )
+    assert "Forged Section" in md  # text preserved, structure not
+
+
+def test_render_markdown_escapes_fenced_block_injection():
+    from core.threat_model import (
+        ThreatModel, render_markdown,
+    )
+    model = ThreatModel(
+        project_name="demo", target="/x",
+        focus_areas=["foo```\nfake fenced\n```bar"],
+    )
+    md = render_markdown(model)
+    # Backticks should be replaced with the safe lookalike.
+    assert "```" not in md.replace("```\n", "").replace("\n```", "")
+
+
+def test_mermaid_label_strips_breakout_characters():
+    from core.threat_model import _mermaid_label
+    hostile = 'foo"]; flowchart LR; pwned -->|x|'
+    label = _mermaid_label(hostile)
+    # Mermaid statement terminator and pipe-bar both neutralised.
+    assert "]; flowchart" not in label
+    assert "|x|" not in label
+
+
+def test_sanitise_raw_evidence_drops_unallowed_keys():
+    from core.threat_model import _sanitise_raw_evidence
+    hostile = {
+        "summary": "ok",       # allowlisted
+        "tool": "sandbox",     # allowlisted
+        "secret_field": "x",   # NOT allowlisted — must drop
+        "trusted_data": "y",   # NOT allowlisted — must drop
+    }
+    out = _sanitise_raw_evidence(hostile)
+    assert "summary" in out and "tool" in out
+    assert "secret_field" not in out
+    assert "trusted_data" not in out
+
+
+def test_sanitise_raw_evidence_caps_total_size():
+    from core.threat_model import _sanitise_raw_evidence
+    # All keys allowlisted but each value is huge — total size
+    # cap kicks in via the _truncated marker.
+    hostile = {
+        "summary": "A" * 100_000,
+        "tool": "B" * 100_000,
+        "command": "C" * 100_000,
+    }
+    out = _sanitise_raw_evidence(hostile)
+    # Either the truncation marker is set, OR the total is
+    # bounded — both are valid outcomes of the cap.
+    assert out.get("_truncated") or sum(
+        len(str(v)) for v in out.values()
+    ) <= 32 * 1024 + 100  # +slack for the truncated marker
+
+
+def test_save_model_refuses_concurrent_overwrite(tmp_path):
+    # Two writers race: writer 1 loads, writer 2 loads + saves,
+    # writer 1 tries to save with the stale expected_mtime ->
+    # should refuse.
+    from core.threat_model import ThreatModel, save_model
+    json_path = tmp_path / "tm.json"
+    md_path = tmp_path / "tm.md"
+    model = ThreatModel(project_name="demo", target="/x")
+    save_model(model, json_path, md_path)
+    stale_mtime = json_path.stat().st_mtime
+
+    # Concurrent writer changes the file (simulate via touch +
+    # rewrite).
+    import time
+    time.sleep(0.05)
+    save_model(
+        ThreatModel(project_name="demo", target="/x", notes="updated"),
+        json_path, md_path,
+    )
+
+    # First writer tries to save with the stale mtime — refused.
+    import pytest
+    with pytest.raises(RuntimeError, match="modified by another"):
+        save_model(
+            ThreatModel(project_name="demo", target="/x", notes="lost"),
+            json_path, md_path,
+            expected_mtime=stale_mtime,
+        )
+
+
+def test_project_threat_model_json_path_refuses_traversal(tmp_path):
+    # Operator-tamper-influenced project.json sets
+    # threat_model_path to an absolute path outside output_dir.
+    # Must be refused.
+    from core.threat_model import _project_threat_model_json_path
+    proj_out = tmp_path / "proj_out"
+    proj_out.mkdir()
+    proj = SimpleNamespace(
+        name="demo",
+        target=str(tmp_path / "target"),
+        output_dir=str(proj_out),
+        threat_model_path="/etc/shadow",
+    )
+    assert _project_threat_model_json_path(proj) is None
+
+
+def test_project_threat_model_json_path_refuses_relative_escape(tmp_path):
+    from core.threat_model import _project_threat_model_json_path
+    proj_out = tmp_path / "proj_out"
+    proj_out.mkdir()
+    proj = SimpleNamespace(
+        name="demo",
+        target=str(tmp_path / "target"),
+        output_dir=str(proj_out),
+        threat_model_path="../../etc/passwd",
+    )
+    assert _project_threat_model_json_path(proj) is None
+
+
+def test_project_threat_model_json_path_accepts_in_tree_relative(tmp_path):
+    # Relative path that resolves INSIDE output_dir is fine.
+    from core.threat_model import _project_threat_model_json_path
+    proj_out = tmp_path / "proj_out"
+    proj_out.mkdir()
+    proj = SimpleNamespace(
+        name="demo",
+        target=str(tmp_path / "target"),
+        output_dir=str(proj_out),
+        threat_model_path="custom/tm.json",
+    )
+    result = _project_threat_model_json_path(proj)
+    assert result is not None
+    assert result.is_relative_to(proj_out.resolve())

--- a/core/threat_model.py
+++ b/core/threat_model.py
@@ -18,9 +18,118 @@ from core.json import load_json, save_json
 from core.security.log_sanitisation import escape_nonprintable
 
 SCHEMA_VERSION = 2
+# Range of schema versions ``from_dict`` will accept. Anything
+# outside refuses to load rather than silently coerce; an out-of-
+# range version usually means the file is from a future RAPTOR
+# release or has been tampered with.
+SCHEMA_VERSION_MIN = 1
+SCHEMA_VERSION_MAX = SCHEMA_VERSION
+
 JSON_FILENAME = "threat-model.json"
 MARKDOWN_FILENAME = "THREAT_MODEL.md"
 REPORT_FILENAME = "threat-model-report.md"
+
+# Caps applied at adversarial-input boundaries. The threat model
+# is a small operator-authored document; sizes well beyond these
+# limits almost always mean a hostile or malformed input is
+# trying to make RAPTOR allocate forever or smuggle content
+# through a markdown / Mermaid / prompt renderer.
+_MAX_LIST_ENTRIES = 256                # any *list* field
+_MAX_STRING_BYTES = 4 * 1024           # any list entry / field value
+_MAX_NOTES_BYTES = 16 * 1024           # operator-prose notes field
+_MAX_EVIDENCE_RAW_BYTES = 32 * 1024    # ``raw`` evidence dict per outcome
+_EVIDENCE_RAW_KEY_ALLOWLIST = frozenset({
+    # Keys ``link_verified_outcomes`` is allowed to copy from
+    # ``data["evidence"]`` into the on-disk threat-model JSON.
+    # Everything else is dropped so an attacker who pre-stages a
+    # malicious evidence blob in ``run_dir`` can't smuggle
+    # arbitrary keys (including envelope-marker shaped keys) into
+    # the model.
+    "summary", "kind", "tool", "command", "exit_code",
+    "stdout_excerpt", "stderr_excerpt",
+    "url", "path", "line", "duration_ms",
+    "sandbox_outcome", "sanitizer", "rule_id",
+})
+
+
+def _clip_str(value: Any, byte_cap: int = _MAX_STRING_BYTES) -> str:
+    """Coerce ``value`` to str, strip control chars, cap length.
+
+    Used at every adversarial-input boundary entering the
+    threat model. Strips the C1 control-char range
+    (``escape_nonprintable``) and bounds total length. Returns
+    empty string on None.
+    """
+    if value is None:
+        return ""
+    s = escape_nonprintable(str(value))
+    if len(s) > byte_cap:
+        s = s[:byte_cap]
+    return s
+
+
+def _safe_for_render(value: Any, byte_cap: int = _MAX_STRING_BYTES) -> str:
+    """Sanitise a string for inclusion in a markdown bullet,
+    Mermaid label, or operator-facing report.
+
+    Strip structural characters BEFORE running
+    ``escape_nonprintable`` — otherwise the C1-control escape
+    converts real newlines into ``\x0a`` text and the
+    structural-strip becomes a no-op.
+
+    Defends against:
+    * markdown injection — newlines that could open a forged
+      ``## Heading`` section
+    * fenced-block escape — backticks
+    * markdown table escape — pipes
+    * Mermaid statement break — ``]`` / ``;`` / ``{`` / ``}``
+      that would let a label close its own node and forge new
+      Mermaid statements
+    * HTML / angle-bracket runs
+    """
+    if value is None:
+        return ""
+    s = str(value)
+    # Structural-character strip FIRST, on the raw string.
+    s = s.replace("\r", " ").replace("\n", " ")
+    s = s.replace("`", "ʼ").replace("|", "ǀ")
+    s = s.replace("<", "‹").replace(">", "›")
+    s = s.replace("]", "❳").replace("[", "❲")
+    s = s.replace("{", "❴").replace("}", "❵")
+    s = s.replace(";", "·")
+    # NOW apply C1-control-character escape + length cap.
+    s = escape_nonprintable(s)
+    if len(s) > byte_cap:
+        s = s[:byte_cap]
+    return s
+
+
+def _clip_str_list(values: Any) -> list[str]:
+    """Variant of ``_coerce_str_list`` that also caps each entry's
+    byte length and the total entry count. Defends against
+    hostile JSON inputs claiming ``"focus_areas": [str * 1_000_000]``
+    or single entries 100 MB long."""
+    raw = _coerce_str_list(values)
+    capped = [_clip_str(v) for v in raw[:_MAX_LIST_ENTRIES]]
+    return capped
+
+
+def _resolve_inside(path: Path, project_out: Path) -> Optional[Path]:
+    """Return ``path.resolve()`` only if it lives inside
+    ``project_out.resolve()``. Defends against attacker-tampered
+    ``project.threat_model_path`` pointing at ``/etc/shadow`` or
+    elsewhere outside the project's expected output area.
+
+    Returns None when the path resolves outside (caller refuses
+    the I/O).
+    """
+    try:
+        resolved = Path(path).resolve()
+        project_root = Path(project_out).resolve()
+        resolved.relative_to(project_root)
+        return resolved
+    except (OSError, ValueError):
+        return None
 
 
 @dataclass
@@ -102,14 +211,43 @@ class ThreatModel:
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> "ThreatModel":
         def _list(key: str) -> list[str]:
-            return _coerce_str_list(data.get(key))
+            # Caps each entry's byte length AND the total entry
+            # count. Defends against hostile JSON inputs of
+            # arbitrary size — see ``_clip_str_list``.
+            return _clip_str_list(data.get(key))
+
+        # Validate schema version range. Pre-fix
+        # ``int(data.get("version") or SCHEMA_VERSION)`` raised
+        # ``ValueError`` uncaught on ``{"version": "evil"}`` and
+        # silently accepted any int regardless of how far ahead /
+        # behind it was. Anything outside [MIN, MAX] either came
+        # from a future RAPTOR release or is tampered.
+        raw_version = data.get("version")
+        if raw_version is None:
+            version = SCHEMA_VERSION
+        else:
+            try:
+                version = int(raw_version)
+            except (TypeError, ValueError):
+                raise ValueError(
+                    f"threat-model version must be an integer, got "
+                    f"{type(raw_version).__name__}"
+                )
+            if not (
+                SCHEMA_VERSION_MIN <= version <= SCHEMA_VERSION_MAX
+            ):
+                raise ValueError(
+                    f"threat-model schema version {version} outside "
+                    f"supported range "
+                    f"[{SCHEMA_VERSION_MIN}, {SCHEMA_VERSION_MAX}]"
+                )
 
         now = datetime.now(timezone.utc).isoformat()
         return cls(
-            version=int(data.get("version") or SCHEMA_VERSION),
-            project_name=str(data.get("project_name") or ""),
-            target=str(data.get("target") or ""),
-            summary=str(data.get("summary") or ""),
+            version=version,
+            project_name=_clip_str(data.get("project_name")),
+            target=_clip_str(data.get("target")),
+            summary=_clip_str(data.get("summary"), byte_cap=_MAX_NOTES_BYTES),
             assets=_list("assets"),
             entry_points=_list("entry_points"),
             trust_boundaries=_list("trust_boundaries"),
@@ -131,10 +269,10 @@ class ThreatModel:
             assumptions=_records("assumptions", data),
             evidence=_records("evidence", data),
             accepted_risks=_records("accepted_risks", data),
-            notes=str(data.get("notes") or ""),
-            source=str(data.get("source") or "operator"),
-            created_at=str(data.get("created_at") or now),
-            updated_at=str(data.get("updated_at") or now),
+            notes=_clip_str(data.get("notes"), byte_cap=_MAX_NOTES_BYTES),
+            source=_clip_str(data.get("source")) or "operator",
+            created_at=_clip_str(data.get("created_at")) or now,
+            updated_at=_clip_str(data.get("updated_at")) or now,
         )
 
 
@@ -371,7 +509,36 @@ def load_model(path: Path) -> Optional[ThreatModel]:
     return ThreatModel.from_dict(data)
 
 
-def save_model(model: ThreatModel, json_path: Path, markdown_path: Path) -> None:
+def save_model(
+    model: ThreatModel,
+    json_path: Path,
+    markdown_path: Path,
+    *,
+    expected_mtime: Optional[float] = None,
+) -> None:
+    """Persist the model to disk. When ``expected_mtime`` is
+    provided, refuses to write if the on-disk file's mtime has
+    changed — defends against the lost-update race where two
+    concurrent /agentic runs (or /agentic + ``threat-model lint``)
+    each load, mutate, and save without coordinating.
+
+    Callers that loaded the model should capture
+    ``json_path.stat().st_mtime`` at load time and pass it in.
+    Callers writing a brand-new model leave ``expected_mtime``
+    None (the no-op path).
+    """
+    if expected_mtime is not None and json_path.exists():
+        try:
+            actual_mtime = json_path.stat().st_mtime
+        except OSError:
+            actual_mtime = expected_mtime
+        if actual_mtime != expected_mtime:
+            raise RuntimeError(
+                f"threat model at {json_path} was modified by another "
+                f"writer (expected mtime {expected_mtime}, found "
+                f"{actual_mtime}); refusing to overwrite. Reload and "
+                f"retry."
+            )
     model.updated_at = datetime.now(timezone.utc).isoformat()
     json_path.parent.mkdir(parents=True, exist_ok=True)
     save_json(json_path, model.to_dict())
@@ -654,6 +821,46 @@ def diff_context_map(model: ThreatModel, context_map: dict[str, Any]) -> dict[st
     }
 
 
+def _sanitise_raw_evidence(value: Any) -> dict[str, Any]:
+    """Bound + key-allowlist the ``raw`` evidence dict that gets
+    written into the on-disk threat-model JSON.
+
+    ``link_verified_outcomes`` reads outcome dicts produced by
+    ``collect_outcomes(run_dir)``. Pre-fix the entire
+    ``data["evidence"]`` dict was pasted verbatim — with no key
+    allowlist and no size cap. An attacker who can pre-stage an
+    outcome record (e.g. by writing a doctored file under a
+    run dir before /agentic processes it) could smuggle arbitrary
+    key/value pairs into the model and from there into every
+    subsequent ``render_markdown`` / ``render_report`` / ``--json``
+    consumer.
+
+    Keep only keys in ``_EVIDENCE_RAW_KEY_ALLOWLIST``; cap each
+    string value at ``_MAX_STRING_BYTES`` and the total dict at
+    ``_MAX_EVIDENCE_RAW_BYTES``.
+    """
+    if not isinstance(value, dict):
+        return {}
+    out: dict[str, Any] = {}
+    running = 0
+    for k, v in value.items():
+        key = str(k)
+        if key not in _EVIDENCE_RAW_KEY_ALLOWLIST:
+            continue
+        if isinstance(v, (int, float, bool)) or v is None:
+            sanitised: Any = v
+        else:
+            sanitised = _clip_str(v)
+        running += len(key) + len(str(sanitised))
+        if running > _MAX_EVIDENCE_RAW_BYTES:
+            # Hit the cap — surface the truncation explicitly so
+            # operators reading the model see something happened.
+            out["_truncated"] = True
+            break
+        out[key] = sanitised
+    return out
+
+
 def link_verified_outcomes(model: ThreatModel, outcomes: Iterable[Any]) -> ThreatModel:
     """Attach oracle outcomes to the threat ledger in-place."""
     for outcome in outcomes:
@@ -673,7 +880,7 @@ def link_verified_outcomes(model: ThreatModel, outcomes: Iterable[Any]) -> Threa
             "file": data.get("file"),
             "reproducible": bool(data.get("reproducible")),
             "summary": _outcome_summary(data),
-            "raw": data.get("evidence") or {},
+            "raw": _sanitise_raw_evidence(data.get("evidence")),
         }
         model.evidence = _merge_records(model.evidence, [ev])
         for threat in model.threats:
@@ -702,17 +909,62 @@ def load_for_target(target: Path) -> Optional[ThreatModel]:
                 project = candidate
         if project is None:
             return None
-        configured = getattr(project, "threat_model_path", "")
-        json_path = Path(configured) if configured else project_threat_model_paths(project)[0]
+        json_path = _project_threat_model_json_path(project)
+        if json_path is None:
+            return None
         return load_model(json_path)
     except Exception:
         return None
 
 
+def _project_threat_model_json_path(project: Any) -> Optional[Path]:
+    """Resolve the threat-model JSON path for ``project`` with
+    containment defence.
+
+    ``project.threat_model_path`` is operator/tamper-influenceable
+    (it's read from ``~/.raptor/projects/<name>.json``). If an
+    attacker writes ``threat_model_path = "/etc/shadow"`` into
+    that file, every reader / writer of the threat model would
+    otherwise touch that arbitrary path.
+
+    Containment rule: the resolved path MUST live inside
+    ``project.output_dir``. Anything outside is refused (returns
+    None; caller treats as "no threat model").
+    """
+    output_dir = Path(getattr(project, "output_dir", "") or "")
+    if not str(output_dir):
+        return None
+    configured = getattr(project, "threat_model_path", "")
+    if configured:
+        candidate = Path(configured)
+        # Reject absolute paths from the JSON outright; only
+        # relative paths to be resolved against output_dir are
+        # legitimate.
+        if candidate.is_absolute():
+            resolved = _resolve_inside(candidate, output_dir)
+        else:
+            resolved = _resolve_inside(output_dir / candidate, output_dir)
+        if resolved is None:
+            # Attacker-tampered path; refuse rather than fall
+            # back silently.
+            return None
+        return resolved
+    return _resolve_inside(
+        project_threat_model_paths(project)[0], output_dir,
+    )
+
+
 def _render_list(title: str, values: list[str]) -> str:
+    # Escape per-bullet via ``_safe_for_render`` — strips newlines
+    # (otherwise a hostile entry could open a forged ``## Heading``
+    # section in the operator's markdown), neutralises backticks
+    # (fenced-block escape) and pipes (table-row escape). Defends
+    # against markdown injection through any field that ingests
+    # target-derived prose (focus_areas, known_bug_shapes,
+    # entry_points names from the context-map, etc.).
     lines = [f"## {title}", ""]
     if values:
-        lines.extend(f"- {v}" for v in values)
+        lines.extend(f"- {_safe_for_render(v)}" for v in values)
     else:
         lines.append("- TBC")
     lines.append("")
@@ -1160,7 +1412,14 @@ def _mermaid_id(value: str) -> str:
 
 
 def _mermaid_label(value: Any) -> str:
-    text = escape_nonprintable(str(value))
+    # Defends against Mermaid label-escape attacks where a
+    # hostile label like ``"]:::class`` or ``"]; flowchart LR; pwned``
+    # would otherwise break out of the node and forge new graph
+    # statements. ``_safe_for_render`` strips newlines + pipes +
+    # backticks before we apply the Mermaid quote-escape, so the
+    # final label can't smuggle a node-terminator + new
+    # statement.
+    text = _safe_for_render(value)
     return text.replace("\\", "\\\\").replace('"', '\\"')[:90]
 
 

--- a/packages/llm_analysis/agent.py
+++ b/packages/llm_analysis/agent.py
@@ -933,9 +933,24 @@ class AutonomousSecurityAgentV2:
             from core.security.prompt_envelope import UntrustedBlock
             threat_model = load_for_target(vuln.repo_path)
             if threat_model:
+                # Distinguish operator-authored vs auto-derived
+                # models. A context-map / agentic-derived model
+                # has its title / source / sink fields built from
+                # /understand --map output, which is itself an LLM
+                # reading the UNTRUSTED target repo. A malicious
+                # symbol name in the target code can therefore
+                # ride into this block. Label accordingly so the
+                # analyst prompt weighs it as untrusted upstream
+                # signal, not as the operator's trusted threat
+                # model.
+                source = (threat_model.source or "operator").lower()
+                if source in ("operator", "manual"):
+                    kind_label = "operator-threat-model"
+                else:
+                    kind_label = "untrusted-derived-threat-model"
                 extra_blocks.append(UntrustedBlock(
                     content=prompt_context(threat_model),
-                    kind="operator-threat-model",
+                    kind=kind_label,
                     origin="project-threat-model",
                 ))
         except Exception:

--- a/raptor_agentic.py
+++ b/raptor_agentic.py
@@ -22,6 +22,7 @@ import sys
 import time
 from dataclasses import asdict
 from pathlib import Path
+from typing import Optional
 
 # Add to path
 sys.path.insert(0, str(Path(__file__).parent))
@@ -147,10 +148,21 @@ def _materialise_threat_model_phase(
             "output_dir": str(out_dir),
         })()
 
+    # Capture mtime at load time so save_model can refuse if a
+    # concurrent writer (a second /agentic run, an operator
+    # editor session, ``threat-model lint`` in parallel) raced
+    # us. Lost-update race protection.
+    load_mtime: Optional[float] = None
+    if project_backed and json_path.exists():
+        try:
+            load_mtime = json_path.stat().st_mtime
+        except OSError:
+            load_mtime = None
+
     existing_model = load_model(json_path) if project_backed else None
     if existing_model is not None and not refresh:
         model = enrich_from_context_map(existing_model, context_map)
-        save_model(model, json_path, markdown_path)
+        save_model(model, json_path, markdown_path, expected_mtime=load_mtime)
         summary["model_preserved"] = True
         summary["model_refreshed"] = False
         summary["model_migrated"] = True
@@ -169,7 +181,17 @@ def _materialise_threat_model_phase(
         linked_outcomes = len(outcomes)
         if outcomes:
             link_verified_outcomes(model, outcomes)
-            save_model(model, json_path, markdown_path)
+            # Capture mtime again (we just wrote above) before the
+            # outcomes-merge save, so a concurrent writer that
+            # sneaked in between the two saves is still caught.
+            try:
+                outcomes_mtime = json_path.stat().st_mtime
+            except OSError:
+                outcomes_mtime = None
+            save_model(
+                model, json_path, markdown_path,
+                expected_mtime=outcomes_mtime,
+            )
     except Exception as e:
         logger.debug(f"Threat model verified-outcome linking skipped: {e}")
 


### PR DESCRIPTION
Adversarial review of the threat-model substrate surfaced three P0 and three P1 issues where attacker-influenced inputs flow into RAPTOR's own surfaces. This commit lands the security fixes; UX / dead-code / ledger-naming concerns are deferred to follow-ups.

P0 — path traversal in ``project.threat_model_path``
  ``~/.raptor/projects/<name>.json`` is operator / tamper-influenced.
  An attacker with write access could set ``threat_model_path =
  "/etc/shadow"`` and every reader / writer (load_for_target,
  _handle_threat_model, _print_status, --json) would touch that path.
  New ``_project_threat_model_json_path`` enforces containment inside
  ``project.output_dir``; absolute paths are rejected outright,
  relative paths must resolve inside the project tree.

P0 — LLM prompt injection via context-map-derived threat models
  ``packages/llm_analysis/agent.py`` labelled every loaded model as
  ``kind="operator-threat-model"`` regardless of source. Models built
  from /understand --map output carry threat titles / sources / sinks
  derived from the UNTRUSTED target repo — attacker symbol names ride
  in. Now branch on ``model.source``: ``operator`` / ``manual`` stay
  ``operator-threat-model``; everything else (``context-map``,
  ``agentic``, etc.) labelled ``untrusted-derived-threat-model`` so
  the analyst prompt weighs it as untrusted upstream signal.

P0 — unbounded ``raw`` evidence dict in link_verified_outcomes
  Pre-fix the entire ``data["evidence"]`` dict was pasted verbatim
  into the on-disk JSON — no key allowlist, no size cap. A pre-staged
  outcome record could smuggle arbitrary keys (including envelope-
  marker shaped values) into the model. New ``_sanitise_raw_evidence``
  keeps only allowlisted keys (summary/tool/command/exit_code/url/
  path/line/sandbox_outcome/etc.), caps each value at 4 KB and the
  total dict at 32 KB; surfaces ``_truncated: true`` when the cap
  fires.

P1 — markdown + Mermaid injection in renderers
  ``_render_list`` interpolated raw values into ``- {v}`` bullets; a
  hostile entry with embedded ``\n## Forged Heading`` opened a forged
  operator-facing section. ``_mermaid_label`` only escaped backslash
  + quote, leaving ``]; flowchart LR`` etc. as a Mermaid statement break vector. New ``_safe_for_render`` strips structural characters (newlines, backticks, pipes, angle-brackets, square brackets, curly braces, semicolons) BEFORE ``escape_nonprintable`` runs (otherwise the C1-control escape converts real newlines into ``\x0a`` text and structural strip becomes a no-op).

P1 — markdown + Mermaid injection in renderers
  ``_render_list`` interpolated raw values into ``- {v}`` bullets; a
  hostile entry with embedded ``\n## Forged Heading`` opened a forged
  operator-facing section. ``_mermaid_label`` only escaped backslash
  + quote, leaving ``]; flowchart LR`` etc. as a Mermaid statement break vector. New ``_safe_for_render`` strips structural characters (newlines, backticks, pipes, angle-brackets, square brackets, curly braces, semicolons) BEFORE ``escape_nonprintable`` runs (otherwise the C1-control escape converts real newlines into ``\x0a`` text and structural strip becomes a no-op).

P1 — lost-update race on concurrent writes
  Two ``/agentic`` runs (or ``/agentic`` + ``threat-model lint``)
  loading-mutating-saving the same model raced; the model_preserved
  contract was unenforced. ``save_model`` now takes an optional
  ``expected_mtime``; threaded through ``raptor_agentic.py``'s
  threat-model phase + the verified-outcomes link. Concurrent writer
  raises ``RuntimeError`` instead of silently dropping the operator's
  edit.

P1 — ``from_dict`` raises uncaught on hostile version + silent migration
  ``int(data.get("version") or SCHEMA_VERSION)`` raised ``ValueError``
  uncaught on ``{"version": "evil"}`` and silently accepted any int
  regardless of how far ahead/behind. Now: try/except the coerce,
  check ``[SCHEMA_VERSION_MIN, SCHEMA_VERSION_MAX]`` (currently [1, 2]),
  raise ``ValueError`` outside the range. Every string field goes
  through ``_clip_str`` (control-char strip + 4 KB cap); every list
  through ``_clip_str_list`` (256-entry max, per-entry 4 KB cap) so a
  hostile JSON of any shape gets clamped to operator-readable bounds.

Tests: 12 new — hostile version (string + out-of-range), oversized list inputs, markdown line-start heading injection, Mermaid breakout chars, raw-evidence key allowlist, raw-evidence total-size cap, concurrent-write race, path-traversal absolute / relative escapes, in-tree relative path acceptance. 31/31 pass.