### PR TITLE
fix(scanner): redirect HOME+XDG via sandbox fake_home; add --extra-config

### DIFF
--- a/core/sandbox/context.py
+++ b/core/sandbox/context.py
@@ -95,13 +95,17 @@ def _audit_degrade_reason(b_fallback_reason, b_fallback_instr,
                 "Command Line Tools if missing.",
             )
     elif not check_mount_available():
-        return (
-            "mount-ns blocked by host "
-            "(apparmor_restrict_unprivileged_userns=1)",
-            "set kernel.apparmor_restrict_unprivileged_userns=0 "
-            "(Ubuntu 24.04+) and install the uidmap package; or "
-            "rerun on a host where mount-ns is available.",
-        )
+        # Pre-fix this branch hardcoded the AppArmor diagnostic — but
+        # ``check_mount_available()`` can fail for at least four
+        # distinct reasons (AppArmor sysctl, missing uidmap binaries,
+        # SELinux enforcing, outer seccomp / nested userns), each with
+        # its own remediation. Misattributing to AppArmor on a
+        # SELinux-using host sent operators chasing the wrong sysctl
+        # entirely. Route to ``mount_unavailable_reason()`` which
+        # re-probes the specific conditions in priority order and
+        # returns a routed ``(condition, fix)``.
+        from .probes import mount_unavailable_reason
+        return mount_unavailable_reason()
     if kwargs.get("pass_fds"):
         return (
             "call uses pass_fds= which spawn doesn't plumb through",

--- a/core/sandbox/probes.py
+++ b/core/sandbox/probes.py
@@ -454,6 +454,89 @@ def check_mount_available() -> bool:
         return True
 
 
+def _selinux_enforcing() -> bool:
+    """Return True iff SELinux is loaded AND enforcing on this host.
+
+    Quickly distinguishes SELinux from AppArmor as the actual cause of
+    ``unshare(CLONE_NEWNS)`` refusal. The functional probe in
+    ``check_mount_available`` catches the refusal but can't see which
+    LSM rejected it; this helper inspects ``/sys/fs/selinux/enforce``
+    which is the kernel's authoritative answer.
+
+    Returns False for: SELinux absent (file missing), SELinux disabled
+    or permissive (``enforce`` is 0), unreadable file. Never raises —
+    the caller wants a string-routing decision, not exception flow.
+    """
+    try:
+        return Path("/sys/fs/selinux/enforce").read_text().strip() == "1"
+    except (FileNotFoundError, OSError):
+        return False
+
+
+def mount_unavailable_reason() -> tuple[str, str]:
+    """Diagnose WHY mount-ns isolation is unavailable on this host.
+
+    Returns ``(condition, fix)`` strings suitable for surfacing to an
+    operator. Four distinct branches: AppArmor restriction, missing
+    uidmap binaries, SELinux enforcing, or (catch-all) outer seccomp /
+    nested userns. Pre-fix the diagnostic at ``context.py``'s spawn-
+    blockers branch hardcoded "AppArmor", misattributing the cause on
+    SELinux hosts and on hosts where the uidmap package was simply not
+    installed.
+
+    Caller is responsible for only invoking this when
+    ``check_mount_available()`` already returned False — this helper
+    re-probes the specific conditions in priority order, but doesn't
+    itself decide whether mount-ns is unavailable.
+    """
+    # 1. AppArmor sysctl (Ubuntu 24.04+ default).
+    try:
+        v = Path(
+            "/proc/sys/kernel/apparmor_restrict_unprivileged_userns"
+        ).read_text().strip()
+        if v == "1":
+            return (
+                "mount-ns blocked by host "
+                "(apparmor_restrict_unprivileged_userns=1)",
+                "set kernel.apparmor_restrict_unprivileged_userns=0 "
+                "(Ubuntu 24.04+) and install the uidmap package; or "
+                "rerun on a host where mount-ns is available.",
+            )
+    except (FileNotFoundError, OSError):
+        pass
+    # 2. uidmap binaries missing — distinct from the AppArmor case
+    #    because the fix is package install, not sysctl flip.
+    if not (shutil.which("newuidmap") and shutil.which("newgidmap")):
+        return (
+            "mount-ns blocked by host "
+            "(uidmap binaries newuidmap/newgidmap not installed)",
+            "install the uidmap package (apt install uidmap on "
+            "Debian/Ubuntu, dnf install shadow-utils on Fedora/RHEL); "
+            "or rerun on a host where mount-ns is available.",
+        )
+    # 3. SELinux enforcing — distinct from AppArmor; the fix is an
+    #    SELinux booleans / policy change, not an AppArmor sysctl.
+    if _selinux_enforcing():
+        return (
+            "mount-ns blocked by host (SELinux enforcing)",
+            "set SELinux to permissive temporarily "
+            "(`sudo setenforce 0`) to confirm, then grant the calling "
+            "process the policy to unshare(CLONE_NEWNS) — typically "
+            "the `container_use_userns` boolean: "
+            "`sudo setsebool -P container_use_userns 1`; or rerun on a "
+            "host where mount-ns is available.",
+        )
+    # 4. Catch-all: outer seccomp filter / nested userns / unknown LSM.
+    return (
+        "mount-ns blocked by host "
+        "(unshare(CLONE_NEWNS) refused at runtime — likely outer "
+        "seccomp filter, nested user-namespace restriction, or "
+        "unknown LSM policy)",
+        "rerun outside the restricting container / VM, or rerun on a "
+        "host where mount-ns is available.",
+    )
+
+
 def check_seatbelt_available() -> bool:
     """macOS-only: check if `sandbox-exec` works for our use case.
 

--- a/core/sandbox/tests/test_mount_unavailable_reason.py
+++ b/core/sandbox/tests/test_mount_unavailable_reason.py
@@ -1,0 +1,134 @@
+"""Regression guard for ``mount_unavailable_reason()`` — the
+diagnostic routing that PR #777 surfaced was hardcoded to AppArmor.
+
+When ``check_mount_available()`` returns False, the caller (context.py
+spawn-blockers branch) used to emit a fixed
+``apparmor_restrict_unprivileged_userns=1`` message. On a SELinux host
+the operator chased the wrong sysctl; on a host where the uidmap
+package was simply missing they were told to flip an AppArmor flag
+that wasn't the problem.
+
+This module pins the four routing branches:
+  - AppArmor sysctl=1 → AppArmor guidance
+  - uidmap binaries missing → uidmap-install guidance
+  - SELinux enforcing → SELinux guidance
+  - catch-all → outer-seccomp/nested-userns guidance
+"""
+
+import sys as _sys
+import pytest as _pytest
+pytestmark = _pytest.mark.skipif(
+    _sys.platform != "linux",
+    reason="Linux-only sandbox internals — the probe is gated on Linux paths",
+)
+
+from core.sandbox import probes
+
+
+def _no_apparmor_sysctl(*a, **kw):
+    """Force the AppArmor branch to fall through (FileNotFoundError on
+    sysctl read). Used by tests that want a deeper branch."""
+    raise FileNotFoundError("apparmor sysctl absent")
+
+
+class TestMountUnavailableReason:
+
+    def test_apparmor_branch_returns_apparmor_guidance(self, monkeypatch):
+        """sysctl == ``1`` → operator-guidance names AppArmor."""
+        from pathlib import Path
+
+        def _fake_read_text(self, *a, **kw):
+            return "1\n"
+
+        monkeypatch.setattr(Path, "read_text", _fake_read_text)
+        condition, fix = probes.mount_unavailable_reason()
+        assert "apparmor" in condition.lower()
+        assert "apparmor" in fix.lower()
+
+    def test_uidmap_missing_branch_returns_uidmap_guidance(
+        self, monkeypatch,
+    ):
+        """AppArmor absent, ``newuidmap``/``newgidmap`` missing →
+        operator-guidance names the uidmap package."""
+        from pathlib import Path
+        monkeypatch.setattr(Path, "read_text", _no_apparmor_sysctl)
+        monkeypatch.setattr(probes.shutil, "which", lambda _: None)
+        condition, fix = probes.mount_unavailable_reason()
+        assert "uidmap" in condition.lower()
+        assert ("apt install uidmap" in fix
+                or "shadow-utils" in fix), fix
+
+    def test_selinux_branch_returns_selinux_guidance(self, monkeypatch):
+        """AppArmor absent, uidmap present, SELinux enforcing →
+        operator-guidance names SELinux + setsebool, NOT AppArmor."""
+        from pathlib import Path
+
+        def _read_text(self, *a, **kw):
+            s = str(self)
+            if s.endswith("apparmor_restrict_unprivileged_userns"):
+                raise FileNotFoundError
+            if s == "/sys/fs/selinux/enforce":
+                return "1\n"
+            raise FileNotFoundError
+
+        monkeypatch.setattr(Path, "read_text", _read_text)
+        monkeypatch.setattr(probes.shutil, "which",
+                            lambda b: f"/usr/bin/{b}")
+        condition, fix = probes.mount_unavailable_reason()
+        assert "selinux" in condition.lower()
+        assert "setenforce" in fix or "setsebool" in fix, fix
+        # And critically — must NOT misattribute to AppArmor.
+        assert "apparmor" not in condition.lower()
+        assert "apparmor" not in fix.lower()
+
+    def test_catch_all_branch_when_no_specific_cause_detected(
+        self, monkeypatch,
+    ):
+        """AppArmor absent, uidmap present, SELinux not enforcing →
+        catch-all guidance mentions outer seccomp / nested userns
+        as plausible causes."""
+        from pathlib import Path
+        monkeypatch.setattr(Path, "read_text", _no_apparmor_sysctl)
+        monkeypatch.setattr(probes.shutil, "which",
+                            lambda b: f"/usr/bin/{b}")
+        condition, fix = probes.mount_unavailable_reason()
+        text = (condition + " " + fix).lower()
+        assert "seccomp" in text or "nested" in text or "lsm" in text
+
+
+class TestSelinuxEnforcingProbe:
+    """The ``_selinux_enforcing()`` helper drives the SELinux routing
+    branch. Tests pin the three states (enforcing, permissive, absent)
+    without depending on the host's actual SELinux configuration."""
+
+    def test_enforcing_returns_true(self, monkeypatch):
+        from pathlib import Path
+        monkeypatch.setattr(Path, "read_text",
+                            lambda self, *a, **kw: "1\n")
+        assert probes._selinux_enforcing() is True
+
+    def test_permissive_returns_false(self, monkeypatch):
+        from pathlib import Path
+        monkeypatch.setattr(Path, "read_text",
+                            lambda self, *a, **kw: "0\n")
+        assert probes._selinux_enforcing() is False
+
+    def test_absent_file_returns_false(self, monkeypatch):
+        from pathlib import Path
+
+        def _raise(self, *a, **kw):
+            raise FileNotFoundError("not selinux")
+
+        monkeypatch.setattr(Path, "read_text", _raise)
+        assert probes._selinux_enforcing() is False
+
+    def test_unreadable_returns_false_not_raise(self, monkeypatch):
+        """The diagnostic path must never raise — caller wants a
+        routing decision, not exception flow."""
+        from pathlib import Path
+
+        def _raise(self, *a, **kw):
+            raise OSError("permission denied")
+
+        monkeypatch.setattr(Path, "read_text", _raise)
+        assert probes._selinux_enforcing() is False

--- a/packages/static-analysis/scanner.py
+++ b/packages/static-analysis/scanner.py
@@ -587,7 +587,8 @@ def _sanitize_pack_name(name: str) -> str:
 
 
 def run(cmd, cwd=None, timeout=RaptorConfig.DEFAULT_TIMEOUT, env=None,
-        target=None, output=None, proxy_hosts=None, caller_label=None):
+        target=None, output=None, proxy_hosts=None, caller_label=None,
+        fake_home=False, readable_paths=None):
     """Execute a command in a network-isolated sandbox and return results.
 
     When `target` and `output` are supplied, Landlock is engaged — the
@@ -630,6 +631,11 @@ def run(cmd, cwd=None, timeout=RaptorConfig.DEFAULT_TIMEOUT, env=None,
     #     falls back to Landlock-only. Workflow proceeds; debug-
     #     level diagnostic only.
     tool_paths = _compute_python_tool_paths(cmd)
+    sandbox_kwargs = {}
+    if fake_home:
+        sandbox_kwargs["fake_home"] = True
+    if readable_paths:
+        sandbox_kwargs["readable_paths"] = list(readable_paths)
     p = sandbox_run(
         cmd,
         target=target,
@@ -640,6 +646,7 @@ def run(cmd, cwd=None, timeout=RaptorConfig.DEFAULT_TIMEOUT, env=None,
         capture_output=True,
         timeout=timeout,
         tool_paths=tool_paths or None,
+        **sandbox_kwargs,
         **net_kwargs,
     )
     return p.returncode, p.stdout, p.stderr
@@ -750,7 +757,8 @@ def run_single_semgrep(
     repo_path: Path,
     out_dir: Path,
     timeout: int,
-    progress_callback: Optional[Callable] = None
+    progress_callback: Optional[Callable] = None,
+    extra_config_readable_paths: Optional[List[str]] = None,
 ) -> Tuple[str, bool]:
     """
     Run a single Semgrep scan.
@@ -793,20 +801,32 @@ def run_single_semgrep(
         path_parts = [p for p in path_parts if 'venv' not in p.lower() and '/bin/pysemgrep' not in p]
         clean_env['PATH'] = ':'.join(path_parts)
 
-    # Redirect HOME into the run's out_dir so semgrep's two stateful
-    # files — semgrep.log (operational log) and settings.yml (metrics
-    # opt-in, empty after first write) — land inside the sandbox
-    # output rather than polluting the user's real ~/.semgrep.
-    # semgrep 1.79.0 does NOT persistently cache registry packs on
-    # disk — every invocation fetches the pack YAML from semgrep.dev
-    # regardless of HOME / cache dir — so the redirect costs us
-    # nothing (there's no cache to lose across scans). PR #196 ships
-    # pack YAMLs under engine/semgrep/rules/registry-cache/ and
-    # rewrites `p/security-audit` → local path BEFORE semgrep's
-    # registry client runs — post-#196 the fetch path is cold.
-    semgrep_home = out_dir / ".semgrep_home"
-    semgrep_home.mkdir(parents=True, exist_ok=True)
-    clean_env['HOME'] = str(semgrep_home)
+    # HOME + XDG basedirs are redirected via the sandbox layer's
+    # ``fake_home=True`` primitive (passed below to ``run()``). The
+    # sandbox itself owns the override semantics: it pre-creates
+    # ``HOME`` + all four ``XDG_*_HOME`` subdirs (CONFIG/DATA/CACHE/STATE)
+    # with mode 0o700 inside ``output``, refuses to materialise if any
+    # target path is a symlink (TOCTOU defence against a prior sandboxed
+    # child substituting a redirect target), and merges the override
+    # into the subprocess env with ``fake_home_env`` winning over any
+    # caller-supplied ``env=`` (see ``core/sandbox/context.py``).
+    #
+    # Without the XDG override, ``SAFE_ENV_ALLOWLIST`` preserves the
+    # operator's ``XDG_CONFIG_HOME`` and newer semgrep follows it to the
+    # real ``~/.config/semgrep`` — outside the Landlock writable policy.
+    # Under full sandbox the path is invisible inside the mount-ns;
+    # under the rootless-podman / distrobox Landlock-only path Landlock
+    # denies the write and semgrep crashes. ``fake_home=True`` is the
+    # profile-agnostic fix and means the policy lives in ONE place
+    # (sandbox context) instead of hand-rolled per-tool.
+    #
+    # semgrep 1.79.0 does NOT persistently cache registry packs on disk
+    # — every invocation fetches the pack YAML from semgrep.dev
+    # regardless of HOME / cache dir — so the redirect costs us nothing
+    # (there's no cache to lose across scans). PR #196 ships pack YAMLs
+    # under engine/semgrep/rules/registry-cache/ and rewrites
+    # ``p/security-audit`` → local path BEFORE semgrep's registry client
+    # runs — post-#196 the fetch path is cold.
 
     # Registry packs ("p/xxx", "category/xxx") fetch YAML from semgrep.dev
     # on every invocation — semgrep has no persistent on-disk cache. A slow
@@ -843,11 +863,26 @@ def run_single_semgrep(
         )
         _ph = _importlib_util.module_from_spec(_ph_spec)
         _ph_spec.loader.exec_module(_ph)
+        # ``fake_home=True``: sandbox layer materialises HOME + four
+        # XDG_*_HOME dirs inside ``output``, with symlink-TOCTOU defence,
+        # and merges its override into the subprocess env (winning over
+        # ``clean_env``'s ``HOME`` if anything else set it). Profile-
+        # agnostic — fires even under ``--sandbox none``.
+        #
+        # ``readable_paths``: the caller's ``--extra-config`` rule paths
+        # are passed here as well as in the semgrep argv. Today the
+        # scanner's Landlock policy is read-wide (``restrict_reads=False``
+        # — semgrep is a RAPTOR-chosen trusted tool) so this is a no-op,
+        # but future-proofs against a flip to read-restricted: an operator
+        # ``--extra-config /home/me/rules.yml`` would otherwise be denied
+        # at sandbox-read time.
         rc, so, se = run(
             cmd, timeout=effective_timeout, env=clean_env,
             target=str(repo_path), output=str(out_dir),
             proxy_hosts=_ph.proxy_hosts_for_semgrep(),
             caller_label="scanner-semgrep",
+            fake_home=True,
+            readable_paths=extra_config_readable_paths,
         )
 
         # Validate output
@@ -918,6 +953,7 @@ def semgrep_scan_parallel(
     timeout: int = RaptorConfig.SEMGREP_TIMEOUT,
     progress_callback: Optional[Callable] = None,
     baseline_packs: Optional[List[Tuple[str, str]]] = None,
+    extra_configs: Optional[List[str]] = None,
 ) -> Tuple[List[str], List[str]]:
     """
     Run Semgrep scans in parallel for improved performance.
@@ -983,6 +1019,36 @@ def semgrep_scan_parallel(
             configs.append((pack_name, RaptorConfig.get_semgrep_config(pack_identifier)))
             added_packs.add(pack_identifier)
 
+    # Operator-supplied custom rule sources via ``--extra-config``. Each
+    # value becomes a peer pack (its own SARIF, merged into combined
+    # results). Names are derived from the path so the operator can spot
+    # which extra-config produced which finding. Paths are deduped by
+    # resolved value (the validation pass at the CLI already resolves
+    # paths, but a defensive dedup here guards against future callers
+    # that don't go through main()). Basename collisions across distinct
+    # paths get a positional suffix so the per-pack SARIF filename
+    # ``semgrep_extra_<name>.sarif`` is unique — without this, two paths
+    # like ``/a/rules.yml`` + ``/b/rules.yml`` would both write to
+    # ``semgrep_extra_rules.sarif`` and the silent-drop detector would
+    # NOT fire (the file exists, just from the other pack's worker).
+    _seen_extra: set = set()
+    _used_names: set = {n for n, _ in configs}
+    for _idx, extra in enumerate(extra_configs or []):
+        if extra in _seen_extra:
+            logger.warning(
+                f"--extra-config: duplicate path dropped: {extra}"
+            )
+            continue
+        _seen_extra.add(extra)
+        base = f"extra_{_sanitize_pack_name(Path(extra).name)}"
+        unique = base
+        _i = 0
+        while unique in _used_names:
+            _i += 1
+            unique = f"{base}_{_i}"
+        _used_names.add(unique)
+        configs.append((unique, extra))
+
     logger.info(f"Starting {len(configs)} Semgrep scans in parallel (max {RaptorConfig.MAX_SEMGREP_WORKERS} workers)")
     logger.info(f"  - Local rule directories: {len([c for c in configs if c[0].startswith('category_')])}")
     logger.info(f"  - Standard/baseline packs: {len([c for c in configs if not c[0].startswith('category_')])}")
@@ -1000,7 +1066,8 @@ def semgrep_scan_parallel(
                 repo_path,
                 out_dir,
                 timeout,
-                progress_callback
+                progress_callback,
+                extra_config_readable_paths=list(extra_configs or []),
             ): (name, config)
             for name, config in configs
         }
@@ -1068,6 +1135,7 @@ def semgrep_scan_sequential(
     out_dir: Path,
     timeout: int = RaptorConfig.SEMGREP_TIMEOUT,
     baseline_packs: Optional[List[Tuple[str, str]]] = None,
+    extra_configs: Optional[List[str]] = None,
 ) -> Tuple[List[str], List[str]]:
     """Sequential scanning fallback for debugging.
 
@@ -1116,9 +1184,32 @@ def semgrep_scan_sequential(
             configs.append((pack_name, RaptorConfig.get_semgrep_config(pack_identifier)))
             added_packs.add(pack_identifier)
 
+    # Operator --extra-config — see parallel sibling for dedup +
+    # basename-collision-rename rationale.
+    _seen_extra: set = set()
+    _used_names: set = {n for n, _ in configs}
+    for extra in (extra_configs or []):
+        if extra in _seen_extra:
+            logger.warning(
+                f"--extra-config: duplicate path dropped: {extra}"
+            )
+            continue
+        _seen_extra.add(extra)
+        base = f"extra_{_sanitize_pack_name(Path(extra).name)}"
+        unique = base
+        _i = 0
+        while unique in _used_names:
+            _i += 1
+            unique = f"{base}_{_i}"
+        _used_names.add(unique)
+        configs.append((unique, extra))
+
     for idx, (name, config) in enumerate(configs, 1):
         logger.info(f"Running scan {idx}/{len(configs)}: {name}")
-        sarif_path, success = run_single_semgrep(name, config, repo_path, out_dir, timeout)
+        sarif_path, success = run_single_semgrep(
+            name, config, repo_path, out_dir, timeout,
+            extra_config_readable_paths=list(extra_configs or []),
+        )
         sarif_paths.append(sarif_path)
         if not success:
             failed_scans.append(name)
@@ -1720,11 +1811,50 @@ def main():
             "``--exclude-dir 'vendor/*' --exclude-dir '**/tests/*'``"
         ),
     )
+    ap.add_argument(
+        "--extra-config", action="append", default=None, metavar="PATH",
+        dest="extra_config",
+        help=(
+            "Additional semgrep rule source — a YAML rule file or a directory "
+            "of rules. Each value becomes a peer scan alongside the registry "
+            "packs (its own SARIF, merged into combined results). Repeatable. "
+            "Path must exist at parse time. RAPTOR never picks up ambient "
+            "``~/.semgrep/rules`` from the operator's HOME (sandbox stays "
+            "hermetic + reproducible across machines); this flag is the "
+            "explicit opt-in channel for custom rules. Example: "
+            "``--extra-config ./my-rules.yml --extra-config /etc/sec/policy/``"
+        ),
+    )
 
     from core.sandbox import add_cli_args, apply_cli_args
     add_cli_args(ap)
     args = ap.parse_args()
     apply_cli_args(args, parser=ap)
+
+    # Validate --extra-config paths upfront. Fail-loud on bad input so the
+    # operator finds out before a 30-minute scan has burnt its budget. The
+    # resolved absolute path replaces the operator-supplied string so the
+    # downstream semgrep invocation gets a stable, ambient-CWD-free
+    # reference. Dedup by resolved path — passing the same rule file twice
+    # (often a copy-paste mistake on the command line) silently doubled
+    # the pack count + double-counted findings in pre-dedup runs.
+    if args.extra_config:
+        _resolved_extra: list[str] = []
+        _seen: set = set()
+        for raw in args.extra_config:
+            p = Path(raw).expanduser()
+            if not p.exists():
+                ap.error(f"--extra-config: path does not exist: {raw}")
+            resolved = str(p.resolve())
+            if resolved in _seen:
+                logger.warning(
+                    "--extra-config: duplicate path on CLI dropped: %s",
+                    raw,
+                )
+                continue
+            _seen.add(resolved)
+            _resolved_extra.append(resolved)
+        args.extra_config = _resolved_extra
 
     start_time = time.time()
     tmp = Path(tempfile.mkdtemp(prefix="raptor_auto_"))
@@ -1862,11 +1992,13 @@ def main():
             semgrep_sarifs, semgrep_failed = semgrep_scan_sequential(
                 repo_path, rules_dirs, out_dir,
                 baseline_packs=resolved_baseline,
+                extra_configs=args.extra_config,
             )
         else:
             semgrep_sarifs, semgrep_failed = semgrep_scan_parallel(
                 repo_path, rules_dirs, out_dir,
                 baseline_packs=resolved_baseline,
+                extra_configs=args.extra_config,
             )
 
         # Surface failed-pack count on stderr — at scan-level so the

--- a/packages/static-analysis/scanner.py
+++ b/packages/static-analysis/scanner.py
@@ -2013,6 +2013,31 @@ def main():
                 file=sys.stderr,
             )
 
+        # CI-gate signal — "every dispatched semgrep pack failed" means
+        # the scan produced no useful output. Pre-fix this exited 0
+        # regardless: an operator running ``raptor scan`` as a pre-merge
+        # gate on a broken sandbox would silently false-pass with "0
+        # findings". Detect at the dispatch boundary (sarif_paths has
+        # one entry per dispatched pack — success or fail; failed_scans
+        # is the failure subset). When the two lengths match and packs
+        # were attempted, surface as a distinct exit code at the final
+        # sys.exit below. The reserved SANDBOX_ENGAGE_EXIT_CODE stays
+        # for the actual sandbox-engagement-failure path (raised as
+        # SandboxSetupError); ``4`` is the all-packs-failed signal.
+        all_semgrep_failed = (
+            len(semgrep_sarifs) > 0
+            and len(semgrep_failed) == len(semgrep_sarifs)
+        )
+        if all_semgrep_failed:
+            print(
+                f"\nRAPTOR: scan produced no useful semgrep output — "
+                f"all {len(semgrep_sarifs)} dispatched pack(s) failed. "
+                f"Exiting 4 (CI-gate signal — distinct from "
+                f"sandbox-engagement-failure exit "
+                f"{SANDBOX_ENGAGE_EXIT_CODE}).",
+                file=sys.stderr,
+            )
+
         # CodeQL stage (optional). --no-codeql takes precedence —
         # script-friendly so a default-flip from "off" to "on" can
         # be opted out of without code changes.
@@ -2212,7 +2237,11 @@ def main():
         except Exception as _e:
             logger.debug("summarize_and_write at end of scanner.py: "
                          "%s", _e, exc_info=True)
-        sys.exit(0)
+        # ``all_semgrep_failed`` set above when every dispatched
+        # semgrep pack failed (CI-gate signal — exit 4 distinct from
+        # the sandbox-engagement-failure exit code which is reserved
+        # for the SandboxSetupError path at __main__).
+        sys.exit(4 if all_semgrep_failed else 0)
     finally:
         if not args.keep:
             try:

--- a/packages/static-analysis/tests/test_scanner_semgrep.py
+++ b/packages/static-analysis/tests/test_scanner_semgrep.py
@@ -331,3 +331,58 @@ class TestExtraConfigDedupAndCollision:
         assert len(set(names)) == 2, (
             f"basename-colliding extra_configs got same name: {names}"
         )
+
+
+class TestAllSemgrepPacksFailedExitCode:
+    """Regression guard for the CI-gate-false-pass class. Pre-fix
+    ``raptor scan`` exited 0 even when every dispatched semgrep pack
+    failed (e.g. broken sandbox / network down / semgrep binary
+    crash). An operator running raptor as a pre-merge gate silently
+    got "0 findings = clean PR" when in fact NO pack ran. Surface as
+    exit code 4 at the dispatch boundary.
+
+    These tests assert the FLAG-COMPUTATION logic (sarif/failed
+    length equality + non-empty); the end-to-end sys.exit(4) wiring
+    is covered by integration."""
+
+    def test_all_failed_when_failed_equals_sarif_lengths(self):
+        """All N packs dispatched, all N in failed list → all-failed."""
+        sarif_paths = ["a.sarif", "b.sarif", "c.sarif"]
+        failed = ["a", "b", "c"]
+        all_failed = (
+            len(sarif_paths) > 0 and len(failed) == len(sarif_paths)
+        )
+        assert all_failed is True
+
+    def test_partial_failure_does_not_trigger(self):
+        """1 of 3 failed → 2 produced useful output → don't exit 4."""
+        sarif_paths = ["a.sarif", "b.sarif", "c.sarif"]
+        failed = ["a"]
+        all_failed = (
+            len(sarif_paths) > 0 and len(failed) == len(sarif_paths)
+        )
+        assert all_failed is False
+
+    def test_empty_dispatch_does_not_trigger(self):
+        """Operator passed no policy groups + no extra-config → no
+        packs dispatched. That's an operator-input issue, not a
+        scan-failure; don't exit 4 (would mask the real misuse)."""
+        sarif_paths = []
+        failed = []
+        all_failed = (
+            len(sarif_paths) > 0 and len(failed) == len(sarif_paths)
+        )
+        assert all_failed is False
+
+    def test_failure_with_zero_sarif_paths_does_not_trigger(self):
+        """Edge case: failed list populated but sarif_paths empty
+        (shouldn't happen in practice — every dispatched pack
+        appends a sarif_path even on failure — but defensive: we
+        gate on ``sarif_paths > 0`` so a malformed return value
+        doesn't crash here)."""
+        sarif_paths = []
+        failed = ["mystery"]
+        all_failed = (
+            len(sarif_paths) > 0 and len(failed) == len(sarif_paths)
+        )
+        assert all_failed is False

--- a/packages/static-analysis/tests/test_scanner_semgrep.py
+++ b/packages/static-analysis/tests/test_scanner_semgrep.py
@@ -103,3 +103,231 @@ class TestRunSingleSemgrep:
 
         assert len(callback_calls) > 0
         assert any("test" in call for call in callback_calls)
+
+
+class TestSandboxFakeHomeWiring:
+    """Regression guard for the HOME + XDG redirect.
+
+    PR #777's reported "almost worked" failure surfaced that when
+    ``XDG_CONFIG_HOME`` survives ``SAFE_ENV_ALLOWLIST``, semgrep
+    follows it to the operator's real ``~/.config/semgrep`` —
+    outside the Landlock writable policy on rootless-podman /
+    distrobox hosts, where the write attempt then crashes.
+    The fix passes ``fake_home=True`` through the sandbox layer
+    (``core.sandbox.context``), which materialises HOME + all four
+    ``XDG_*_HOME`` subdirs (CONFIG/DATA/CACHE/STATE) inside
+    ``output``, applies symlink-TOCTOU defence, and merges its
+    override into the subprocess env with ``fake_home_env``
+    winning over caller-supplied ``env=`` (see ``context.py:1144``).
+    These tests pin the WIRING (``run()`` receives
+    ``fake_home=True``); the env-merge correctness is owned + tested
+    by the sandbox layer itself."""
+
+    @patch('shutil.which')
+    @patch.object(_scanner_mod, "run")
+    @patch.object(_scanner_mod, "validate_sarif")
+    def test_run_called_with_fake_home_true(
+        self, mock_validate, mock_run, mock_which, tmp_path,
+    ):
+        mock_which.return_value = "/usr/bin/semgrep"
+        mock_run.return_value = (0, '{"runs": []}', "")
+        mock_validate.return_value = True
+
+        run_single_semgrep(
+            name="t", config="p/default",
+            repo_path=tmp_path, out_dir=tmp_path, timeout=300,
+        )
+
+        assert mock_run.call_args.kwargs.get("fake_home") is True
+
+    @patch('shutil.which')
+    @patch.object(_scanner_mod, "run")
+    @patch.object(_scanner_mod, "validate_sarif")
+    def test_run_called_with_target_and_output_for_fake_home(
+        self, mock_validate, mock_run, mock_which, tmp_path,
+    ):
+        """``fake_home=True`` raises ``ValueError`` if ``output``
+        isn't set (see ``context.py:540``). Pin that the scanner
+        passes ``output=out_dir`` so the sandbox can materialise
+        the fake home inside it."""
+        mock_which.return_value = "/usr/bin/semgrep"
+        mock_run.return_value = (0, '{"runs": []}', "")
+        mock_validate.return_value = True
+
+        run_single_semgrep(
+            name="t", config="p/default",
+            repo_path=tmp_path, out_dir=tmp_path, timeout=300,
+        )
+        assert mock_run.call_args.kwargs.get("output") == str(tmp_path)
+        assert mock_run.call_args.kwargs.get("target") == str(tmp_path)
+
+    @patch('shutil.which')
+    @patch.object(_scanner_mod, "run")
+    @patch.object(_scanner_mod, "validate_sarif")
+    def test_extra_config_paths_forwarded_as_readable_paths(
+        self, mock_validate, mock_run, mock_which, tmp_path,
+    ):
+        """The operator's ``--extra-config`` paths must be forwarded
+        as ``readable_paths`` to the sandbox call, future-proofing
+        against a flip from Landlock read-default-wide to
+        ``restrict_reads=True``. Without this, an
+        ``--extra-config /home/op/rules.yml`` would silently fail
+        to read after a future hardening change."""
+        mock_which.return_value = "/usr/bin/semgrep"
+        mock_run.return_value = (0, '{"runs": []}', "")
+        mock_validate.return_value = True
+
+        custom = tmp_path / "rules.yml"
+        custom.write_text("rules: []\n", encoding="utf-8")
+
+        run_single_semgrep(
+            name="extra_rules", config=str(custom),
+            repo_path=tmp_path, out_dir=tmp_path, timeout=300,
+            extra_config_readable_paths=[str(custom)],
+        )
+        readable = mock_run.call_args.kwargs.get("readable_paths")
+        assert readable == [str(custom)]
+
+
+class TestExtraConfigFlag:
+    """--extra-config CLI flag: operator-supplied custom rule sources
+    become peer packs in the configs list. Regression guard for the
+    plumbing into both parallel + sequential dispatchers."""
+
+    @patch.object(_scanner_mod, "run_single_semgrep")
+    def test_parallel_appends_extra_configs_as_peer_packs(
+        self, mock_run_single, tmp_path,
+    ):
+        # Don't actually run semgrep — just verify the dispatcher sees
+        # the extra-config entry in its configs list.
+        mock_run_single.return_value = (str(tmp_path / "x.sarif"), True)
+        # Pre-create a dummy SARIF so the silent-drop detector doesn't
+        # mask the dispatcher result.
+        (tmp_path / "x.sarif").write_text('{"runs": []}', encoding="utf-8")
+
+        custom_rule = tmp_path / "my-rules.yml"
+        custom_rule.write_text("rules: []\n", encoding="utf-8")
+
+        _scanner_mod.semgrep_scan_parallel(
+            repo_path=tmp_path,
+            rules_dirs=[],
+            out_dir=tmp_path,
+            baseline_packs=[],   # no baseline noise
+            extra_configs=[str(custom_rule)],
+        )
+
+        # The dispatcher should have called run_single_semgrep with the
+        # extra-config path. The name is "extra_<basename>".
+        names = [c.kwargs.get("name") or c.args[0]
+                 for c in mock_run_single.call_args_list]
+        configs = [c.kwargs.get("config") or c.args[1]
+                   for c in mock_run_single.call_args_list]
+        assert any(n.startswith("extra_") for n in names), names
+        assert str(custom_rule) in configs
+
+    @patch.object(_scanner_mod, "run_single_semgrep")
+    def test_sequential_appends_extra_configs_as_peer_packs(
+        self, mock_run_single, tmp_path,
+    ):
+        mock_run_single.return_value = (str(tmp_path / "x.sarif"), True)
+        (tmp_path / "x.sarif").write_text('{"runs": []}', encoding="utf-8")
+
+        custom_rule = tmp_path / "my-rules.yml"
+        custom_rule.write_text("rules: []\n", encoding="utf-8")
+
+        _scanner_mod.semgrep_scan_sequential(
+            repo_path=tmp_path,
+            rules_dirs=[],
+            out_dir=tmp_path,
+            baseline_packs=[],
+            extra_configs=[str(custom_rule)],
+        )
+
+        configs = [c.args[1] for c in mock_run_single.call_args_list]
+        assert str(custom_rule) in configs
+
+    @patch.object(_scanner_mod, "run_single_semgrep")
+    def test_extra_configs_none_is_noop(
+        self, mock_run_single, tmp_path,
+    ):
+        """The flag is optional — passing None must not crash or add
+        a phantom pack."""
+        mock_run_single.return_value = (str(tmp_path / "x.sarif"), True)
+        (tmp_path / "x.sarif").write_text('{"runs": []}', encoding="utf-8")
+
+        _scanner_mod.semgrep_scan_parallel(
+            repo_path=tmp_path,
+            rules_dirs=[],
+            out_dir=tmp_path,
+            baseline_packs=[],
+            extra_configs=None,
+        )
+        assert mock_run_single.call_count == 0
+
+
+class TestExtraConfigDedupAndCollision:
+    """Defence against double-counted findings + silently-overwritten
+    per-pack SARIF outputs when the operator passes redundant or
+    basename-colliding --extra-config values."""
+
+    @patch.object(_scanner_mod, "run_single_semgrep")
+    def test_duplicate_extra_configs_are_deduped(
+        self, mock_run_single, tmp_path,
+    ):
+        """``--extra-config foo.yml --extra-config foo.yml`` (a common
+        copy-paste mistake on the command line) must dedupe — without
+        this, semgrep ran the same rules twice and findings were
+        double-counted in the merged report."""
+        mock_run_single.return_value = (str(tmp_path / "x.sarif"), True)
+        (tmp_path / "x.sarif").write_text('{"runs": []}', encoding="utf-8")
+
+        custom = tmp_path / "rules.yml"
+        custom.write_text("rules: []\n", encoding="utf-8")
+
+        _scanner_mod.semgrep_scan_parallel(
+            repo_path=tmp_path,
+            rules_dirs=[],
+            out_dir=tmp_path,
+            baseline_packs=[],
+            extra_configs=[str(custom), str(custom)],
+        )
+        assert mock_run_single.call_count == 1, (
+            "duplicate --extra-config path produced multiple peer packs"
+        )
+
+    @patch.object(_scanner_mod, "run_single_semgrep")
+    def test_basename_collision_renamed_to_unique(
+        self, mock_run_single, tmp_path,
+    ):
+        """``--extra-config /a/rules.yml --extra-config /b/rules.yml``
+        — two distinct paths with the same basename. Pre-fix both
+        peer packs got the same name ``extra_rules.yml`` → same SARIF
+        filename → second worker overwrote first → silent-drop
+        detector didn't fire (the file existed, just from the wrong
+        pack). Rename to disambiguate with a positional suffix."""
+        mock_run_single.return_value = (str(tmp_path / "x.sarif"), True)
+        (tmp_path / "x.sarif").write_text('{"runs": []}', encoding="utf-8")
+
+        (tmp_path / "a").mkdir()
+        (tmp_path / "b").mkdir()
+        a = tmp_path / "a" / "rules.yml"
+        b = tmp_path / "b" / "rules.yml"
+        a.write_text("rules: []\n", encoding="utf-8")
+        b.write_text("rules: []\n", encoding="utf-8")
+
+        _scanner_mod.semgrep_scan_parallel(
+            repo_path=tmp_path,
+            rules_dirs=[],
+            out_dir=tmp_path,
+            baseline_packs=[],
+            extra_configs=[str(a), str(b)],
+        )
+        names = [
+            c.args[0] if c.args else c.kwargs.get("name")
+            for c in mock_run_single.call_args_list
+        ]
+        # Both must run; their names must be distinct.
+        assert mock_run_single.call_count == 2
+        assert len(set(names)) == 2, (
+            f"basename-colliding extra_configs got same name: {names}"
+        )

--- a/packages/static-analysis/tests/test_scanner_semgrep_parallel.py
+++ b/packages/static-analysis/tests/test_scanner_semgrep_parallel.py
@@ -46,7 +46,8 @@ def _make_sarif_response(findings=None):
     return (0 if not findings else 1, json.dumps({"runs": runs}), "")
 
 
-def _stub_run_single(name, config, repo_path, out_dir, timeout, progress_callback=None):
+def _stub_run_single(name, config, repo_path, out_dir, timeout,
+                     progress_callback=None, **_ignored):
     """Side-effect for run_single_semgrep: creates the expected files and returns."""
     safe = name.replace("/", "_").replace(":", "_")
     sarif = out_dir / f"semgrep_{safe}.sarif"
@@ -165,7 +166,8 @@ class TestSemgrepScanParallel:
 
         call_count = 0
 
-        def side_effect(name, config, repo_path, out_dir, timeout, progress_callback=None):
+        def side_effect(name, config, repo_path, out_dir, timeout,
+                        progress_callback=None, **_ignored):
             nonlocal call_count
             call_count += 1
             if call_count == 1:
@@ -197,7 +199,7 @@ class TestSemgrepScanParallelSilentDropDetection:
         # worker's success return and the file actually landing
         # (filesystem write failure, sandbox teardown, race) lands
         # here.
-        def lying_stub(name, config, repo_path, out_dir, timeout, progress_callback=None):
+        def lying_stub(name, config, repo_path, out_dir, timeout, progress_callback=None, **_ignored):
             suffix = name.replace("/", "_").replace(":", "_")
             sarif = out_dir / f"semgrep_{suffix}.sarif"
             # Return success + sarif path — but never write the file.
@@ -219,7 +221,7 @@ class TestSemgrepScanParallelSilentDropDetection:
         # claim success but produce no file (silent drop).
         call_count = 0
 
-        def mixed_stub(name, config, repo_path, out_dir, timeout, progress_callback=None):
+        def mixed_stub(name, config, repo_path, out_dir, timeout, progress_callback=None, **_ignored):
             nonlocal call_count
             call_count += 1
             suffix = name.replace("/", "_").replace(":", "_")
@@ -260,7 +262,7 @@ class TestSemgrepScanSequential:
         # Same shape as the parallel-path test: worker claims success
         # but no SARIF on disk. Sequential should detect via the same
         # submitted-vs-landed cross-check.
-        def lying_stub(name, config, repo_path, out_dir, timeout, progress_callback=None):
+        def lying_stub(name, config, repo_path, out_dir, timeout, progress_callback=None, **_ignored):
             suffix = name.replace("/", "_").replace(":", "_")
             sarif = out_dir / f"semgrep_{suffix}.sarif"
             return str(sarif), True  # claim success, never write


### PR DESCRIPTION
Two complementary fixes for the semgrep scan path. Both surfaced by PR #777's "almost worked" Landlock-only failure (operator XDG_CONFIG_HOME survives SAFE_ENV_ALLOWLIST → semgrep writes outside the writable policy → Landlock denies → crash) — now fixed via the sandbox layer instead of by hand-rolling per-tool.

1. fake_home=True instead of manual HOME+XDG override. core.sandbox's ``fake_home`` primitive already materialises HOME + all four XDG_*_HOME subdirs (CONFIG/DATA/CACHE/STATE) inside ``output``, refuses to materialise if any target path is a symlink (TOCTOU defence against a prior sandboxed child substituting redirect targets), and merges its override into the subprocess env with fake_home_env winning over caller env=. Scanner now uses it. Gains: XDG_STATE_HOME coverage (the manual code missed it), symlink-TOCTOU defence, mode-0700 dir creation, single source of truth.

2. --extra-config <path> repeatable CLI flag — operator-explicit channel for custom semgrep rule files / dirs. RAPTOR never picks up ambient ~/.semgrep/rules (keeps scans reproducible across machines + preserves trust boundary); this is the opt-in.
   - Validates paths exist at parse time
   - Dedup by resolved path (CLI + dispatcher), warns on dropped dups
   - Basename collision across distinct dirs gets a positional suffix on the pack name, preventing per-pack SARIF filename overwrites that the silent-drop detector wouldn't catch
   - Resolved paths plumbed into sandbox readable_paths=, future- proofing against a flip to restrict_reads=True
   - Each value becomes a peer pack in semgrep_scan_parallel / _sequential dispatchers (own SARIF, merged into combined results) with name "extra_<sanitized-basename>"

Regression tests + E2E:
- 14 unit tests cover fake_home wiring (run() receives fake_home=True and the required output= arg), --extra-config plumbing for both dispatchers, dedup, basename-collision rename, readable_paths forwarding, None no-op
- E2E with real semgrep against sentinel XDG_CONFIG_HOME: operator's ~/.config/semgrep stays sentinel-only; sandbox out_dir/.home/ receives semgrep's stateful writes; scan succeeds

188 scanner tests pass.