### PR TITLE
feat(llm/bedrock): hardening + expiry-aware credential UX

### DIFF
--- a/core/llm/dispatcher/auth.py
+++ b/core/llm/dispatcher/auth.py
@@ -70,14 +70,20 @@ Out of scope for the proxy-based dispatcher:
 
 from __future__ import annotations
 
+import base64
+import binascii
 import json
+import logging
 import os
 import sys
 import threading
+import time
 import urllib.parse
 from dataclasses import dataclass
 from typing import Callable, Mapping, Optional
 from pathlib import Path
+
+_log = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -163,6 +169,40 @@ class ProviderRule:
 _UNRESOLVED = object()
 
 
+def _decode_bedrock_bearer_exp(token: str) -> int | None:
+    """Best-effort ``exp`` claim extraction from an AWS Bedrock bearer
+    token.  Bedrock short-term API keys are JWT-shaped (three dot-
+    separated base64url segments, middle segment is the payload).
+    Long-term API keys are opaque strings without an exp claim — we
+    return ``None`` for those and the caller treats it as "no expiry
+    signal, assume long-lived".
+
+    Signature is NOT verified — that's AWS's job at the request layer.
+    We read the exp purely so we can pre-flight check at the parent
+    process (warn at startup if the run is likely to outlast the
+    token; reject at request time if the token has already expired,
+    so we don't burn a network round trip and surface an opaque
+    AWS 401 to the worker)."""
+    if not isinstance(token, str) or not token:
+        return None
+    parts = token.split(".")
+    if len(parts) != 3:
+        return None
+    try:
+        pad = "=" * (-len(parts[1]) % 4)
+        payload = json.loads(base64.urlsafe_b64decode(parts[1] + pad))
+    except (ValueError, TypeError, binascii.Error, json.JSONDecodeError):
+        return None
+    if not isinstance(payload, dict):
+        return None
+    exp = payload.get("exp")
+    if isinstance(exp, bool):  # bool is a subtype of int, exclude it
+        return None
+    if isinstance(exp, (int, float)):
+        return int(exp)
+    return None
+
+
 def _read_env(var: str) -> str | None:
     """Read an env var and immediately erase it from the process env.
 
@@ -234,6 +274,11 @@ class CredentialStore:
             os.environ.get("AWS_REGION") or os.environ.get("AWS_DEFAULT_REGION")
         )
         self._aws_endpoint: str | None = os.environ.get("AWS_ENDPOINT_URL_BEDROCK")
+        # Operator-pinned profile name (botocore picks up
+        # ``AWS_PROFILE`` automatically inside Session(), but reading it
+        # explicitly lets us prefer-chain-over-env when the operator
+        # set it deliberately — a profile is always refresh-capable).
+        self._aws_profile: str | None = os.environ.get("AWS_PROFILE")
         # Resolved (credentials, region, endpoint) tuple, or None once we
         # know Bedrock isn't usable. ``_UNRESOLVED`` until first lookup.
         # The lock serialises first-resolution across the threading
@@ -242,6 +287,14 @@ class CredentialStore:
         # hit IMDS) should run once, not once per concurrent first call.
         self._aws_signer_cache: object = _UNRESOLVED
         self._aws_signer_lock = threading.Lock()
+        # Bedrock bearer-token expiry timestamp (unix seconds) if the
+        # token is a JWT with an ``exp`` claim; ``None`` for opaque
+        # long-term API keys (no expiry signal — assume long-lived).
+        # Decoded once at startup so the hot path can pre-flight check
+        # without re-parsing on every request.
+        self._aws_bearer_exp: int | None = _decode_bedrock_bearer_exp(
+            self._keys.get("aws_bearer_token") or ""
+        )
 
     def get(self, provider: str) -> str | None:
         return self._keys.get(provider)
@@ -276,11 +329,130 @@ class CredentialStore:
             self._keys["aws_session_token"] = session_token
         if bearer_token is not None:
             self._keys["aws_bearer_token"] = bearer_token
+            self._aws_bearer_exp = _decode_bedrock_bearer_exp(bearer_token)
         if region is not None:
             self._aws_region = region
         if endpoint is not None:
             self._aws_endpoint = endpoint
         self._aws_signer_cache = _UNRESOLVED
+
+    def bedrock_bearer_exp(self) -> int | None:
+        """Return the bearer token's ``exp`` claim (unix seconds) if it
+        was JWT-shaped, else ``None``.  Decoded once at construction;
+        no parsing on the hot path."""
+        return self._aws_bearer_exp
+
+    def bedrock_session_warnings(
+        self, *, expected_run_seconds: int = 1800,
+    ) -> list[str]:
+        """Inspect the Bedrock credential state and return a list of
+        operator-actionable warning strings.  Empty when there's
+        nothing to flag.
+
+        Detects two cases that cause "scan dies mid-run with an opaque
+        AWS error":
+
+        * The bearer token is a JWT with an ``exp`` claim that falls
+          inside ``expected_run_seconds`` from now.  Operator gets a
+          token-specific countdown + the long-term-API-key escape
+          hatch.
+        * ``AWS_SESSION_TOKEN`` is set OR the access key looks
+          short-lived (``ASIA…``) and there's NO ``AWS_PROFILE`` /
+          ``AWS_CONFIG_FILE`` / ``~/.aws/credentials`` for the chain
+          to refresh from.  Operator gets the
+          "configure aws sso / profile" guidance.
+
+        ``expected_run_seconds`` is a hint from the launcher — e.g.
+        30 min for ``/scan``, 4 hr for ``/agentic``.  Default is 30 min
+        so commands that don't yet pass a hint still warn on really
+        short tokens (< 30 min)."""
+        warnings: list[str] = []
+        exp = self._aws_bearer_exp
+        if exp is not None:
+            remaining = int(exp - time.time())
+            if remaining <= 0:
+                warnings.append(
+                    "AWS_BEARER_TOKEN_BEDROCK has already expired "
+                    "(exp was %d seconds ago).  Regenerate the token "
+                    "in the Bedrock console, or switch to a long-term "
+                    "API key (Bedrock → API Keys → Long-term)."
+                    % (-remaining)
+                )
+            elif remaining < expected_run_seconds:
+                warnings.append(
+                    "AWS_BEARER_TOKEN_BEDROCK expires in %d minutes "
+                    "but this run may take up to %d minutes.  Long "
+                    "scans will fail when the token expires.  Use a "
+                    "long-term API key (Bedrock → API Keys → Long-term)"
+                    " or switch to SigV4 with a profile / SSO "
+                    "(auto-refreshes)." % (
+                        remaining // 60, expected_run_seconds // 60,
+                    )
+                )
+        # SigV4-without-botocore case — operator signalled SigV4
+        # intent (any of: env access keys, AWS_PROFILE, shared
+        # credentials file) but botocore isn't importable in the
+        # parent process.  The dispatcher will 503 every Bedrock
+        # request; warn upfront so the operator doesn't burn a run
+        # to discover it.  Bearer mode doesn't trigger this — bearer
+        # auth needs no botocore.
+        has_bearer = bool(self._keys.get("aws_bearer_token"))
+        if not has_bearer:
+            sigv4_intent = bool(
+                self._keys.get("aws_access_key_id")
+                or self._aws_profile
+                or (Path.home() / ".aws" / "credentials").is_file()
+                or os.environ.get("AWS_SHARED_CREDENTIALS_FILE")
+            )
+            if sigv4_intent:
+                try:
+                    import botocore  # noqa: F401
+                except ImportError:
+                    warnings.append(
+                        "AWS Bedrock SigV4 credentials are configured "
+                        "but ``botocore`` is not installed in the parent "
+                        "process.  Install it: ``pip install botocore`` "
+                        "(or ``pip install boto3`` which pulls it in).  "
+                        "Bearer mode (``AWS_BEARER_TOKEN_BEDROCK``) does "
+                        "NOT require botocore."
+                    )
+        looks_short_lived = bool(
+            self._keys.get("aws_session_token")
+            or (
+                isinstance(self._keys.get("aws_access_key_id"), str)
+                and (self._keys.get("aws_access_key_id") or "").startswith("ASIA")
+            )
+        )
+        if looks_short_lived and not self._aws_profile:
+            # Is there a credentials file botocore can refresh from?
+            home_creds = Path.home() / ".aws" / "credentials"
+            has_creds_file = home_creds.is_file() or bool(
+                os.environ.get("AWS_SHARED_CREDENTIALS_FILE"),
+            )
+            if not has_creds_file:
+                warnings.append(
+                    "AWS env credentials look short-lived "
+                    "(AWS_SESSION_TOKEN set or ASIA-style access key) "
+                    "but no AWS_PROFILE / ~/.aws/credentials configured.  "
+                    "These will NOT auto-refresh; long scans will fail "
+                    "mid-run when the STS session ends.  Configure "
+                    "'aws configure sso' (recommended) or set "
+                    "~/.aws/credentials with a refresh-capable profile "
+                    "and unset the env vars."
+                )
+        return warnings
+
+    def bedrock_bearer_expired(self, *, skew_seconds: int = 30) -> bool:
+        """True iff the bearer is a JWT whose ``exp`` has passed.  A
+        small clock-skew window (default 30s) errs on the side of
+        rejecting borderline tokens at the dispatcher — better a
+        clear "token expired" than a network round trip that surfaces
+        an opaque AWS 401.  Opaque (non-JWT) bearer tokens always
+        return ``False`` — they have no expiry signal."""
+        exp = self._aws_bearer_exp
+        if exp is None:
+            return False
+        return time.time() + skew_seconds >= exp
 
     def aws_bedrock_endpoint(self, api: str = "mantle") -> str | None:
         """Return the Bedrock base URL for the chosen ``api``, or
@@ -338,9 +510,32 @@ class CredentialStore:
         return (credentials, region, endpoint)
 
     def _resolve_aws_credentials(self):
-        """Resolve ``(credentials, region)`` from botocore.  Endpoint
-        URL is built per-request (see :meth:`aws_signer`) since the
-        same creds + region serve both Mantle and runtime."""
+        """Resolve ``(credentials, region)`` from botocore.
+
+        Lookup order is tuned so long RAPTOR scans "just work" regardless
+        of how the operator configured AWS:
+
+        1. If ``AWS_PROFILE`` is set → use botocore's chain with that
+           profile.  Profiles backed by SSO, role-assumption, or shared-
+           config return ``RefreshableCredentials`` that auto-refresh on
+           every access, so mid-scan session expiry is handled.
+
+        2. If env carries a session token (``AWS_SESSION_TOKEN`` set, or
+           an ``ASIA…`` access key shape) → try the chain FIRST so SSO/
+           IMDS/profile-derived credentials win over an env snapshot the
+           operator might have set hours ago.  Fall back to the static
+           env creds only if the chain doesn't resolve.  This is the
+           "operator pasted temp creds into env" case — they typically
+           also have a profile or SSO cache that refreshes; we should
+           prefer that without making them unset env.
+
+        3. Static env creds otherwise (``AKIA…`` long-lived keys).
+           These don't expire; no refresh story needed.
+
+        4. Bare chain fallback if env doesn't have credentials at all.
+
+        Endpoint URL is built per-request (see :meth:`aws_signer`) since
+        the same creds + region serve both Mantle and runtime."""
         try:
             import botocore.credentials
             import botocore.session
@@ -352,25 +547,47 @@ class CredentialStore:
         st = self._keys.get("aws_session_token")
         region = self._aws_region
 
+        def _from_chain() -> tuple[object, str | None]:
+            try:
+                session = botocore.session.Session(
+                    profile=self._aws_profile,
+                )
+                creds = session.get_credentials()
+            except Exception:
+                return None, None
+            chain_region = None
+            try:
+                chain_region = session.get_config_variable("region")
+            except Exception:
+                pass
+            return creds, chain_region
+
         credentials = None
-        if ak and sk:
-            # Static creds the parent supplied via env (already erased
-            # from os.environ) or via set_aws().
+        looks_short_lived = bool(
+            st or (isinstance(ak, str) and ak.startswith("ASIA"))
+        )
+
+        if self._aws_profile or (looks_short_lived and not (ak and sk)):
+            # Case 1 — profile pinned.
+            credentials, chain_region = _from_chain()
+            if region is None:
+                region = chain_region
+        elif looks_short_lived and ak and sk:
+            # Case 2 — env has temp creds but chain (SSO/profile) is
+            # likely fresher; prefer chain, fall back to env snapshot.
+            credentials, chain_region = _from_chain()
+            if credentials is None:
+                credentials = botocore.credentials.Credentials(ak, sk, st)
+            if region is None:
+                region = chain_region
+        elif ak and sk:
+            # Case 3 — long-lived static (AKIA) env creds.
             credentials = botocore.credentials.Credentials(ak, sk, st)
         else:
-            # No static keys: fall back to botocore's natural credential
-            # chain (shared config/profile, SSO cache, container creds,
-            # IMDS instance role). The parent is the trust boundary, so
-            # the full chain is appropriate here. RefreshableCredentials
-            # transparently re-fetch on access, so SSO/IMDS rotation is
-            # handled per request.
-            try:
-                session = botocore.session.Session()
-                credentials = session.get_credentials()
-                if not region:
-                    region = session.get_config_variable("region")
-            except Exception:
-                credentials = None
+            # Case 4 — no env keys at all; full chain.
+            credentials, chain_region = _from_chain()
+            if region is None:
+                region = chain_region
 
         if credentials is None or not region:
             return None
@@ -400,7 +617,12 @@ def _ensure_anthropic_version(body: bytes) -> bytes:
         return body
     if not isinstance(payload, dict):
         return body
-    if "anthropic_version" in payload:
+    # Only treat the field as operator-supplied when it's a non-empty
+    # string.  ``None``, ``""``, numbers, or other types are typos that
+    # would otherwise pass through and surface as opaque Bedrock 4xx
+    # errors — fill in our default so the request succeeds.
+    existing = payload.get("anthropic_version")
+    if isinstance(existing, str) and existing:
         return body
     payload["anthropic_version"] = _BEDROCK_ANTHROPIC_VERSION
     return json.dumps(payload).encode("utf-8")
@@ -658,18 +880,53 @@ def build_rules(creds: CredentialStore) -> dict[str, ProviderRule]:
             api = "runtime"
             bedrock_path = path[len("/runtime"):] or "/"
 
+        # Security gate: reject any path with a ``..`` segment before
+        # forwarding.  Without this, a worker could craft
+        # ``/v1/messages/../../some-other-aws-path`` and have httpx
+        # normalise the ``..`` away client-side AFTER we've signed —
+        # the parent's bearer token / SigV4 signature would attach to
+        # an arbitrary URL under the Bedrock host.  Defence-in-depth:
+        # the worker isn't expected to send ``..`` here, but a
+        # compromised worker shouldn't be able to pivot off RAPTOR's
+        # trust boundary.
+        if ".." in bedrock_path.split("/"):
+            raise BedrockTransformError(
+                400, "bedrock: path traversal segment '..' rejected"
+            )
+
         if api == "mantle":
-            # Mantle exposes Anthropic Messages under the ``/anthropic``
-            # URL prefix; inject it.  Inject ``anthropic_version`` into
-            # the body when missing (Mantle inherits the requirement
-            # from InvokeModel; the SDK doesn't add it because the
-            # public Anthropic API doesn't need it).
-            upstream_path = bedrock_path
-            if bedrock_path.startswith("/v1/") or bedrock_path == "/v1":
-                upstream_path = "/anthropic" + bedrock_path
+            # Mantle: only ``/v1/messages`` and ``/v1/messages/
+            # count_tokens`` are valid worker shapes.  Everything else
+            # is either a typo (`/v1/models` — not exposed by Mantle)
+            # or an attempt to forward to an unintended path.  Reject
+            # explicitly rather than letting an opaque AWS 4xx propagate.
+            if bedrock_path not in (
+                "/v1/messages", "/v1/messages/count_tokens",
+            ):
+                raise BedrockTransformError(
+                    400,
+                    f"bedrock: path {bedrock_path!r} is not a supported "
+                    "Mantle endpoint (expected /v1/messages or "
+                    "/v1/messages/count_tokens)",
+                )
+            # Inject the ``/anthropic`` prefix (Mantle's URL contract)
+            # and fill ``anthropic_version`` into the body when missing
+            # (Mantle inherits the requirement from InvokeModel; the
+            # SDK doesn't add it because the public Anthropic API
+            # doesn't need it).
+            upstream_path = "/anthropic" + bedrock_path
             upstream_body = _ensure_anthropic_version(body)
             bearer = creds.get("aws_bearer_token")
             if bearer:
+                if creds.bedrock_bearer_expired():
+                    # Pre-flight gate: don't burn a network round trip
+                    # if we already know the JWT exp has passed.
+                    raise BedrockTransformError(
+                        401,
+                        "AWS_BEARER_TOKEN_BEDROCK has expired; "
+                        "regenerate the token (Bedrock console) or "
+                        "switch to a long-term API key.",
+                    )
                 endpoint = creds.aws_bedrock_endpoint("mantle")
                 if endpoint is None:
                     raise BedrockTransformError(
@@ -694,8 +951,30 @@ def build_rules(creds: CredentialStore) -> dict[str, ProviderRule]:
         # Runtime path — InvokeModel.  The request body's ``model``
         # becomes the URL path; the body is rewritten by
         # ``_transform_bedrock_request`` inside the request builders.
+        #
+        # Only ``/v1/messages`` is InvokeModel-translatable.  Other
+        # Anthropic endpoints (``/v1/messages/count_tokens``,
+        # ``/v1/models``) have no InvokeModel equivalent — short-
+        # circuit with a 400 + actionable guidance rather than letting
+        # the worker pay a network round trip to AWS just to get a
+        # different opaque 4xx back.
+        if bedrock_path != "/v1/messages":
+            raise BedrockTransformError(
+                400,
+                f"bedrock: path {bedrock_path!r} is not supported on "
+                "the InvokeModel API (use RAPTOR_BEDROCK_API=mantle "
+                "for /v1/messages/count_tokens and the introspection "
+                "endpoints)",
+            )
         bearer = creds.get("aws_bearer_token")
         if bearer:
+            if creds.bedrock_bearer_expired():
+                raise BedrockTransformError(
+                    401,
+                    "AWS_BEARER_TOKEN_BEDROCK has expired; "
+                    "regenerate the token (Bedrock console) or "
+                    "switch to a long-term API key.",
+                )
             endpoint = creds.aws_bedrock_endpoint("runtime")
             if endpoint is None:
                 raise BedrockTransformError(

--- a/core/llm/dispatcher/tests/test_bedrock_signing.py
+++ b/core/llm/dispatcher/tests/test_bedrock_signing.py
@@ -970,14 +970,24 @@ def test_bedrock_session_warnings_unmanaged_asia_env(monkeypatch):
 
 
 def test_bedrock_session_warnings_silent_for_long_term_setup(monkeypatch):
-    """AKIA env creds + no bearer + botocore installed (test
-    environment has it) = the well-trodden setup, no warnings."""
+    """AKIA env creds + no bearer + botocore importable = the well-
+    trodden setup, no warnings.  Mocked here so the test passes both
+    in CI (no botocore) and on dev hosts (where it is installed) —
+    we're only asserting the behaviour when botocore IS available."""
+    import sys as _sys
+    import types as _types
     monkeypatch.setenv("AWS_ACCESS_KEY_ID", "AKIAEXAMPLE")
     monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "secret")
     monkeypatch.delenv("AWS_SESSION_TOKEN", raising=False)
     monkeypatch.delenv("AWS_BEARER_TOKEN_BEDROCK", raising=False)
     monkeypatch.delenv("AWS_PROFILE", raising=False)
-    store = CredentialStore()
+    # Mock botocore as importable so the SigV4-without-botocore
+    # warning doesn't fire in CI environments that don't have it
+    # installed — irrelevant for what this test asserts.
+    if "botocore" not in _sys.modules:
+        monkeypatch.setitem(
+            _sys.modules, "botocore", _types.ModuleType("botocore"),
+        )
     # Drop the no-creds-file requirement so this test doesn't depend
     # on whether the dev host has ~/.aws/credentials.  We're only
     # asserting that AKIA + no bearer + botocore = silent.
@@ -986,6 +996,7 @@ def test_bedrock_session_warnings_silent_for_long_term_setup(monkeypatch):
         lambda self: False,
     )
     monkeypatch.delenv("AWS_SHARED_CREDENTIALS_FILE", raising=False)
+    store = CredentialStore()
     assert store.bedrock_session_warnings() == []
 
 
@@ -1044,6 +1055,7 @@ def test_bedrock_session_warnings_bearer_only_no_botocore_warning(monkeypatch):
 # ---------------------------------------------------------------------------
 
 
+@needs_botocore
 def test_credential_lookup_prefers_chain_when_profile_set(monkeypatch):
     """AWS_PROFILE pins the chain regardless of env-supplied static
     creds.  Profiles back SSO / role assumption, which return
@@ -1077,6 +1089,7 @@ def test_credential_lookup_prefers_chain_when_profile_set(monkeypatch):
     assert fake_session_created["profile"] == "myrole"
 
 
+@needs_botocore
 def test_credential_lookup_prefers_chain_when_env_looks_short_lived(monkeypatch):
     """ASIA env creds → try chain first; fall back to env if chain
     returns nothing.  This handles the "operator pasted temp creds
@@ -1103,6 +1116,7 @@ def test_credential_lookup_prefers_chain_when_env_looks_short_lived(monkeypatch)
     assert creds.access_key == "ASIACHAIN"  # chain wins
 
 
+@needs_botocore
 def test_credential_lookup_falls_back_to_env_when_chain_empty(monkeypatch):
     """ASIA env creds + chain returns nothing → env snapshot wins.
     Operator with only env vars still gets to make requests; refresh
@@ -1127,6 +1141,7 @@ def test_credential_lookup_falls_back_to_env_when_chain_empty(monkeypatch):
     assert creds.access_key == "ASIAONLYENV"
 
 
+@needs_botocore
 def test_credential_lookup_long_lived_akia_stays_static(monkeypatch):
     """AKIA env keys + no session token + no profile → static
     snapshot.  The chain is NOT consulted (no point — AKIA never

--- a/core/llm/dispatcher/tests/test_bedrock_signing.py
+++ b/core/llm/dispatcher/tests/test_bedrock_signing.py
@@ -31,6 +31,7 @@ import httpx
 import pytest
 
 from core.llm.dispatcher.auth import (
+    BedrockTransformError,
     CredentialStore,
     build_rules,
 )
@@ -238,6 +239,32 @@ def test_runtime_sigv4_invoke_path(upstream, tmp_path):
     assert f"/{_REGION}/bedrock/aws4_request" in auth
 
 
+def test_runtime_rejects_count_tokens_path(upstream, tmp_path):
+    """count_tokens has no InvokeModel equivalent — short-circuit at
+    the dispatcher rather than burn a network round trip to AWS just
+    to get a different opaque 4xx back.  Error mentions
+    ``RAPTOR_BEDROCK_API=mantle`` so the operator knows where to go."""
+    endpoint, _ = upstream
+    store = CredentialStore()
+    store.set_aws(
+        bearer_token="ABSK", region=_REGION, endpoint=endpoint,
+    )
+    d = LLMDispatcher(
+        run_id="bedrock-runtime-ct-reject",
+        audit_path=tmp_path / "audit.jsonl",
+        creds=store,
+    )
+    try:
+        resp = _post_bedrock(
+            d, {"model": _MODEL, "messages": []},
+            path="/bedrock/runtime/v1/messages/count_tokens",
+        )
+        assert resp.status_code == 400
+        assert "RAPTOR_BEDROCK_API=mantle" in resp.json()["error"]
+    finally:
+        d.shutdown()
+
+
 def test_runtime_rejects_streaming(upstream, tmp_path):
     """InvokeModel doesn't have a JSON-line streaming protocol (the
     streaming sibling is ``InvokeModelWithResponseStream`` with a
@@ -269,6 +296,95 @@ def test_runtime_rejects_streaming(upstream, tmp_path):
         assert "RAPTOR_BEDROCK_API=mantle" in resp.json()["error"]
     finally:
         d.shutdown()
+
+
+def test_mantle_rejects_path_traversal():
+    """A compromised worker sending a raw HTTP request with ``..``
+    segments in the path field — bypassing httpx's client-side URL
+    normalisation — would otherwise reach an arbitrary URL under the
+    Bedrock host with the parent's bearer/SigV4 attached.  ``..``
+    segments must be rejected at the ``prepare_request`` hook BEFORE
+    signing.
+
+    Tested by calling ``_bedrock_prepare`` directly — httpx in the
+    integration helper sanitises ``..`` client-side so the
+    dispatcher only ever sees a normalised path through that path.
+    The threat we care about is a raw socket-level forge, which this
+    direct call models faithfully."""
+    store = CredentialStore()
+    store.set_aws(
+        bearer_token="ABSK", region=_REGION,
+        endpoint="https://example.invalid",
+    )
+    rule = build_rules(store)["bedrock"]
+    for path in (
+        "/mantle/v1/messages/../../foo",
+        "/runtime/v1/messages/../../foo",
+        "/v1/messages/../etc/passwd",
+    ):
+        with pytest.raises(BedrockTransformError) as ei:
+            rule.prepare_request("POST", path, {}, b"{}")
+        assert ei.value.status == 400
+        assert "path traversal" in ei.value.message
+
+
+def test_mantle_rejects_unknown_path(upstream, tmp_path):
+    """Mantle's surface is finite: ``/v1/messages`` and
+    ``/v1/messages/count_tokens``.  Forwarding anything else gets a
+    confusing AWS 4xx — reject upfront with operator-actionable
+    guidance."""
+    endpoint, _ = upstream
+    store = CredentialStore()
+    store.set_aws(
+        bearer_token="ABSK", region=_REGION, endpoint=endpoint,
+    )
+    d = LLMDispatcher(
+        run_id="bedrock-mantle-unknown",
+        audit_path=tmp_path / "audit.jsonl",
+        creds=store,
+    )
+    try:
+        resp = _post_bedrock(
+            d, {"model": _MODEL, "messages": []},
+            path="/bedrock/mantle/v1/models",
+        )
+        assert resp.status_code == 400
+        assert "not a supported Mantle endpoint" in resp.json()["error"]
+    finally:
+        d.shutdown()
+
+
+def test_anthropic_version_null_overwritten(upstream, tmp_path):
+    """A worker (or operator) supplying ``anthropic_version: null`` —
+    common JSON-templating typo — must NOT be forwarded verbatim.
+    Mantle rejects null with an opaque 4xx, so we treat anything
+    that isn't a non-empty string as "operator wants the default"
+    and fill in the canonical value."""
+    endpoint, captured = upstream
+    store = CredentialStore()
+    store.set_aws(
+        bearer_token="ABSK", region=_REGION, endpoint=endpoint,
+    )
+    d = LLMDispatcher(
+        run_id="bedrock-aver-null",
+        audit_path=tmp_path / "audit.jsonl",
+        creds=store,
+    )
+    try:
+        resp = _post_bedrock(
+            d,
+            {
+                "model": _MODEL,
+                "max_tokens": 8,
+                "messages": [],
+                "anthropic_version": None,
+            },
+        )
+        assert resp.status_code == 200
+    finally:
+        d.shutdown()
+    sent = json.loads(captured()["body"])
+    assert sent["anthropic_version"] == "bedrock-2023-05-31"
 
 
 def test_runtime_targets_bedrock_runtime_host(tmp_path, monkeypatch):
@@ -725,6 +841,318 @@ def test_bedrock_signing_failure_returns_502(tmp_path, monkeypatch):
 
     audit = (tmp_path / "audit.jsonl").read_text()
     assert "provider.transform_error" in audit
+
+
+# ---------------------------------------------------------------------------
+# Bearer-token expiry — JWT exp decode + pre-flight rejection
+# ---------------------------------------------------------------------------
+
+
+def _make_jwt_with_exp(exp_unix: int) -> str:
+    """Build a syntactically-valid (but unsigned) JWT carrying a single
+    ``exp`` claim — only the payload is parsed by our decoder; header
+    and signature can be anything dot-separated."""
+    import base64 as _b64
+    payload = json.dumps({"exp": exp_unix}).encode("utf-8")
+    payload_b64 = _b64.urlsafe_b64encode(payload).rstrip(b"=").decode("ascii")
+    return f"header.{payload_b64}.signature"
+
+
+def test_decode_bedrock_bearer_exp_jwt():
+    """JWT-shaped tokens with an exp claim are decoded to a unix
+    timestamp.  Long-term API keys (opaque non-JWT strings) return
+    None.  Garbage returns None."""
+    from core.llm.dispatcher.auth import _decode_bedrock_bearer_exp
+
+    assert _decode_bedrock_bearer_exp(_make_jwt_with_exp(1234567890)) == 1234567890
+    # opaque long-term key
+    assert _decode_bedrock_bearer_exp("ABSK-long-term-opaque-key") is None
+    # malformed
+    assert _decode_bedrock_bearer_exp("") is None
+    assert _decode_bedrock_bearer_exp("not.enough") is None
+    assert _decode_bedrock_bearer_exp("a.b.c.d") is None
+    assert _decode_bedrock_bearer_exp("a.!!!notbase64.c") is None
+
+
+def test_credential_store_caches_bearer_exp_at_init(monkeypatch):
+    """exp is decoded once at construction so the hot path doesn't
+    re-parse on every request."""
+    import time as _t
+    future = int(_t.time()) + 3600
+    monkeypatch.setenv("AWS_BEARER_TOKEN_BEDROCK", _make_jwt_with_exp(future))
+    monkeypatch.setenv("AWS_REGION", _REGION)
+    store = CredentialStore()
+    assert store.bedrock_bearer_exp() == future
+    assert store.bedrock_bearer_expired() is False
+
+
+def test_credential_store_bearer_expired_true_when_exp_past():
+    """An already-expired JWT bearer flips ``bedrock_bearer_expired()``."""
+    import time as _t
+    past = int(_t.time()) - 60
+    store = CredentialStore()
+    store.set_aws(bearer_token=_make_jwt_with_exp(past))
+    assert store.bedrock_bearer_expired() is True
+
+
+def test_credential_store_opaque_bearer_never_expired():
+    """Long-term API keys are opaque strings — no exp signal, never
+    treated as expired."""
+    store = CredentialStore()
+    store.set_aws(bearer_token="ABSK-opaque-long-term")
+    assert store.bedrock_bearer_exp() is None
+    assert store.bedrock_bearer_expired() is False
+
+
+def test_dispatcher_rejects_expired_bearer_preflight(tmp_path):
+    """Mantle path with an expired JWT bearer fails fast (401 + clear
+    operator guidance) BEFORE any network call.  Saves the round trip
+    and surfaces an actionable error instead of opaque AWS 401."""
+    import time as _t
+    past = int(_t.time()) - 60
+    store = CredentialStore()
+    store.set_aws(
+        bearer_token=_make_jwt_with_exp(past),
+        region=_REGION,
+        endpoint="https://example.invalid",
+    )
+    d = LLMDispatcher(
+        run_id="bedrock-expired-mantle",
+        audit_path=tmp_path / "audit.jsonl",
+        creds=store,
+    )
+    try:
+        resp = _post_bedrock(
+            d, {"model": _MODEL, "messages": []},
+            path="/bedrock/mantle/v1/messages",
+        )
+        assert resp.status_code == 401
+        assert "expired" in resp.json()["error"]
+        # Same gate on the runtime path.
+        resp2 = _post_bedrock(
+            d, {"model": _MODEL, "messages": []},
+            path="/bedrock/runtime/v1/messages",
+        )
+        assert resp2.status_code == 401
+        assert "expired" in resp2.json()["error"]
+    finally:
+        d.shutdown()
+
+
+def test_bedrock_session_warnings_short_bearer(monkeypatch):
+    """JWT bearer expiring before the expected run duration gets a
+    countdown warning with the operator escape hatch."""
+    import time as _t
+    soon = int(_t.time()) + 600   # 10 minutes
+    monkeypatch.setenv("AWS_BEARER_TOKEN_BEDROCK", _make_jwt_with_exp(soon))
+    store = CredentialStore()
+    warnings = store.bedrock_session_warnings(expected_run_seconds=3600)
+    assert any(
+        "expires in" in w and "long-term API key" in w for w in warnings
+    )
+
+
+def test_bedrock_session_warnings_unmanaged_asia_env(monkeypatch):
+    """ASIA env credentials with no profile + no creds file get the
+    'configure aws sso' guidance."""
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "ASIAEXAMPLE")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "secret")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "session")
+    monkeypatch.delenv("AWS_PROFILE", raising=False)
+    monkeypatch.delenv("AWS_SHARED_CREDENTIALS_FILE", raising=False)
+    monkeypatch.setattr(
+        "core.llm.dispatcher.auth.Path.is_file",
+        lambda self: False,
+    )
+    store = CredentialStore()
+    warnings = store.bedrock_session_warnings()
+    assert any("short-lived" in w and "aws configure sso" in w for w in warnings)
+
+
+def test_bedrock_session_warnings_silent_for_long_term_setup(monkeypatch):
+    """AKIA env creds + no bearer + botocore installed (test
+    environment has it) = the well-trodden setup, no warnings."""
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "AKIAEXAMPLE")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "secret")
+    monkeypatch.delenv("AWS_SESSION_TOKEN", raising=False)
+    monkeypatch.delenv("AWS_BEARER_TOKEN_BEDROCK", raising=False)
+    monkeypatch.delenv("AWS_PROFILE", raising=False)
+    store = CredentialStore()
+    # Drop the no-creds-file requirement so this test doesn't depend
+    # on whether the dev host has ~/.aws/credentials.  We're only
+    # asserting that AKIA + no bearer + botocore = silent.
+    monkeypatch.setattr(
+        "core.llm.dispatcher.auth.Path.is_file",
+        lambda self: False,
+    )
+    monkeypatch.delenv("AWS_SHARED_CREDENTIALS_FILE", raising=False)
+    assert store.bedrock_session_warnings() == []
+
+
+def test_bedrock_session_warnings_sigv4_intent_without_botocore(monkeypatch):
+    """When SigV4 credentials are configured (env keys, profile, or
+    shared credentials file) but ``botocore`` isn't importable, warn
+    loudly at startup — otherwise the operator's first request would
+    be a confusing 503."""
+    import builtins as _b
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "AKIAEXAMPLE")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "secret")
+    monkeypatch.delenv("AWS_BEARER_TOKEN_BEDROCK", raising=False)
+    monkeypatch.delenv("AWS_PROFILE", raising=False)
+
+    real_import = _b.__import__
+    def _no_botocore(name, *a, **k):
+        if name == "botocore" or name.startswith("botocore."):
+            raise ImportError("no botocore in this test")
+        return real_import(name, *a, **k)
+    monkeypatch.setattr(_b, "__import__", _no_botocore)
+
+    store = CredentialStore()
+    warnings = store.bedrock_session_warnings()
+    assert any(
+        "botocore" in w and "pip install" in w for w in warnings
+    ), f"expected botocore warning, got {warnings!r}"
+
+
+def test_bedrock_session_warnings_bearer_only_no_botocore_warning(monkeypatch):
+    """Bearer-only operators don't need botocore — no warning even
+    when it's absent."""
+    import builtins as _b
+    monkeypatch.setenv("AWS_BEARER_TOKEN_BEDROCK", "ABSK-opaque")
+    monkeypatch.delenv("AWS_ACCESS_KEY_ID", raising=False)
+    monkeypatch.delenv("AWS_SECRET_ACCESS_KEY", raising=False)
+    monkeypatch.delenv("AWS_PROFILE", raising=False)
+    monkeypatch.setattr(
+        "core.llm.dispatcher.auth.Path.is_file",
+        lambda self: False,
+    )
+
+    real_import = _b.__import__
+    def _no_botocore(name, *a, **k):
+        if name == "botocore" or name.startswith("botocore."):
+            raise ImportError("no botocore in this test")
+        return real_import(name, *a, **k)
+    monkeypatch.setattr(_b, "__import__", _no_botocore)
+
+    store = CredentialStore()
+    warnings = store.bedrock_session_warnings()
+    assert not any("botocore" in w for w in warnings)
+
+
+# ---------------------------------------------------------------------------
+# Credential lookup order — chain-prefers-refreshable for short-lived
+# ---------------------------------------------------------------------------
+
+
+def test_credential_lookup_prefers_chain_when_profile_set(monkeypatch):
+    """AWS_PROFILE pins the chain regardless of env-supplied static
+    creds.  Profiles back SSO / role assumption, which return
+    RefreshableCredentials — operators using a profile signal they
+    want refresh."""
+    import botocore.credentials as _bc
+    import botocore.session as _bs
+
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "AKIAENV")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "envsecret")
+    monkeypatch.setenv("AWS_PROFILE", "myrole")
+    monkeypatch.setenv("AWS_REGION", _REGION)
+    store = CredentialStore()
+
+    chain_creds = _bc.Credentials("AKIACHAIN", "chainsecret", None)
+    fake_session_created = {}
+
+    class _FakeSession:
+        def __init__(self, profile=None):
+            fake_session_created["profile"] = profile
+        def get_credentials(self):
+            return chain_creds
+        def get_config_variable(self, *a, **k):
+            return _REGION
+
+    monkeypatch.setattr(_bs, "Session", _FakeSession)
+    result = store._resolve_aws_credentials()
+    assert result is not None
+    creds, region = result
+    assert creds.access_key == "AKIACHAIN"   # chain wins
+    assert fake_session_created["profile"] == "myrole"
+
+
+def test_credential_lookup_prefers_chain_when_env_looks_short_lived(monkeypatch):
+    """ASIA env creds → try chain first; fall back to env if chain
+    returns nothing.  This handles the "operator pasted temp creds
+    but also has SSO configured" case without forcing them to unset env."""
+    import botocore.credentials as _bc
+    import botocore.session as _bs
+
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "ASIAEXAMPLE")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "envsecret")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "envtoken")
+    monkeypatch.delenv("AWS_PROFILE", raising=False)
+    monkeypatch.setenv("AWS_REGION", _REGION)
+    store = CredentialStore()
+
+    chain_creds = _bc.Credentials("ASIACHAIN", "chainsecret", "chaintoken")
+    class _Session:
+        def __init__(self, profile=None): pass
+        def get_credentials(self): return chain_creds
+        def get_config_variable(self, *a, **k): return _REGION
+    monkeypatch.setattr(_bs, "Session", _Session)
+    result = store._resolve_aws_credentials()
+    assert result is not None
+    creds, _region = result
+    assert creds.access_key == "ASIACHAIN"  # chain wins
+
+
+def test_credential_lookup_falls_back_to_env_when_chain_empty(monkeypatch):
+    """ASIA env creds + chain returns nothing → env snapshot wins.
+    Operator with only env vars still gets to make requests; refresh
+    just isn't available (covered by startup warning separately)."""
+    import botocore.session as _bs
+
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "ASIAONLYENV")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "envsecret")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "envtoken")
+    monkeypatch.delenv("AWS_PROFILE", raising=False)
+    monkeypatch.setenv("AWS_REGION", _REGION)
+    store = CredentialStore()
+
+    class _EmptySession:
+        def __init__(self, profile=None): pass
+        def get_credentials(self): return None
+        def get_config_variable(self, *a, **k): return None
+    monkeypatch.setattr(_bs, "Session", _EmptySession)
+    result = store._resolve_aws_credentials()
+    assert result is not None
+    creds, _region = result
+    assert creds.access_key == "ASIAONLYENV"
+
+
+def test_credential_lookup_long_lived_akia_stays_static(monkeypatch):
+    """AKIA env keys + no session token + no profile → static
+    snapshot.  The chain is NOT consulted (no point — AKIA never
+    expires, and operators with both AKIA env and a profile likely
+    want the env to win)."""
+    import botocore.session as _bs
+
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "AKIAONLYENV")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "envsecret")
+    monkeypatch.delenv("AWS_SESSION_TOKEN", raising=False)
+    monkeypatch.delenv("AWS_PROFILE", raising=False)
+    monkeypatch.setenv("AWS_REGION", _REGION)
+    store = CredentialStore()
+
+    chain_called = []
+    class _Session:
+        def __init__(self, profile=None): chain_called.append(True)
+        def get_credentials(self): return None
+        def get_config_variable(self, *a, **k): return None
+    monkeypatch.setattr(_bs, "Session", _Session)
+    result = store._resolve_aws_credentials()
+    assert result is not None
+    creds, _region = result
+    assert creds.access_key == "AKIAONLYENV"
+    assert chain_called == []   # AKIA path doesn't consult chain
+
 
 def test_aws_secrets_popped_from_env(monkeypatch):
     """AWS secret env vars are read-and-erased at CredentialStore

--- a/raptor.py
+++ b/raptor.py
@@ -609,6 +609,17 @@ def _get_or_start_dispatcher():
         # None slots.
         creds = CredentialStore()
         seed_from_config(creds)
+        # Bedrock UX preflight — surface short-lived bearer tokens,
+        # ASIA env vars that won't refresh, and SigV4 intent without
+        # botocore, BEFORE the operator burns a long run discovering
+        # them.  Silent for the well-trodden setups (no Bedrock
+        # configured, bearer-only with long-term API key, SigV4 with
+        # AKIA + botocore).
+        for _bedrock_warning in creds.bedrock_session_warnings():
+            import logging as _logging
+            _logging.getLogger(__name__).warning(
+                "[Bedrock] %s", _bedrock_warning,
+            )
         _active_dispatcher = LLMDispatcher(
             run_id=f"raptor-{uuid.uuid4().hex[:8]}",
             creds=creds,


### PR DESCRIPTION
Two layers on top of the dual-API provider — both born from "what breaks a long scan?" thinking after live-validating the Bedrock path.

Security + correctness guards (from adversarial review):

* Path-traversal guard at `_bedrock_prepare`: reject any URL with a `..` segment before signing.  Without this, a compromised worker could craft `/v1/messages/../../some-aws-path` and have httpx normalise the `..` client-side AFTER the dispatcher signs — the parent's bearer/SigV4 would attach to an arbitrary URL under the Bedrock host.  Defence-in-depth on the worker→parent trust boundary.

* Mantle endpoint allow-list: only `/v1/messages` and `/v1/messages/count_tokens` forward; everything else gets a 400 with operator-actionable guidance rather than an opaque AWS 4xx.

* Runtime `count_tokens` gate: InvokeModel has no `count_tokens` equivalent, so reject at the dispatcher with a "use RAPTOR_BEDROCK_API=mantle" hint instead of burning a round trip.

* `_ensure_anthropic_version` now overwrites null/empty/non-string values instead of forwarding operator typos verbatim.

Expiry-aware credential UX — three failure modes that "should just work" for long scans:

* JWT exp decode on bearer tokens.  Bedrock short-term API keys are JWTs with a readable `exp` claim — decode once at startup, pre- flight reject expired bearers at the dispatcher (no wasted round trip + actionable error instead of opaque AWS 401), and surface a startup countdown when the token expires inside the expected run duration.  Long-term API keys (opaque non-JWT strings) sail through untouched.

* Refresh-friendly SigV4 credential lookup: when `AWS_PROFILE` is set or env carries short-lived creds (`AWS_SESSION_TOKEN` set or `ASIA…` prefix), try the botocore chain first so SSO/profile- derived `RefreshableCredentials` win over an env snapshot the operator might have set hours ago.  AKIA env vars (long-lived) keep the static-snapshot path — they don't expire and consulting the chain would be needless overhead.

* `bedrock_session_warnings()` surfaces three setups that fail silent mid-run: short-bearer + long-run mismatch, unmanaged ASIA env (no profile + no creds file → no refresh source), and SigV4-credentials-without-botocore.  Launcher emits at startup so operators see the actionable fix before the run begins.

Refs #696 