### PR TITLE
fix(sandbox): route fail-loud downgrade guidance by failure kind

### DIFF
--- a/core/sandbox/context.py
+++ b/core/sandbox/context.py
@@ -1671,10 +1671,10 @@ def sandbox(block_network: bool = False, target: str = None, output: str = None,
                 _mac_status = getattr(result, "_setup_status", None)
                 if _mac_status is not None and _mac_status[0] == "E":
                     from .errors import SandboxSetupError
-                    from .probes import ENGAGE_FAIL_INSTRUCTIONS
+                    from .probes import SEATBELT_FAIL_INSTRUCTIONS
                     raise SandboxSetupError(
                         f"sandbox seatbelt setup failed: {_mac_status[1]}",
-                        ENGAGE_FAIL_INSTRUCTIONS,
+                        SEATBELT_FAIL_INSTRUCTIONS,
                     )
             elif spawn_eligible:
                 try:
@@ -1764,14 +1764,25 @@ def sandbox(block_network: bool = False, target: str = None, output: str = None,
                         _setup_status = getattr(result, "_setup_status", None)
                         if _setup_status is not None and _setup_status[0] in ("L", "S", "U"):
                             from .errors import SandboxSetupError
-                            from .probes import ENGAGE_FAIL_INSTRUCTIONS
+                            from .probes import (
+                                ENGAGE_FAIL_INSTRUCTIONS,
+                                LAYER_FAIL_INSTRUCTIONS,
+                            )
                             _layer = {"L": "Landlock", "S": "seccomp",
                                       "U": "namespace unshare"}.get(
                                           _setup_status[0], _setup_status[0])
+                            # Namespace (U) failures need the same remedy as the
+                            # engagement gate — network-only also needs the
+                            # namespace, so only `none` avoids it. Landlock/
+                            # seccomp (L/S) ARE dropped by network-only, so it
+                            # is a real downgrade for those.
+                            _instr = (ENGAGE_FAIL_INSTRUCTIONS
+                                      if _setup_status[0] == "U"
+                                      else LAYER_FAIL_INSTRUCTIONS)
                             raise SandboxSetupError(
                                 f"sandbox {_layer} setup failed in the spawn "
                                 f"child: {_setup_status[1]}",
-                                ENGAGE_FAIL_INSTRUCTIONS,
+                                _instr,
                             )
                         # Degrade-to-Landlock-only on a mount-ns ('M') or
                         # in-sandbox exec ('X') failure reported by the exec-

--- a/core/sandbox/probes.py
+++ b/core/sandbox/probes.py
@@ -93,12 +93,42 @@ def _resolve_sandbox_binary(name: str) -> str:
 # to operators verbatim (also reused by context.py when it raises
 # SandboxSetupError), so it must name the concrete escape hatch. Policy:
 # RAPTOR never silently downgrades — the operator chooses.
+# Namespace layer can't engage (unshare user/pid/ipc/net). This layer backs
+# the network/PID/IPC isolation, so EVERY network-blocking profile (full,
+# debug, network-only) needs it and fails here the same way — network-only
+# does NOT help. The only profile that avoids the namespace layer is `none`.
 ENGAGE_FAIL_INSTRUCTIONS = (
-    "the requested sandbox isolation cannot engage on this host (common on "
-    "rootless podman / distrobox / nested user namespaces). Re-run with "
-    "`--sandbox network-only` to keep network-egress blocking while dropping "
-    "the namespace layers that won't load here, or `--sandbox none` to "
-    "disable isolation entirely (last resort). RAPTOR will not silently "
+    "the sandbox namespace layer cannot engage on this host (common on "
+    "rootless podman / distrobox / nested user namespaces, where the kernel "
+    "restricts unprivileged user-namespace creation). This layer backs the "
+    "network / PID / IPC isolation, so every network-blocking profile "
+    "(full, debug, network-only) needs it and fails here the same way — "
+    "`--sandbox network-only` will NOT help. Either enable unprivileged user "
+    "namespaces on the host (distro-specific — e.g. the "
+    "kernel.unprivileged_userns_clone or "
+    "kernel.apparmor_restrict_unprivileged_userns sysctl, or the container "
+    "runtime's userns policy), or re-run with `--sandbox none` to run "
+    "without namespace isolation (resource limits only — last resort). "
+    "RAPTOR will not silently downgrade for you."
+)
+
+# A hardening layer (Landlock or seccomp) passed its probe but failed to
+# APPLY. Unlike the namespace layer, these ARE dropped by network-only, so
+# it is a genuine downgrade here (keeps network + namespace isolation).
+LAYER_FAIL_INSTRUCTIONS = (
+    "a sandbox hardening layer (Landlock or seccomp) passed its probe but "
+    "could not apply on this host. Re-run with `--sandbox network-only` to "
+    "drop Landlock and seccomp while keeping network and namespace "
+    "isolation, or `--sandbox none` to disable isolation entirely (last "
+    "resort). RAPTOR will not silently downgrade for you."
+)
+
+# macOS seatbelt (sandbox-exec) could not apply its profile. There is no
+# Landlock/namespace layering to fall back to — `none` is the only downgrade.
+SEATBELT_FAIL_INSTRUCTIONS = (
+    "the macOS seatbelt sandbox (sandbox-exec) could not apply its profile "
+    "on this host. Re-run with `--sandbox none` to run without isolation "
+    "(resource limits only — last resort). RAPTOR will not silently "
     "downgrade for you."
 )
 

--- a/core/sandbox/tests/test_engagement_failloud.py
+++ b/core/sandbox/tests/test_engagement_failloud.py
@@ -39,9 +39,32 @@ class TestEngagementGateRaises:
             with pytest.raises(SandboxSetupError) as ei:
                 run(["echo", "hi"], capture_output=True, text=True)
         msg = str(ei.value)
-        # Actionable, explicit-downgrade-only guidance.
-        assert "--sandbox network-only" in msg
+        # Actionable, explicit-downgrade-only guidance. For a NAMESPACE
+        # engagement failure, network-only ALSO needs the namespace, so the
+        # message must point to `--sandbox none` and must NOT offer
+        # network-only as a fix (it would fail the same way).
+        assert "--sandbox none" in msg
+        assert "NOT help" in msg  # explicitly disclaims network-only
         assert "will not silently downgrade" in msg
+
+    def test_instruction_strings_route_by_failure_kind(self):
+        """The three downgrade-guidance strings must give the right remedy:
+        namespace failure -> none (network-only disclaimed); hardening-layer
+        failure -> network-only is valid; macOS seatbelt -> none."""
+        from core.sandbox.probes import (
+            ENGAGE_FAIL_INSTRUCTIONS,
+            LAYER_FAIL_INSTRUCTIONS,
+            SEATBELT_FAIL_INSTRUCTIONS,
+        )
+        # Namespace can't engage: only `none` avoids it; network-only disclaimed.
+        assert "--sandbox none" in ENGAGE_FAIL_INSTRUCTIONS
+        assert "NOT help" in ENGAGE_FAIL_INSTRUCTIONS
+        # Landlock/seccomp apply failure: network-only IS a real downgrade.
+        assert "--sandbox network-only" in LAYER_FAIL_INSTRUCTIONS
+        assert "NOT help" not in LAYER_FAIL_INSTRUCTIONS
+        # macOS seatbelt: no layering to fall back to -> none.
+        assert "--sandbox none" in SEATBELT_FAIL_INSTRUCTIONS
+        assert "network-only" not in SEATBELT_FAIL_INSTRUCTIONS
 
     def test_failure_does_not_return_empty_result(self):
         # The whole point: a setup failure must NOT come back as a


### PR DESCRIPTION
ENGAGE_FAIL_INSTRUCTIONS was shared across every sandbox setup failure and always pointed the operator at `--sandbox network-only`. But network-only keeps block_network=True, so it still runs the same `unshare --user --pid --fork --ipc --net`. For a namespace-engagement failure (rootless podman / distrobox / nested user namespaces) that unshare is exactly what failed — network-only fails identically and the advice sent the operator in a circle. Only `--sandbox none` avoids the namespace layer.

Split the guidance into three messages routed by failure kind:
  - ENGAGE_FAIL_INSTRUCTIONS (namespace can't engage / unshare 'U' apply failure): recommend enabling unprivileged user namespaces on the host, or `--sandbox none`. States explicitly that network-only will NOT help.
  - LAYER_FAIL_INSTRUCTIONS (Landlock/seccomp 'L'/'S' apply failure): these ARE dropped by network-only, so it is a genuine downgrade — recommend network-only or none.
  - SEATBELT_FAIL_INSTRUCTIONS (macOS sandbox-exec apply failure): no layering to fall back to — recommend none.

Wire the spawn-child L/S/U site to pick ENGAGE (U) vs LAYER (L/S), and the macOS branch to SEATBELT. Tests assert the routing and that the namespace-failure message points to none, not network-only.