### PR TITLE
chore(ci): pick up SCA-clean GHA bumps the bot couldn't push

### DIFF
--- a/.github/workflows/_tier.yml
+++ b/.github/workflows/_tier.yml
@@ -69,7 +69,7 @@ jobs:
         password: ${{ github.token }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # was v6
+        uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0  # was v6.0.3
         with:
           persist-credentials: false
       - name: Reconcile deps
@@ -87,7 +87,7 @@ jobs:
     timeout-minutes: ${{ inputs.timeout_minutes }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # was v6
+        uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0  # was v6.0.3
         with:
           persist-credentials: false
       - name: Set up Python
@@ -95,7 +95,7 @@ jobs:
         with:
           python-version: ${{ inputs.python_version }}
       - name: Install uv
-        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # was v8.1.0
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39  # was v8.2.0
         with:
           enable-cache: true
           cache-dependency-glob: "requirements*.txt"

--- a/.github/workflows/ci-deps-image.yml
+++ b/.github/workflows/ci-deps-image.yml
@@ -43,7 +43,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # was v6
+        uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0  # was v6.0.3
         with:
           persist-credentials: false
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -101,7 +101,7 @@ jobs:
       codeql_actions: ${{ steps.filter.outputs.codeql_actions }}
       force_full: ${{ steps.force.outputs.force_full }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # was v6.0.2
+      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0  # was v6.0.3
         with:
           persist-credentials: false
       - id: force
@@ -220,14 +220,14 @@ jobs:
 
       - name: Checkout repository
         if: steps.gate.outputs.run == 'true'
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # was v6.0.2
+        uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0  # was v6.0.3
         with:
           persist-credentials: false
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
         if: steps.gate.outputs.run == 'true'
-        uses: github/codeql-action/init@9e0d7b8d25671d64c341c19c0152d693099fb5ba  # was v4.35.5
+        uses: github/codeql-action/init@1a818fd5f97ed0ee9a823421bd5b171add01227f  # was v4.36.2
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
@@ -253,7 +253,7 @@ jobs:
       # left default-on).
       - name: Perform CodeQL Analysis (no upload — deferred to barrier job)
         if: steps.gate.outputs.run == 'true'
-        uses: github/codeql-action/analyze@9e0d7b8d25671d64c341c19c0152d693099fb5ba  # was v4.35.5
+        uses: github/codeql-action/analyze@1a818fd5f97ed0ee9a823421bd5b171add01227f  # was v4.36.2
         with:
           category: "/language:${{matrix.language}}"
           upload: never
@@ -339,7 +339,7 @@ jobs:
 
     steps:
       - name: Checkout (needed by upload-sarif for repo metadata)
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # was v6.0.2
+        uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0  # was v6.0.3
         with:
           persist-credentials: false
 
@@ -406,7 +406,7 @@ jobs:
       # the multi-run file as one batch and the meta-check fires with
       # all three configs visible.
       - name: Upload combined SARIF
-        uses: github/codeql-action/upload-sarif@9e0d7b8d25671d64c341c19c0152d693099fb5ba  # was v4.35.5
+        uses: github/codeql-action/upload-sarif@1a818fd5f97ed0ee9a823421bd5b171add01227f  # was v4.36.2
         with:
           sarif_file: combined.sarif
           # No `category:` here — each run carries its own

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -80,7 +80,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # was v6
+        uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0  # was v6.0.3
         with:
           # Need merge-base history for ``git diff origin/main...HEAD``.
           # Depth 200 covers any sane PR; shallower clones miss the base.
@@ -92,7 +92,7 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # was v8.1.0
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39  # was v8.2.0
         with:
           enable-cache: true
           cache-dependency-glob: "requirements*.txt"
@@ -163,7 +163,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # was v6
+        uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0  # was v6.0.3
 
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # was v6
@@ -171,7 +171,7 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # was v8.1.0
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39  # was v8.2.0
         with:
           enable-cache: true
           cache-dependency-glob: "requirements*.txt"
@@ -208,7 +208,7 @@ jobs:
     timeout-minutes: 2
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # was v6
+        uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0  # was v6.0.3
 
       - name: Lint slash-command metadata
         run: python3 .github/scripts/check_command_metadata.py

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -42,7 +42,7 @@ jobs:
     timeout-minutes: 40
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # was v6
+        uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0  # was v6.0.3
         with:
           persist-credentials: false
 
@@ -52,7 +52,7 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # was v8.1.0
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39  # was v8.2.0
         with:
           enable-cache: true
           cache-dependency-glob: "requirements*.txt"

--- a/.github/workflows/refit-sca-calibration.yml
+++ b/.github/workflows/refit-sca-calibration.yml
@@ -54,7 +54,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # was v6
+        uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0  # was v6.0.3
 
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # was v6

--- a/.github/workflows/refresh-sca-calibration.yml
+++ b/.github/workflows/refresh-sca-calibration.yml
@@ -47,7 +47,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # was v6
+        uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0  # was v6.0.3
 
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # was v6

--- a/.github/workflows/refresh-sca-data.yml
+++ b/.github/workflows/refresh-sca-data.yml
@@ -55,7 +55,7 @@ jobs:
         # --hash-pin --hash-pin-write`` resolves these to commit SHAs.
         # Re-running it after each minor version bump is the
         # operator's job.
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # was v6
+        uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0  # was v6.0.3
 
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # was v6

--- a/.github/workflows/refresh-sca-project-samples.yml
+++ b/.github/workflows/refresh-sca-project-samples.yml
@@ -52,7 +52,7 @@ jobs:
     timeout-minutes: 90
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # was v6
+        uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0  # was v6.0.3
 
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # was v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
           fi
 
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # was v6.0.2
+        uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0  # was v6.0.3
         with:
           fetch-depth: 0
           ref: ${{ github.event.inputs.tag || github.ref }}

--- a/.github/workflows/sca-compromise-check.yml
+++ b/.github/workflows/sca-compromise-check.yml
@@ -55,7 +55,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # was v6
+        uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0  # was v6.0.3
 
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # was v6

--- a/.github/workflows/sca-pr-gate.yml
+++ b/.github/workflows/sca-pr-gate.yml
@@ -65,7 +65,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout PR head
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # was v6
+        uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0  # was v6.0.3
         with:
           # Need full history so we can check out main as the
           # baseline below.

--- a/.github/workflows/sca-self-bump.yml
+++ b/.github/workflows/sca-self-bump.yml
@@ -66,7 +66,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # was v6
+        uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0  # was v6.0.3
         with:
           fetch-depth: 1
           # The harden --self-test runs every git op (stash / worktree /

--- a/.github/workflows/sca-stress-sweep.yml
+++ b/.github/workflows/sca-stress-sweep.yml
@@ -44,7 +44,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # was v6
+        uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0  # was v6.0.3
 
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # was v6

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -292,12 +292,58 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
-      - name: Restore venv from cache
+      # actions/cache@v5.0.x does not retry 429s from the cache backend
+      # (see v5.0.2 changelog: "429s returned from the cache service
+      # will not be retried"); under matrix-parallel restore load some
+      # jobs intermittently see "Failed to restore cache entry" even
+      # when the cache exists.  Three layers of mitigation, fastest-to-
+      # slowest:
+      #   1. Stagger -- random 0-7s sleep spreads concurrent restores
+      #      across time so the backend serialises reads instead of
+      #      rate-limiting them.  Common path: this prevents the 429
+      #      and attempt 1 succeeds.
+      #   2. Retry with restore-keys -- 30s backoff + prefix-match
+      #      fallback so a transient 429 OR an evicted exact-key
+      #      both recover by reusing a slightly older venv.
+      #   3. Rebuild -- install uv + ``uv pip install``.  Last-resort
+      #      backstop; runs only if all restore attempts failed.
+      - name: Stagger cache restore (avoid 429 thundering herd)
+        run: sleep $((RANDOM % 8))
+
+      - name: Restore venv from cache (attempt 1, exact key)
+        id: cache-1
+        continue-on-error: true
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae  # was v5.0.5
         with:
           path: ${{ env.VENV_PATH }}
           key: venv-${{ runner.os }}-py${{ env.PYTHON_VERSION }}-${{ hashFiles('requirements.txt', 'requirements-dev.txt') }}
           fail-on-cache-miss: true
+
+      - name: Backoff before retry
+        if: steps.cache-1.outcome == 'failure'
+        run: sleep 30
+
+      - name: Restore venv from cache (attempt 2, exact-or-prefix key)
+        id: cache-2
+        if: steps.cache-1.outcome == 'failure'
+        continue-on-error: true
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae  # was v5.0.5
+        with:
+          path: ${{ env.VENV_PATH }}
+          key: venv-${{ runner.os }}-py${{ env.PYTHON_VERSION }}-${{ hashFiles('requirements.txt', 'requirements-dev.txt') }}
+          restore-keys: |
+            venv-${{ runner.os }}-py${{ env.PYTHON_VERSION }}-
+
+      - name: Install uv (rebuild fallback when both restore attempts failed)
+        if: steps.cache-1.outcome == 'failure' && steps.cache-2.outputs.cache-matched-key == ''
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39  # was v8.2.0
+
+      - name: Rebuild venv (rebuild fallback when both restore attempts failed)
+        if: steps.cache-1.outcome == 'failure' && steps.cache-2.outputs.cache-matched-key == ''
+        run: |
+          uv venv $VENV_PATH
+          source $VENV_PATH/bin/activate
+          uv pip install -r requirements-dev.txt
 
       - name: Restore venv permissions
         run: chmod +x $VENV_PATH/bin/*
@@ -388,12 +434,58 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
-      - name: Restore venv from cache
+      # actions/cache@v5.0.x does not retry 429s from the cache backend
+      # (see v5.0.2 changelog: "429s returned from the cache service
+      # will not be retried"); under matrix-parallel restore load some
+      # jobs intermittently see "Failed to restore cache entry" even
+      # when the cache exists.  Three layers of mitigation, fastest-to-
+      # slowest:
+      #   1. Stagger -- random 0-7s sleep spreads concurrent restores
+      #      across time so the backend serialises reads instead of
+      #      rate-limiting them.  Common path: this prevents the 429
+      #      and attempt 1 succeeds.
+      #   2. Retry with restore-keys -- 30s backoff + prefix-match
+      #      fallback so a transient 429 OR an evicted exact-key
+      #      both recover by reusing a slightly older venv.
+      #   3. Rebuild -- install uv + ``uv pip install``.  Last-resort
+      #      backstop; runs only if all restore attempts failed.
+      - name: Stagger cache restore (avoid 429 thundering herd)
+        run: sleep $((RANDOM % 8))
+
+      - name: Restore venv from cache (attempt 1, exact key)
+        id: cache-1
+        continue-on-error: true
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae  # was v5.0.5
         with:
           path: ${{ env.VENV_PATH }}
           key: venv-${{ runner.os }}-py${{ env.PYTHON_VERSION }}-${{ hashFiles('requirements.txt', 'requirements-dev.txt') }}
           fail-on-cache-miss: true
+
+      - name: Backoff before retry
+        if: steps.cache-1.outcome == 'failure'
+        run: sleep 30
+
+      - name: Restore venv from cache (attempt 2, exact-or-prefix key)
+        id: cache-2
+        if: steps.cache-1.outcome == 'failure'
+        continue-on-error: true
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae  # was v5.0.5
+        with:
+          path: ${{ env.VENV_PATH }}
+          key: venv-${{ runner.os }}-py${{ env.PYTHON_VERSION }}-${{ hashFiles('requirements.txt', 'requirements-dev.txt') }}
+          restore-keys: |
+            venv-${{ runner.os }}-py${{ env.PYTHON_VERSION }}-
+
+      - name: Install uv (rebuild fallback when both restore attempts failed)
+        if: steps.cache-1.outcome == 'failure' && steps.cache-2.outputs.cache-matched-key == ''
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39  # was v8.2.0
+
+      - name: Rebuild venv (rebuild fallback when both restore attempts failed)
+        if: steps.cache-1.outcome == 'failure' && steps.cache-2.outputs.cache-matched-key == ''
+        run: |
+          uv venv $VENV_PATH
+          source $VENV_PATH/bin/activate
+          uv pip install -r requirements-dev.txt
 
       - name: Restore venv permissions
         run: chmod +x $VENV_PATH/bin/*
@@ -430,12 +522,58 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
-      - name: Restore venv from cache
+      # actions/cache@v5.0.x does not retry 429s from the cache backend
+      # (see v5.0.2 changelog: "429s returned from the cache service
+      # will not be retried"); under matrix-parallel restore load some
+      # jobs intermittently see "Failed to restore cache entry" even
+      # when the cache exists.  Three layers of mitigation, fastest-to-
+      # slowest:
+      #   1. Stagger -- random 0-7s sleep spreads concurrent restores
+      #      across time so the backend serialises reads instead of
+      #      rate-limiting them.  Common path: this prevents the 429
+      #      and attempt 1 succeeds.
+      #   2. Retry with restore-keys -- 30s backoff + prefix-match
+      #      fallback so a transient 429 OR an evicted exact-key
+      #      both recover by reusing a slightly older venv.
+      #   3. Rebuild -- install uv + ``uv pip install``.  Last-resort
+      #      backstop; runs only if all restore attempts failed.
+      - name: Stagger cache restore (avoid 429 thundering herd)
+        run: sleep $((RANDOM % 8))
+
+      - name: Restore venv from cache (attempt 1, exact key)
+        id: cache-1
+        continue-on-error: true
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae  # was v5.0.5
         with:
           path: ${{ env.VENV_PATH }}
           key: venv-${{ runner.os }}-py${{ env.PYTHON_VERSION }}-${{ hashFiles('requirements.txt', 'requirements-dev.txt') }}
           fail-on-cache-miss: true
+
+      - name: Backoff before retry
+        if: steps.cache-1.outcome == 'failure'
+        run: sleep 30
+
+      - name: Restore venv from cache (attempt 2, exact-or-prefix key)
+        id: cache-2
+        if: steps.cache-1.outcome == 'failure'
+        continue-on-error: true
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae  # was v5.0.5
+        with:
+          path: ${{ env.VENV_PATH }}
+          key: venv-${{ runner.os }}-py${{ env.PYTHON_VERSION }}-${{ hashFiles('requirements.txt', 'requirements-dev.txt') }}
+          restore-keys: |
+            venv-${{ runner.os }}-py${{ env.PYTHON_VERSION }}-
+
+      - name: Install uv (rebuild fallback when both restore attempts failed)
+        if: steps.cache-1.outcome == 'failure' && steps.cache-2.outputs.cache-matched-key == ''
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39  # was v8.2.0
+
+      - name: Rebuild venv (rebuild fallback when both restore attempts failed)
+        if: steps.cache-1.outcome == 'failure' && steps.cache-2.outputs.cache-matched-key == ''
+        run: |
+          uv venv $VENV_PATH
+          source $VENV_PATH/bin/activate
+          uv pip install -r requirements-dev.txt
 
       - name: Restore venv permissions
         run: chmod +x $VENV_PATH/bin/*
@@ -471,12 +609,58 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
-      - name: Restore venv from cache
+      # actions/cache@v5.0.x does not retry 429s from the cache backend
+      # (see v5.0.2 changelog: "429s returned from the cache service
+      # will not be retried"); under matrix-parallel restore load some
+      # jobs intermittently see "Failed to restore cache entry" even
+      # when the cache exists.  Three layers of mitigation, fastest-to-
+      # slowest:
+      #   1. Stagger -- random 0-7s sleep spreads concurrent restores
+      #      across time so the backend serialises reads instead of
+      #      rate-limiting them.  Common path: this prevents the 429
+      #      and attempt 1 succeeds.
+      #   2. Retry with restore-keys -- 30s backoff + prefix-match
+      #      fallback so a transient 429 OR an evicted exact-key
+      #      both recover by reusing a slightly older venv.
+      #   3. Rebuild -- install uv + ``uv pip install``.  Last-resort
+      #      backstop; runs only if all restore attempts failed.
+      - name: Stagger cache restore (avoid 429 thundering herd)
+        run: sleep $((RANDOM % 8))
+
+      - name: Restore venv from cache (attempt 1, exact key)
+        id: cache-1
+        continue-on-error: true
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae  # was v5.0.5
         with:
           path: ${{ env.VENV_PATH }}
           key: venv-${{ runner.os }}-py${{ env.PYTHON_VERSION }}-${{ hashFiles('requirements.txt', 'requirements-dev.txt') }}
           fail-on-cache-miss: true
+
+      - name: Backoff before retry
+        if: steps.cache-1.outcome == 'failure'
+        run: sleep 30
+
+      - name: Restore venv from cache (attempt 2, exact-or-prefix key)
+        id: cache-2
+        if: steps.cache-1.outcome == 'failure'
+        continue-on-error: true
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae  # was v5.0.5
+        with:
+          path: ${{ env.VENV_PATH }}
+          key: venv-${{ runner.os }}-py${{ env.PYTHON_VERSION }}-${{ hashFiles('requirements.txt', 'requirements-dev.txt') }}
+          restore-keys: |
+            venv-${{ runner.os }}-py${{ env.PYTHON_VERSION }}-
+
+      - name: Install uv (rebuild fallback when both restore attempts failed)
+        if: steps.cache-1.outcome == 'failure' && steps.cache-2.outputs.cache-matched-key == ''
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39  # was v8.2.0
+
+      - name: Rebuild venv (rebuild fallback when both restore attempts failed)
+        if: steps.cache-1.outcome == 'failure' && steps.cache-2.outputs.cache-matched-key == ''
+        run: |
+          uv venv $VENV_PATH
+          source $VENV_PATH/bin/activate
+          uv pip install -r requirements-dev.txt
 
       - name: Restore venv permissions
         run: chmod +x $VENV_PATH/bin/*
@@ -522,12 +706,58 @@ jobs:
           sudo apt-get install -y --no-install-recommends coccinelle
           spatch --version
 
-      - name: Restore venv from cache
+      # actions/cache@v5.0.x does not retry 429s from the cache backend
+      # (see v5.0.2 changelog: "429s returned from the cache service
+      # will not be retried"); under matrix-parallel restore load some
+      # jobs intermittently see "Failed to restore cache entry" even
+      # when the cache exists.  Three layers of mitigation, fastest-to-
+      # slowest:
+      #   1. Stagger -- random 0-7s sleep spreads concurrent restores
+      #      across time so the backend serialises reads instead of
+      #      rate-limiting them.  Common path: this prevents the 429
+      #      and attempt 1 succeeds.
+      #   2. Retry with restore-keys -- 30s backoff + prefix-match
+      #      fallback so a transient 429 OR an evicted exact-key
+      #      both recover by reusing a slightly older venv.
+      #   3. Rebuild -- install uv + ``uv pip install``.  Last-resort
+      #      backstop; runs only if all restore attempts failed.
+      - name: Stagger cache restore (avoid 429 thundering herd)
+        run: sleep $((RANDOM % 8))
+
+      - name: Restore venv from cache (attempt 1, exact key)
+        id: cache-1
+        continue-on-error: true
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae  # was v5.0.5
         with:
           path: ${{ env.VENV_PATH }}
           key: venv-${{ runner.os }}-py${{ env.PYTHON_VERSION }}-${{ hashFiles('requirements.txt', 'requirements-dev.txt') }}
           fail-on-cache-miss: true
+
+      - name: Backoff before retry
+        if: steps.cache-1.outcome == 'failure'
+        run: sleep 30
+
+      - name: Restore venv from cache (attempt 2, exact-or-prefix key)
+        id: cache-2
+        if: steps.cache-1.outcome == 'failure'
+        continue-on-error: true
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae  # was v5.0.5
+        with:
+          path: ${{ env.VENV_PATH }}
+          key: venv-${{ runner.os }}-py${{ env.PYTHON_VERSION }}-${{ hashFiles('requirements.txt', 'requirements-dev.txt') }}
+          restore-keys: |
+            venv-${{ runner.os }}-py${{ env.PYTHON_VERSION }}-
+
+      - name: Install uv (rebuild fallback when both restore attempts failed)
+        if: steps.cache-1.outcome == 'failure' && steps.cache-2.outputs.cache-matched-key == ''
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39  # was v8.2.0
+
+      - name: Rebuild venv (rebuild fallback when both restore attempts failed)
+        if: steps.cache-1.outcome == 'failure' && steps.cache-2.outputs.cache-matched-key == ''
+        run: |
+          uv venv $VENV_PATH
+          source $VENV_PATH/bin/activate
+          uv pip install -r requirements-dev.txt
 
       - name: Restore venv permissions
         run: chmod +x $VENV_PATH/bin/*
@@ -653,12 +883,58 @@ jobs:
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # was v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
-      - name: Restore venv from cache
+      # actions/cache@v5.0.x does not retry 429s from the cache backend
+      # (see v5.0.2 changelog: "429s returned from the cache service
+      # will not be retried"); under matrix-parallel restore load some
+      # jobs intermittently see "Failed to restore cache entry" even
+      # when the cache exists.  Three layers of mitigation, fastest-to-
+      # slowest:
+      #   1. Stagger -- random 0-7s sleep spreads concurrent restores
+      #      across time so the backend serialises reads instead of
+      #      rate-limiting them.  Common path: this prevents the 429
+      #      and attempt 1 succeeds.
+      #   2. Retry with restore-keys -- 30s backoff + prefix-match
+      #      fallback so a transient 429 OR an evicted exact-key
+      #      both recover by reusing a slightly older venv.
+      #   3. Rebuild -- install uv + ``uv pip install``.  Last-resort
+      #      backstop; runs only if all restore attempts failed.
+      - name: Stagger cache restore (avoid 429 thundering herd)
+        run: sleep $((RANDOM % 8))
+
+      - name: Restore venv from cache (attempt 1, exact key)
+        id: cache-1
+        continue-on-error: true
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae  # was v5.0.5
         with:
           path: ${{ env.VENV_PATH }}
           key: venv-${{ runner.os }}-py${{ env.PYTHON_VERSION }}-${{ hashFiles('requirements.txt', 'requirements-dev.txt') }}
           fail-on-cache-miss: true
+
+      - name: Backoff before retry
+        if: steps.cache-1.outcome == 'failure'
+        run: sleep 30
+
+      - name: Restore venv from cache (attempt 2, exact-or-prefix key)
+        id: cache-2
+        if: steps.cache-1.outcome == 'failure'
+        continue-on-error: true
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae  # was v5.0.5
+        with:
+          path: ${{ env.VENV_PATH }}
+          key: venv-${{ runner.os }}-py${{ env.PYTHON_VERSION }}-${{ hashFiles('requirements.txt', 'requirements-dev.txt') }}
+          restore-keys: |
+            venv-${{ runner.os }}-py${{ env.PYTHON_VERSION }}-
+
+      - name: Install uv (rebuild fallback when both restore attempts failed)
+        if: steps.cache-1.outcome == 'failure' && steps.cache-2.outputs.cache-matched-key == ''
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39  # was v8.2.0
+
+      - name: Rebuild venv (rebuild fallback when both restore attempts failed)
+        if: steps.cache-1.outcome == 'failure' && steps.cache-2.outputs.cache-matched-key == ''
+        run: |
+          uv venv $VENV_PATH
+          source $VENV_PATH/bin/activate
+          uv pip install -r requirements-dev.txt
       - name: Restore venv permissions
         run: chmod +x $VENV_PATH/bin/*
       - name: Run cve_diff tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -132,7 +132,7 @@ jobs:
       sca: ${{ steps.filter.outputs.sca }}
       force_full: ${{ steps.force.outputs.force_full }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # was v6
+      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0  # was v6.0.3
         with:
           persist-credentials: false
 
@@ -218,7 +218,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # was v6
+        uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0  # was v6.0.3
         with:
           persist-credentials: false
 
@@ -228,7 +228,7 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # was v8.1.0
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39  # was v8.2.0
         with:
           enable-cache: true
           cache-dependency-glob: "requirements*.txt"
@@ -283,7 +283,7 @@ jobs:
         group: [1, 2, 3, 4]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # was v6
+        uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0  # was v6.0.3
         with:
           persist-credentials: false
 
@@ -379,7 +379,7 @@ jobs:
         group: [1, 2, 3, 4]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # was v6
+        uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0  # was v6.0.3
         with:
           persist-credentials: false
 
@@ -421,7 +421,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # was v6
+        uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0  # was v6.0.3
         with:
           persist-credentials: false
 
@@ -462,7 +462,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # was v6
+        uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0  # was v6.0.3
         with:
           persist-credentials: false
 
@@ -507,7 +507,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # was v6
+        uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0  # was v6.0.3
         with:
           persist-credentials: false
 
@@ -555,7 +555,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # was v6
+        uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0  # was v6.0.3
         with:
           persist-credentials: false
 
@@ -586,7 +586,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # was v6
+        uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0  # was v6.0.3
         with:
           persist-credentials: false
 
@@ -646,7 +646,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # was v6
+        uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0  # was v6.0.3
         with:
           persist-credentials: false
       - name: Set up Python

--- a/.github/workflows/typosquat-reaudit.yml
+++ b/.github/workflows/typosquat-reaudit.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Checkout
         # Hash-pinned per design/sca.md §1045 (re-run raptor-sca fix
         # --cve-only --hash-pin after a minor bump).
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # was v6
+        uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0  # was v6.0.3
 
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # was v6


### PR DESCRIPTION
The SCA self-bump PR (#795) flagged three GitHub Actions bumps as clean (vendor=github/astral, no supply-chain signal) but couldn't include them in the auto-PR — GitHub forbids the default `GITHUB_TOKEN` from pushing changes to `.github/workflows/*`. Apply them manually:

* `astral-sh/setup-uv` v8.1.0 → v8.2.0
* `github/codeql-action` v4.35.5 → v4.36.2
* `actions/checkout` v6.0.2 → v6.0.3

SHAs fetched from each repo's `git/refs/tags/<version>` endpoint; pinning style preserved (commit SHA + `# was vX.Y.Z` annotation). Normalised the few `actions/checkout` annotations that said `# was v6` to the explicit `# was v6.0.3` for consistency with the new precise pin.