### PR TITLE
fix(sandbox): tear down sandbox pid-ns when orchestrator is hard-killed

### DIFF
--- a/core/sandbox/context.py
+++ b/core/sandbox/context.py
@@ -1351,11 +1351,23 @@ def sandbox(block_network: bool = False, target: str = None, output: str = None,
             # binaries that run under our Landlock+seccomp but skip the
             # actual unshare, leaving the child in the host's net/pid/ipc
             # namespaces (= full outbound network).
-            from .probes import _resolve_sandbox_binary
+            from .probes import (
+                _resolve_sandbox_binary,
+                unshare_supports_kill_child,
+            )
             unshare_cmd = [_resolve_sandbox_binary("unshare"),
                            "--user", "--pid", "--fork", "--ipc"]
             if block_network:
                 unshare_cmd.append("--net")
+            # Belt-and-braces orphan teardown: if `unshare` is killed
+            # directly (orchestrator still alive), --kill-child SIGKILLs the
+            # pid-1 shim → kernel cascades the pid-ns. The PRIMARY teardown
+            # (orchestrator hard-killed mid-run) is the death-pipe the shim
+            # watches; see the `need_unshare` block at the subprocess.run
+            # call. Gated on a cached capability probe (older util-linux
+            # lacks the flag) so we never feed `unshare` an unknown option.
+            if unshare_supports_kill_child():
+                unshare_cmd.append("--kill-child=SIGKILL")
             # prlimit wrapper: sits INSIDE the unshare chain so
             # RLIMIT_NPROC counts against the ns-local UID (nobody =
             # zero existing processes). prlimit is part of util-linux
@@ -1978,7 +1990,39 @@ def sandbox(block_network: bool = False, target: str = None, output: str = None,
                         # path run.
                         pass
                 if not _audit_landlock_engaged:
-                    result = subprocess.run(full_cmd, **kwargs)
+                    if need_unshare:
+                        # Orphan-teardown: the shim (pid-1 of the new pid-ns)
+                        # would otherwise outlive an ORCHESTRATOR that is
+                        # hard-killed (SIGKILL/OOM/crash) mid-run — the
+                        # blocking subprocess.run can't run cleanup, the
+                        # `unshare` intermediate reparents to init, and the
+                        # ns leaks. Hand the shim the READ end of a liveness
+                        # pipe; we hold the WRITE end here for exactly this
+                        # call. If this process dies, the write end closes →
+                        # the shim reads EOF → it exits → the kernel cascade-
+                        # SIGKILLs the whole pid-ns. The fd is a one-bit
+                        # liveness signal (nothing is written); write end is
+                        # CLOEXEC (os.pipe default) so no child inherits it,
+                        # read end is passed only to the shim via pass_fds
+                        # and the shim CLOEXEC's it away from the target.
+                        _death_r, _death_w = os.pipe()
+                        try:
+                            _dk = dict(kwargs)
+                            _dk["pass_fds"] = (
+                                tuple(_dk.get("pass_fds") or ()) + (_death_r,)
+                            )
+                            _denv = dict(_dk.get("env") or os.environ)
+                            _denv["_RAPTOR_DEATH_FD"] = str(_death_r)
+                            _dk["env"] = _denv
+                            result = subprocess.run(full_cmd, **_dk)
+                        finally:
+                            for _dfd in (_death_r, _death_w):
+                                try:
+                                    os.close(_dfd)
+                                except OSError:
+                                    pass
+                    else:
+                        result = subprocess.run(full_cmd, **kwargs)
         finally:
             events = (
                 proxy_instance.unregister_sandbox(proxy_token)

--- a/core/sandbox/probes.py
+++ b/core/sandbox/probes.py
@@ -10,6 +10,7 @@ respectively, because those tests are syscall-level (ctypes) rather than
 subprocess-level.
 """
 
+import functools
 import logging
 import os
 import shutil
@@ -100,6 +101,27 @@ ENGAGE_FAIL_INSTRUCTIONS = (
     "disable isolation entirely (last resort). RAPTOR will not silently "
     "downgrade for you."
 )
+
+
+@functools.lru_cache(maxsize=1)
+def unshare_supports_kill_child() -> bool:
+    """Whether this host's ``unshare`` supports ``--kill-child`` (util-linux
+    ≥ 2.32, 2018). Used as belt-and-braces teardown: ``unshare --kill-child=
+    SIGKILL`` kills its pid-1 child (and thus cascades the pid-ns) if unshare
+    itself dies. The primary orphan-teardown is the death-pipe in
+    raptor-pid1-shim; this just covers "unshare killed directly". Probed via
+    ``--help`` (cheap, no namespace creation) and cached for the process; a
+    host without the flag silently runs without it.
+    """
+    try:
+        from core.config import RaptorConfig
+        out = subprocess.run(
+            [_resolve_sandbox_binary("unshare"), "--help"],
+            capture_output=True, timeout=5, env=RaptorConfig.get_safe_env(),
+        )
+        return b"--kill-child" in (out.stdout or b"") + (out.stderr or b"")
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+        return False
 
 
 def check_unshare_engages(unshare_flags) -> tuple:

--- a/core/sandbox/tests/test_pid1_shim.py
+++ b/core/sandbox/tests/test_pid1_shim.py
@@ -172,3 +172,96 @@ class TestPid1ShimContract(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestPid1ShimDeathPipe(unittest.TestCase):
+    """Orphan-teardown: the shim watches an orchestrator-liveness ('death')
+    pipe and tears the pid-ns down when the orchestrator dies — covering the
+    SIGKILL/OOM/crash case that no graceful cleanup can."""
+
+    def setUp(self):
+        if not SHIM_PATH.is_file() or not os.access(SHIM_PATH, os.X_OK):
+            self.skipTest("shim missing/not executable")
+
+    def test_death_pipe_eof_exits_shim(self):
+        """Direct (no pid-ns): when the death-pipe write end closes (EOF),
+        the shim stops waiting on its long target and exits with the
+        teardown code. The kernel cascade to the target is covered by the
+        integration test below."""
+        marker = "raptor_shimdeath_7271"
+        death_r, death_w = os.pipe()
+        env = dict(os.environ, _RAPTOR_TRUSTED="1",
+                   _RAPTOR_DEATH_FD=str(death_r))
+        proc = subprocess.Popen(
+            [str(SHIM_PATH), "/bin/sleep", marker.split("_")[-1]],
+            pass_fds=(death_r,), env=env,
+            stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+        )
+        try:
+            os.close(death_r)  # parent holds only the write end
+            import time
+            time.sleep(0.5)    # let the shim fork the target + enter watch
+            os.close(death_w)  # EOF → shim must tear down
+            try:
+                rc = proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                self.fail("shim did not exit after death-pipe EOF")
+            self.assertEqual(rc, 137,  # _DEATH_TEARDOWN_EXIT
+                             "shim should exit with the teardown code on EOF")
+        finally:
+            if proc.poll() is None:
+                proc.kill()
+                proc.wait()
+            subprocess.run(["pkill", "-9", "-f", marker.split("_")[-1]],
+                           capture_output=True)
+
+    def test_orphan_teardown_on_orchestrator_kill(self):
+        """Integration: an orchestrator running a long target through the
+        subprocess/shim sandbox path, then SIGKILLed mid-run (OOM/crash
+        simulation), must leave NO lingering sandbox processes — the shim
+        reads EOF and the kernel cascade-SIGKILLs the pid-ns."""
+        import time
+        marker = "313339"
+
+        def lineage():
+            out = subprocess.run(["pgrep", "-af", marker],
+                                 capture_output=True, text=True).stdout
+            return [ln for ln in out.splitlines() if "pgrep" not in ln]
+
+        orch = subprocess.Popen(
+            ["python3", "-c",
+             "from core.sandbox import sandbox\n"
+             "with sandbox(block_network=True) as run:\n"
+             "    run(['/bin/sleep','%s'], capture_output=True, text=True)\n"
+             % marker],
+            cwd=str(Path(__file__).resolve().parents[3]),
+            env=dict(os.environ, _RAPTOR_TRUSTED="1"),
+            stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+        )
+        try:
+            # Only proceed once the SHIM actually wraps the target — i.e. the
+            # subprocess/pid-ns path engaged. On a no-namespace runner the
+            # target would run bare (no shim, no death-pipe), which has no
+            # teardown guarantee and isn't what this test covers → skip.
+            for _ in range(150):
+                time.sleep(0.1)
+                if any("raptor-pid1-shim" in p and marker in p
+                       for p in lineage()):
+                    break
+            else:
+                self.skipTest("subprocess/shim sandbox path did not engage "
+                              "here (namespaces unavailable)")
+            orch.send_signal(signal.SIGKILL)
+            orch.wait()
+            # Poll up to 5s for full teardown.
+            for _ in range(50):
+                time.sleep(0.1)
+                if not lineage():
+                    break
+            self.assertEqual(lineage(), [],
+                             "sandbox lineage leaked after orchestrator kill")
+        finally:
+            if orch.poll() is None:
+                orch.kill()
+                orch.wait()
+            subprocess.run(["pkill", "-9", "-f", marker], capture_output=True)

--- a/libexec/raptor-pid1-shim
+++ b/libexec/raptor-pid1-shim
@@ -82,6 +82,45 @@ if not (os.environ.get("CLAUDECODE")
 
 
 
+# Shim exit code used when the orchestrator-liveness pipe goes EOF (the
+# orchestrator died) and the shim tears the pid-ns down. Nobody meaningful
+# reaps it (the orchestrator is gone); distinct from the target's own codes
+# and the 254/255 sentinels purely for post-mortem log clarity.
+_DEATH_TEARDOWN_EXIT = 137
+
+
+def _resolve_death_fd():
+    """Resolve the orchestrator-liveness ("death") pipe read-end fd, or None.
+
+    context.py creates ONE pipe per orchestrator process, keeps the WRITE end
+    open for the orchestrator's whole lifetime, and passes the READ end down
+    to this shim (Popen ``pass_fds`` + the ``_RAPTOR_DEATH_FD`` env var). When
+    the orchestrator — and every copy of the write end — dies, INCLUDING on
+    SIGKILL / OOM / crash that no cleanup handler can catch, this read end
+    goes EOF; the shim then exits and the kernel cascade-SIGKILLs the pid-ns.
+
+    Security/hygiene: this fd is a one-bit liveness signal for the trusted
+    shim only — nothing is ever written to it, so it carries no data and is
+    no IPC/side channel. Set CLOEXEC so the sandboxed (untrusted) target,
+    forked + exec'd below, never inherits it; non-blocking so the post-select
+    read can never stall the shim.
+    """
+    raw = os.environ.get("_RAPTOR_DEATH_FD")
+    if not raw:
+        return None
+    try:
+        fd = int(raw)
+        os.fstat(fd)  # validate it's a real, open fd
+    except (ValueError, OSError):
+        return None
+    try:
+        os.set_inheritable(fd, False)  # CLOEXEC → target can't inherit it
+        os.set_blocking(fd, False)
+    except OSError:
+        return None
+    return fd
+
+
 def main() -> int:
     if len(sys.argv) < 2:
         # No target argv supplied — operator bug.
@@ -92,6 +131,12 @@ def main() -> int:
         return 2
 
     target_argv = sys.argv[1:]
+
+    # Orchestrator-liveness pipe (read end), or None when not configured.
+    # Resolved BEFORE the fork so the CLOEXEC set here is in place for the
+    # target's exec; we additionally close it explicitly in the target
+    # branch below (belt-and-braces — the target subtree never holds it).
+    death_fd = _resolve_death_fd()
 
     # Install signal handlers BEFORE fork. The shim runs as pid-1
     # in the new pid namespace, where the kernel's default
@@ -120,7 +165,16 @@ def main() -> int:
 
     child = os.fork()
     if child == 0:
-        # Target branch. We want the target to be the session leader
+        # Target branch — close the death-pipe read end immediately so it
+        # never reaches the (untrusted) target or its descendants. CLOEXEC
+        # would drop it at the grandchild's exec anyway; this also keeps the
+        # non-exec intermediate (pid-2) from holding a stray copy.
+        if death_fd is not None:
+            try:
+                os.close(death_fd)
+            except OSError:
+                pass
+        # We want the target to be the session leader
         # of its pid-ns — matches pre-shim behaviour where target was
         # pid-1 and (under start_new_session=True from the Popen
         # preexec) effectively the session leader. `ps -o sid` then
@@ -181,6 +235,10 @@ def main() -> int:
                     signal.signal(s, signal.SIG_DFL)
                 except (OSError, ValueError):
                     pass
+            # Don't leak the RAPTOR-internal liveness-fd marker into the
+            # (untrusted) target's env. The fd it names is already CLOEXEC'd
+            # shut, so this is belt-and-braces hygiene.
+            os.environ.pop("_RAPTOR_DEATH_FD", None)
             try:
                 os.execvp(target_argv[0], target_argv)
             except FileNotFoundError:
@@ -224,21 +282,64 @@ def main() -> int:
     # Reap until the target is seen. Other zombies (if target
     # forked) are collected but their status is discarded.
     target_status = None
-    while True:
-        try:
-            reaped_pid, status = os.waitpid(-1, 0)
-        except ChildProcessError:
-            # No children left — target must have been reaped
-            # already (shouldn't happen with our single-fork
-            # layout, but be defensive).
-            break
-        except InterruptedError:
-            # A forwarded signal interrupted waitpid. Loop.
-            continue
-        if reaped_pid == child:
-            target_status = status
-            break
-        # Orphan reaped; continue waiting for target.
+    if death_fd is None:
+        # No liveness pipe configured — original blocking reap (unchanged).
+        while True:
+            try:
+                reaped_pid, status = os.waitpid(-1, 0)
+            except ChildProcessError:
+                # No children left — target must have been reaped
+                # already (shouldn't happen with our single-fork
+                # layout, but be defensive).
+                break
+            except InterruptedError:
+                # A forwarded signal interrupted waitpid. Loop.
+                continue
+            if reaped_pid == child:
+                target_status = status
+                break
+            # Orphan reaped; continue waiting for target.
+    else:
+        # Liveness pipe configured: multiplex the reap with a watch on the
+        # orchestrator-death fd. When the orchestrator (and every copy of
+        # the write end) dies — including SIGKILL/OOM/crash that no cleanup
+        # handler can catch — this read end goes EOF; the shim exits and the
+        # kernel cascade-SIGKILLs the whole pid-ns (target + descendants).
+        # select() with a short timeout also lets us notice the target
+        # exiting (SIGCHLD is ignored by default, so it won't interrupt the
+        # wait); a forwarded signal interrupting select() just re-loops.
+        import select as _select
+        while target_status is None:
+            try:
+                ready, _, _ = _select.select([death_fd], [], [], 0.1)
+            except InterruptedError:
+                ready = ()
+            if ready:
+                try:
+                    _alive = os.read(death_fd, 256)
+                except BlockingIOError:
+                    _alive = b"x"          # spurious wake, not EOF
+                except OSError:
+                    _alive = b""           # fd error → fail safe to teardown
+                if not _alive:
+                    # EOF → orchestrator gone → tear the pid-ns down.
+                    os._exit(_DEATH_TEARDOWN_EXIT)
+            # Reap whatever has exited (non-blocking).
+            no_children = False
+            while True:
+                try:
+                    reaped_pid, status = os.waitpid(-1, os.WNOHANG)
+                except ChildProcessError:
+                    no_children = True
+                    break
+                if reaped_pid == 0:
+                    break                  # nothing ready right now
+                if reaped_pid == child:
+                    target_status = status
+                    break
+                # Orphan reaped; keep going.
+            if no_children:
+                break
 
     if target_status is None:
         # Fell out without seeing target — shouldn't happen. Report


### PR DESCRIPTION
The subprocess/Landlock sandbox path runs the target under a pid-1 shim inside a new pid namespace. If the orchestrator was killed ungracefully (SIGKILL/OOM/crash) while a target was running or hung, the blocking subprocess.run never reached its timeout-driven cleanup, the unshare intermediate reparented to init, and the whole pid-ns (shim + target) orphaned and leaked indefinitely — surviving as processes blocked in accept()/read() that no graceful path could reap.

Add an orchestrator-liveness ("death") pipe: context.py creates a pipe per subprocess run, hands the read end to the shim (pass_fds + _RAPTOR_DEATH_FD) and holds the write end for the call's lifetime. When the orchestrator dies, every copy of the write end closes, the shim reads EOF and exits, and the kernel cascade-SIGKILLs the pid-ns. The shim multiplexes this watch with its existing reap loop via select().

The pipe is liveness-only: nothing is ever written, so it carries no data and is no IPC/side channel. The write end never crosses the sandbox boundary (not in pass_fds, CLOEXEC by default). The read end is removed from the untrusted target three ways — CLOEXEC re-set in the shim before fork, explicit close in the target branch, and the env marker popped before execvp — so the target inherits neither end.

Belt-and-braces: append `unshare --kill-child=SIGKILL` when the host's unshare supports it (probed via --help, cached), covering the case where unshare itself is killed directly.

Tests: a namespace-free unit test (death-pipe EOF -> shim exits 137) and a skip-guarded integration test (orchestrator SIGKILL -> full lineage teardown, zero leaked).