### PR TITLE
fix(cve-env): floor interrupted-exit cost by turns under session auth

### DIFF
--- a/packages/cve_env/PROVENANCE.md
+++ b/packages/cve_env/PROVENANCE.md
@@ -8,3 +8,9 @@ This package was imported from the standalone repository **gadievron/cve-env**.
 - Not copied: `pyproject.toml`, `uv.lock`, virtualenvs, caches, `cve-env.toml.example`. Dependencies are declared in the repo-root `requirements.txt` per raptor's "no per-package build config" convention.
 
 Phase 1 of the integration is a behavior-preserving lift-and-shift: cve-env keeps its own agent loop (claude-agent-sdk), Docker tooling, dockerfile generation, config, and HTTP layer. It adopts **zero** raptor `core/` modules in this phase. Selective `core/` adoption is deferred to a later phase behind behavior-equivalence checks.
+
+## Divergences from the imported snapshot
+
+The vendored copy tracks upstream `gadievron/cve-env` with cherry-picked fixes applied on top of the `ba9f91c` snapshot:
+
+- **Cost-floor on interrupted exits** (this PR) — ports upstream cve-env `89917d8` (PR #2): floors `total_cost_usd` by engine turn count when a build ends on an interrupted status with no token usage (the Claude Code session-auth case), so interrupted runs no longer log ~$0. Files: `cve_env/config.py` (`estimate_cost_from_turns`), `cve_env/agent/loop.py` (`_floor_cost` + `_INTERRUPTED_EXIT_STATUSES`), `tests/unit/test_cost_floor_non_clean_exit.py`.

--- a/packages/cve_env/cve_env/agent/loop.py
+++ b/packages/cve_env/cve_env/agent/loop.py
@@ -86,6 +86,7 @@ from cve_env.config import (
     TURN_EXTENSION_PCT,
     VERSION_ASSERTION_CMD_PATTERN,
     estimate_cost_from_tokens,
+    estimate_cost_from_turns,
     get_benign_verify_continuation_max,
     get_enable_benign_verify_continuation,
     get_enable_halt_on_verified_success,
@@ -594,6 +595,56 @@ def _latch_assistant_token_cost(state: _StreamState, msg: Any, model: str) -> No
                 state.am_credited_per_segment.get(state.current_segment_id, 0.0)
                 + cost
             )
+
+
+# Terminal statuses where the SDK was INTERRUPTED mid-run (no clean end_turn
+# ResultMessage emitted) so its reported cost is unreliable — the turns-based
+# floor applies only to these. Covers every abnormal termination in the
+# OutcomeStatus taxonomy (models.py): the turn/budget caps, a mid-run exception
+# (``error`` and the generic ``interrupted``/``incomplete`` alias — the default
+# terminal status on the exception path), and a 529 throttle giving up
+# (``rate_limited``). Clean exits — success, verified_partial, verify_failed,
+# launched_no_verify, and the give-up family (unresolvable), which all end via a
+# natural end_turn with the SDK's full cost reported — are excluded so the floor
+# never inflates a correctly-reported cost.
+_INTERRUPTED_EXIT_STATUSES = frozenset(
+    {"turn_cap", "budget_exhausted", "error", "interrupted", "incomplete", "rate_limited"}
+)
+
+
+def _floor_cost(
+    status: str,
+    num_turns: int,
+    last_cost_usd: float,
+    cont_cost_usd: float,
+    input_tokens: int,
+    output_tokens: int,
+    model: str,
+    effective_max_cost_usd: float,
+) -> float:
+    """Resolve the final ``total_cost_usd`` with all floors applied.
+
+    Base = max(SDK-reported cost, continuation-summed cost, token estimate).
+    Adds a turns-based floor ONLY for an interrupted exit with no token usage —
+    the Claude Code session-auth + max_turns_reached case, where the SDK
+    under-reports cost AND ``usage`` is absent so the token estimate is 0 and a
+    multi-turn run would otherwise log ~$0. Gating leaves correctly-reported
+    clean runs and API-key (token-bearing) runs untouched (the turns floor only
+    ever raises). The turns floor is bounded by ``effective_max_cost_usd`` — a
+    run cannot have cost more than its budget cap (else it would have ended as
+    budget_exhausted), so the estimate never exceeds the cap.
+    """
+    cost = max(
+        last_cost_usd,
+        cont_cost_usd,
+        estimate_cost_from_tokens(input_tokens, output_tokens, model),
+    )
+    if status in _INTERRUPTED_EXIT_STATUSES and input_tokens == 0 and output_tokens == 0:
+        turns_floor = estimate_cost_from_turns(num_turns, model)
+        if effective_max_cost_usd > 0:
+            turns_floor = min(turns_floor, effective_max_cost_usd)
+        cost = max(cost, turns_floor)
+    return cost
 
 
 def _latch_text_and_scan(
@@ -2177,14 +2228,19 @@ async def build(
             # (→ state.last_num_turns) UNDERREPORTS it, confounding
             # turn-cap-vs-cost-bound diagnosis. max() keeps the existing floors.
             num_turns=max(state.turn, state.last_num_turns, len(state.tool_uses_seen)),
-            # Fall back to a token-based estimate when the SDK never emitted a
-            # cost-bearing ResultMessage. max() ensures the estimate only kicks in
-            # if the reported cost is zero/missing.
-            total_cost_usd=max(
+            # Floors: SDK-reported cost, then a token-based estimate, then a
+            # turns-based estimate for interrupted exits with no token usage
+            # (session auth). max() ensures a floor only kicks in when the
+            # reported cost is zero/missing. See _floor_cost.
+            total_cost_usd=_floor_cost(
+                terminal_status_on_err,
+                max(state.turn, state.last_num_turns, len(state.tool_uses_seen)),
                 state.last_cost_usd,
-                estimate_cost_from_tokens(
-                    state.total_input_tokens, state.total_output_tokens, model
-                ),
+                0.0,
+                state.total_input_tokens,
+                state.total_output_tokens,
+                model,
+                state.effective_max_cost_usd,
             ),
             verify_passed=state.verify_passed,
             verify_result=state.last_verify_result,
@@ -2449,15 +2505,19 @@ async def build(
         # continuation runs) is the real turn count; the SDK msg.num_turns
         # underreports it. max() keeps the existing floors.
         num_turns=max(state.turn, state.last_num_turns, cont_turns_acc, len(state.tool_uses_seen)),
-        # Include a token-based estimate as a third floor. The SDK has been
-        # observed reporting total_cost_usd=0 on max_turns_reached even after
-        # multiple LLM rounds; the estimate recovers that data.
-        total_cost_usd=max(
+        # Include a token-based estimate as a third floor, then a turns-based
+        # floor for interrupted exits with no token usage (session auth). The SDK
+        # has been observed reporting total_cost_usd=0 on max_turns_reached even
+        # after multiple LLM rounds; the floors recover that data. See _floor_cost.
+        total_cost_usd=_floor_cost(
+            status,
+            max(state.turn, state.last_num_turns, cont_turns_acc, len(state.tool_uses_seen)),
             state.last_cost_usd,
             cont_cost_acc,
-            estimate_cost_from_tokens(
-                state.total_input_tokens, state.total_output_tokens, model
-            ),
+            state.total_input_tokens,
+            state.total_output_tokens,
+            model,
+            state.effective_max_cost_usd,
         ),
         session_id=run.session_id,
         stop_reason=run.stop_reason,

--- a/packages/cve_env/cve_env/config.py
+++ b/packages/cve_env/cve_env/config.py
@@ -806,6 +806,31 @@ def estimate_cost_from_tokens(
     return (input_tokens * in_rate + output_tokens * out_rate) / 1_000_000.0
 
 
+# Conservative per-turn token volume for the turns-based cost floor. Sized from
+# observed agentic rounds (cf. tests/unit/test_b19_b20_cost_extension.py:
+# "~5K in, ~500 out per LLM round").
+_TURN_COST_INPUT_TOKENS = 5000
+_TURN_COST_OUTPUT_TOKENS = 500
+
+
+def estimate_cost_from_turns(num_turns: int, model: str = MODEL) -> float:
+    """Lower-bound cost estimate from the engine turn count.
+
+    For interrupted runs (turn_cap / budget) where the SDK reports neither a
+    usable ``total_cost_usd`` nor token ``usage`` — the Claude Code session-auth
+    case — both ``estimate_cost_from_tokens`` (tokens are 0) and the SDK cost
+    collapse, leaving a multi-turn run logged as ~$0. This recovers a defensible
+    floor from ``num_turns``. Returns 0.0 for non-positive ``num_turns``.
+    """
+    if num_turns <= 0:
+        return 0.0
+    return estimate_cost_from_tokens(
+        num_turns * _TURN_COST_INPUT_TOKENS,
+        num_turns * _TURN_COST_OUTPUT_TOKENS,
+        model,
+    )
+
+
 # Opt-in lifecycle hooks. After ``cve-env build`` exits (success OR failure),
 # run cleanup helpers if enabled. All default false to preserve existing
 # behavior. Both env var and CLI flag are supported; CLI OR-merges with env

--- a/packages/cve_env/tests/unit/test_cost_floor_non_clean_exit.py
+++ b/packages/cve_env/tests/unit/test_cost_floor_non_clean_exit.py
@@ -1,0 +1,167 @@
+"""BUG-1 (trace br-7e06a0b-costfloor): cost telemetry under-reports on a
+non-clean exit (turn_cap / max_turns_reached) when the SDK reports neither a
+plausible cost nor token usage — the Claude Code session-auth case, where
+``usage`` is ``None`` on every message and the interrupted-run ResultMessage
+carries an implausibly-low ``total_cost_usd``.
+
+At HEAD the terminal Outcome floors ``total_cost_usd`` on
+``max(last_cost_usd, token_estimate)`` only; with token usage absent the
+estimate is 0 and the cost collapses to the SDK's low value while ``num_turns``
+(from the authoritative ``state.turn``) stays correct — e.g. a 46-turn build
+logged ``$0.013``.
+
+Fix: a turns-based cost floor, gated to non-clean exits + absent token usage,
+so correctly-reported ``success`` runs and API-key (token-bearing) runs are
+untouched.
+"""
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from cve_env.agent.loop import _floor_cost, build
+from cve_env.config import MODEL, estimate_cost_from_tokens, estimate_cost_from_turns
+
+# Reuse the canned-stream helpers (same dir). _result() emits usage=None,
+# matching the session-auth case under test.
+from .test_bench200_bug_fixes import (  # type: ignore[import-untyped]
+    _assistant,
+    _cve,
+    _fake_run_agent_factory,
+    _host,
+    _result,
+    _text_block,
+)
+
+# Every abnormal-termination status in the OutcomeStatus taxonomy (models.py)
+# whose SDK cost is unreliable mid-run — the turns floor MUST fire for each.
+_INTERRUPTED = [
+    "turn_cap", "budget_exhausted", "error", "interrupted", "incomplete", "rate_limited",
+]
+# Clean end_turn exits with reliable SDK cost — the floor MUST NOT fire (else a
+# correctly-reported cost is inflated, the verified_partial regression).
+_CLEAN = ["success", "verified_partial", "verify_failed", "launched_no_verify", "unresolvable"]
+
+
+@pytest.mark.parametrize("status", _INTERRUPTED)
+def test_floor_fires_for_every_interrupted_status_with_no_token_usage(status: str) -> None:
+    """The gate must cover ALL abnormal terminations, not just turn_cap — the
+    exception path's default status is 'interrupted' and a 529 gives 'rate_limited'.
+    With a low SDK cost + no token usage, each must be floored up by turns."""
+    floored = _floor_cost(
+        status, num_turns=40, last_cost_usd=0.01, cont_cost_usd=0.0,
+        input_tokens=0, output_tokens=0, model=MODEL, effective_max_cost_usd=10.0,
+    )
+    assert floored > 0.01, f"{status!r} not floored: {floored}"
+    assert floored >= estimate_cost_from_tokens(40 * 1000, 0, MODEL)
+
+
+@pytest.mark.parametrize("status", _CLEAN)
+def test_floor_does_not_fire_for_clean_exit_statuses(status: str) -> None:
+    """Clean exits report cost reliably; the floor must leave a low reported cost
+    untouched (it is only a floor for interrupted runs). Guards the verified_partial
+    regression and its siblings."""
+    floored = _floor_cost(
+        status, num_turns=40, last_cost_usd=0.01, cont_cost_usd=0.0,
+        input_tokens=0, output_tokens=0, model=MODEL, effective_max_cost_usd=10.0,
+    )
+    assert floored == 0.01, f"{status!r} wrongly floored to {floored}"
+
+
+def test_turn_cap_cost_floored_by_turns_when_no_token_usage(tmp_path: Path) -> None:
+    """RED: a turn_cap run whose ResultMessage reports a low cost ($0.013),
+    46 turns, and usage=None must NOT log a cost far below what 46 turns imply.
+    At HEAD outcome.total_cost_usd is stuck at $0.013."""
+    messages = [
+        _assistant(_text_block("working on it")),
+        _result("max_turns_reached", cost_usd=0.013, turns=46),
+    ]
+    with patch("cve_env.agent.loop.run_agent", _fake_run_agent_factory(messages)):
+        outcome = asyncio.run(
+            build(
+                _cve(),
+                _host(),
+                run_id="run-costfloor-red",
+                audit_root=tmp_path,
+                max_turns=96,
+                max_cost_usd=10.0,  # high cap so the budget gate doesn't fire on the floored cost
+                max_turn_extensions=0,
+            )
+        )
+
+    assert outcome.status == "turn_cap", f"expected turn_cap, got {outcome.status!r}"
+    assert outcome.num_turns >= 46, f"num_turns lost: {outcome.num_turns}"
+    # The bug: cost stuck at the SDK's implausibly-low report despite 46 turns.
+    assert outcome.total_cost_usd > 0.013, (
+        f"cost not floored: total_cost_usd={outcome.total_cost_usd} still at the "
+        f"SDK's $0.013 despite {outcome.num_turns} turns + no token usage"
+    )
+    # Floor must be turns-proportional — at least ~1000 input-tokens/turn worth
+    # (well below the implementation's per-turn figure; decouples the test from
+    # the exact constant).
+    min_floor = estimate_cost_from_tokens(outcome.num_turns * 1000, 0, MODEL)
+    assert outcome.total_cost_usd >= min_floor, (
+        f"floor not turns-proportional: {outcome.total_cost_usd} < {min_floor}"
+    )
+
+
+def test_turn_cap_high_reported_cost_not_lowered_by_floor(tmp_path: Path) -> None:
+    """Regression: the turns floor only RAISES cost (it is a floor via max()).
+    A turn_cap run whose SDK cost ($1.00, under the budget cap) already exceeds
+    the 2-turn estimate keeps its reported cost unchanged."""
+    messages = [
+        _assistant(_text_block("working")),
+        _result("max_turns_reached", cost_usd=1.00, turns=2),
+    ]
+    with patch("cve_env.agent.loop.run_agent", _fake_run_agent_factory(messages)):
+        outcome = asyncio.run(
+            build(
+                _cve(),
+                _host(),
+                run_id="run-costfloor-highcost",
+                audit_root=tmp_path,
+                max_turns=96,
+                max_cost_usd=10.0,  # high cap so $1.00 doesn't trip budget_exhausted
+                max_turn_extensions=0,
+            )
+        )
+
+    assert outcome.status == "turn_cap"
+    # Test assumption: the few-turn floor is well under the reported $1.00 at any
+    # model rate, so max() must keep the reported cost.
+    floor = estimate_cost_from_turns(outcome.num_turns, MODEL)
+    assert floor < 1.00, f"test assumption broken: floor={floor} >= $1.00"
+    assert outcome.total_cost_usd == 1.00, (
+        f"floor wrongly altered a correctly-reported cost: {outcome.total_cost_usd}"
+    )
+
+
+def test_turn_cap_floor_bounded_by_budget_cap(tmp_path: Path) -> None:
+    """The turns floor never exceeds the run's budget cap — a run can't cost more
+    than its budget (else it would have ended budget_exhausted). 46 turns
+    (uncapped floor ~$5) is bounded to the $1.20 cap."""
+    messages = [
+        _assistant(_text_block("working")),
+        _result("max_turns_reached", cost_usd=0.013, turns=46),
+    ]
+    with patch("cve_env.agent.loop.run_agent", _fake_run_agent_factory(messages)):
+        outcome = asyncio.run(
+            build(
+                _cve(),
+                _host(),
+                run_id="run-costfloor-bounded",
+                audit_root=tmp_path,
+                max_turns=96,
+                max_cost_usd=1.20,
+                max_turn_extensions=0,
+            )
+        )
+
+    assert outcome.status == "turn_cap"
+    assert outcome.total_cost_usd > 0.013, "floor did not lift the SDK's low value"
+    assert outcome.total_cost_usd <= 1.20 + 1e-9, (
+        f"floor exceeded the budget cap: {outcome.total_cost_usd} > 1.20"
+    )


### PR DESCRIPTION
## What

Floor a build's reported `total_cost_usd` by its turn count when the run ends on
an interrupted status (`turn_cap` / `budget_exhausted` / `error` / `interrupted` /
`incomplete` / `rate_limited`) and the SDK reports no token usage — the Claude
Code session-auth case. Ports upstream `gadievron/cve-env` `89917d8` (PR #2) into
the vendored `packages/cve_env/`.

> **Depends-on: #802** — `packages/cve_env/` is introduced by the integration PR;
> this fix stacks on `feat/cve-env-integration`. GitHub will retarget to `main`
> once #802 merges.

## Why

Both `Outcome` finalization sites in `packages/cve_env/cve_env/agent/loop.py`
(the normal `_map_status` path and the exception/terminal path) floored
`total_cost_usd` on `max(last_cost_usd, continuation_cost, token_estimate)`.
Under Claude Code **session auth** the SDK sets `usage=None` on every message, so
`state.total_input/output_tokens == 0` and `estimate_cost_from_tokens(...) == 0`.
On an interrupted exit the SDK's `ResultMessage.total_cost_usd` is also
implausibly low, so `max()` collapsed to that value even though `num_turns`
(from the authoritative `state.turn`) stayed correct — a 46-turn build logged
`$0.013`.

## Root cause

The cost floor had no fallback derived from the engine turn count, so an
interrupted run with absent token usage lost its accumulated cost while keeping
an accurate turn count.

## How

- `config.py:estimate_cost_from_turns(num_turns, model)` — a turns-based lower
  bound (`5000` in / `500` out tokens per turn, sized from the existing
  `test_b19_b20_cost_extension.py` "~5K in, ~500 out per LLM round" figure),
  routed through `estimate_cost_from_tokens`; returns `0.0` for non-positive turns.
- `loop.py:_floor_cost(...)` — a shared helper applied at both `Outcome` sites.
  Base floor unchanged; adds the turns-based floor **only** when the status is in
  `_INTERRUPTED_EXIT_STATUSES = {turn_cap, budget_exhausted, error, interrupted,
  incomplete, rate_limited}` AND there is no token usage, bounded by
  `effective_max_cost_usd` so the estimate never exceeds the run's budget cap.
- Clean exits (`success`, `verified_partial`, `verify_failed`,
  `launched_no_verify`, `unresolvable`) end via `end_turn` with reliable SDK cost
  and are excluded so the floor never inflates a correctly-reported cost.

## Regression test

5 test functions in `packages/cve_env/tests/unit/test_cost_floor_non_clean_exit.py`,
including 2 parametrized over the full OutcomeStatus partition (floor fires for
every interrupted status, never for a clean one).

```
Vendored package (pytest tests/unit/test_cost_floor_non_clean_exit.py): 14 passed
Regression (verify + map_status + loop + cost_floor): 244 passed
raptor ruff-pr gate (--select F401,F811,F821,F841): All checks passed
```

## Compatibility

No API change. Clean exits and token-bearing (API-key) runs are untouched; the
floor only ever raises a collapsed cost. Vendored-copy change only — no raptor
`core/` modules touched.

## Author notes

**Q1 — which lines implement the fix?** `config.py` `estimate_cost_from_turns`
and `loop.py` `_floor_cost` gated on
`status in _INTERRUPTED_EXIT_STATUSES and input_tokens == 0 and output_tokens == 0`,
called at both `Outcome(... total_cost_usd=_floor_cost(...))` sites.

**Q2 — one concrete input handled wrong before, right now:** an interrupted
outcome with `ResultMessage(total_cost_usd=0.013, num_turns=46, usage=None)`
previously logged $0.013; it now logs a turns-proportional floor bounded by the
budget cap.

**Q3 — likely reviewer pushback + answer:** "Why not re-sync the whole vendored
package instead of cherry-picking?" This is a single targeted upstream fix with a
regression test; a full re-sync is a larger change better done deliberately. The
divergence is recorded in `PROVENANCE.md`.

Upstream: `gadievron/cve-env` `89917d8` (PR #2, merged).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Telemetry-only change behind strict status and zero-token gates; clean exits and token-bearing runs are untouched, with regression tests covering the status partition.
> 
> **Overview**
> Ports upstream **cost-floor on interrupted exits** into vendored `cve-env`: when a build ends on an abnormal status and the SDK reports no token `usage` (Claude Code session auth), `Outcome.total_cost_usd` no longer collapses to a tiny SDK value while `num_turns` stays accurate.
> 
> **`estimate_cost_from_turns`** in `config.py` derives a conservative lower bound from turn count (5K in / 500 out tokens per turn via existing `estimate_cost_from_tokens`). **`_floor_cost`** in `loop.py` centralizes final cost: `max(SDK cost, continuation cost, token estimate)`, then optionally applies the turns floor only when `status ∈ _INTERRUPTED_EXIT_STATUSES` and both token totals are zero, capped by `effective_max_cost_usd`. Both normal and exception-path `Outcome` construction call `_floor_cost` instead of inline `max(...)`.
> 
> Clean exits (`success`, `verified_partial`, etc.) and API-key runs with real token usage are unchanged. **`PROVENANCE.md`** records the cherry-pick from upstream `89917d8`. New unit tests parametrize interrupted vs clean statuses and integration cases for turn_cap.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 93de23e9a1786b26ce8d2b9883bc2887ab6d7c38. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->