### PR TITLE
fix(sandbox): silence env-warning under strict_env + route Landlock-only attribution

### DIFF
--- a/core/sandbox/context.py
+++ b/core/sandbox/context.py
@@ -755,14 +755,25 @@ def sandbox(block_network: bool = False, target: str = None, output: str = None,
         # is the load-bearing defence in this mode.  See
         # ``core/security/THREAT_MODEL.md`` (invariant I2-(a)).
         if state.warn_once("_sandbox_landlock_only_warned"):
+            # Pre-fix this warning hardcoded
+            # "kernel.apparmor_restrict_unprivileged_userns=1" as the
+            # likely cause. Operator on PR #777 hit this on a SELinux
+            # + rootless-podman host where the AppArmor sysctl doesn't
+            # exist — being told to flip a non-existent sysctl is
+            # active misdirection. Route through ``mount_unavailable_
+            # reason()`` (same helper the spawn-blockers branch uses)
+            # so AppArmor / uidmap / SELinux / nested-userns all get
+            # their own diagnostic instead of all collapsing to
+            # "AppArmor".
+            from .probes import mount_unavailable_reason
+            _condition, _ = mount_unavailable_reason()
             logger.warning(
                 "RAPTOR: sandbox running in Landlock-only mode — "
-                "mount namespace unavailable, likely "
-                "kernel.apparmor_restrict_unprivileged_userns=1. "
-                "Credential exfil is bounded only by Landlock; "
+                "%s. Credential exfil is bounded only by Landlock; "
                 "callers that dispatch LLM-driven sub-agents on "
                 "hostile source should set restrict_reads=True. "
                 "See core/security/THREAT_MODEL.md (I2-(a)).",
+                _condition,
             )
 
     effective_limits = dict(_DEFAULT_LIMITS)
@@ -1111,15 +1122,27 @@ def sandbox(block_network: bool = False, target: str = None, output: str = None,
             # in normal-verbosity logs so a stray ``env=`` argument
             # doesn't quietly wave through ``EDITOR`` / ``PAGER`` /
             # ``BROWSER`` from an attacker-influenced parent.
-            # ``strict_env=True`` is the safe-rebound form below.
-            logger.warning(
-                "Sandbox: caller supplied custom env= for "
-                "%s — get_safe_env() not applied; caller env "
-                "passed through. Pass strict_env=True to strip "
-                "DANGEROUS_ENV_VARS from the caller env if you "
-                "only intended to override a few keys.",
-                " ".join(cmd[:_CMD_DISPLAY_MAX_ARGS]) or repr(cmd),
-            )
+            #
+            # Gate on ``not strict_env``: ``strict_env=True`` is the
+            # safe-rebound form (applied below) where the caller has
+            # explicitly asked us to strip DANGEROUS_ENV_VARS from
+            # their env. Once they've opted into that, the warning is
+            # contradictory noise — the warning literally tells them
+            # to pass ``strict_env=True`` as the fix. Operator on PR
+            # #777 surfaced this firing ~12× per scan run from the
+            # semgrep path; the path passes a ``get_safe_env()``-
+            # derived env (already DANGEROUS-stripped) plus a few
+            # explicit overrides, exactly the "I know what I'm doing"
+            # case the gate is meant to silence.
+            if not strict_env:
+                logger.warning(
+                    "Sandbox: caller supplied custom env= for "
+                    "%s — get_safe_env() not applied; caller env "
+                    "passed through. Pass strict_env=True to strip "
+                    "DANGEROUS_ENV_VARS from the caller env if you "
+                    "only intended to override a few keys.",
+                    " ".join(cmd[:_CMD_DISPLAY_MAX_ARGS]) or repr(cmd),
+                )
             if strict_env:
                 _dangerous = set(RaptorConfig.DANGEROUS_ENV_VARS)
                 _stripped = [k for k in kwargs["env"] if k in _dangerous]

--- a/core/sandbox/tests/test_env_warning_silenced_under_strict_env.py
+++ b/core/sandbox/tests/test_env_warning_silenced_under_strict_env.py
@@ -1,0 +1,89 @@
+"""Regression guard for the env-supplied-warning spam ferr079
+surfaced on PR #777.
+
+When a caller supplies ``env=`` to ``sandbox()``, the sandbox logged a
+WARNING saying "Pass strict_env=True to ... strip DANGEROUS_ENV_VARS".
+Pre-fix the warning fired regardless of whether the caller HAD already
+passed ``strict_env=True`` — operators got the warning ~12× per scan
+run while doing the documented mitigation, with no way to silence.
+
+Gate the warning on ``not strict_env``: callers who have opted into
+the safe-rebound get quiet output. Callers without strict_env still
+see the warning (they should — env= without the strip is the
+genuine bypass case the warning exists to surface).
+
+Tests drive a real ``profile="none"`` sandbox (no kernel engagement,
+fast) so the env-handling block is exercised end-to-end, and patch
+``logger.warning`` to capture what would have been emitted."""
+
+import sys as _sys
+import pytest as _pytest
+pytestmark = _pytest.mark.skipif(
+    _sys.platform != "linux",
+    reason="Linux-only sandbox internals",
+)
+
+from unittest.mock import patch
+
+
+def _run_envcheck(strict_env: bool):
+    """Run a ``profile="none"`` sandbox with a caller-supplied ``env=``
+    and the given ``strict_env``. Captures every ``logger.warning``
+    call made during the run and returns the formatted messages.
+
+    profile="none" means no kernel sandbox engagement — the child
+    just exec's /usr/bin/true. Fast, no real-sandbox cost; the env-
+    handling block we're testing still runs."""
+    from core.sandbox import context as ctx
+
+    captured: list[str] = []
+
+    def _capture(msg, *args, **kwargs):
+        try:
+            captured.append(msg % args if args else msg)
+        except Exception:
+            captured.append(str(msg))
+
+    with patch.object(ctx.logger, "warning", side_effect=_capture):
+        with ctx.sandbox(profile="none") as run:
+            try:
+                run(
+                    ["/usr/bin/true"],
+                    env={"FOO": "bar"},
+                    strict_env=strict_env,
+                    text=True, capture_output=True,
+                )
+            except Exception:
+                # Anything past the env-handling block is fine — the
+                # warning fires (or correctly doesn't) before kernel
+                # engagement.
+                pass
+    return captured
+
+
+class TestEnvWarningSilencedUnderStrictEnv:
+    """The ``strict_env=True`` documented-mitigation must silence
+    the env-supplied warning. Pre-fix the warning fired regardless."""
+
+    def test_warning_fires_when_strict_env_false(self):
+        msgs = _run_envcheck(strict_env=False)
+        env_warning_count = sum(
+            1 for m in msgs if "get_safe_env() not applied" in m
+        )
+        assert env_warning_count >= 1, (
+            "expected the env-supplied warning to fire when "
+            "strict_env=False (caller has not opted into the "
+            f"documented mitigation); captured: {msgs}"
+        )
+
+    def test_warning_silenced_when_strict_env_true(self):
+        msgs = _run_envcheck(strict_env=True)
+        env_warning_count = sum(
+            1 for m in msgs if "get_safe_env() not applied" in m
+        )
+        assert env_warning_count == 0, (
+            "expected the env-supplied warning to be silenced when "
+            "strict_env=True (the warning literally tells callers to "
+            "pass strict_env=True as the mitigation; firing it after "
+            f"they comply is contradictory noise); captured: {msgs}"
+        )

--- a/core/sandbox/tests/test_mount_unavailable_reason.py
+++ b/core/sandbox/tests/test_mount_unavailable_reason.py
@@ -132,3 +132,40 @@ class TestSelinuxEnforcingProbe:
 
         monkeypatch.setattr(Path, "read_text", _raise)
         assert probes._selinux_enforcing() is False
+
+
+class TestLandlockOnlyWarningRouting:
+    """Pre-PR-#777-followup the Landlock-only warning at
+    ``context.py:755`` hardcoded
+    ``kernel.apparmor_restrict_unprivileged_userns=1`` as the likely
+    cause. On a SELinux + rootless-podman host (no AppArmor sysctl)
+    operators were told to flip a non-existent sysctl — actively
+    misleading. The warning now sources its attribution from
+    ``mount_unavailable_reason()`` so each LSM gets its own message.
+
+    Construct the warning string the same way the runtime path does
+    and pin that the routing actually surfaces."""
+
+    def test_selinux_landlock_warning_does_not_mention_apparmor(
+        self, monkeypatch,
+    ):
+        from pathlib import Path
+
+        def _read_text(self, *a, **kw):
+            s = str(self)
+            if s.endswith("apparmor_restrict_unprivileged_userns"):
+                raise FileNotFoundError
+            if s == "/sys/fs/selinux/enforce":
+                return "1\n"
+            raise FileNotFoundError
+
+        monkeypatch.setattr(Path, "read_text", _read_text)
+        monkeypatch.setattr(probes.shutil, "which",
+                            lambda b: f"/usr/bin/{b}")
+        condition, _ = probes.mount_unavailable_reason()
+        warning = (
+            f"RAPTOR: sandbox running in Landlock-only mode — "
+            f"{condition}. Credential exfil ..."
+        )
+        assert "apparmor" not in warning.lower()
+        assert "selinux" in warning.lower()

--- a/packages/static-analysis/scanner.py
+++ b/packages/static-analysis/scanner.py
@@ -636,12 +636,21 @@ def run(cmd, cwd=None, timeout=RaptorConfig.DEFAULT_TIMEOUT, env=None,
         sandbox_kwargs["fake_home"] = True
     if readable_paths:
         sandbox_kwargs["readable_paths"] = list(readable_paths)
+    # ``strict_env=True`` acknowledges that this caller deliberately
+    # supplies env= (a ``get_safe_env()``-derived dict with HOME / XDG
+    # overrides from the semgrep-specific path). Without it, the sandbox
+    # logs a one-line WARNING per invocation telling us to do exactly
+    # this. Operator on PR #777 surfaced the warning firing ~12× per
+    # scan run. The strip is a no-op for us (``get_safe_env`` already
+    # excludes DANGEROUS_ENV_VARS) but the flag is also the documented
+    # "I'm aware of the bypass" marker.
     p = sandbox_run(
         cmd,
         target=target,
         output=output,
         cwd=cwd,
         env=env or RaptorConfig.get_safe_env(),
+        strict_env=True,
         text=True,
         capture_output=True,
         timeout=timeout,


### PR DESCRIPTION
Two operator-facing followups to ferr079's testing of PR #777's ship (`d223b176`):

1. Sandbox env-supplied warning fired ~12× per scan run with no way to silence. The warning text literally says "Pass strict_env=True to ... strip DANGEROUS_ENV_VARS" — but the gate was on env= presence, not strict_env value, so callers doing the documented mitigation got the warning anyway. Gate on `not strict_env`. Scanner.py passes strict_env=True (no-op strip — clean_env is already get_safe_env-derived — but the flag is the documented "I'm aware of the bypass" marker the gate now respects).

2. The Landlock-only fallback warning at context.py:755 still hardcoded "kernel.apparmor_restrict_unprivileged_userns=1" as the likely cause — the earlier mount_unavailable_reason() fix routed the spawn-blockers branch but not this informational one. On SELinux + rootless-podman hosts (where the AppArmor sysctl doesn't exist) operators were told to flip a non- existent flag. Route this warning through mount_unavailable_ reason() too.

Regression tests pin both: the env-warning silencing under strict_env=True (and continued firing when False), and that the SELinux landlock attribution does not mention AppArmor.

1204 sandbox + scanner tests pass.