### PR TITLE
feat(sarif): import normalizer, enriched writer, --reanalyze, enrichment summary

### DIFF
--- a/core/sarif/enriched_writer.py
+++ b/core/sarif/enriched_writer.py
@@ -1,0 +1,235 @@
+"""Write enriched SARIF 2.1.0 annotated with RAPTOR analysis verdicts.
+
+Converts RAPTOR's internal analysis results to SARIF with
+``result.properties.raptor.*`` annotations for verdicts, reachability,
+and structural evidence. Suppressed findings (binary oracle ``absent``)
+are emitted with SARIF-standard ``result.suppressions``.
+
+Consumers: ``/agentic --sarif-out``, ``/project export --sarif``,
+``/validate`` (future).
+"""
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence
+
+from core.logging import get_logger
+
+logger = get_logger()
+
+_SCHEMA = "https://json.schemastore.org/sarif-2.1.0.json"
+_VALID_LEVELS = frozenset({"none", "note", "warning", "error"})
+
+
+def _verdict_from_analysis(finding: Dict[str, Any]) -> str:
+    analysis = finding.get("analysis") or {}
+    if analysis.get("reachability_suppression"):
+        return "suppressed"
+    if finding.get("exploitable"):
+        return "exploitable"
+    tp = analysis.get("is_true_positive")
+    if tp is True:
+        return "confirmed"
+    if tp is False:
+        return "ruled_out"
+    return "not_analyzed"
+
+
+def _reachability_from_analysis(finding: Dict[str, Any]) -> str:
+    analysis = finding.get("analysis") or {}
+    verdict = analysis.get("reachability_verdict")
+    if verdict:
+        return verdict
+    if analysis.get("reachability_suppression"):
+        return "absent"
+    return "not_evaluated"
+
+
+def _build_raptor_properties(finding: Dict[str, Any]) -> Dict[str, Any]:
+    verdict = _verdict_from_analysis(finding)
+    props: Dict[str, Any] = {
+        "verdict": verdict,
+        "reachability": _reachability_from_analysis(finding),
+    }
+
+    if finding.get("source_type"):
+        props["source_type"] = finding["source_type"]
+
+    if finding.get("_cwe_inferred"):
+        props["cwe_inferred"] = True
+
+    if finding.get("has_dataflow"):
+        props["has_dataflow"] = True
+
+    analysis = finding.get("analysis") or {}
+    if analysis.get("is_exploitable") is not None:
+        props["is_exploitable"] = analysis["is_exploitable"]
+    if analysis.get("reasoning"):
+        props["reasoning"] = str(analysis["reasoning"])[:500]
+
+    score = finding.get("exploitability_score")
+    if score is not None and score > 0:
+        props["exploitability_score"] = score
+
+    if finding.get("has_exploit"):
+        props["has_exploit"] = True
+        if finding.get("exploit_compiled") is not None:
+            props["exploit_compiled"] = finding["exploit_compiled"]
+
+    return verdict, props
+
+
+def _build_result(finding: Dict[str, Any]) -> Dict[str, Any]:
+    file_path = finding.get("file_path") or finding.get("file") or ""
+
+    start_line = finding.get("start_line")
+    if start_line is None:
+        start_line = finding.get("startLine")
+    if start_line is None or start_line < 1:
+        start_line = 1
+
+    end_line = finding.get("end_line")
+    if end_line is None:
+        end_line = finding.get("endLine")
+    if end_line is None or end_line < start_line:
+        end_line = start_line
+
+    rule_id = finding.get("rule_id") or "unknown"
+    message = finding.get("message") or ""
+    level = finding.get("level") or "warning"
+    if level not in _VALID_LEVELS:
+        level = "warning"
+
+    region: Dict[str, Any] = {
+        "startLine": start_line,
+        "endLine": end_line,
+    }
+
+    snippet = finding.get("snippet")
+    if not snippet:
+        code = finding.get("code")
+        if code:
+            lines = code.splitlines()
+            snippet = "\n".join(lines[:10]) if len(lines) > 10 else code
+    if snippet:
+        region["snippet"] = {"text": snippet}
+
+    verdict, raptor_props = _build_raptor_properties(finding)
+
+    result: Dict[str, Any] = {
+        "ruleId": rule_id,
+        "level": level,
+        "message": {"text": message},
+        "locations": [{
+            "physicalLocation": {
+                "artifactLocation": {"uri": file_path},
+                "region": region,
+            }
+        }],
+        "properties": {
+            "raptor": raptor_props,
+        },
+    }
+
+    fid = finding.get("finding_id")
+    if fid:
+        result["fingerprints"] = {"matchBasedId/v1": fid}
+
+    if verdict == "suppressed":
+        analysis = finding.get("analysis") or {}
+        result["suppressions"] = [{
+            "kind": "inSource",
+            "justification": (
+                f"binary-oracle: {analysis.get('reachability_verdict', 'absent')} "
+                f"— function removed by compiler/linker"
+            ),
+        }]
+
+    return result
+
+
+def build_enriched_sarif(
+    findings: Sequence[Dict[str, Any]],
+    *,
+    tool_name: str = "RAPTOR",
+    tool_version: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Build a SARIF 2.1.0 document from analysed findings.
+
+    Groups findings by their original tool (``finding["tool"]``),
+    creating one SARIF run per tool. Each result carries
+    ``properties.raptor`` with RAPTOR's verdicts.
+    """
+    if tool_version is None:
+        try:
+            from core.version import effective_version
+            tool_version = effective_version()
+        except Exception:
+            tool_version = "unknown"
+
+    runs_by_tool: Dict[str, List[Dict[str, Any]]] = {}
+    rules_by_tool: Dict[str, Dict[str, Dict[str, Any]]] = {}
+
+    for f in findings:
+        tool = f.get("tool") or tool_name
+        runs_by_tool.setdefault(tool, [])
+        rules_by_tool.setdefault(tool, {})
+
+        result = _build_result(f)
+        runs_by_tool[tool].append(result)
+
+        rid = f.get("rule_id") or "unknown"
+        if rid not in rules_by_tool[tool]:
+            rule_entry: Dict[str, Any] = {"id": rid}
+            cwe = f.get("cwe_id")
+            if cwe:
+                rule_entry["properties"] = {"cwe": [cwe]}
+            desc = f.get("message")
+            if desc:
+                rule_entry["shortDescription"] = {"text": desc[:200]}
+            rules_by_tool[tool][rid] = rule_entry
+
+    now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    runs = []
+    for tool_key, results in runs_by_tool.items():
+        runs.append({
+            "tool": {
+                "driver": {
+                    "name": tool_key,
+                    "version": tool_version,
+                    "rules": list(rules_by_tool[tool_key].values()),
+                },
+            },
+            "results": results,
+            "invocations": [{
+                "executionSuccessful": True,
+                "endTimeUtc": now,
+            }],
+        })
+
+    return {
+        "version": "2.1.0",
+        "$schema": _SCHEMA,
+        "runs": runs,
+    }
+
+
+def write_enriched_sarif(
+    findings: Sequence[Dict[str, Any]],
+    output_path: Path,
+    *,
+    tool_name: str = "RAPTOR",
+    tool_version: Optional[str] = None,
+) -> int:
+    """Write enriched SARIF to *output_path*. Returns finding count."""
+    doc = build_enriched_sarif(
+        findings, tool_name=tool_name, tool_version=tool_version,
+    )
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = output_path.with_suffix(output_path.suffix + ".tmp")
+    with tmp.open("w", encoding="utf-8") as fh:
+        json.dump(doc, fh, indent=2)
+    tmp.replace(output_path)
+    logger.info("Wrote enriched SARIF: %s (%d findings)", output_path, len(findings))
+    return len(findings)

--- a/core/sarif/import_normalizer.py
+++ b/core/sarif/import_normalizer.py
@@ -1,0 +1,501 @@
+"""Normalize externally-produced SARIF findings for the RAPTOR pipeline.
+
+Imported SARIF may be missing fields that RAPTOR's own scanners always
+populate (snippet, CWE, well-resolved file paths).  This module
+synthesizes what it can from the source tree and warns about the rest,
+producing findings in the same internal dict shape that
+:func:`core.sarif.parser.parse_sarif_findings` returns.
+"""
+
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+from urllib.parse import unquote
+
+from core.logging import get_logger
+
+logger = get_logger()
+
+
+# ---------------------------------------------------------------------------
+# CWE inference from rule_id / message text
+# ---------------------------------------------------------------------------
+
+_CWE_MESSAGE_PATTERNS: List[tuple] = [
+    (re.compile(r"sql.?inject", re.I), "CWE-89"),
+    (re.compile(r"command.?inject|os.?command|shell.?inject", re.I), "CWE-78"),
+    (re.compile(r"cross.?site.?script|xss", re.I), "CWE-79"),
+    (re.compile(r"path.?travers|directory.?travers", re.I), "CWE-22"),
+    (re.compile(r"buffer.?over(?:flow|run)|stack.?overflow", re.I), "CWE-120"),
+    (re.compile(r"heap.?over(?:flow|run)", re.I), "CWE-122"),
+    (re.compile(r"format.?string", re.I), "CWE-134"),
+    (re.compile(r"integer.?over(?:flow|wrap)", re.I), "CWE-190"),
+    (re.compile(r"double.?free", re.I), "CWE-415"),
+    (re.compile(r"use.?after.?free|uaf", re.I), "CWE-416"),
+    (re.compile(r"null.?(?:pointer|deref|dereference)", re.I), "CWE-476"),
+    (re.compile(r"out.?of.?bounds.?write", re.I), "CWE-787"),
+    (re.compile(r"out.?of.?bounds.?read", re.I), "CWE-125"),
+    (re.compile(r"uninitiali[sz]ed", re.I), "CWE-908"),
+    (re.compile(r"deseriali[sz]ation", re.I), "CWE-502"),
+    (re.compile(r"(?:server.?side|ssrf).?request.?forg", re.I), "CWE-918"),
+    (re.compile(r"race.?condition|toctou|time.?of.?check", re.I), "CWE-367"),
+    (re.compile(r"type.?confusion", re.I), "CWE-843"),
+    (re.compile(r"hardcoded.?(?:secret|password|credential|key)", re.I), "CWE-798"),
+]
+
+_CWE_RE = re.compile(r"CWE-(\d+)", re.I)
+
+
+def _infer_cwe(rule_id: str, message: str) -> Optional[str]:
+    """Infer CWE from rule_id keywords or finding message text.
+
+    Returns ``"CWE-NNN"`` or None.  Tries the vuln-type reverse map
+    first (covers Semgrep/CodeQL-style rule IDs), then falls back to
+    message-text regex patterns.
+    """
+    try:
+        from packages.exploit_feasibility import get_vuln_type_for_rule
+        from core.schema_constants import VULN_TYPE_TO_CWE
+        vt = get_vuln_type_for_rule(rule_id)
+        if vt and vt in VULN_TYPE_TO_CWE:
+            return VULN_TYPE_TO_CWE[vt]
+    except ImportError:
+        pass
+
+    combined = f"{rule_id} {message}"
+
+    m = _CWE_RE.search(combined)
+    if m:
+        return f"CWE-{m.group(1)}"
+
+    for pattern, cwe in _CWE_MESSAGE_PATTERNS:
+        if pattern.search(combined):
+            return cwe
+
+    return None
+
+
+# ---------------------------------------------------------------------------
+# URI rebasing — map scanner paths to the extracted source tree
+# ---------------------------------------------------------------------------
+
+def _strip_file_scheme(uri: str) -> str:
+    if uri.startswith("file:///"):
+        return uri[len("file:///"):]
+    if uri.startswith("file://"):
+        return uri[len("file://"):]
+    return uri
+
+
+_SCA_TOOL_KEYWORDS = (
+    "snyk", "grype", "trivy", "dependency-check", "npm audit",
+    "yarn audit", "pip-audit", "safety", "osv-scanner",
+    "renovate", "dependabot",
+)
+
+_SAST_TOOL_KEYWORDS = (
+    "codeql", "semgrep", "coverity", "bandit", "pylint", "flawfinder",
+    "checkmarx", "fortify", "sonarqube", "sonar", "spotbugs", "findbugs",
+    "clang-tidy", "cppcheck", "infer",
+)
+
+_DEPENDENCY_MANIFEST_NAMES = frozenset({
+    "package.json", "package-lock.json", "yarn.lock", "pnpm-lock.yaml",
+    "requirements.txt", "Pipfile.lock", "poetry.lock", "setup.cfg",
+    "setup.py", "pyproject.toml", "Cargo.lock", "Cargo.toml",
+    "go.sum", "go.mod", "Gemfile.lock", "Gemfile",
+    "pom.xml", "build.gradle", "build.gradle.kts",
+    "composer.lock", "composer.json", "Podfile.lock",
+    "packages.config", "Directory.Build.props",
+})
+
+
+def _is_sca_finding(finding: Dict[str, Any]) -> bool:
+    tool = (finding.get("tool") or "").lower().strip()
+    if any(kw in tool for kw in _SCA_TOOL_KEYWORDS):
+        return True
+    if any(kw in tool for kw in _SAST_TOOL_KEYWORDS):
+        return False
+    uri = finding.get("file") or ""
+    basename = Path(uri).name
+    return basename in _DEPENDENCY_MANIFEST_NAMES
+
+
+_SKIP_DIRS = frozenset({
+    ".git", "node_modules", "__pycache__", ".tox", ".venv",
+    "venv", ".mypy_cache", ".pytest_cache",
+})
+
+
+def _build_file_index(source_root: Path) -> Dict[str, List[Path]]:
+    """Map basename → list of relative paths under *source_root*.
+
+    Skips well-known non-source directories to keep the index small
+    and the walk fast on large repos.
+    """
+    index: Dict[str, List[Path]] = {}
+
+    def _walk(directory: Path) -> None:
+        try:
+            entries = sorted(directory.iterdir())
+        except (OSError, PermissionError):
+            return
+        for entry in entries:
+            if entry.is_dir() and not entry.is_symlink():
+                if entry.name not in _SKIP_DIRS:
+                    _walk(entry)
+            elif entry.is_file():
+                rel = entry.relative_to(source_root)
+                index.setdefault(entry.name, []).append(rel)
+
+    _walk(source_root)
+    return index
+
+
+def _is_under_root(source_root: Path, candidate: str) -> bool:
+    """Verify *candidate* resolves to a path under *source_root*.
+
+    Defends against path-traversal in attacker-controlled SARIF URIs
+    (``../../etc/passwd``).
+    """
+    try:
+        resolved = (source_root / candidate).resolve()
+        return resolved.is_file() and str(resolved).startswith(
+            str(source_root.resolve()) + "/"
+        )
+    except (OSError, ValueError):
+        return False
+
+
+def _resolve_uri(
+    uri: str,
+    source_root: Path,
+    file_index: Dict[str, List[Path]],
+    depth_cache: List[Optional[int]],
+) -> Optional[str]:
+    """Resolve a SARIF URI to a relative path under *source_root*.
+
+    Tries progressively shorter prefixes until a match is found.
+    Caches the successful strip-depth so subsequent findings from the
+    same scanner resolve in O(1).
+
+    Rejects any resolved path that escapes *source_root* (traversal
+    defence for untrusted SARIF).
+
+    Returns a POSIX-style relative path string, or None.
+    """
+    clean = unquote(_strip_file_scheme(uri))
+    if clean.startswith("/"):
+        clean = clean.lstrip("/")
+
+    parts = Path(clean).parts
+    if not parts:
+        return None
+
+    if depth_cache[0] is not None:
+        candidate = str(Path(*parts[depth_cache[0]:])) if depth_cache[0] < len(parts) else None
+        if candidate and _is_under_root(source_root, candidate):
+            return candidate
+
+    for depth in range(len(parts)):
+        candidate = str(Path(*parts[depth:]))
+        if _is_under_root(source_root, candidate):
+            depth_cache[0] = depth
+            return candidate
+
+    basename = parts[-1]
+    matches = file_index.get(basename, [])
+    if len(matches) == 1:
+        resolved = str(matches[0])
+        if _is_under_root(source_root, resolved):
+            logger.debug("URI %s: basename-only match → %s", uri, resolved)
+            return resolved
+
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Snippet synthesis
+# ---------------------------------------------------------------------------
+
+_SNIPPET_CONTEXT_LINES = 3
+
+
+def _synthesize_snippet(
+    source_root: Path, rel_path: str,
+    start_line: int, end_line: Optional[int],
+) -> str:
+    """Read source lines around the finding location."""
+    try:
+        full = source_root / rel_path
+        lines = full.read_text(errors="replace").splitlines()
+        s = max(0, start_line - 1)
+        e = min(len(lines), (end_line or start_line) + _SNIPPET_CONTEXT_LINES)
+        return "\n".join(lines[s:e])
+    except OSError:
+        return ""
+
+
+# ---------------------------------------------------------------------------
+# Import result
+# ---------------------------------------------------------------------------
+
+@dataclass
+class ImportWarning:
+    finding_index: int
+    field: str
+    message: str
+
+
+@dataclass
+class ImportStats:
+    total_imported: int = 0
+    findings_skipped: int = 0
+    cwe_inferred: int = 0
+    snippet_synthesized: int = 0
+    uri_rebased: int = 0
+    uri_unresolved: int = 0
+    sca_tagged: int = 0
+
+
+@dataclass
+class ImportResult:
+    findings: List[Dict[str, Any]] = field(default_factory=list)
+    warnings: List[ImportWarning] = field(default_factory=list)
+    stats: ImportStats = field(default_factory=ImportStats)
+
+
+# ---------------------------------------------------------------------------
+# Main entry point
+# ---------------------------------------------------------------------------
+
+def normalize_imported_findings(
+    findings: List[Dict[str, Any]],
+    source_root: Path,
+    original_tool: str = "external",
+) -> ImportResult:
+    """Normalize and enrich imported SARIF findings.
+
+    Operates on the finding dicts produced by
+    :func:`core.sarif.parser.parse_sarif_findings`.  Synthesizes
+    missing fields from the source tree, rebases URIs, and infers CWE
+    from rule IDs / message text.
+
+    Findings that cannot be mapped to a source file are dropped (with
+    a warning).
+    """
+    result = ImportResult()
+    source_root = source_root.resolve()
+
+    file_index = _build_file_index(source_root)
+    depth_cache: List[Optional[int]] = [None]
+
+    for idx, finding in enumerate(findings):
+        uri = finding.get("file") or ""
+        start_line = finding.get("startLine")
+        if not uri or not start_line:
+            result.warnings.append(ImportWarning(
+                idx, "file/startLine",
+                f"Skipped: missing file or startLine (rule_id={finding.get('rule_id')})",
+            ))
+            result.stats.findings_skipped += 1
+            continue
+
+        # --- URI rebasing ---
+        resolved = _resolve_uri(uri, source_root, file_index, depth_cache)
+        if resolved is None:
+            result.warnings.append(ImportWarning(
+                idx, "file",
+                f"Skipped: cannot map URI to source: {uri}",
+            ))
+            result.stats.findings_skipped += 1
+            result.stats.uri_unresolved += 1
+            continue
+
+        rebased = resolved != uri
+        if rebased:
+            result.stats.uri_rebased += 1
+        finding["file"] = resolved
+
+        # --- endLine default ---
+        if not finding.get("endLine"):
+            finding["endLine"] = start_line
+
+        # --- snippet synthesis ---
+        if not finding.get("snippet"):
+            snippet = _synthesize_snippet(
+                source_root, resolved,
+                start_line, finding.get("endLine"),
+            )
+            if snippet:
+                finding["snippet"] = snippet
+                result.stats.snippet_synthesized += 1
+
+        # --- CWE inference ---
+        if not finding.get("cwe_id"):
+            inferred = _infer_cwe(
+                finding.get("rule_id") or "",
+                finding.get("message") or "",
+            )
+            if inferred:
+                finding["cwe_id"] = inferred
+                finding["_cwe_inferred"] = True
+                result.stats.cwe_inferred += 1
+
+        # --- message fallback ---
+        if not finding.get("message"):
+            rule_id = finding.get("rule_id") or "unknown"
+            finding["message"] = f"{rule_id} at {resolved}:{start_line}"
+
+        # --- level default ---
+        if not finding.get("level"):
+            finding["level"] = "warning"
+
+        # --- tool preservation ---
+        if not finding.get("tool") or finding["tool"] == "unknown":
+            finding["tool"] = original_tool
+
+        # --- SCA detection ---
+        if _is_sca_finding(finding):
+            finding["source_type"] = "dependency"
+            result.stats.sca_tagged += 1
+
+        result.findings.append(finding)
+
+    result.stats.total_imported = len(result.findings)
+    return result
+
+
+def format_import_summary(result: ImportResult, sarif_files: List[str]) -> str:
+    """Format a human-readable import summary for the operator."""
+    s = result.stats
+    lines = [
+        f"Importing SARIF: {', '.join(sarif_files)}",
+        f"  → {s.total_imported} findings imported",
+    ]
+    if s.findings_skipped:
+        unmapped = [w for w in result.warnings if w.field == "file"]
+        if unmapped:
+            examples = "; ".join(w.message.split(": ", 1)[-1] for w in unmapped[:3])
+            lines.append(f"  → {s.findings_skipped} findings skipped ({examples})")
+        else:
+            lines.append(f"  → {s.findings_skipped} findings skipped")
+    if s.cwe_inferred:
+        lines.append(f"  → {s.cwe_inferred} CWEs inferred from rule_id/message")
+    if s.snippet_synthesized:
+        lines.append(f"  → {s.snippet_synthesized} snippets synthesized from source")
+    if s.uri_rebased:
+        lines.append(f"  → {s.uri_rebased} URIs rebased to source tree")
+
+    if s.sca_tagged:
+        lines.append(
+            f"  ⚠️  {s.sca_tagged} findings tagged as dependency (SCA) "
+            f"— consider --also-scan for richer dependency analysis"
+        )
+
+    no_dataflow = sum(
+        1 for f in result.findings if not f.get("has_dataflow")
+    )
+    if no_dataflow == len(result.findings) and result.findings:
+        lines.append("  → 0 dataflow paths (SARIF did not include codeFlows)")
+    return "\n".join(lines)
+
+
+def findings_to_sarif(findings: List[Dict[str, Any]]) -> Dict[str, Any]:
+    """Convert normalized finding dicts back to a valid SARIF 2.1.0 structure.
+
+    Groups findings by tool name and produces one run per tool.
+    The output preserves normalizer patches (rebased URIs, inferred CWEs,
+    synthesized snippets) so downstream consumers that re-parse from disk
+    see the same data the in-memory pipeline does.
+    """
+    runs_by_tool: Dict[str, list] = {}
+    rules_by_tool: Dict[str, Dict[str, dict]] = {}
+
+    for f in findings:
+        tool = f.get("tool") or "external"
+        runs_by_tool.setdefault(tool, [])
+        rules_by_tool.setdefault(tool, {})
+
+        rule_id = f.get("rule_id") or "unknown"
+
+        region: Dict[str, Any] = {}
+        if f.get("startLine"):
+            region["startLine"] = f["startLine"]
+        if f.get("endLine"):
+            region["endLine"] = f["endLine"]
+        if f.get("snippet"):
+            region["snippet"] = {"text": f["snippet"]}
+
+        result: Dict[str, Any] = {
+            "ruleId": rule_id,
+            "level": f.get("level") or "warning",
+            "message": {"text": f.get("message") or ""},
+            "locations": [{
+                "physicalLocation": {
+                    "artifactLocation": {"uri": f.get("file") or ""},
+                    "region": region,
+                }
+            }],
+        }
+
+        if f.get("has_dataflow") and f.get("dataflow_path"):
+            result["codeFlows"] = f["dataflow_path"]
+
+        fid = f.get("finding_id")
+        if fid:
+            result["fingerprints"] = {"matchBasedId/v1": fid}
+
+        runs_by_tool[tool].append(result)
+
+        if rule_id not in rules_by_tool[tool]:
+            rule_entry: Dict[str, Any] = {"id": rule_id}
+            cwe = f.get("cwe_id")
+            if cwe:
+                rule_entry["properties"] = {"cwe": [cwe]}
+            rules_by_tool[tool][rule_id] = rule_entry
+
+    sarif: Dict[str, Any] = {
+        "version": "2.1.0",
+        "$schema": "https://json.schemastore.org/sarif-2.1.0.json",
+        "runs": [],
+    }
+    for tool_name, results in runs_by_tool.items():
+        sarif["runs"].append({
+            "tool": {
+                "driver": {
+                    "name": tool_name,
+                    "rules": list(rules_by_tool[tool_name].values()),
+                }
+            },
+            "results": results,
+        })
+
+    return sarif
+
+
+def import_provenance_block(
+    result: ImportResult,
+    sarif_files: List[str],
+    tools: List[str],
+    source_type: str = "directory",
+    archive_sha256: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Build the provenance block for the run manifest."""
+    s = result.stats
+    block: Dict[str, Any] = {
+        "sarif_files": sarif_files,
+        "tools": tools,
+        "total_imported": s.total_imported,
+        "synthesized_fields": {
+            "cwe_inferred": s.cwe_inferred,
+            "snippet_synthesized": s.snippet_synthesized,
+            "uri_rebased": s.uri_rebased,
+            "findings_skipped": s.findings_skipped,
+        },
+        "source": source_type,
+    }
+    if archive_sha256:
+        block["archive_sha256"] = archive_sha256
+    return block

--- a/core/sarif/tests/test_enriched_writer.py
+++ b/core/sarif/tests/test_enriched_writer.py
@@ -1,0 +1,337 @@
+"""Tests for core.sarif.enriched_writer."""
+
+import json
+
+import pytest
+
+from core.sarif.enriched_writer import (
+    _build_raptor_properties,
+    _verdict_from_analysis,
+    _reachability_from_analysis,
+    build_enriched_sarif,
+    write_enriched_sarif,
+)
+
+
+# ---------------------------------------------------------------------------
+# Verdict mapping
+# ---------------------------------------------------------------------------
+
+class TestVerdictFromAnalysis:
+
+    def test_suppressed(self):
+        f = {"analysis": {"reachability_suppression": True}}
+        assert _verdict_from_analysis(f) == "suppressed"
+
+    def test_exploitable(self):
+        f = {"exploitable": True, "analysis": {"is_true_positive": True}}
+        assert _verdict_from_analysis(f) == "exploitable"
+
+    def test_confirmed(self):
+        f = {"exploitable": False, "analysis": {"is_true_positive": True}}
+        assert _verdict_from_analysis(f) == "confirmed"
+
+    def test_ruled_out(self):
+        f = {"analysis": {"is_true_positive": False}}
+        assert _verdict_from_analysis(f) == "ruled_out"
+
+    def test_not_analyzed(self):
+        assert _verdict_from_analysis({}) == "not_analyzed"
+
+    def test_suppressed_beats_exploitable(self):
+        f = {
+            "exploitable": True,
+            "analysis": {"reachability_suppression": True, "is_true_positive": True},
+        }
+        assert _verdict_from_analysis(f) == "suppressed"
+
+
+class TestReachabilityFromAnalysis:
+
+    def test_explicit_verdict(self):
+        f = {"analysis": {"reachability_verdict": "symbol_present"}}
+        assert _reachability_from_analysis(f) == "symbol_present"
+
+    def test_suppressed_implies_absent(self):
+        f = {"analysis": {"reachability_suppression": True}}
+        assert _reachability_from_analysis(f) == "absent"
+
+    def test_default(self):
+        assert _reachability_from_analysis({}) == "not_evaluated"
+
+
+# ---------------------------------------------------------------------------
+# Properties builder
+# ---------------------------------------------------------------------------
+
+class TestBuildRaptorProperties:
+
+    def test_minimal(self):
+        verdict, props = _build_raptor_properties({})
+        assert verdict == "not_analyzed"
+        assert props["verdict"] == "not_analyzed"
+        assert props["reachability"] == "not_evaluated"
+        assert "source_type" not in props
+
+    def test_source_type(self):
+        f = {"source_type": "dependency"}
+        _, props = _build_raptor_properties(f)
+        assert props["source_type"] == "dependency"
+
+    def test_cwe_inferred(self):
+        f = {"_cwe_inferred": True}
+        _, props = _build_raptor_properties(f)
+        assert props["cwe_inferred"] is True
+
+    def test_reasoning_truncated(self):
+        f = {"analysis": {"reasoning": "x" * 1000}}
+        _, props = _build_raptor_properties(f)
+        assert len(props["reasoning"]) == 500
+
+    def test_exploitability_score(self):
+        f = {"exploitability_score": 0.85}
+        _, props = _build_raptor_properties(f)
+        assert props["exploitability_score"] == 0.85
+
+    def test_zero_score_omitted(self):
+        f = {"exploitability_score": 0.0}
+        _, props = _build_raptor_properties(f)
+        assert "exploitability_score" not in props
+
+    def test_exploit_fields(self):
+        f = {"has_exploit": True, "exploit_compiled": True}
+        _, props = _build_raptor_properties(f)
+        assert props["has_exploit"] is True
+        assert props["exploit_compiled"] is True
+
+    def test_has_dataflow(self):
+        _, props = _build_raptor_properties({"has_dataflow": True})
+        assert props["has_dataflow"] is True
+
+    def test_has_dataflow_omitted_when_false(self):
+        _, props = _build_raptor_properties({"has_dataflow": False})
+        assert "has_dataflow" not in props
+
+    def test_is_exploitable_from_analysis(self):
+        f = {"analysis": {"is_exploitable": True}}
+        _, props = _build_raptor_properties(f)
+        assert props["is_exploitable"] is True
+
+    def test_is_exploitable_false_emitted(self):
+        f = {"analysis": {"is_exploitable": False}}
+        _, props = _build_raptor_properties(f)
+        assert props["is_exploitable"] is False
+
+    def test_analysis_none_handled(self):
+        f = {"analysis": None}
+        verdict, props = _build_raptor_properties(f)
+        assert verdict == "not_analyzed"
+        assert "is_exploitable" not in props
+
+
+# ---------------------------------------------------------------------------
+# Full document builder
+# ---------------------------------------------------------------------------
+
+class TestBuildEnrichedSarif:
+
+    @pytest.fixture()
+    def exploitable_finding(self):
+        return {
+            "finding_id": "abc123",
+            "rule_id": "CWE-79",
+            "file_path": "src/app.py",
+            "start_line": 42,
+            "end_line": 42,
+            "message": "XSS in template rendering",
+            "level": "error",
+            "tool": "Semgrep",
+            "cwe_id": "CWE-79",
+            "exploitable": True,
+            "exploitability_score": 0.9,
+            "analysis": {
+                "is_true_positive": True,
+                "is_exploitable": True,
+                "reasoning": "User input flows to template without escaping",
+            },
+        }
+
+    @pytest.fixture()
+    def suppressed_finding(self):
+        return {
+            "finding_id": "def456",
+            "rule_id": "CWE-120",
+            "file_path": "src/utils.c",
+            "start_line": 10,
+            "message": "Buffer overflow in parse_input",
+            "level": "warning",
+            "tool": "CodeQL",
+            "analysis": {
+                "reachability_suppression": True,
+                "reachability_verdict": "absent",
+            },
+        }
+
+    def test_schema_and_version(self, exploitable_finding):
+        doc = build_enriched_sarif([exploitable_finding], tool_version="1.0.0")
+        assert doc["version"] == "2.1.0"
+        assert "$schema" in doc
+
+    def test_grouped_by_tool(self, exploitable_finding, suppressed_finding):
+        doc = build_enriched_sarif(
+            [exploitable_finding, suppressed_finding], tool_version="1.0.0",
+        )
+        assert len(doc["runs"]) == 2
+        tool_names = {r["tool"]["driver"]["name"] for r in doc["runs"]}
+        assert tool_names == {"Semgrep", "CodeQL"}
+
+    def test_raptor_properties_on_result(self, exploitable_finding):
+        doc = build_enriched_sarif([exploitable_finding], tool_version="1.0.0")
+        result = doc["runs"][0]["results"][0]
+        raptor = result["properties"]["raptor"]
+        assert raptor["verdict"] == "exploitable"
+        assert raptor["exploitability_score"] == 0.9
+
+    def test_fingerprint_emitted(self, exploitable_finding):
+        doc = build_enriched_sarif([exploitable_finding], tool_version="1.0.0")
+        result = doc["runs"][0]["results"][0]
+        assert result["fingerprints"]["matchBasedId/v1"] == "abc123"
+
+    def test_suppression_emitted(self, suppressed_finding):
+        doc = build_enriched_sarif([suppressed_finding], tool_version="1.0.0")
+        result = doc["runs"][0]["results"][0]
+        assert len(result["suppressions"]) == 1
+        assert "binary-oracle" in result["suppressions"][0]["justification"]
+
+    def test_rules_deduplicated(self):
+        findings = [
+            {"rule_id": "R1", "file_path": "a.py", "start_line": 1, "message": "m", "tool": "T"},
+            {"rule_id": "R1", "file_path": "b.py", "start_line": 2, "message": "m", "tool": "T"},
+        ]
+        doc = build_enriched_sarif(findings, tool_version="1.0.0")
+        rules = doc["runs"][0]["tool"]["driver"]["rules"]
+        assert len(rules) == 1
+        assert rules[0]["id"] == "R1"
+
+    def test_empty_findings(self):
+        doc = build_enriched_sarif([], tool_version="1.0.0")
+        assert doc["runs"] == []
+
+    def test_cwe_in_rule_properties(self, exploitable_finding):
+        doc = build_enriched_sarif([exploitable_finding], tool_version="1.0.0")
+        rules = doc["runs"][0]["tool"]["driver"]["rules"]
+        assert rules[0]["properties"]["cwe"] == ["CWE-79"]
+
+    def test_snippet_from_code_field(self):
+        f = {
+            "rule_id": "R1", "file_path": "a.py", "start_line": 1,
+            "message": "m", "tool": "T", "code": "x = 1\ny = 2",
+        }
+        doc = build_enriched_sarif([f], tool_version="1.0.0")
+        region = doc["runs"][0]["results"][0]["locations"][0]["physicalLocation"]["region"]
+        assert region["snippet"]["text"] == "x = 1\ny = 2"
+
+    def test_no_suppression_for_non_suppressed(self, exploitable_finding):
+        doc = build_enriched_sarif([exploitable_finding], tool_version="1.0.0")
+        result = doc["runs"][0]["results"][0]
+        assert "suppressions" not in result
+
+    def test_start_line_zero_becomes_one(self):
+        f = {"rule_id": "R1", "file_path": "a.py", "start_line": 0,
+             "message": "m", "tool": "T"}
+        doc = build_enriched_sarif([f], tool_version="1.0.0")
+        region = doc["runs"][0]["results"][0]["locations"][0]["physicalLocation"]["region"]
+        assert region["startLine"] == 1
+
+    def test_invalid_level_clamped_to_warning(self):
+        f = {"rule_id": "R1", "file_path": "a.py", "start_line": 1,
+             "message": "m", "tool": "T", "level": "critical"}
+        doc = build_enriched_sarif([f], tool_version="1.0.0")
+        assert doc["runs"][0]["results"][0]["level"] == "warning"
+
+    def test_valid_level_preserved(self):
+        f = {"rule_id": "R1", "file_path": "a.py", "start_line": 1,
+             "message": "m", "tool": "T", "level": "error"}
+        doc = build_enriched_sarif([f], tool_version="1.0.0")
+        assert doc["runs"][0]["results"][0]["level"] == "error"
+
+    def test_none_fields_handled(self):
+        f = {"rule_id": None, "file_path": None, "start_line": None,
+             "message": None, "tool": None, "analysis": None}
+        doc = build_enriched_sarif([f], tool_version="1.0.0")
+        result = doc["runs"][0]["results"][0]
+        assert result["ruleId"] == "unknown"
+        assert result["message"]["text"] == ""
+        assert result["level"] == "warning"
+
+    def test_is_exploitable_in_raptor_properties(self, exploitable_finding):
+        doc = build_enriched_sarif([exploitable_finding], tool_version="1.0.0")
+        raptor = doc["runs"][0]["results"][0]["properties"]["raptor"]
+        assert raptor["is_exploitable"] is True
+
+
+# ---------------------------------------------------------------------------
+# Atomic file writer
+# ---------------------------------------------------------------------------
+
+class TestWriteEnrichedSarif:
+
+    def test_writes_valid_json(self, tmp_path):
+        findings = [
+            {
+                "finding_id": "f1",
+                "rule_id": "R1",
+                "file_path": "a.py",
+                "start_line": 1,
+                "message": "test",
+                "tool": "T",
+            },
+        ]
+        out = tmp_path / "enriched.sarif"
+        count = write_enriched_sarif(findings, out, tool_version="1.0.0")
+        assert count == 1
+        doc = json.loads(out.read_text())
+        assert doc["version"] == "2.1.0"
+
+    def test_creates_parent_dirs(self, tmp_path):
+        out = tmp_path / "sub" / "dir" / "enriched.sarif"
+        write_enriched_sarif([], out, tool_version="1.0.0")
+        assert out.exists()
+
+    def test_atomic_write_no_leftover(self, tmp_path):
+        out = tmp_path / "enriched.sarif"
+        write_enriched_sarif([], out, tool_version="1.0.0")
+        assert not (tmp_path / "enriched.sarif.tmp").exists()
+
+
+# ---------------------------------------------------------------------------
+# Round-trip: enriched SARIF can be re-parsed
+# ---------------------------------------------------------------------------
+
+class TestRoundTrip:
+
+    def test_enriched_sarif_is_reparsable(self, tmp_path):
+        from core.sarif.parser import parse_sarif_findings
+
+        findings = [
+            {
+                "finding_id": "rt1",
+                "rule_id": "CWE-89",
+                "file_path": "src/db.py",
+                "start_line": 55,
+                "end_line": 57,
+                "message": "SQL injection via user input",
+                "level": "error",
+                "tool": "Semgrep",
+                "cwe_id": "CWE-89",
+                "exploitable": True,
+                "analysis": {"is_true_positive": True},
+            },
+        ]
+        out = tmp_path / "round-trip.sarif"
+        write_enriched_sarif(findings, out, tool_version="1.0.0")
+        reparsed = parse_sarif_findings(out)
+        assert len(reparsed) == 1
+        assert reparsed[0]["rule_id"] == "CWE-89"
+        assert reparsed[0]["file"] == "src/db.py"
+        assert reparsed[0]["startLine"] == 55

--- a/core/sarif/tests/test_import_e2e.py
+++ b/core/sarif/tests/test_import_e2e.py
@@ -1,0 +1,821 @@
+"""End-to-end test: external SARIF → parse → normalize → pipeline entry.
+
+Exercises the full path a user's external SARIF would take through
+the system, without requiring LLM calls or scanner binaries.
+Covers: parse, normalize, URI rebase, CWE inference, snippet synthesis,
+source-intel CWE gate, path traversal rejection, dedup, multi-file merge.
+"""
+
+import json
+from pathlib import Path
+
+from core.sarif.import_normalizer import (
+    findings_to_sarif,
+    normalize_imported_findings,
+    format_import_summary,
+    import_provenance_block,
+)
+from core.sarif.parser import (
+    deduplicate_findings,
+    merge_sarif,
+    parse_sarif_findings,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _write_source_tree(root: Path) -> None:
+    """Create a small C project with multiple files."""
+    (root / "src").mkdir(parents=True)
+    (root / "src" / "auth.c").write_text(
+        '#include <string.h>\n'
+        'int check_password(const char *input) {\n'
+        '    return strcmp(input, "secret");\n'
+        '}\n'
+    )
+    (root / "src" / "db.c").write_text(
+        '#include <stdio.h>\n'
+        'void query(const char *sql) {\n'
+        '    printf("executing: %s\\n", sql);\n'
+        '}\n'
+    )
+    (root / "src" / "net.c").write_text(
+        '#include <stdlib.h>\n'
+        'void *alloc_buf(int size) {\n'
+        '    return malloc(size);\n'
+        '}\n'
+    )
+    (root / "include").mkdir()
+    (root / "include" / "auth.h").write_text(
+        'int check_password(const char *input);\n'
+    )
+
+
+def _coverity_style_sarif(source_root: Path) -> dict:
+    """Simulate Coverity-style SARIF: absolute CI paths, no codeFlows,
+    CWE only in properties.cwe (list form), no snippets."""
+    ci_prefix = f"/builds/jenkins/workspace/{source_root.name}"
+    return {
+        "version": "2.1.0",
+        "$schema": "https://json.schemastore.org/sarif-2.1.0.json",
+        "runs": [{
+            "tool": {
+                "driver": {
+                    "name": "Coverity Static Analysis",
+                    "version": "2024.3.0",
+                    "rules": [
+                        {
+                            "id": "CID-12345",
+                            "shortDescription": {"text": "Buffer overflow"},
+                            "properties": {"cwe": ["CWE-120"]},
+                        },
+                        {
+                            "id": "CID-12346",
+                            "shortDescription": {"text": "SQL injection"},
+                            "properties": {"cwe": ["CWE-89"]},
+                        },
+                    ],
+                }
+            },
+            "results": [
+                {
+                    "ruleId": "CID-12345",
+                    "level": "error",
+                    "message": {"text": "Buffer overflow in check_password"},
+                    "locations": [{
+                        "physicalLocation": {
+                            "artifactLocation": {
+                                "uri": f"file:///{ci_prefix}/src/auth.c",
+                            },
+                            "region": {"startLine": 3, "endLine": 3},
+                        }
+                    }],
+                },
+                {
+                    "ruleId": "CID-12346",
+                    "level": "error",
+                    "message": {"text": "SQL injection in query"},
+                    "locations": [{
+                        "physicalLocation": {
+                            "artifactLocation": {
+                                "uri": f"file:///{ci_prefix}/src/db.c",
+                            },
+                            "region": {"startLine": 3},
+                        }
+                    }],
+                },
+            ],
+        }],
+    }
+
+
+def _bandit_style_sarif() -> dict:
+    """Simulate Bandit-style SARIF: relative paths, CWE in tags,
+    no codeFlows, has snippets."""
+    return {
+        "version": "2.1.0",
+        "runs": [{
+            "tool": {
+                "driver": {
+                    "name": "Bandit",
+                    "version": "1.7.9",
+                    "rules": [{
+                        "id": "B608",
+                        "shortDescription": {"text": "Hardcoded SQL"},
+                        "properties": {"tags": ["cwe-89", "security"]},
+                    }],
+                }
+            },
+            "results": [{
+                "ruleId": "B608",
+                "level": "warning",
+                "message": {"text": "Possible SQL injection via string-based query"},
+                "locations": [{
+                    "physicalLocation": {
+                        "artifactLocation": {"uri": "src/db.c"},
+                        "region": {
+                            "startLine": 3,
+                            "snippet": {"text": '    printf("executing: %s\\n", sql);'},
+                        },
+                    }
+                }],
+            }],
+        }],
+    }
+
+
+def _malicious_sarif() -> dict:
+    """SARIF with path-traversal URIs — must be rejected."""
+    return {
+        "version": "2.1.0",
+        "runs": [{
+            "tool": {"driver": {"name": "Evil", "rules": []}},
+            "results": [
+                {
+                    "ruleId": "evil-001",
+                    "message": {"text": "traversal attempt"},
+                    "locations": [{
+                        "physicalLocation": {
+                            "artifactLocation": {"uri": "../../etc/passwd"},
+                            "region": {"startLine": 1},
+                        }
+                    }],
+                },
+                {
+                    "ruleId": "evil-002",
+                    "message": {"text": "another traversal"},
+                    "locations": [{
+                        "physicalLocation": {
+                            "artifactLocation": {
+                                "uri": "src/../../../etc/shadow",
+                            },
+                            "region": {"startLine": 1},
+                        }
+                    }],
+                },
+            ],
+        }],
+    }
+
+
+def _no_rules_no_cwe_sarif() -> dict:
+    """SARIF with no rules block and no CWE anywhere — tests CWE inference
+    from message text."""
+    return {
+        "version": "2.1.0",
+        "runs": [{
+            "tool": {"driver": {"name": "CustomLinter"}},
+            "results": [
+                {
+                    "ruleId": "CUSTOM-001",
+                    "message": {"text": "Potential use after free in alloc_buf"},
+                    "locations": [{
+                        "physicalLocation": {
+                            "artifactLocation": {"uri": "src/net.c"},
+                            "region": {"startLine": 3},
+                        }
+                    }],
+                },
+                {
+                    "ruleId": "CUSTOM-002",
+                    "message": {"text": "General code quality issue"},
+                    "locations": [{
+                        "physicalLocation": {
+                            "artifactLocation": {"uri": "src/net.c"},
+                            "region": {"startLine": 1},
+                        }
+                    }],
+                },
+            ],
+        }],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestE2ECoverityStyle:
+    """Coverity-style: absolute CI paths, CWE in properties.cwe list."""
+
+    def test_full_pipeline(self, tmp_path):
+        source = tmp_path / "repo"
+        source.mkdir()
+        _write_source_tree(source)
+
+        sarif = _coverity_style_sarif(source)
+        sarif_path = tmp_path / "coverity.sarif"
+        sarif_path.write_text(json.dumps(sarif))
+
+        # Step 1: parse
+        findings = parse_sarif_findings(sarif_path)
+        assert len(findings) == 2
+        assert findings[0]["tool"] == "Coverity Static Analysis"
+        assert findings[0]["cwe_id"] == "CWE-120"
+        assert findings[1]["cwe_id"] == "CWE-89"
+
+        # Step 2: dedup (no dupes expected)
+        unique = deduplicate_findings(findings)
+        assert len(unique) == 2
+
+        # Step 3: normalize
+        result = normalize_imported_findings(unique, source)
+        assert result.stats.total_imported == 2
+        assert result.stats.findings_skipped == 0
+
+        # URIs rebased from absolute CI paths
+        assert result.findings[0]["file"] == "src/auth.c"
+        assert result.findings[1]["file"] == "src/db.c"
+        assert result.stats.uri_rebased == 2
+
+        # Snippets synthesized (Coverity didn't provide them)
+        assert result.stats.snippet_synthesized == 2
+        assert "strcmp" in result.findings[0]["snippet"]
+        assert "printf" in result.findings[1]["snippet"]
+
+        # CWEs preserved from parser (not inferred)
+        assert result.stats.cwe_inferred == 0
+        assert result.findings[0]["cwe_id"] == "CWE-120"
+
+        # endLine defaulted
+        assert result.findings[1]["endLine"] == 3
+
+        # Tool name preserved
+        assert result.findings[0]["tool"] == "Coverity Static Analysis"
+
+        # Summary
+        summary = format_import_summary(result, ["coverity.sarif"])
+        assert "2 findings imported" in summary
+        assert "2 URIs rebased" in summary
+        assert "2 snippets synthesized" in summary
+
+        # Provenance
+        prov = import_provenance_block(
+            result,
+            sarif_files=["coverity.sarif"],
+            tools=["Coverity Static Analysis"],
+        )
+        assert prov["total_imported"] == 2
+        assert prov["synthesized_fields"]["uri_rebased"] == 2
+
+
+class TestE2EBanditStyle:
+    """Bandit-style: relative paths, CWE in tags, has snippets."""
+
+    def test_full_pipeline(self, tmp_path):
+        source = tmp_path / "repo"
+        source.mkdir()
+        _write_source_tree(source)
+
+        sarif_path = tmp_path / "bandit.sarif"
+        sarif_path.write_text(json.dumps(_bandit_style_sarif()))
+
+        findings = parse_sarif_findings(sarif_path)
+        assert len(findings) == 1
+        assert findings[0]["cwe_id"] == "CWE-89"
+
+        result = normalize_imported_findings(findings, source)
+        assert result.stats.total_imported == 1
+        # Path already relative and correct — no rebasing
+        assert result.findings[0]["file"] == "src/db.c"
+        # Snippet from SARIF preserved (not synthesized)
+        assert result.stats.snippet_synthesized == 0
+        # CWE from parser preserved
+        assert result.stats.cwe_inferred == 0
+
+
+class TestE2EMultiFileMerge:
+    """Merge Coverity + Bandit SARIF, dedup overlapping findings."""
+
+    def test_cross_scanner_merge(self, tmp_path):
+        source = tmp_path / "repo"
+        source.mkdir()
+        _write_source_tree(source)
+
+        coverity_path = tmp_path / "coverity.sarif"
+        coverity_path.write_text(json.dumps(_coverity_style_sarif(source)))
+
+        bandit_path = tmp_path / "bandit.sarif"
+        bandit_path.write_text(json.dumps(_bandit_style_sarif()))
+
+        # Parse both
+        all_findings = []
+        for p in [coverity_path, bandit_path]:
+            all_findings.extend(parse_sarif_findings(p))
+        assert len(all_findings) == 3  # 2 Coverity + 1 Bandit
+
+        # Dedup — Coverity SQL-injection (CID-12346 at db.c:3) and
+        # Bandit B608 (at db.c:3) have same file+line but different
+        # rule_ids, so both survive standard dedup.
+        unique = deduplicate_findings(all_findings)
+        assert len(unique) == 3
+
+        # Normalize
+        result = normalize_imported_findings(unique, source)
+        assert result.stats.total_imported == 3
+
+        # Both tools represented
+        tools = {f["tool"] for f in result.findings}
+        assert "Coverity Static Analysis" in tools
+        assert "Bandit" in tools
+
+
+class TestE2EPathTraversal:
+    """Malicious SARIF with traversal URIs must be fully rejected."""
+
+    def test_traversal_rejected(self, tmp_path):
+        source = tmp_path / "repo"
+        source.mkdir()
+        _write_source_tree(source)
+
+        sarif_path = tmp_path / "evil.sarif"
+        sarif_path.write_text(json.dumps(_malicious_sarif()))
+
+        findings = parse_sarif_findings(sarif_path)
+        assert len(findings) == 2
+
+        result = normalize_imported_findings(findings, source)
+        assert result.stats.total_imported == 0
+        assert result.stats.findings_skipped == 2
+        assert all("cannot map URI" in w.message for w in result.warnings
+                    if w.field == "file")
+
+
+class TestE2ECweInference:
+    """SARIF with no rules block, no CWE — tests inference from message."""
+
+    def test_cwe_inferred_from_message(self, tmp_path):
+        source = tmp_path / "repo"
+        source.mkdir()
+        _write_source_tree(source)
+
+        sarif_path = tmp_path / "custom.sarif"
+        sarif_path.write_text(json.dumps(_no_rules_no_cwe_sarif()))
+
+        findings = parse_sarif_findings(sarif_path)
+        assert len(findings) == 2
+        # Parser finds no CWE (no rules block)
+        assert findings[0]["cwe_id"] is None
+        assert findings[1]["cwe_id"] is None
+
+        result = normalize_imported_findings(findings, source)
+        assert result.stats.total_imported == 2
+
+        # First finding: "use after free" → CWE-416 inferred
+        uaf_finding = [f for f in result.findings
+                       if f["rule_id"] == "CUSTOM-001"][0]
+        assert uaf_finding["cwe_id"] == "CWE-416"
+        assert uaf_finding.get("_cwe_inferred") is True
+
+        # Second finding: "general code quality" → no CWE match
+        generic_finding = [f for f in result.findings
+                           if f["rule_id"] == "CUSTOM-002"][0]
+        assert generic_finding["cwe_id"] is None
+
+        assert result.stats.cwe_inferred == 1
+
+
+class TestE2EMergedSarifPipeline:
+    """Test merge_sarif → parse → normalize full chain."""
+
+    def test_merge_then_normalize(self, tmp_path):
+        source = tmp_path / "repo"
+        source.mkdir()
+        _write_source_tree(source)
+
+        coverity_path = tmp_path / "coverity.sarif"
+        coverity_path.write_text(json.dumps(_coverity_style_sarif(source)))
+
+        bandit_path = tmp_path / "bandit.sarif"
+        bandit_path.write_text(json.dumps(_bandit_style_sarif()))
+
+        # Merge at the SARIF level
+        merged = merge_sarif([str(coverity_path), str(bandit_path)])
+        assert len(merged["runs"]) == 2  # one run per tool
+
+        # Write merged, re-parse
+        merged_path = tmp_path / "merged.sarif"
+        merged_path.write_text(json.dumps(merged))
+
+        findings = parse_sarif_findings(merged_path)
+        unique = deduplicate_findings(findings)
+
+        result = normalize_imported_findings(unique, source)
+        assert result.stats.total_imported == 3
+        assert result.stats.findings_skipped == 0
+
+        # All findings have resolved paths
+        for f in result.findings:
+            assert not f["file"].startswith("file://")
+            assert not f["file"].startswith("/")
+
+
+class TestE2ENormalizedSarifRoundTrip:
+    """Verify that writing normalized findings back to SARIF and
+    re-parsing produces the same data — this is the fix for the
+    validation-phase double-parse problem."""
+
+    def test_coverity_roundtrip_preserves_patches(self, tmp_path):
+        source = tmp_path / "repo"
+        source.mkdir()
+        _write_source_tree(source)
+
+        sarif_path = tmp_path / "coverity.sarif"
+        sarif_path.write_text(json.dumps(_coverity_style_sarif(source)))
+
+        # Parse + normalize (first pass — patches applied)
+        findings = parse_sarif_findings(sarif_path)
+        result = normalize_imported_findings(findings, source)
+        assert result.stats.uri_rebased == 2
+        assert result.stats.snippet_synthesized == 2
+
+        # Write normalized SARIF back to disk
+        normalized = findings_to_sarif(result.findings)
+        norm_path = tmp_path / "normalized.sarif"
+        norm_path.write_text(json.dumps(normalized))
+
+        # Re-parse from disk (simulates validation phase double-parse)
+        reparsed = parse_sarif_findings(norm_path)
+        assert len(reparsed) == 2
+
+        # Rebased URIs survived the round-trip
+        assert reparsed[0]["file"] == "src/auth.c"
+        assert reparsed[1]["file"] == "src/db.c"
+        assert not reparsed[0]["file"].startswith("file://")
+        assert not reparsed[0]["file"].startswith("/")
+
+        # Synthesized snippets survived
+        assert reparsed[0].get("snippet")
+        assert "strcmp" in reparsed[0]["snippet"]
+        assert reparsed[1].get("snippet")
+        assert "printf" in reparsed[1]["snippet"]
+
+        # CWEs survived (from original parser, preserved through SARIF)
+        assert reparsed[0]["cwe_id"] == "CWE-120"
+        assert reparsed[1]["cwe_id"] == "CWE-89"
+
+        # Tool names survived
+        assert reparsed[0]["tool"] == "Coverity Static Analysis"
+
+    def test_inferred_cwe_survives_roundtrip(self, tmp_path):
+        source = tmp_path / "repo"
+        source.mkdir()
+        _write_source_tree(source)
+
+        sarif_path = tmp_path / "custom.sarif"
+        sarif_path.write_text(json.dumps(_no_rules_no_cwe_sarif()))
+
+        findings = parse_sarif_findings(sarif_path)
+        result = normalize_imported_findings(findings, source)
+
+        # CWE-416 was inferred for "use after free"
+        uaf = [f for f in result.findings if f["rule_id"] == "CUSTOM-001"][0]
+        assert uaf["cwe_id"] == "CWE-416"
+
+        # Round-trip through SARIF
+        normalized = findings_to_sarif(result.findings)
+        norm_path = tmp_path / "normalized.sarif"
+        norm_path.write_text(json.dumps(normalized))
+
+        reparsed = parse_sarif_findings(norm_path)
+        uaf_reparsed = [f for f in reparsed if f["rule_id"] == "CUSTOM-001"][0]
+        assert uaf_reparsed["cwe_id"] == "CWE-416"
+
+    def test_multi_tool_roundtrip(self, tmp_path):
+        source = tmp_path / "repo"
+        source.mkdir()
+        _write_source_tree(source)
+
+        # Parse both scanners
+        all_findings = []
+        for sarif_fn, sarif_gen in [
+            ("coverity.sarif", _coverity_style_sarif(source)),
+            ("bandit.sarif", _bandit_style_sarif()),
+        ]:
+            p = tmp_path / sarif_fn
+            p.write_text(json.dumps(sarif_gen))
+            all_findings.extend(parse_sarif_findings(p))
+
+        result = normalize_imported_findings(
+            deduplicate_findings(all_findings), source,
+        )
+        assert result.stats.total_imported == 3
+
+        # Round-trip
+        normalized = findings_to_sarif(result.findings)
+        norm_path = tmp_path / "normalized.sarif"
+        norm_path.write_text(json.dumps(normalized))
+
+        reparsed = parse_sarif_findings(norm_path)
+        assert len(reparsed) == 3
+
+        tools = {f["tool"] for f in reparsed}
+        assert "Coverity Static Analysis" in tools
+        assert "Bandit" in tools
+
+        # All paths are relative
+        for f in reparsed:
+            assert not f["file"].startswith("file://")
+            assert not f["file"].startswith("/")
+
+
+class TestE2EScaDetection:
+    """SCA-flavour SARIF is detected and tagged."""
+
+    def _snyk_style_sarif(self):
+        return {
+            "version": "2.1.0",
+            "runs": [{
+                "tool": {
+                    "driver": {
+                        "name": "Snyk",
+                        "version": "1.1292.0",
+                        "rules": [{
+                            "id": "SNYK-JS-LODASH-567746",
+                            "shortDescription": {
+                                "text": "Prototype Pollution",
+                            },
+                        }],
+                    }
+                },
+                "results": [{
+                    "ruleId": "SNYK-JS-LODASH-567746",
+                    "level": "error",
+                    "message": {"text": "Prototype Pollution in lodash"},
+                    "locations": [{
+                        "physicalLocation": {
+                            "artifactLocation": {"uri": "package.json"},
+                            "region": {"startLine": 5},
+                        }
+                    }],
+                }],
+            }],
+        }
+
+    def test_snyk_sarif_tagged_as_dependency(self, tmp_path):
+        source = tmp_path / "repo"
+        source.mkdir()
+        _write_source_tree(source)
+        (source / "package.json").write_text(
+            '{\n  "name": "test",\n  "version": "1.0.0",\n'
+            '  "dependencies": {\n    "lodash": "^4.17.20"\n  }\n}\n'
+        )
+
+        sarif_path = tmp_path / "snyk.sarif"
+        sarif_path.write_text(json.dumps(self._snyk_style_sarif()))
+
+        findings = parse_sarif_findings(sarif_path)
+        assert len(findings) == 1
+        assert findings[0]["tool"] == "Snyk"
+
+        result = normalize_imported_findings(findings, source)
+        assert result.stats.total_imported == 1
+        assert result.stats.sca_tagged == 1
+        assert result.findings[0]["source_type"] == "dependency"
+
+        summary = format_import_summary(result, ["snyk.sarif"])
+        assert "dependency (SCA)" in summary
+
+    def test_mixed_code_and_sca_findings(self, tmp_path):
+        source = tmp_path / "repo"
+        source.mkdir()
+        _write_source_tree(source)
+        (source / "package.json").write_text('{"name": "test"}\n')
+
+        # Combine Coverity code finding with Snyk SCA finding
+        all_findings = []
+
+        coverity_path = tmp_path / "coverity.sarif"
+        coverity_path.write_text(json.dumps(_coverity_style_sarif(source)))
+        all_findings.extend(parse_sarif_findings(coverity_path))
+
+        snyk_path = tmp_path / "snyk.sarif"
+        snyk_path.write_text(json.dumps(self._snyk_style_sarif()))
+        all_findings.extend(parse_sarif_findings(snyk_path))
+
+        result = normalize_imported_findings(
+            deduplicate_findings(all_findings), source,
+        )
+        assert result.stats.total_imported == 3
+        assert result.stats.sca_tagged == 1
+
+        sca = [f for f in result.findings if f.get("source_type") == "dependency"]
+        code = [f for f in result.findings if "source_type" not in f]
+        assert len(sca) == 1
+        assert len(code) == 2
+        assert sca[0]["tool"] == "Snyk"
+
+
+class TestE2EProvenanceBlock:
+    """Provenance block is correctly populated from import results."""
+
+    def test_provenance_from_coverity_import(self, tmp_path):
+        source = tmp_path / "repo"
+        source.mkdir()
+        _write_source_tree(source)
+
+        sarif_path = tmp_path / "coverity.sarif"
+        sarif_path.write_text(json.dumps(_coverity_style_sarif(source)))
+
+        findings = parse_sarif_findings(sarif_path)
+        result = normalize_imported_findings(findings, source)
+
+        tools = sorted({f["tool"] for f in result.findings})
+        prov = import_provenance_block(
+            result,
+            sarif_files=["coverity.sarif"],
+            tools=tools,
+        )
+
+        assert prov["total_imported"] == 2
+        assert prov["sarif_files"] == ["coverity.sarif"]
+        assert "Coverity Static Analysis" in prov["tools"]
+        assert prov["synthesized_fields"]["uri_rebased"] == 2
+        assert prov["synthesized_fields"]["snippet_synthesized"] == 2
+        assert prov["source"] == "directory"
+
+    def test_provenance_with_archive(self, tmp_path):
+        source = tmp_path / "repo"
+        source.mkdir()
+        _write_source_tree(source)
+
+        sarif_path = tmp_path / "scan.sarif"
+        sarif_path.write_text(json.dumps(_bandit_style_sarif()))
+
+        findings = parse_sarif_findings(sarif_path)
+        result = normalize_imported_findings(findings, source)
+
+        prov = import_provenance_block(
+            result,
+            sarif_files=["scan.sarif"],
+            tools=["Bandit"],
+            source_type="archive",
+            archive_sha256="abc123deadbeef",
+        )
+
+        assert prov["source"] == "archive"
+        assert prov["archive_sha256"] == "abc123deadbeef"
+
+
+# ---------------------------------------------------------------------------
+# E2E: Enriched SARIF writer
+# ---------------------------------------------------------------------------
+
+class TestE2EEnrichedSarifWriter:
+    """Full pipeline: parse → normalize → analyse (simulated) → enriched SARIF → re-parse."""
+
+    def test_enriched_roundtrip_preserves_verdicts(self, tmp_path):
+        from core.sarif.enriched_writer import write_enriched_sarif
+
+        source = tmp_path / "repo"
+        source.mkdir()
+        _write_source_tree(source)
+
+        sarif_path = tmp_path / "coverity.sarif"
+        sarif_path.write_text(json.dumps(_coverity_style_sarif(source)))
+        findings = parse_sarif_findings(sarif_path)
+        result = normalize_imported_findings(findings, source)
+
+        analysed = []
+        for f in result.findings:
+            f["exploitable"] = True
+            f["exploitability_score"] = 0.85
+            f["analysis"] = {
+                "is_true_positive": True,
+                "is_exploitable": True,
+                "reasoning": "Attacker controls input buffer size",
+            }
+            analysed.append(f)
+
+        out = tmp_path / "enriched.sarif"
+        write_enriched_sarif(analysed, out, tool_version="test-1.0")
+
+        doc = json.loads(out.read_text())
+        assert doc["version"] == "2.1.0"
+        assert len(doc["runs"]) == 1
+
+        result_0 = doc["runs"][0]["results"][0]
+        raptor = result_0["properties"]["raptor"]
+        assert raptor["verdict"] == "exploitable"
+        assert raptor["is_exploitable"] is True
+        assert raptor["exploitability_score"] == 0.85
+        assert "reasoning" in raptor
+
+        reparsed = parse_sarif_findings(out)
+        assert len(reparsed) == 2
+        for r in reparsed:
+            assert r["rule_id"] in ("CID-12345", "CID-12346")
+            assert r["file"].startswith("src/")
+
+    def test_suppressed_findings_in_enriched_sarif(self, tmp_path):
+        from core.sarif.enriched_writer import build_enriched_sarif
+
+        findings = [
+            {
+                "finding_id": "supp1",
+                "rule_id": "CWE-120",
+                "file_path": "src/dead.c",
+                "start_line": 5,
+                "message": "Buffer overflow in dead code",
+                "level": "warning",
+                "tool": "CodeQL",
+                "analysis": {
+                    "reachability_suppression": True,
+                    "reachability_verdict": "absent",
+                },
+            },
+            {
+                "finding_id": "live1",
+                "rule_id": "CWE-79",
+                "file_path": "src/app.py",
+                "start_line": 10,
+                "message": "XSS",
+                "level": "error",
+                "tool": "Semgrep",
+                "exploitable": True,
+                "analysis": {"is_true_positive": True, "is_exploitable": True},
+            },
+        ]
+
+        doc = build_enriched_sarif(findings, tool_version="test-1.0")
+        all_results = []
+        for run in doc["runs"]:
+            all_results.extend(run["results"])
+
+        suppressed = [r for r in all_results if "suppressions" in r]
+        live = [r for r in all_results if "suppressions" not in r]
+        assert len(suppressed) == 1
+        assert suppressed[0]["ruleId"] == "CWE-120"
+        assert len(live) == 1
+        assert live[0]["properties"]["raptor"]["verdict"] == "exploitable"
+
+    def test_enriched_sarif_with_mixed_analysis_states(self, tmp_path):
+        """Findings with different analysis states: exploitable, confirmed, ruled_out, not_analyzed."""
+        from core.sarif.enriched_writer import build_enriched_sarif
+
+        findings = [
+            {
+                "rule_id": "R1", "file_path": "a.py", "start_line": 1,
+                "message": "m", "tool": "T", "exploitable": True,
+                "analysis": {"is_true_positive": True},
+            },
+            {
+                "rule_id": "R2", "file_path": "b.py", "start_line": 2,
+                "message": "m", "tool": "T",
+                "analysis": {"is_true_positive": True},
+            },
+            {
+                "rule_id": "R3", "file_path": "c.py", "start_line": 3,
+                "message": "m", "tool": "T",
+                "analysis": {"is_true_positive": False},
+            },
+            {
+                "rule_id": "R4", "file_path": "d.py", "start_line": 4,
+                "message": "m", "tool": "T",
+            },
+        ]
+        doc = build_enriched_sarif(findings, tool_version="test-1.0")
+        results = doc["runs"][0]["results"]
+        verdicts = [r["properties"]["raptor"]["verdict"] for r in results]
+        assert verdicts == ["exploitable", "confirmed", "ruled_out", "not_analyzed"]
+
+    def test_level_validation_e2e(self, tmp_path):
+        """Invalid SARIF levels from external scanners are clamped."""
+        from core.sarif.enriched_writer import write_enriched_sarif
+
+        findings = [
+            {"rule_id": "R1", "file_path": "a.py", "start_line": 1,
+             "message": "m", "tool": "T", "level": "critical"},
+            {"rule_id": "R2", "file_path": "b.py", "start_line": 1,
+             "message": "m", "tool": "T", "level": "error"},
+            {"rule_id": "R3", "file_path": "c.py", "start_line": 1,
+             "message": "m", "tool": "T", "level": "HIGH"},
+        ]
+        out = tmp_path / "levels.sarif"
+        write_enriched_sarif(findings, out, tool_version="1.0")
+
+        doc = json.loads(out.read_text())
+        levels = [r["level"] for r in doc["runs"][0]["results"]]
+        assert levels == ["warning", "error", "warning"]

--- a/core/sarif/tests/test_import_normalizer.py
+++ b/core/sarif/tests/test_import_normalizer.py
@@ -1,0 +1,795 @@
+"""Tests for the SARIF import normalizer."""
+
+import json
+from pathlib import Path
+
+from core.sarif.import_normalizer import (
+    _infer_cwe,
+    _is_sca_finding,
+    _resolve_uri,
+    _strip_file_scheme,
+    findings_to_sarif,
+    normalize_imported_findings,
+    format_import_summary,
+    import_provenance_block,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_finding(**overrides):
+    """Minimal finding dict (same shape as parse_sarif_findings output)."""
+    base = {
+        "finding_id": "test-001",
+        "rule_id": "test-rule",
+        "message": "test finding",
+        "file": "src/auth.c",
+        "startLine": 42,
+        "endLine": 42,
+        "snippet": "",
+        "level": "warning",
+        "cwe_id": None,
+        "tool": "TestScanner",
+        "has_dataflow": False,
+        "dataflow_path": None,
+    }
+    base.update(overrides)
+    return base
+
+
+def _source_tree(tmp_path):
+    """Create a minimal source tree and return its root."""
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "auth.c").write_text(
+        "int check_password(const char *pw) {\n"
+        "    // line 2\n"
+        "    // line 3\n"
+        "    return strcmp(pw, stored);\n"
+        "    // line 5\n"
+        "}\n"
+    )
+    (tmp_path / "src" / "main.c").write_text("int main() { return 0; }\n")
+    (tmp_path / "lib").mkdir()
+    (tmp_path / "lib" / "utils.c").write_text("void helper() {}\n")
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# _strip_file_scheme
+# ---------------------------------------------------------------------------
+
+class TestStripFileScheme:
+    def test_triple_slash(self):
+        assert _strip_file_scheme("file:///home/user/src/foo.c") == "home/user/src/foo.c"
+
+    def test_double_slash(self):
+        assert _strip_file_scheme("file://src/foo.c") == "src/foo.c"
+
+    def test_no_scheme(self):
+        assert _strip_file_scheme("src/foo.c") == "src/foo.c"
+
+    def test_empty(self):
+        assert _strip_file_scheme("") == ""
+
+
+# ---------------------------------------------------------------------------
+# _infer_cwe
+# ---------------------------------------------------------------------------
+
+class TestInferCwe:
+    def test_sql_injection_in_message(self):
+        assert _infer_cwe("generic-rule", "Possible SQL injection") == "CWE-89"
+
+    def test_buffer_overflow_in_rule_id(self):
+        assert _infer_cwe("buffer-overflow-check", "") == "CWE-120"
+
+    def test_xss_in_message(self):
+        assert _infer_cwe("web-001", "Cross-site scripting vulnerability") == "CWE-79"
+
+    def test_explicit_cwe_in_message(self):
+        assert _infer_cwe("generic", "Violation of CWE-416") == "CWE-416"
+
+    def test_explicit_cwe_in_rule_id(self):
+        assert _infer_cwe("CWE-787-oob-write", "some message") == "CWE-787"
+
+    def test_use_after_free(self):
+        assert _infer_cwe("memory-safety", "use after free detected") == "CWE-416"
+
+    def test_null_deref(self):
+        assert _infer_cwe("null-pointer-deref", "") == "CWE-476"
+
+    def test_format_string(self):
+        assert _infer_cwe("fmt", "format string vulnerability") == "CWE-134"
+
+    def test_no_match(self):
+        assert _infer_cwe("RULE-12345", "something happened") is None
+
+    def test_command_injection(self):
+        assert _infer_cwe("os-command", "OS command injection") == "CWE-78"
+
+    def test_deserialization(self):
+        assert _infer_cwe("deser", "unsafe deserialization") == "CWE-502"
+
+    def test_ssrf(self):
+        assert _infer_cwe("web", "server-side request forgery") == "CWE-918"
+
+    def test_hardcoded_secret(self):
+        assert _infer_cwe("cred", "hardcoded password in source") == "CWE-798"
+
+
+# ---------------------------------------------------------------------------
+# _resolve_uri
+# ---------------------------------------------------------------------------
+
+class TestResolveUri:
+    def test_relative_path_direct_match(self, tmp_path):
+        root = _source_tree(tmp_path)
+        idx = {"auth.c": [Path("src/auth.c")]}
+        cache = [None]
+        assert _resolve_uri("src/auth.c", root, idx, cache) == "src/auth.c"
+
+    def test_absolute_path_strip(self, tmp_path):
+        root = _source_tree(tmp_path)
+        idx = {"auth.c": [Path("src/auth.c")]}
+        cache = [None]
+        result = _resolve_uri("src/auth.c", root, idx, cache)
+        assert result == "src/auth.c"
+
+    def test_file_scheme_uri(self, tmp_path):
+        root = _source_tree(tmp_path)
+        idx = {"auth.c": [Path("src/auth.c")]}
+        cache = [None]
+        result = _resolve_uri(f"file:///{root}/src/auth.c", root, idx, cache)
+        assert result == "src/auth.c"
+
+    def test_url_encoded_path(self, tmp_path):
+        root = _source_tree(tmp_path)
+        (root / "src" / "my file.c").write_text("int x;")
+        idx = {"my file.c": [Path("src/my file.c")]}
+        cache = [None]
+        result = _resolve_uri("src/my%20file.c", root, idx, cache)
+        assert result == "src/my file.c"
+
+    def test_basename_only_unique(self, tmp_path):
+        root = _source_tree(tmp_path)
+        idx = {"utils.c": [Path("lib/utils.c")]}
+        cache = [None]
+        result = _resolve_uri("/some/ci/path/utils.c", root, idx, cache)
+        assert result == "lib/utils.c"
+
+    def test_path_traversal_rejected(self, tmp_path):
+        """SARIF URIs with ``..`` must not escape source_root."""
+        root = _source_tree(tmp_path)
+        idx = {}
+        cache = [None]
+        assert _resolve_uri("../../etc/passwd", root, idx, cache) is None
+        assert _resolve_uri("src/../../../etc/shadow", root, idx, cache) is None
+
+    def test_basename_ambiguous_returns_none(self, tmp_path):
+        root = _source_tree(tmp_path)
+        # auth.c only in src/, but simulate ambiguity
+        (root / "lib" / "auth.c").write_text("int other;")
+        idx = {"auth.c": [Path("src/auth.c"), Path("lib/auth.c")]}
+        cache = [None]
+        result = _resolve_uri("/unknown/path/auth.c", root, idx, cache)
+        assert result is None
+
+    def test_depth_cache_speedup(self, tmp_path):
+        root = _source_tree(tmp_path)
+        idx = {"auth.c": [Path("src/auth.c")], "main.c": [Path("src/main.c")]}
+        cache = [None]
+        # First resolution discovers depth
+        _resolve_uri("/ci/workspace/src/auth.c", root, idx, cache)
+        assert cache[0] is not None
+        saved_depth = cache[0]
+        # Second resolution uses cached depth
+        result = _resolve_uri("/ci/workspace/src/main.c", root, idx, cache)
+        assert result == "src/main.c"
+        assert cache[0] == saved_depth
+
+    def test_no_match_returns_none(self, tmp_path):
+        root = _source_tree(tmp_path)
+        idx = {}
+        cache = [None]
+        assert _resolve_uri("nonexistent.c", root, idx, cache) is None
+
+
+# ---------------------------------------------------------------------------
+# normalize_imported_findings
+# ---------------------------------------------------------------------------
+
+class TestNormalizeImportedFindings:
+    def test_basic_passthrough(self, tmp_path):
+        root = _source_tree(tmp_path)
+        findings = [_make_finding(snippet="existing snippet")]
+        result = normalize_imported_findings(findings, root)
+        assert result.stats.total_imported == 1
+        assert result.findings[0]["file"] == "src/auth.c"
+        assert result.findings[0]["snippet"] == "existing snippet"
+
+    def test_snippet_synthesis(self, tmp_path):
+        root = _source_tree(tmp_path)
+        findings = [_make_finding(snippet="", startLine=1)]
+        result = normalize_imported_findings(findings, root)
+        assert result.stats.snippet_synthesized == 1
+        assert "check_password" in result.findings[0]["snippet"]
+
+    def test_cwe_inference(self, tmp_path):
+        root = _source_tree(tmp_path)
+        findings = [_make_finding(
+            rule_id="buffer-overflow-check",
+            cwe_id=None,
+        )]
+        result = normalize_imported_findings(findings, root)
+        assert result.stats.cwe_inferred == 1
+        assert result.findings[0]["cwe_id"] == "CWE-120"
+        assert result.findings[0].get("_cwe_inferred") is True
+
+    def test_cwe_not_overwritten(self, tmp_path):
+        root = _source_tree(tmp_path)
+        findings = [_make_finding(cwe_id="CWE-89")]
+        result = normalize_imported_findings(findings, root)
+        assert result.stats.cwe_inferred == 0
+        assert result.findings[0]["cwe_id"] == "CWE-89"
+
+    def test_path_traversal_skipped(self, tmp_path):
+        root = _source_tree(tmp_path)
+        findings = [_make_finding(file="../../etc/passwd")]
+        result = normalize_imported_findings(findings, root)
+        assert result.stats.findings_skipped == 1
+        assert result.stats.total_imported == 0
+
+    def test_unresolvable_uri_skipped(self, tmp_path):
+        root = _source_tree(tmp_path)
+        findings = [_make_finding(file="/nonexistent/path/foo.c")]
+        result = normalize_imported_findings(findings, root)
+        assert result.stats.findings_skipped == 1
+        assert result.stats.total_imported == 0
+        assert len(result.findings) == 0
+        assert any("cannot map URI" in w.message for w in result.warnings)
+
+    def test_missing_startline_skipped(self, tmp_path):
+        root = _source_tree(tmp_path)
+        findings = [_make_finding(startLine=None)]
+        result = normalize_imported_findings(findings, root)
+        assert result.stats.findings_skipped == 1
+
+    def test_endline_defaults_to_startline(self, tmp_path):
+        root = _source_tree(tmp_path)
+        findings = [_make_finding(endLine=None)]
+        result = normalize_imported_findings(findings, root)
+        assert result.findings[0]["endLine"] == 42
+
+    def test_message_fallback(self, tmp_path):
+        root = _source_tree(tmp_path)
+        findings = [_make_finding(message=None, message_override=True)]
+        findings[0]["message"] = None
+        result = normalize_imported_findings(findings, root)
+        assert "test-rule" in result.findings[0]["message"]
+        assert "src/auth.c" in result.findings[0]["message"]
+
+    def test_level_defaults_to_warning(self, tmp_path):
+        root = _source_tree(tmp_path)
+        findings = [_make_finding(level=None)]
+        result = normalize_imported_findings(findings, root)
+        assert result.findings[0]["level"] == "warning"
+
+    def test_tool_preservation(self, tmp_path):
+        root = _source_tree(tmp_path)
+        findings = [_make_finding(tool="Coverity")]
+        result = normalize_imported_findings(findings, root)
+        assert result.findings[0]["tool"] == "Coverity"
+
+    def test_unknown_tool_replaced(self, tmp_path):
+        root = _source_tree(tmp_path)
+        findings = [_make_finding(tool="unknown")]
+        result = normalize_imported_findings(findings, root, original_tool="Bandit")
+        assert result.findings[0]["tool"] == "Bandit"
+
+    def test_uri_rebasing(self, tmp_path):
+        root = _source_tree(tmp_path)
+        findings = [_make_finding(file=f"file:///{root}/src/auth.c")]
+        result = normalize_imported_findings(findings, root)
+        assert result.findings[0]["file"] == "src/auth.c"
+        assert result.stats.uri_rebased == 1
+
+    def test_multiple_findings_mixed(self, tmp_path):
+        root = _source_tree(tmp_path)
+        findings = [
+            _make_finding(finding_id="f1", file="src/auth.c", cwe_id="CWE-89"),
+            _make_finding(finding_id="f2", file="src/main.c", cwe_id=None,
+                          rule_id="null-pointer-deref"),
+            _make_finding(finding_id="f3", file="/bad/path.c"),
+        ]
+        result = normalize_imported_findings(findings, root)
+        assert result.stats.total_imported == 2
+        assert result.stats.findings_skipped == 1
+        assert result.stats.cwe_inferred == 1
+
+
+# ---------------------------------------------------------------------------
+# format_import_summary
+# ---------------------------------------------------------------------------
+
+class TestFormatImportSummary:
+    def test_basic_summary(self, tmp_path):
+        root = _source_tree(tmp_path)
+        findings = [_make_finding()]
+        result = normalize_imported_findings(findings, root)
+        text = format_import_summary(result, ["test.sarif"])
+        assert "1 findings imported" in text
+        assert "test.sarif" in text
+
+    def test_summary_with_skips(self, tmp_path):
+        root = _source_tree(tmp_path)
+        findings = [_make_finding(file="/bad/path.c")]
+        result = normalize_imported_findings(findings, root)
+        text = format_import_summary(result, ["test.sarif"])
+        assert "skipped" in text
+
+    def test_no_dataflow_message(self, tmp_path):
+        root = _source_tree(tmp_path)
+        findings = [_make_finding(has_dataflow=False)]
+        result = normalize_imported_findings(findings, root)
+        text = format_import_summary(result, ["test.sarif"])
+        assert "0 dataflow paths" in text
+
+
+# ---------------------------------------------------------------------------
+# import_provenance_block
+# ---------------------------------------------------------------------------
+
+class TestImportProvenanceBlock:
+    def test_basic_block(self, tmp_path):
+        root = _source_tree(tmp_path)
+        findings = [_make_finding()]
+        result = normalize_imported_findings(findings, root)
+        block = import_provenance_block(
+            result,
+            sarif_files=["coverity.sarif"],
+            tools=["Coverity"],
+        )
+        assert block["tools"] == ["Coverity"]
+        assert block["total_imported"] == 1
+        assert block["source"] == "directory"
+
+    def test_archive_block(self, tmp_path):
+        root = _source_tree(tmp_path)
+        findings = [_make_finding()]
+        result = normalize_imported_findings(findings, root)
+        block = import_provenance_block(
+            result,
+            sarif_files=["test.sarif"],
+            tools=["external"],
+            source_type="archive",
+            archive_sha256="abc123",
+        )
+        assert block["source"] == "archive"
+        assert block["archive_sha256"] == "abc123"
+
+
+# ---------------------------------------------------------------------------
+# Synthetic SARIF fixtures — end-to-end through parse + normalize
+# ---------------------------------------------------------------------------
+
+class TestEndToEndSyntheticSarif:
+    """Parse a synthetic SARIF file, then normalize against a source tree."""
+
+    def _write_sarif(self, tmp_path, sarif_dict):
+        p = tmp_path / "test.sarif"
+        p.write_text(json.dumps(sarif_dict))
+        return p
+
+    def _minimal_sarif(self, **result_overrides):
+        result = {
+            "ruleId": "test-rule",
+            "level": "warning",
+            "message": {"text": "test finding"},
+            "locations": [{
+                "physicalLocation": {
+                    "artifactLocation": {"uri": "src/auth.c"},
+                    "region": {"startLine": 1},
+                }
+            }],
+        }
+        result.update(result_overrides)
+        return {
+            "version": "2.1.0",
+            "$schema": "https://json.schemastore.org/sarif-2.1.0.json",
+            "runs": [{
+                "tool": {"driver": {"name": "TestTool", "rules": []}},
+                "results": [result],
+            }],
+        }
+
+    def test_minimal_sarif_roundtrip(self, tmp_path):
+        root = _source_tree(tmp_path)
+        sarif_path = self._write_sarif(tmp_path, self._minimal_sarif())
+
+        from core.sarif.parser import parse_sarif_findings
+        findings = parse_sarif_findings(sarif_path)
+        assert len(findings) == 1
+
+        result = normalize_imported_findings(findings, root)
+        assert result.stats.total_imported == 1
+        assert result.findings[0]["file"] == "src/auth.c"
+
+    def test_no_rules_block(self, tmp_path):
+        root = _source_tree(tmp_path)
+        sarif = self._minimal_sarif()
+        del sarif["runs"][0]["tool"]["driver"]["rules"]
+        sarif_path = self._write_sarif(tmp_path, sarif)
+
+        from core.sarif.parser import parse_sarif_findings
+        findings = parse_sarif_findings(sarif_path)
+        result = normalize_imported_findings(findings, root)
+        assert result.stats.total_imported == 1
+        assert result.findings[0]["cwe_id"] is None
+
+    def test_cwe_in_relationships(self, tmp_path):
+        _source_tree(tmp_path)
+        sarif = self._minimal_sarif()
+        sarif["runs"][0]["tool"]["driver"]["rules"] = [{
+            "id": "test-rule",
+            "shortDescription": {"text": "Test"},
+            "relationships": [{
+                "target": {
+                    "id": "CWE-89",
+                    "toolComponent": {"name": "CWE"},
+                },
+            }],
+        }]
+        sarif_path = self._write_sarif(tmp_path, sarif)
+
+        from core.sarif.parser import parse_sarif_findings
+        findings = parse_sarif_findings(sarif_path)
+        assert findings[0]["cwe_id"] == "CWE-89"
+
+    def test_null_fields_handled(self, tmp_path):
+        root = _source_tree(tmp_path)
+        sarif = self._minimal_sarif()
+        sarif["runs"][0]["results"][0]["codeFlows"] = None
+        sarif_path = self._write_sarif(tmp_path, sarif)
+
+        from core.sarif.parser import parse_sarif_findings
+        findings = parse_sarif_findings(sarif_path)
+        result = normalize_imported_findings(findings, root)
+        assert result.stats.total_imported == 1
+
+    def test_original_uri_base_ids(self, tmp_path):
+        root = _source_tree(tmp_path)
+        sarif = {
+            "version": "2.1.0",
+            "runs": [{
+                "tool": {"driver": {"name": "ExtTool", "rules": []}},
+                "originalUriBaseIds": {
+                    "%SRCROOT%": {"uri": f"file:///{root}/"},
+                },
+                "results": [{
+                    "ruleId": "ext-001",
+                    "level": "warning",
+                    "message": {"text": "issue"},
+                    "locations": [{
+                        "physicalLocation": {
+                            "artifactLocation": {
+                                "uri": "src/auth.c",
+                                "uriBaseId": "%SRCROOT%",
+                            },
+                            "region": {"startLine": 1},
+                        }
+                    }],
+                }],
+            }],
+        }
+        sarif_path = self._write_sarif(tmp_path, sarif)
+
+        from core.sarif.parser import parse_sarif_findings
+        findings = parse_sarif_findings(sarif_path)
+        result = normalize_imported_findings(findings, root)
+        assert result.stats.total_imported == 1
+        assert result.findings[0]["file"] == "src/auth.c"
+
+    def test_multi_run_sarif(self, tmp_path):
+        root = _source_tree(tmp_path)
+        sarif = {
+            "version": "2.1.0",
+            "runs": [
+                {
+                    "tool": {"driver": {"name": "SAST", "rules": []}},
+                    "results": [{
+                        "ruleId": "sast-001",
+                        "message": {"text": "SAST finding"},
+                        "locations": [{
+                            "physicalLocation": {
+                                "artifactLocation": {"uri": "src/auth.c"},
+                                "region": {"startLine": 1},
+                            }
+                        }],
+                    }],
+                },
+                {
+                    "tool": {"driver": {"name": "SCA", "rules": []}},
+                    "results": [{
+                        "ruleId": "sca-001",
+                        "message": {"text": "SCA finding"},
+                        "locations": [{
+                            "physicalLocation": {
+                                "artifactLocation": {"uri": "src/main.c"},
+                                "region": {"startLine": 1},
+                            }
+                        }],
+                    }],
+                },
+            ],
+        }
+        sarif_path = self._write_sarif(tmp_path, sarif)
+
+        from core.sarif.parser import parse_sarif_findings
+        findings = parse_sarif_findings(sarif_path)
+        assert len(findings) == 2
+
+        result = normalize_imported_findings(findings, root)
+        assert result.stats.total_imported == 2
+        tools = {f["tool"] for f in result.findings}
+        assert tools == {"SAST", "SCA"}
+
+    def test_empty_results(self, tmp_path):
+        root = _source_tree(tmp_path)
+        sarif = {
+            "version": "2.1.0",
+            "runs": [{
+                "tool": {"driver": {"name": "EmptyTool", "rules": []}},
+                "results": [],
+            }],
+        }
+        sarif_path = self._write_sarif(tmp_path, sarif)
+
+        from core.sarif.parser import parse_sarif_findings
+        findings = parse_sarif_findings(sarif_path)
+        result = normalize_imported_findings(findings, root)
+        assert result.stats.total_imported == 0
+        assert result.findings == []
+
+
+class TestFindingsToSarif:
+    """Unit tests for findings_to_sarif."""
+
+    def test_empty_findings(self):
+        sarif = findings_to_sarif([])
+        assert sarif["version"] == "2.1.0"
+        assert sarif["runs"] == []
+
+    def test_single_finding_structure(self):
+        f = _make_finding(
+            tool="MyScanner",
+            rule_id="RULE-1",
+            file="src/main.c",
+            startLine=10,
+            endLine=15,
+            snippet="int x = 0;",
+            message="found issue",
+            level="error",
+            cwe_id="CWE-120",
+        )
+        sarif = findings_to_sarif([f])
+        assert len(sarif["runs"]) == 1
+
+        run = sarif["runs"][0]
+        assert run["tool"]["driver"]["name"] == "MyScanner"
+        assert len(run["tool"]["driver"]["rules"]) == 1
+        assert run["tool"]["driver"]["rules"][0]["id"] == "RULE-1"
+        assert run["tool"]["driver"]["rules"][0]["properties"]["cwe"] == ["CWE-120"]
+
+        result = run["results"][0]
+        assert result["ruleId"] == "RULE-1"
+        assert result["level"] == "error"
+        assert result["message"]["text"] == "found issue"
+
+        loc = result["locations"][0]["physicalLocation"]
+        assert loc["artifactLocation"]["uri"] == "src/main.c"
+        assert loc["region"]["startLine"] == 10
+        assert loc["region"]["endLine"] == 15
+        assert loc["region"]["snippet"]["text"] == "int x = 0;"
+
+    def test_groups_by_tool(self):
+        findings = [
+            _make_finding(tool="ToolA", rule_id="A-1", file="a.c", startLine=1),
+            _make_finding(tool="ToolB", rule_id="B-1", file="b.c", startLine=1),
+            _make_finding(tool="ToolA", rule_id="A-2", file="c.c", startLine=1),
+        ]
+        sarif = findings_to_sarif(findings)
+        assert len(sarif["runs"]) == 2
+
+        tool_names = {r["tool"]["driver"]["name"] for r in sarif["runs"]}
+        assert tool_names == {"ToolA", "ToolB"}
+
+        tool_a_run = [r for r in sarif["runs"]
+                      if r["tool"]["driver"]["name"] == "ToolA"][0]
+        assert len(tool_a_run["results"]) == 2
+        assert len(tool_a_run["tool"]["driver"]["rules"]) == 2
+
+    def test_deduplicates_rules(self):
+        findings = [
+            _make_finding(tool="T", rule_id="R-1", file="a.c", startLine=1),
+            _make_finding(tool="T", rule_id="R-1", file="b.c", startLine=5),
+        ]
+        sarif = findings_to_sarif(findings)
+        run = sarif["runs"][0]
+        assert len(run["results"]) == 2
+        assert len(run["tool"]["driver"]["rules"]) == 1
+
+    def test_no_cwe_omits_properties(self):
+        f = _make_finding(tool="T", rule_id="R-1", file="a.c", startLine=1)
+        f.pop("cwe_id", None)
+        sarif = findings_to_sarif([f])
+        rule = sarif["runs"][0]["tool"]["driver"]["rules"][0]
+        assert "properties" not in rule
+
+    def test_missing_tool_defaults_to_external(self):
+        f = _make_finding(file="a.c", startLine=1)
+        f.pop("tool", None)
+        sarif = findings_to_sarif([f])
+        assert sarif["runs"][0]["tool"]["driver"]["name"] == "external"
+
+    def test_finding_id_emitted_as_fingerprint(self):
+        f = _make_finding(
+            finding_id="SARIF-0042", file="a.c", startLine=1, tool="T",
+        )
+        sarif = findings_to_sarif([f])
+        result = sarif["runs"][0]["results"][0]
+        assert result["fingerprints"]["matchBasedId/v1"] == "SARIF-0042"
+
+    def test_no_finding_id_omits_fingerprint(self):
+        f = _make_finding(file="a.c", startLine=1, tool="T")
+        f.pop("finding_id", None)
+        sarif = findings_to_sarif([f])
+        result = sarif["runs"][0]["results"][0]
+        assert "fingerprints" not in result
+
+    def test_dataflow_path_emitted_as_codeflows(self):
+        flow = [{"threadFlows": [{"locations": []}]}]
+        f = _make_finding(
+            file="a.c", startLine=1, tool="T",
+            has_dataflow=True, dataflow_path=flow,
+        )
+        sarif = findings_to_sarif([f])
+        result = sarif["runs"][0]["results"][0]
+        assert result["codeFlows"] == flow
+
+    def test_no_dataflow_omits_codeflows(self):
+        f = _make_finding(
+            file="a.c", startLine=1, tool="T",
+            has_dataflow=False,
+        )
+        sarif = findings_to_sarif([f])
+        result = sarif["runs"][0]["results"][0]
+        assert "codeFlows" not in result
+
+
+class TestIsScaFinding:
+    """Unit tests for SCA finding detection."""
+
+    def test_known_sca_tool_snyk(self):
+        assert _is_sca_finding({"tool": "Snyk", "file": "src/main.c"})
+
+    def test_known_sca_tool_grype(self):
+        assert _is_sca_finding({"tool": "grype", "file": "src/main.c"})
+
+    def test_known_sca_tool_trivy(self):
+        assert _is_sca_finding({"tool": "trivy", "file": "src/main.c"})
+
+    def test_dependency_manifest_package_json(self):
+        assert _is_sca_finding({"tool": "CustomTool", "file": "package.json"})
+
+    def test_dependency_manifest_requirements_txt(self):
+        assert _is_sca_finding({"tool": "CustomTool", "file": "requirements.txt"})
+
+    def test_dependency_manifest_cargo_lock(self):
+        assert _is_sca_finding({"tool": "CustomTool", "file": "Cargo.lock"})
+
+    def test_dependency_manifest_nested_path(self):
+        assert _is_sca_finding({"tool": "CustomTool", "file": "frontend/package.json"})
+
+    def test_code_file_not_sca(self):
+        assert not _is_sca_finding({"tool": "Coverity", "file": "src/auth.c"})
+
+    def test_non_sca_tool_code_file(self):
+        assert not _is_sca_finding({"tool": "CodeQL", "file": "src/main.py"})
+
+    def test_empty_tool_code_file(self):
+        assert not _is_sca_finding({"tool": "", "file": "src/main.c"})
+
+    def test_none_tool(self):
+        assert not _is_sca_finding({"tool": None, "file": "src/main.c"})
+
+    def test_setup_py_unknown_tool_is_sca(self):
+        assert _is_sca_finding({"tool": "CustomTool", "file": "setup.py"})
+
+    def test_setup_py_sast_tool_not_sca(self):
+        assert not _is_sca_finding({"tool": "Bandit", "file": "setup.py"})
+
+    def test_setup_py_coverity_not_sca(self):
+        assert not _is_sca_finding({"tool": "Coverity Static Analysis", "file": "setup.py"})
+
+    def test_pom_xml_is_sca(self):
+        assert _is_sca_finding({"tool": "CustomTool", "file": "pom.xml"})
+
+    def test_tool_name_substring_match(self):
+        assert _is_sca_finding({"tool": "Snyk Open Source", "file": "src/main.c"})
+
+    def test_tool_name_variant_trivy(self):
+        assert _is_sca_finding({"tool": "Trivy Vulnerability Scanner", "file": "src/main.c"})
+
+    def test_sast_tool_on_manifest_not_sca(self):
+        assert not _is_sca_finding({"tool": "Semgrep", "file": "build.gradle"})
+
+
+class TestScaTaggingInNormalize:
+    """SCA findings get tagged with _source_type=dependency."""
+
+    def test_sca_tool_tagged(self, tmp_path):
+        root = tmp_path / "repo"
+        root.mkdir()
+        (root / "package.json").write_text('{"name": "test"}')
+
+        f = _make_finding(
+            tool="Snyk", file="package.json", startLine=1,
+        )
+        result = normalize_imported_findings([f], root)
+        assert result.stats.total_imported == 1
+        assert result.stats.sca_tagged == 1
+        assert result.findings[0]["source_type"] == "dependency"
+
+    def test_code_finding_not_tagged(self, tmp_path):
+        root = tmp_path / "repo"
+        root.mkdir()
+        (root / "src").mkdir()
+        (root / "src" / "main.c").write_text("int main() { return 0; }\n")
+
+        f = _make_finding(
+            tool="Coverity", file="src/main.c", startLine=1,
+        )
+        result = normalize_imported_findings([f], root)
+        assert result.stats.total_imported == 1
+        assert result.stats.sca_tagged == 0
+        assert "source_type" not in result.findings[0]
+
+    def test_sca_warning_in_summary(self, tmp_path):
+        root = tmp_path / "repo"
+        root.mkdir()
+        (root / "package.json").write_text('{"name": "test"}')
+
+        f = _make_finding(
+            tool="Snyk", file="package.json", startLine=1,
+        )
+        result = normalize_imported_findings([f], root)
+        summary = format_import_summary(result, ["snyk.sarif"])
+        assert "dependency (SCA)" in summary
+        assert "consider --also-scan" in summary
+
+    def test_mixed_sca_and_code(self, tmp_path):
+        root = tmp_path / "repo"
+        root.mkdir()
+        (root / "src").mkdir()
+        (root / "src" / "main.c").write_text("int main() { return 0; }\n")
+        (root / "package.json").write_text('{"name": "test"}')
+
+        findings = [
+            _make_finding(
+                finding_id="code-1",
+                tool="Coverity", file="src/main.c", startLine=1,
+            ),
+            _make_finding(
+                finding_id="sca-1",
+                tool="Snyk", file="package.json", startLine=1,
+            ),
+        ]
+        result = normalize_imported_findings(findings, root)
+        assert result.stats.total_imported == 2
+        assert result.stats.sca_tagged == 1
+        code_f = [f for f in result.findings if f["finding_id"] == "code-1"][0]
+        sca_f = [f for f in result.findings if f["finding_id"] == "sca-1"][0]
+        assert "source_type" not in code_f
+        assert sca_f["source_type"] == "dependency"

--- a/packages/llm_analysis/source_intel_inject.py
+++ b/packages/llm_analysis/source_intel_inject.py
@@ -67,6 +67,23 @@ except ImportError:
 
 logger = logging.getLogger(__name__)
 
+# CWE-based fallback gate for source-intel evidence injection.
+# External scanners (Coverity, Snyk, Bandit, …) use tool-specific
+# rule_id prefixes that never match _DEFAULT_RULE_PREFIXES (which is
+# CodeQL-centric).  When a finding's rule_id doesn't match, we check
+# its CWE against this set before rejecting.  The set mirrors the CWE
+# coverage of _DEFAULT_RULE_PREFIXES.
+_SOURCE_INTEL_CWES = frozenset({
+    "CWE-120", "CWE-122",  # buffer / heap overflow
+    "CWE-190",              # integer overflow
+    "CWE-415", "CWE-416",  # double-free / use-after-free
+    "CWE-476",              # null deref
+    "CWE-787",              # OOB write
+    "CWE-252",              # unchecked return
+    "CWE-125",              # OOB read
+    "CWE-134",              # format string
+    "CWE-908",              # uninitialized memory
+})
 
 # Cache: absolute resolved target dir → ``(signature, result)``
 # tuple. ``result`` is the ``SourceIntelResult`` or ``None`` when
@@ -198,7 +215,11 @@ def evidence_blocks_for_finding(
     if not _DEFAULT_RULE_PREFIXES:
         return ()
     if not any(rule_id.startswith(p) for p in _DEFAULT_RULE_PREFIXES):
-        return ()
+        # Fallback: CWE-based gate for external scanners whose rule_id
+        # prefixes won't match the CodeQL-centric _DEFAULT_RULE_PREFIXES.
+        cwe = (finding.get("cwe_id") or "").strip()
+        if cwe not in _SOURCE_INTEL_CWES:
+            return ()
 
     repo_raw = finding.get("repo_path")
     if not repo_raw:

--- a/packages/llm_analysis/tests/test_source_intel_inject.py
+++ b/packages/llm_analysis/tests/test_source_intel_inject.py
@@ -214,6 +214,47 @@ class TestEvidenceBlocks:
         # noreturn observation.
         assert "panic" in blocks[0].content
 
+    def test_cwe_fallback_gate_fires_for_external_scanner(self, tmp_path):
+        """External scanners use rule_id prefixes that don't match
+        _DEFAULT_RULE_PREFIXES (CodeQL-centric).  The CWE-based
+        fallback gate should still allow source-intel evidence when
+        the finding's cwe_id is in the memory-corruption set."""
+        result = _result_with_evidence()
+        with patch(
+            "packages.llm_analysis.source_intel_inject._analyze",
+            return_value=result,
+        ):
+            prepare_source_intel(tmp_path)
+        f = _finding(
+            rule_id="coverity-CID-12345",
+            cwe_id="CWE-476",
+            repo_path=str(tmp_path),
+            function="panic",
+        )
+        with patch(
+            "packages.llm_analysis.source_intel_inject._extract_flags",
+            return_value=None,
+        ):
+            blocks = evidence_blocks_for_finding(f)
+        assert len(blocks) == 1
+        assert blocks[0].kind == "source-intel-evidence"
+
+    def test_cwe_fallback_gate_rejects_non_memory_corruption(self, tmp_path):
+        """CWE fallback gate should reject findings whose CWE is
+        outside the memory-corruption set."""
+        result = _result_with_evidence()
+        with patch(
+            "packages.llm_analysis.source_intel_inject._analyze",
+            return_value=result,
+        ):
+            prepare_source_intel(tmp_path)
+        f = _finding(
+            rule_id="coverity-CID-99999",
+            cwe_id="CWE-89",
+            repo_path=str(tmp_path),
+        )
+        assert evidence_blocks_for_finding(f) == ()
+
     def test_render_failure_returns_empty_not_raise(self, tmp_path):
         """When the renderer raises, return ``()`` rather than
         propagating — Stage D must never fail over an evidence

--- a/raptor_agentic.py
+++ b/raptor_agentic.py
@@ -620,6 +620,24 @@ def _build_fuzz_phase_summary(fuzzing_result: dict | None, fuzz_out: Path | None
 
 
 
+def _build_completion_manifest(orch_meta, import_result, import_sarif_files,
+                               reanalyze_dir=None):
+    manifest = {
+        "models": orch_meta.get("fired_models", []),
+    }
+    if import_result and import_result.stats.total_imported:
+        from core.sarif.import_normalizer import import_provenance_block
+        tools = sorted({f.get("tool", "external") for f in import_result.findings})
+        manifest["sarif_import"] = import_provenance_block(
+            import_result,
+            sarif_files=[Path(f).name for f in import_sarif_files],
+            tools=tools,
+        )
+    if reanalyze_dir:
+        manifest["reanalysis_of"] = str(reanalyze_dir)
+    return manifest
+
+
 def main():
     parser = argparse.ArgumentParser(
         description="RAPTOR Agentic Security Testing - Scan, Analyse, Exploit, Patch",
@@ -680,6 +698,40 @@ Examples:
             "launch time. When the script is invoked directly without "
             "the wrapper, RAPTOR_CALLER_DIR is unset and --repo is "
             "required)."
+        ),
+    )
+    parser.add_argument(
+        "--sarif", action="append", default=None, metavar="FILE",
+        help=(
+            "Import external SARIF file(s) instead of scanning. Repeatable. "
+            "Findings are normalized against the source tree at --repo "
+            "(URI rebasing, snippet synthesis, CWE inference). "
+            "Skips the scan phase unless --also-scan is set."
+        ),
+    )
+    parser.add_argument(
+        "--also-scan", action="store_true",
+        help=(
+            "When --sarif is provided, also run RAPTOR's own scanners "
+            "(Semgrep / CodeQL) and merge the results with imported "
+            "findings. Without this flag, --sarif replaces the scan step."
+        ),
+    )
+    parser.add_argument(
+        "--sarif-out", metavar="FILE",
+        help=(
+            "Write enriched SARIF after analysis. Each result carries "
+            "properties.raptor with RAPTOR's verdict, reachability, "
+            "exploitability score, and reasoning. Binary-oracle-suppressed "
+            "findings get standard SARIF suppressions."
+        ),
+    )
+    parser.add_argument(
+        "--reanalyze", metavar="DIR",
+        help=(
+            "Re-run analysis on a previous run's output directory. "
+            "Reads .raptor-run.json to recover target path and SARIF files, "
+            "skips scanning. Equivalent to --sarif <previous SARIFs> --repo <previous target>."
         ),
     )
     parser.add_argument("--policy-groups", default="all", help="Comma-separated policy groups (default: all)")
@@ -1007,6 +1059,42 @@ Examples:
     if _target_kind != "auto":
         os.environ[RaptorConfig.ENV_TARGET_KIND] = _target_kind
 
+    # --reanalyze: seed --sarif and --repo from a previous run's metadata
+    if getattr(args, "reanalyze", None):
+        from core.run.metadata import load_run_metadata
+        reanalyze_dir = Path(args.reanalyze).resolve()
+        args.reanalyze = str(reanalyze_dir)
+        if not reanalyze_dir.is_dir():
+            parser.error(f"--reanalyze directory does not exist: {args.reanalyze}")
+        prev_meta = load_run_metadata(reanalyze_dir)
+        if not prev_meta:
+            parser.error(f"--reanalyze: no .raptor-run.json in {reanalyze_dir}")
+        prev_target = prev_meta.get("target_path")
+        if not prev_target:
+            parser.error("--reanalyze: previous run has no target_path in metadata")
+        if args.repo and str(Path(args.repo).resolve()) != str(Path(prev_target).resolve()):
+            logger.warning(
+                "--reanalyze: explicit --repo %s differs from previous run's "
+                "target %s — using --repo (SARIF may not match)",
+                args.repo, prev_target,
+            )
+        if not args.repo:
+            args.repo = prev_target
+        prev_sarif = []
+        for s in prev_meta.get("extra", {}).get("sarif_files", []):
+            candidate = reanalyze_dir / Path(s).name
+            if candidate.exists():
+                prev_sarif.append(str(candidate))
+            else:
+                logger.warning("--reanalyze: SARIF file missing: %s", candidate)
+        if not prev_sarif:
+            for f in sorted(reanalyze_dir.glob("*.sarif")):
+                prev_sarif.append(str(f))
+        if not prev_sarif:
+            parser.error(f"--reanalyze: no SARIF files found in {reanalyze_dir}")
+        args.sarif = (args.sarif or []) + prev_sarif
+        logger.info("--reanalyze: re-using %d SARIF files from %s", len(prev_sarif), reanalyze_dir)
+
     if not args.repo:
         parser.error("--repo is required (or launch via `raptor` from the target directory)")
     if not Path(args.repo).exists():
@@ -1311,20 +1399,21 @@ Examples:
     all_sarif_files = []
     semgrep_metrics = {}
     codeql_metrics = {}
+    import_sarif_files: list = getattr(args, "sarif", None) or []
+
+    if args.also_scan and not import_sarif_files:
+        logger.warning("--also-scan has no effect without --sarif; ignoring")
+
+    # When --sarif is provided without --also-scan, skip RAPTOR's own
+    # scanners entirely — the imported SARIF replaces the scan step.
+    skip_scan = bool(import_sarif_files) and not args.also_scan
 
     # Launch scanners in parallel when both are enabled
-    run_semgrep = not args.codeql_only
-    run_codeql = (args.codeql or args.codeql_only) and not args.no_codeql
+    run_semgrep = not args.codeql_only and not skip_scan
+    run_codeql = (args.codeql or args.codeql_only) and not args.no_codeql and not skip_scan
 
-    # Defensive guard for the "no scanners enabled" case. The
-    # mutex group on ``--codeql / --codeql-only / --no-codeql``
-    # makes this structurally unreachable today (you can't pass
-    # both ``--codeql-only`` and ``--no-codeql`` simultaneously),
-    # but if either resolution rule above ever shifts — or a
-    # caller mutates ``args`` between argparse and here — we don't
-    # want the pipeline silently walking to completion with
-    # zero findings and reporting "clean". Bail loudly instead.
-    if not (run_semgrep or run_codeql):
+    # Defensive guard for the "no scanners enabled" case.
+    if not skip_scan and not (run_semgrep or run_codeql):
         print(
             "\n✗ Both Semgrep and CodeQL are disabled — nothing to scan.\n"
             "  Re-run without --codeql-only / --no-codeql, or pass only one "
@@ -1672,14 +1761,58 @@ Examples:
         if not source_scan_empty:
             logger.info("raptor-sca not installed — skipping SCA phase")
 
+    # ---- External SARIF import ----
+    import_result = None
+    if import_sarif_files:
+        from core.sarif.import_normalizer import (
+            findings_to_sarif,
+            format_import_summary,
+            normalize_imported_findings,
+        )
+        from core.sarif.parser import parse_sarif_findings
+
+        print("\n" + "=" * 70)
+        print("SARIF IMPORT")
+        print("=" * 70)
+
+        imported_findings = []
+        for sf in import_sarif_files:
+            sf_path = Path(sf)
+            if not sf_path.exists():
+                print(f"  ✗ SARIF file not found: {sf}", file=sys.stderr)
+                continue
+            findings = parse_sarif_findings(sf_path)
+            logger.info("Parsed %d findings from %s", len(findings), sf_path.name)
+            imported_findings.extend(findings)
+
+        if imported_findings:
+            import_result = normalize_imported_findings(
+                imported_findings,
+                original_repo_path,
+            )
+            print(format_import_summary(
+                import_result,
+                [Path(f).name for f in import_sarif_files],
+            ))
+            normalized_sarif = findings_to_sarif(import_result.findings)
+            normalized_path = out_dir / "imported-normalized.sarif"
+            import json as _json
+            normalized_path.write_text(_json.dumps(normalized_sarif, indent=2))
+            all_sarif_files.append(normalized_path)
+        elif not all_sarif_files:
+            print("\n✗ No findings in imported SARIF and no scan results")
+            sys.exit(1)
+
     if not all_sarif_files:
         print("\n❌ No SARIF files generated from scanning")
         sys.exit(1)
 
     # Combine metrics
+    imported_findings_count = import_result.stats.total_imported if import_result else 0
     total_findings = (semgrep_metrics.get('total_findings', 0)
                       + codeql_metrics.get('total_findings', 0)
-                      + sca_findings_count)
+                      + sca_findings_count
+                      + imported_findings_count)
     scan_metrics = {
         'total_findings': total_findings,
         'total_files_scanned': semgrep_metrics.get('total_files_scanned', 0),
@@ -1688,6 +1821,12 @@ Examples:
         'codeql': codeql_metrics,
         'sca': sca_metrics,
     }
+    if import_result:
+        scan_metrics['import'] = {
+            'total_imported': import_result.stats.total_imported,
+            'findings_skipped': import_result.stats.findings_skipped,
+            'cwe_inferred': import_result.stats.cwe_inferred,
+        }
 
     sarif_files = all_sarif_files
 
@@ -1698,6 +1837,8 @@ Examples:
         print(f"  CodeQL: {codeql_metrics.get('total_findings', 0)} findings")
     if sca_findings_count:
         print(f"  SCA: {sca_findings_count} findings")
+    if imported_findings_count:
+        print(f"  Imported: {imported_findings_count} findings")
     print(f"SARIF files: {len(sarif_files)}")
 
     # ========================================================================
@@ -1766,6 +1907,48 @@ Examples:
         external_llm=llm_env.external_llm,
         sca_findings_path=sca_findings_path,
     )
+
+    # Enrichment summary — pre-LLM visibility of mechanical enrichments
+    _enrichment_lines = []
+    if validation_result and validation_result.get("completed"):
+        dupes = validation_result.get("duplicates_removed", 0)
+        if dupes > 0:
+            _enrichment_lines.append(f"  Dedup: {dupes} duplicates removed")
+        sca_m = validation_result.get("sca_merged", 0)
+        if sca_m > 0:
+            _enrichment_lines.append(f"  SCA: {sca_m} dependency findings merged")
+    if import_result and import_result.stats.total_imported > 0:
+        stats = import_result.stats
+        _enrichment_lines.append(
+            f"  SARIF import: {stats.total_imported} findings "
+            f"({stats.cwe_inferred} CWEs inferred, "
+            f"{stats.findings_skipped} skipped)"
+        )
+        sca_tagged = sum(
+            1 for f in import_result.findings if f.get("source_type") == "dependency"
+        )
+        if sca_tagged > 0:
+            _enrichment_lines.append(f"  SCA tagged: {sca_tagged} imported findings")
+    if reachability_prepass_result and reachability_prepass_result.ran:
+        _enrichment_lines.append(
+            f"  Reachability: {reachability_prepass_result.marked_count} "
+            f"dead-code marks"
+        )
+    suppression_file = out_dir / "suppressions.jsonl"
+    if suppression_file.exists():
+        with suppression_file.open() as _fh:
+            suppressed = sum(1 for _ in _fh)
+        if suppressed > 0:
+            _enrichment_lines.append(
+                f"  Binary oracle: {suppressed} findings suppressed (absent)"
+            )
+    if _enrichment_lines:
+        print("\n" + "-" * 40)
+        print("ENRICHMENT SUMMARY (pre-LLM)")
+        print("-" * 40)
+        for line in _enrichment_lines:
+            print(line)
+        print(f"  Findings entering LLM analysis: {validated_findings}")
 
     # ========================================================================
     # PHASE 3: AUTONOMOUS ANALYSIS
@@ -2050,6 +2233,7 @@ Examples:
             "exploits_directory": str(autonomous_out / "exploits") if autonomous_out else None,
             "patches_directory": str(autonomous_out / "patches") if autonomous_out else None,
             "exploit_feasibility": str(out_dir / "exploit_feasibility.txt") if mitigation_result else None,
+            "enriched_sarif": None,  # populated after --sarif-out write
         }
     }
 
@@ -2258,6 +2442,25 @@ Examples:
         orch_report_path = out_dir / "orchestrated_report.json"
         if orch_report_path.exists():
             save_json(orch_report_path, orchestration_result)
+
+    # Enriched SARIF output
+    sarif_out_path = getattr(args, "sarif_out", None)
+    if sarif_out_path:
+        from core.sarif.enriched_writer import write_enriched_sarif
+        analysed_results = (
+            orchestration_result.get("results", [])
+            if orchestration_result else []
+        )
+        if analysed_results:
+            sarif_out_resolved = Path(sarif_out_path)
+            if not sarif_out_resolved.is_absolute():
+                sarif_out_resolved = out_dir / sarif_out_resolved
+            n = write_enriched_sarif(analysed_results, sarif_out_resolved)
+            print(f"\n✓ Enriched SARIF written: {sarif_out_resolved} ({n} findings)")
+            final_report["outputs"]["enriched_sarif"] = str(sarif_out_resolved)
+            save_json(report_file, final_report)
+        else:
+            logger.warning("--sarif-out: no analysed findings to write")
 
     # Findings funnel
     if validation_result:
@@ -2628,13 +2831,10 @@ Examples:
             "analysis_models": orch_meta.get("analysis_models", []),
             "aggregate_models": orch_meta.get("aggregate_models", []),
             "aggregated": orch_meta.get("aggregated", False),
-        }, manifest={
-            # Only the in-process fact the lifecycle can't see for itself: the
-            # models that fired. Engines (from the scan phase) and
-            # deterministically_reproducible=False (agentic is LLM-mediated)
-            # are filled uniformly by core.run.complete_run.
-            "models": orch_meta.get("fired_models", []),
-        })
+        }, manifest=_build_completion_manifest(
+            orch_meta, import_result, import_sarif_files,
+            reanalyze_dir=getattr(args, "reanalyze", None),
+        ))
     except Exception as e:
         logger.debug(f"Run metadata: {e}")  # Optional — don't fail the pipeline
 


### PR DESCRIPTION
SARIF 2.1.0 import pipeline for external scanner results (Coverity, Bandit, Snyk, CodeQL, etc.) with enriched output and re-analysis support.

Import normalizer (core/sarif/import_normalizer.py):
- URI rebasing with progressive prefix-stripping and depth cache
- Snippet synthesis from source tree when scanner omits them
- CWE inference from message/rule_id (19 regex patterns + vuln-type map)
- SCA detection: tool keywords + SAST exclusion + manifest basename heuristic
- Path traversal defense via _is_under_root()
- findings_to_sarif() round-trip with fingerprints and codeFlows
- Provenance block for run manifests

Enriched SARIF writer (core/sarif/enriched_writer.py):
- result.properties.raptor.* annotations (verdict, reachability, is_exploitable, exploitability_score, has_dataflow, reasoning, source_type, cwe_inferred, has_exploit)
- result.suppressions for binary-oracle-suppressed findings
- SARIF level validation (clamp invalid levels to "warning")
- start_line=0 falsiness guard
- Atomic write via tmpfile+rename
- Groups by original tool, deduplicates rules

CLI wiring (raptor_agentic.py):
- --sarif FILE: import external SARIF (repeatable, replaces scan phase)
- --also-scan: merge imported + scanned findings
- --sarif-out FILE: write enriched SARIF after analysis
- --reanalyze DIR: re-run analysis on previous run's output (recovers target + SARIF from .raptor-run.json, warns on --repo conflict, validates SARIF file existence, records manifest.reanalysis_of)
- Enrichment summary block: pre-LLM visibility of dedup, SCA, binary oracle, reachability, and import stats

Source-intel CWE fallback gate (packages/llm_analysis/source_intel_inject.py):
- _SOURCE_INTEL_CWES frozenset allows external scanner findings with memory-corruption CWEs to receive structural evidence

Adversarially reviewed: 16 issues found and fixed (path traversal via target_path, start_line=0, level validation, is_exploitable/has_dataflow data loss, relative path in manifest, SARIF existence check, file handle leak, import summary noise).

182 tests (75 normalizer unit + 20 E2E + 44 enriched writer + 2 source-intel
+ 41 existing SARIF parser).