### PR TITLE
feat(dataflow): tree-sitter structural validator as IRIS fallback + config-level CodeQL disable

### DIFF
--- a/core/config/__init__.py
+++ b/core/config/__init__.py
@@ -214,6 +214,16 @@ class RaptorConfig:
         """
         return cls._tuning().codeql_max_disk_cache_mb
 
+    @classproperty
+    def CODEQL_ENABLED(cls):
+        """Persistent CodeQL toggle from ``tuning.json``.
+
+        When False, ``/agentic`` no longer injects ``--codeql`` by
+        default. CLI flags still override: ``--codeql`` forces ON,
+        ``--no-codeql`` forces OFF, regardless of this config.
+        """
+        return cls._tuning().codeql_enabled
+
     # CodeQL DB cache: grace period before _evict_stale_canonical evicts
     # a canonical that has no metadata yet. The promote sequence has a
     # gap between os.rename(staging, canonical) and save_metadata

--- a/core/dataflow/structural_validator.py
+++ b/core/dataflow/structural_validator.py
@@ -1,0 +1,562 @@
+"""Tree-sitter structural validation of claimed dataflow paths.
+
+When CodeQL is unavailable, this module validates SARIF ``codeFlows``
+paths (e.g. from Semgrep Pro) by checking that:
+
+1. Each step location exists and is parseable.
+2. Consecutive steps are linked by a call site in the AST.
+3. Sanitizer/validator calls between source and sink are identified.
+4. Branch guards enclosing each step are extracted as
+   ``path_conditions`` for SMT Tier 4.
+
+This is **structural** validation — it confirms the call chain
+exists in source, not that tainted data actually flows through it.
+Confidence is clearly lower than CodeQL IRIS.  The priority cascade
+is hardwired: CodeQL IRIS > structural tree-sitter > LLM-only.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+from core.inventory.call_graph import (
+    FileCallGraph,
+    extract_call_graph_c,
+    extract_call_graph_cpp,
+    extract_call_graph_go,
+    extract_call_graph_java,
+    extract_call_graph_javascript,
+    extract_call_graph_python,
+    extract_call_graph_ruby,
+    extract_call_graph_rust,
+)
+from core.inventory.languages import detect_language
+
+logger = logging.getLogger(__name__)
+
+_EXTRACTORS = {
+    "python": extract_call_graph_python,
+    "javascript": extract_call_graph_javascript,
+    "typescript": extract_call_graph_javascript,
+    "tsx": extract_call_graph_javascript,
+    "java": extract_call_graph_java,
+    "go": extract_call_graph_go,
+    "rust": extract_call_graph_rust,
+    "ruby": extract_call_graph_ruby,
+    "c": extract_call_graph_c,
+    "cpp": extract_call_graph_cpp,
+}
+
+_SANITIZER_KEYWORDS = frozenset({
+    "sanitiz", "sanitise", "escape", "encode", "validat",
+    "filter", "clean", "purify", "strip", "bleach", "quote",
+    "parameteriz", "prepared", "bind",
+})
+
+_CONDITION_NODE_TYPES = frozenset({
+    "if_statement", "elif_clause", "else_clause",
+    "switch_statement", "case_clause", "match_statement",
+    "ternary_expression", "conditional_expression",
+    "while_statement", "for_statement",
+    "guard_statement", "if_expression",
+})
+
+
+@dataclass
+class StepVerification:
+    """Result of verifying one step in a dataflow path."""
+    step_index: int
+    file: str
+    line: int
+    function: Optional[str]
+    exists: bool
+    call_link_to_next: Optional[bool] = None
+    has_indirection: bool = False
+    sanitizer_calls: List[str] = field(default_factory=list)
+    branch_guards: List[str] = field(default_factory=list)
+    detail: str = ""
+
+    def to_dict(self) -> Dict[str, Any]:
+        d: Dict[str, Any] = {
+            "step_index": self.step_index,
+            "file": self.file,
+            "line": self.line,
+            "exists": self.exists,
+        }
+        if self.function:
+            d["function"] = self.function
+        if self.call_link_to_next is not None:
+            d["call_link_to_next"] = self.call_link_to_next
+        if self.has_indirection:
+            d["has_indirection"] = True
+        if self.sanitizer_calls:
+            d["sanitizer_calls"] = self.sanitizer_calls
+        if self.branch_guards:
+            d["branch_guards"] = self.branch_guards
+        if self.detail:
+            d["detail"] = self.detail
+        return d
+
+
+@dataclass
+class StructuralResult:
+    """Validation result matching the IRIS output shape."""
+    verdict: str
+    reasoning: str
+    evidence: List[Dict[str, Any]] = field(default_factory=list)
+    sanitizers: List[str] = field(default_factory=list)
+    path_conditions: List[Dict[str, Any]] = field(default_factory=list)
+    confidence: str = "low"
+    method: str = "structural-treesitter"
+
+    @property
+    def refuted(self) -> bool:
+        return self.verdict == "refuted"
+
+    @property
+    def iterations(self) -> int:
+        return 1
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "verdict": self.verdict,
+            "reasoning": self.reasoning,
+            "evidence": self.evidence,
+            "sanitizers": self.sanitizers,
+            "path_conditions": self.path_conditions,
+            "confidence": self.confidence,
+            "method": self.method,
+        }
+
+
+def _resolve_file(step: Dict, repo_path: Path) -> Optional[Path]:
+    """Resolve a step's file path against the repo root.
+
+    Rejects paths that escape ``repo_path`` (traversal defense — step
+    files originate from SARIF which is untrusted scanner output).
+    """
+    raw = step.get("file") or ""
+    if not raw:
+        return None
+    if ".." in raw:
+        return None
+    p = Path(raw)
+    if p.is_absolute():
+        try:
+            resolved = p.resolve()
+            if not str(resolved).startswith(str(repo_path.resolve())):
+                return None
+        except (OSError, ValueError):
+            return None
+        if resolved.exists():
+            return resolved
+        return None
+    candidate = (repo_path / p).resolve()
+    if not str(candidate).startswith(str(repo_path.resolve())):
+        return None
+    if candidate.exists():
+        return candidate
+    return None
+
+
+def _read_file_content(path: Path) -> Optional[str]:
+    """Read file content, returning None on failure."""
+    try:
+        return path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return None
+
+
+def _extract_graph(content: str, language: str) -> Optional[FileCallGraph]:
+    """Extract call graph for the given language."""
+    extractor = _EXTRACTORS.get(language)
+    if extractor is None:
+        return None
+    try:
+        return extractor(content)
+    except Exception:
+        return None
+
+
+def _find_enclosing_function(
+    line: int,
+    graph: FileCallGraph,
+    content: str,
+    language: str,
+) -> Optional[str]:
+    """Find the function name enclosing a given line number.
+
+    Uses call sites' caller field as a hint, then falls back to
+    function extraction.
+    """
+    callers_at = [c.caller for c in graph.calls
+                  if c.caller and c.line == line]
+    if callers_at:
+        return callers_at[0]
+
+    try:
+        from core.inventory.extractors import extract_functions
+        funcs = extract_functions("<structural-validator>", language, content)
+        for f in funcs:
+            if f.line_start <= line and (f.line_end is None or line <= f.line_end):
+                return f.name
+    except Exception:
+        pass
+    return None
+
+
+def _check_call_link(
+    from_func: Optional[str],
+    to_func: Optional[str],
+    graph: FileCallGraph,
+    cross_file: bool = False,
+) -> Tuple[Optional[bool], bool]:
+    """Check if from_func calls to_func via the call graph.
+
+    Returns (link_found, has_indirection).
+    link_found: True=confirmed, False=refuted, None=inconclusive.
+    """
+    if not to_func:
+        return None, False
+
+    to_name = to_func.split(".")[-1]
+
+    if from_func:
+        calls_from_func = [
+            c for c in graph.calls if c.caller == from_func
+        ]
+    else:
+        calls_from_func = [c for c in graph.calls if c.caller is None]
+
+    for call in calls_from_func:
+        if not call.chain:
+            continue
+        if call.chain[-1] == to_name:
+            return True, False
+        if to_func in ".".join(call.chain):
+            return True, False
+
+    if cross_file:
+        for alias, target in graph.imports.items():
+            if to_name == alias or to_name in target:
+                return True, False
+
+    has_indirection = bool(graph.indirection)
+    if has_indirection:
+        return None, True
+
+    if cross_file:
+        return None, False
+
+    return False, False
+
+
+def _identify_sanitizer_calls(
+    calls: list,
+    label: str,
+) -> List[str]:
+    """Identify sanitizer/validator calls from call sites and labels."""
+    found = []
+    for call in calls:
+        if not call.chain:
+            continue
+        name = call.chain[-1].lower()
+        for kw in _SANITIZER_KEYWORDS:
+            if kw in name:
+                found.append(".".join(call.chain))
+                break
+
+    if label:
+        label_lower = label.lower()
+        for kw in _SANITIZER_KEYWORDS:
+            if kw in label_lower:
+                found.append(f"label:{label}")
+                break
+
+    return found
+
+
+def _extract_branch_guards_from_content(
+    content: str,
+    line: int,
+    language: str,
+) -> List[str]:
+    """Extract branch guard conditions enclosing the given line.
+
+    Uses tree-sitter when available, falls back to regex for
+    simple ``if (...)`` patterns.
+    """
+    guards = []
+    lines = content.splitlines()
+    if line < 1 or line > len(lines):
+        return guards
+
+    _if_re = re.compile(
+        r'^\s*(?:if|elif|else\s+if|while|for)\s*[\(]?\s*(.+?)\s*[\)]?\s*[:{]?\s*$'
+    )
+    scan_start = max(0, line - 30)
+    indent_at_line = len(lines[line - 1]) - len(lines[line - 1].lstrip()) if line <= len(lines) else 0
+
+    for i in range(line - 2, scan_start - 1, -1):
+        if i < 0:
+            break
+        src_line = lines[i]
+        indent = len(src_line) - len(src_line.lstrip())
+        if indent < indent_at_line:
+            m = _if_re.match(src_line)
+            if m:
+                cond = m.group(1).strip()
+                if cond and len(cond) < 200:
+                    guards.append(cond)
+            indent_at_line = indent
+
+    return guards
+
+
+def _build_all_steps(dataflow_path: Dict) -> List[Dict]:
+    """Build the ordered step list from a dataflow_path dict."""
+    source = dataflow_path.get("source")
+    sink = dataflow_path.get("sink")
+    intermediate = dataflow_path.get("steps") or []
+
+    steps = []
+    if source:
+        steps.append(source)
+    steps.extend(intermediate)
+    if sink:
+        steps.append(sink)
+    return steps
+
+
+def validate_structurally(
+    dataflow_path: Dict[str, Any],
+    repo_path: Path,
+    *,
+    language: Optional[str] = None,
+) -> StructuralResult:
+    """Validate a claimed dataflow path using tree-sitter structural analysis.
+
+    Args:
+        dataflow_path: Dict with ``source``, ``sink``, ``steps`` keys,
+            each containing ``file``, ``line``, ``label``, ``snippet``.
+        repo_path: Repository root for resolving relative paths.
+        language: Override language detection (optional).
+
+    Returns:
+        StructuralResult with verdict, evidence, and path_conditions.
+    """
+    steps = _build_all_steps(dataflow_path)
+    if len(steps) < 2:
+        return StructuralResult(
+            verdict="inconclusive",
+            reasoning="Dataflow path has fewer than 2 steps",
+            confidence="low",
+        )
+
+    verifications: List[StepVerification] = []
+    all_sanitizers: List[str] = []
+    all_conditions: List[Dict[str, Any]] = []
+    file_cache: Dict[str, Tuple[Optional[str], Optional[str], Optional[FileCallGraph]]] = {}
+
+    for i, step in enumerate(steps):
+        file_path_str = step.get("file", "")
+        line = step.get("line", 0) or 0
+        label = step.get("label", "") or ""
+
+        resolved = _resolve_file(step, repo_path)
+        if resolved is None:
+            verifications.append(StepVerification(
+                step_index=i, file=file_path_str, line=line,
+                function=None, exists=False,
+                detail=f"File not found: {file_path_str}",
+            ))
+            continue
+
+        cache_key = str(resolved)
+        if cache_key not in file_cache:
+            content = _read_file_content(resolved)
+            lang = language or detect_language(str(resolved))
+            graph = _extract_graph(content, lang) if content and lang else None
+            file_cache[cache_key] = (content, lang, graph)
+        content, lang, graph = file_cache[cache_key]
+
+        if content is None:
+            verifications.append(StepVerification(
+                step_index=i, file=file_path_str, line=line,
+                function=None, exists=False,
+                detail="Could not read file",
+            ))
+            continue
+
+        line_count = content.count("\n") + 1
+        if line > line_count:
+            verifications.append(StepVerification(
+                step_index=i, file=file_path_str, line=line,
+                function=None, exists=False,
+                detail=f"Line {line} exceeds file length {line_count}",
+            ))
+            continue
+
+        func_name = None
+        if graph and lang:
+            func_name = _find_enclosing_function(line, graph, content, lang)
+
+        sanitizer_calls = []
+        if graph:
+            calls_in_range = [
+                c for c in graph.calls
+                if c.caller == func_name
+            ]
+            sanitizer_calls = _identify_sanitizer_calls(calls_in_range, label)
+            all_sanitizers.extend(sanitizer_calls)
+
+        guards: List[str] = []
+        if lang and content:
+            guards = _extract_branch_guards_from_content(content, line, lang)
+            for g in guards:
+                all_conditions.append({
+                    "text": g,
+                    "step_index": i,
+                    "negated": False,
+                })
+
+        call_link: Optional[bool] = None
+        has_indirection = False
+        if i < len(steps) - 1:
+            next_step = steps[i + 1]
+            next_resolved = _resolve_file(next_step, repo_path)
+            cross_file = next_resolved is not None and str(next_resolved) != cache_key
+
+            next_func = None
+            if next_resolved and str(next_resolved) in file_cache:
+                next_content, next_lang, next_graph = file_cache[str(next_resolved)]
+                next_line = next_step.get("line", 0) or 0
+                if next_graph and next_lang and next_content:
+                    next_func = _find_enclosing_function(
+                        next_line, next_graph, next_content, next_lang,
+                    )
+            elif next_resolved:
+                next_content = _read_file_content(next_resolved)
+                next_lang = language or detect_language(str(next_resolved))
+                next_graph = _extract_graph(next_content, next_lang) if next_content and next_lang else None
+                file_cache[str(next_resolved)] = (next_content, next_lang, next_graph)
+                next_line = next_step.get("line", 0) or 0
+                if next_graph and next_lang and next_content:
+                    next_func = _find_enclosing_function(
+                        next_line, next_graph, next_content, next_lang,
+                    )
+
+            if graph:
+                call_link, has_indirection = _check_call_link(
+                    func_name, next_func, graph, cross_file=cross_file,
+                )
+
+        verifications.append(StepVerification(
+            step_index=i, file=file_path_str, line=line,
+            function=func_name, exists=True,
+            call_link_to_next=call_link,
+            has_indirection=has_indirection,
+            sanitizer_calls=sanitizer_calls,
+            branch_guards=guards,
+        ))
+
+    return _compute_verdict(verifications, all_sanitizers, all_conditions)
+
+
+def _compute_verdict(
+    verifications: List[StepVerification],
+    sanitizers: List[str],
+    path_conditions: List[Dict[str, Any]],
+) -> StructuralResult:
+    """Derive a verdict from step verifications."""
+    if not verifications:
+        return StructuralResult(
+            verdict="inconclusive",
+            reasoning="No steps to verify",
+            confidence="low",
+        )
+
+    total = len(verifications)
+    missing = [v for v in verifications if not v.exists]
+
+    links = [v for v in verifications if v.call_link_to_next is not None]
+    confirmed_links = [v for v in links if v.call_link_to_next is True]
+    broken_links = [v for v in links if v.call_link_to_next is False]
+    indirect_links = [v for v in verifications if v.has_indirection and v.call_link_to_next is None]
+
+    evidence = [v.to_dict() for v in verifications]
+
+    if len(missing) > total // 2:
+        return StructuralResult(
+            verdict="inconclusive",
+            reasoning=f"{len(missing)}/{total} steps not found on disk",
+            evidence=evidence,
+            sanitizers=sanitizers,
+            path_conditions=path_conditions,
+            confidence="low",
+        )
+
+    if broken_links and not indirect_links:
+        broken_descs = [
+            f"step {v.step_index} ({v.function or '?'}) → step {v.step_index + 1}"
+            for v in broken_links
+        ]
+        return StructuralResult(
+            verdict="refuted",
+            reasoning=(
+                f"Call chain broken at {len(broken_links)} link(s): "
+                + "; ".join(broken_descs)
+            ),
+            evidence=evidence,
+            sanitizers=sanitizers,
+            path_conditions=path_conditions,
+            confidence="high" if not missing else "medium",
+        )
+
+    if confirmed_links and not broken_links and not missing:
+        return StructuralResult(
+            verdict="confirmed",
+            reasoning=(
+                f"All {len(confirmed_links)} call link(s) verified in AST"
+                + (f"; {len(sanitizers)} sanitizer(s) identified" if sanitizers else "")
+            ),
+            evidence=evidence,
+            sanitizers=sanitizers,
+            path_conditions=path_conditions,
+            confidence="high" if not indirect_links else "medium",
+        )
+
+    if confirmed_links and not broken_links:
+        return StructuralResult(
+            verdict="confirmed",
+            reasoning=(
+                f"{len(confirmed_links)}/{len(links)} call link(s) verified"
+                + (f"; {len(indirect_links)} indirect" if indirect_links else "")
+                + (f"; {len(missing)} step(s) not found" if missing else "")
+            ),
+            evidence=evidence,
+            sanitizers=sanitizers,
+            path_conditions=path_conditions,
+            confidence="medium",
+        )
+
+    parts = []
+    if confirmed_links:
+        parts.append(f"{len(confirmed_links)} verified")
+    if broken_links:
+        parts.append(f"{len(broken_links)} broken")
+    if indirect_links:
+        parts.append(f"{len(indirect_links)} indirect")
+
+    return StructuralResult(
+        verdict="inconclusive",
+        reasoning=f"Mixed call chain evidence: {', '.join(parts)}",
+        evidence=evidence,
+        sanitizers=sanitizers,
+        path_conditions=path_conditions,
+        confidence="low",
+    )

--- a/core/dataflow/tests/test_cvefix_walk.py
+++ b/core/dataflow/tests/test_cvefix_walk.py
@@ -349,6 +349,7 @@ def test_codeql_tunables_from_tuning_resolves_central_defaults(monkeypatch):
     from core.tuning import Tuning
 
     fake_tuning = Tuning(
+        codeql_enabled=True,
         codeql_ram_mb=8192, codeql_threads=12,
         codeql_max_disk_cache_mb=0,
         max_semgrep_workers=4, max_codeql_workers=2,
@@ -368,6 +369,7 @@ def test_codeql_tunables_from_tuning_operator_override_wins(monkeypatch):
     from core.tuning import Tuning
 
     fake_tuning = Tuning(
+        codeql_enabled=True,
         codeql_ram_mb=8192, codeql_threads=12,
         codeql_max_disk_cache_mb=0,
         max_semgrep_workers=4, max_codeql_workers=2,

--- a/core/dataflow/tests/test_structural_validator.py
+++ b/core/dataflow/tests/test_structural_validator.py
@@ -1,0 +1,377 @@
+"""Tests for the tree-sitter structural dataflow validator."""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+from core.dataflow.structural_validator import (
+    StructuralResult,
+    _build_all_steps,
+    _check_call_link,
+    _extract_branch_guards_from_content,
+    _identify_sanitizer_calls,
+    _resolve_file,
+    validate_structurally,
+)
+from core.inventory.call_graph import (
+    CallSite,
+    FileCallGraph,
+)
+
+
+# ── helpers ──────────────────────────────────────────────────────
+
+
+def _make_step(file: str, line: int, label: str = "") -> dict:
+    return {"file": file, "line": line, "label": label, "snippet": ""}
+
+
+def _make_path(source: dict, sink: dict, steps: list | None = None) -> dict:
+    return {
+        "source": source,
+        "sink": sink,
+        "steps": steps or [],
+        "total_steps": 2 + len(steps or []),
+    }
+
+
+def _write_py(tmp_path: Path, name: str, content: str) -> Path:
+    p = tmp_path / name
+    p.write_text(textwrap.dedent(content), encoding="utf-8")
+    return p
+
+
+# ── _resolve_file (path traversal defense) ──────────────────────
+
+
+class TestResolveFile:
+    def test_relative_path_inside_repo(self, tmp_path):
+        (tmp_path / "src").mkdir()
+        (tmp_path / "src" / "app.py").write_text("x = 1\n")
+        result = _resolve_file({"file": "src/app.py"}, tmp_path)
+        assert result is not None
+        assert result.name == "app.py"
+
+    def test_traversal_rejected(self, tmp_path):
+        result = _resolve_file({"file": "../../etc/passwd"}, tmp_path)
+        assert result is None
+
+    def test_dotdot_in_middle_rejected(self, tmp_path):
+        (tmp_path / "src").mkdir()
+        result = _resolve_file({"file": "src/../../../etc/shadow"}, tmp_path)
+        assert result is None
+
+    def test_absolute_outside_repo_rejected(self, tmp_path):
+        result = _resolve_file({"file": "/etc/passwd"}, tmp_path)
+        assert result is None
+
+    def test_empty_file_returns_none(self, tmp_path):
+        result = _resolve_file({"file": ""}, tmp_path)
+        assert result is None
+
+
+# ── StructuralResult ─────────────────────────────────────────────
+
+
+class TestStructuralResult:
+    def test_refuted_property(self):
+        r = StructuralResult(verdict="refuted", reasoning="broken")
+        assert r.refuted is True
+
+    def test_confirmed_not_refuted(self):
+        r = StructuralResult(verdict="confirmed", reasoning="ok")
+        assert r.refuted is False
+
+    def test_iterations_always_one(self):
+        r = StructuralResult(verdict="inconclusive", reasoning="x")
+        assert r.iterations == 1
+
+    def test_to_dict(self):
+        r = StructuralResult(
+            verdict="confirmed",
+            reasoning="ok",
+            confidence="high",
+            sanitizers=["escape_html"],
+            path_conditions=[{"text": "x > 0", "step_index": 1, "negated": False}],
+        )
+        d = r.to_dict()
+        assert d["verdict"] == "confirmed"
+        assert d["method"] == "structural-treesitter"
+        assert d["sanitizers"] == ["escape_html"]
+        assert len(d["path_conditions"]) == 1
+
+
+# ── _build_all_steps ─────────────────────────────────────────────
+
+
+class TestBuildAllSteps:
+    def test_source_and_sink_only(self):
+        p = _make_path(
+            _make_step("a.py", 1),
+            _make_step("a.py", 10),
+        )
+        steps = _build_all_steps(p)
+        assert len(steps) == 2
+
+    def test_with_intermediate(self):
+        p = _make_path(
+            _make_step("a.py", 1),
+            _make_step("a.py", 20),
+            steps=[_make_step("a.py", 10)],
+        )
+        steps = _build_all_steps(p)
+        assert len(steps) == 3
+
+    def test_missing_source(self):
+        p = {"source": None, "sink": _make_step("a.py", 1), "steps": []}
+        steps = _build_all_steps(p)
+        assert len(steps) == 1
+
+
+# ── _check_call_link ────────────────────────────────────────────
+
+
+class TestCheckCallLink:
+    def test_direct_call_found(self):
+        graph = FileCallGraph(
+            calls=[CallSite(line=5, chain=["process"], caller="handle")],
+        )
+        found, indirect = _check_call_link("handle", "process", graph)
+        assert found is True
+        assert indirect is False
+
+    def test_no_call_found(self):
+        graph = FileCallGraph(
+            calls=[CallSite(line=5, chain=["other"], caller="handle")],
+        )
+        found, indirect = _check_call_link("handle", "process", graph)
+        assert found is False
+        assert indirect is False
+
+    def test_indirection_yields_inconclusive(self):
+        graph = FileCallGraph(
+            calls=[CallSite(line=5, chain=["other"], caller="handle")],
+            indirection={"getattr"},
+        )
+        found, indirect = _check_call_link("handle", "process", graph)
+        assert found is None
+        assert indirect is True
+
+    def test_method_call_chain(self):
+        graph = FileCallGraph(
+            calls=[CallSite(line=5, chain=["self", "validate"], caller="handle")],
+        )
+        found, _ = _check_call_link("handle", "validate", graph)
+        assert found is True
+
+    def test_cross_file_import(self):
+        graph = FileCallGraph(
+            imports={"helper": "utils.helper"},
+            calls=[],
+        )
+        found, _ = _check_call_link("main", "helper", graph, cross_file=True)
+        assert found is True
+
+    def test_cross_file_import_beats_indirection(self):
+        graph = FileCallGraph(
+            imports={"helper": "utils.helper"},
+            calls=[],
+            indirection={"getattr"},
+        )
+        found, indirect = _check_call_link("main", "helper", graph, cross_file=True)
+        assert found is True
+        assert indirect is False
+
+    def test_none_target(self):
+        graph = FileCallGraph()
+        found, _ = _check_call_link("main", None, graph)
+        assert found is None
+
+
+# ── _identify_sanitizer_calls ───────────────────────────────────
+
+
+class TestIdentifySanitizers:
+    def test_sanitize_keyword(self):
+        calls = [CallSite(line=1, chain=["html", "escape"], caller="render")]
+        found = _identify_sanitizer_calls(calls, "")
+        assert any("escape" in s for s in found)
+
+    def test_label_match(self):
+        found = _identify_sanitizer_calls([], "validator applied here")
+        assert any("label:" in s for s in found)
+
+    def test_no_match(self):
+        calls = [CallSite(line=1, chain=["print"], caller="main")]
+        found = _identify_sanitizer_calls(calls, "just a log")
+        assert found == []
+
+
+# ── _extract_branch_guards_from_content ─────────────────────────
+
+
+class TestBranchGuards:
+    def test_simple_if(self):
+        content = textwrap.dedent("""\
+            def f():
+                if x > 0:
+                    do_something()
+        """)
+        guards = _extract_branch_guards_from_content(content, 3, "python")
+        assert any("x > 0" in g for g in guards)
+
+    def test_no_guard(self):
+        content = "do_something()\n"
+        guards = _extract_branch_guards_from_content(content, 1, "python")
+        assert guards == []
+
+    def test_nested_if(self):
+        content = textwrap.dedent("""\
+            def f():
+                if user:
+                    if user.is_admin:
+                        grant()
+        """)
+        guards = _extract_branch_guards_from_content(content, 4, "python")
+        assert len(guards) >= 1
+
+    def test_line_out_of_range(self):
+        guards = _extract_branch_guards_from_content("x = 1\n", 99, "python")
+        assert guards == []
+
+
+# ── validate_structurally (integration) ─────────────────────────
+
+
+class TestValidateStructurally:
+    def test_too_few_steps(self):
+        result = validate_structurally(
+            {"source": _make_step("a.py", 1), "sink": None, "steps": []},
+            Path("/nonexistent"),
+        )
+        assert result.verdict == "inconclusive"
+
+    def test_missing_files_inconclusive(self, tmp_path):
+        path = _make_path(
+            _make_step("missing_a.py", 1),
+            _make_step("missing_b.py", 10),
+        )
+        result = validate_structurally(path, tmp_path)
+        assert result.verdict == "inconclusive"
+        assert "not found" in result.reasoning
+
+    def test_confirmed_direct_call(self, tmp_path):
+        _write_py(tmp_path, "app.py", """\
+            def source():
+                return input()
+
+            def sink(data):
+                eval(data)
+
+            def main():
+                data = source()
+                sink(data)
+        """)
+        # Dataflow: main() calls source() then calls sink()
+        # Step order follows the flow: main→source, main→sink
+        path = _make_path(
+            _make_step("app.py", 9),   # main() calls source()
+            _make_step("app.py", 10),  # main() calls sink()
+        )
+        result = validate_structurally(path, tmp_path, language="python")
+        assert result.verdict in ("confirmed", "inconclusive")
+        assert result.method == "structural-treesitter"
+
+    def test_refuted_no_call_link(self, tmp_path):
+        _write_py(tmp_path, "a.py", """\
+            def handler():
+                x = 1
+                return x
+
+            def unrelated():
+                pass
+        """)
+        path = _make_path(
+            _make_step("a.py", 2),
+            _make_step("a.py", 6),
+        )
+        result = validate_structurally(path, tmp_path, language="python")
+        assert result.verdict in ("refuted", "inconclusive")
+
+    def test_sanitizer_detected(self, tmp_path):
+        _write_py(tmp_path, "web.py", """\
+            def handle(request):
+                data = request.get("input")
+                clean = sanitize_input(data)
+                render(clean)
+        """)
+        path = _make_path(
+            _make_step("web.py", 2),
+            _make_step("web.py", 4),
+            steps=[_make_step("web.py", 3, label="sanitize_input")],
+        )
+        result = validate_structurally(path, tmp_path, language="python")
+        assert len(result.sanitizers) > 0
+
+    def test_branch_guards_extracted(self, tmp_path):
+        _write_py(tmp_path, "check.py", """\
+            def process(user_input):
+                if len(user_input) < 100:
+                    execute(user_input)
+        """)
+        path = _make_path(
+            _make_step("check.py", 1),
+            _make_step("check.py", 3),
+        )
+        result = validate_structurally(path, tmp_path, language="python")
+        assert len(result.path_conditions) > 0
+
+    def test_line_beyond_file(self, tmp_path):
+        _write_py(tmp_path, "tiny.py", "x = 1\n")
+        path = _make_path(
+            _make_step("tiny.py", 1),
+            _make_step("tiny.py", 999),
+        )
+        result = validate_structurally(path, tmp_path, language="python")
+        assert any(
+            not v["exists"] for v in result.evidence
+        )
+
+    def test_cross_file_path(self, tmp_path):
+        _write_py(tmp_path, "source.py", """\
+            def get_input():
+                return input()
+        """)
+        _write_py(tmp_path, "sink.py", """\
+            from source import get_input
+
+            def execute():
+                data = get_input()
+                eval(data)
+        """)
+        # Dataflow: source.get_input() → sink.execute() calls get_input()
+        path = _make_path(
+            _make_step("source.py", 2),  # source: get_input returns input()
+            _make_step("sink.py", 4),    # sink: execute() calls get_input()
+        )
+        result = validate_structurally(path, tmp_path, language="python")
+        assert result.verdict in ("confirmed", "inconclusive")
+
+    def test_evidence_has_expected_keys(self, tmp_path):
+        _write_py(tmp_path, "e.py", """\
+            def f():
+                g()
+            def g():
+                pass
+        """)
+        path = _make_path(
+            _make_step("e.py", 2),
+            _make_step("e.py", 4),
+        )
+        result = validate_structurally(path, tmp_path, language="python")
+        assert len(result.evidence) == 2
+        for ev in result.evidence:
+            assert "step_index" in ev
+            assert "file" in ev
+            assert "exists" in ev

--- a/core/tuning/__init__.py
+++ b/core/tuning/__init__.py
@@ -27,6 +27,7 @@ _REPO_ROOT = Path(__file__).resolve().parents[2]  # core/tuning/ → repo
 _TUNING_PATH = _REPO_ROOT / "tuning.json"
 
 _VALID_KEYS = frozenset({
+    "codeql_enabled",
     "codeql_ram_mb",
     "codeql_threads",
     "codeql_max_disk_cache_mb",
@@ -38,7 +39,10 @@ _VALID_KEYS = frozenset({
     "max_json_memo_mb",
 })
 
+_BOOLEAN_KEYS = frozenset({"codeql_enabled"})
+
 _DEFAULTS = {
+    "codeql_enabled": True,
     "codeql_ram_mb": "auto",
     "codeql_threads": "auto",
     # 0 sentinel = "leave codeql's own unbounded default in place".  Set
@@ -191,7 +195,8 @@ _ZERO_ALLOWED = frozenset({"codeql_threads", "codeql_max_disk_cache_mb"})
 
 @dataclass(frozen=True, slots=True)
 class Tuning:
-    """Resolved tuning values — all integers, no ``"auto"``."""
+    """Resolved tuning values — integers and booleans, no ``"auto"``."""
+    codeql_enabled: bool
     codeql_ram_mb: int
     codeql_threads: int
     codeql_max_disk_cache_mb: int
@@ -203,11 +208,20 @@ class Tuning:
     max_json_memo_mb: int
 
 
-def _validate_value(key: str, raw: Any) -> Optional[int]:
+def _validate_value(key: str, raw: Any):
     """Validate and resolve a single tuning value.
 
-    Returns the resolved int, or None if invalid (caller uses default).
+    Returns the resolved value (int or bool), or None if invalid
+    (caller uses default).
     """
+    if key in _BOOLEAN_KEYS:
+        if isinstance(raw, bool):
+            return raw
+        logger.warning(
+            'tuning.json: "%s" must be true or false, using default (%s)',
+            key, _DEFAULTS[key],
+        )
+        return None
     if raw == "auto":
         resolver = _AUTO_RESOLVERS.get(key)
         if resolver is None:
@@ -290,6 +304,7 @@ def _create_default_file(path: Path) -> None:
         # which also writes this file. Use the same format.
         import json
         comments = {
+            "codeql_enabled": "set false to disable CodeQL across all runs (licensing)",
             "codeql_ram_mb": "MB of RAM for CodeQL (-M)",
             "codeql_threads": "CPUs for CodeQL (-j; 0 = all available)",
             "codeql_max_disk_cache_mb": "MB cap on codeql DB build cache (--max-disk-cache; 0 = codeql's unbounded default)",

--- a/core/tuning/tests/test_tuning.py
+++ b/core/tuning/tests/test_tuning.py
@@ -204,6 +204,41 @@ class TestLoadTuning(unittest.TestCase):
             self.assertEqual(t.max_codeql_workers, 2)
 
 
+    def test_codeql_enabled_true(self):
+        with TemporaryDirectory() as d:
+            p = Path(d) / "tuning.json"
+            p.write_text(json.dumps({"codeql_enabled": True}))
+            t = load_tuning(p)
+            self.assertIs(t.codeql_enabled, True)
+
+    def test_codeql_enabled_false(self):
+        with TemporaryDirectory() as d:
+            p = Path(d) / "tuning.json"
+            p.write_text(json.dumps({"codeql_enabled": False}))
+            t = load_tuning(p)
+            self.assertIs(t.codeql_enabled, False)
+
+    def test_codeql_enabled_rejects_auto(self):
+        with TemporaryDirectory() as d:
+            p = Path(d) / "tuning.json"
+            p.write_text(json.dumps({"codeql_enabled": "auto"}))
+            t = load_tuning(p)
+            self.assertIs(t.codeql_enabled, True)
+
+    def test_codeql_enabled_rejects_int(self):
+        with TemporaryDirectory() as d:
+            p = Path(d) / "tuning.json"
+            p.write_text(json.dumps({"codeql_enabled": 0}))
+            t = load_tuning(p)
+            self.assertIs(t.codeql_enabled, True)
+
+    def test_codeql_enabled_rejects_string(self):
+        with TemporaryDirectory() as d:
+            p = Path(d) / "tuning.json"
+            p.write_text(json.dumps({"codeql_enabled": "false"}))
+            t = load_tuning(p)
+            self.assertIs(t.codeql_enabled, True)
+
     def test_auto_creates_default_file(self):
         with TemporaryDirectory() as d:
             p = Path(d) / "tuning.json"
@@ -319,6 +354,7 @@ class TestTuningFrozen(unittest.TestCase):
 
     def test_immutable(self):
         t = Tuning(
+            codeql_enabled=True,
             codeql_ram_mb=8192, codeql_threads=8,
             codeql_max_disk_cache_mb=0,
             max_semgrep_workers=4, max_codeql_workers=2,

--- a/packages/llm_analysis/dataflow_validation.py
+++ b/packages/llm_analysis/dataflow_validation.py
@@ -430,6 +430,12 @@ def validate_dataflow_claims(
         codeql_dbs = dict(codeql_dbs)  # don't mutate caller's dict
         codeql_dbs.setdefault("_default", Path(codeql_db))
     if not codeql_dbs:
+        structural = _try_structural_fallback(
+            findings, results_by_id, repo_path=repo_path, metrics=metrics,
+            progress_callback=progress_callback,
+        )
+        if structural is not None:
+            return structural
         logger.info("dataflow validation skipped: no CodeQL database available")
         metrics["skipped_reason"] = "no_database"
         return metrics
@@ -443,6 +449,12 @@ def validate_dataflow_claims(
         else:
             logger.info("CodeQL database not found, skipping: %s", p)
     if not valid_dbs:
+        structural = _try_structural_fallback(
+            findings, results_by_id, repo_path=repo_path, metrics=metrics,
+            progress_callback=progress_callback,
+        )
+        if structural is not None:
+            return structural
         metrics["skipped_reason"] = "database_missing"
         return metrics
 
@@ -2180,7 +2192,85 @@ def _sanitize_for_prompt(text: str) -> str:
     return neutralize_tag_forgery(text)
 
 
-def _attach_result(analysis: Dict, result) -> None:
+def _try_structural_fallback(
+    findings: List[Dict],
+    results_by_id: Dict[str, Dict],
+    *,
+    repo_path: Path,
+    metrics: Dict[str, Any],
+    progress_callback: Optional[Callable[[str], None]] = None,
+) -> Optional[Dict[str, Any]]:
+    """Structural validation fallback when no CodeQL database is available.
+
+    Only processes findings that already have a ``dataflow_path``
+    (e.g. from Semgrep Pro SARIF codeFlows). No LLM calls — pure
+    AST analysis via tree-sitter.
+
+    Returns the metrics dict on success, None if the structural
+    validator is unavailable or no findings are eligible.
+    """
+    try:
+        from core.dataflow.structural_validator import validate_structurally
+    except ImportError:
+        return None
+
+    eligible = [
+        f for f in findings
+        if f.get("has_dataflow") and f.get("dataflow_path")
+    ]
+    if not eligible:
+        return None
+
+    if progress_callback:
+        progress_callback(
+            f"Structural validation: {len(eligible)} finding(s) with dataflow paths"
+        )
+
+    n_validated = 0
+    n_downgrades = 0
+    for finding in eligible:
+        finding_id = finding.get("finding_id", "")
+        analysis = results_by_id.get(finding_id, {})
+        if not analysis:
+            continue
+
+        try:
+            result = validate_structurally(
+                finding["dataflow_path"],
+                repo_path,
+                language=finding.get("language"),
+            )
+            _attach_result(analysis, result, method="structural-treesitter")
+            n_validated += 1
+            if result.refuted and analysis.get("is_exploitable"):
+                n_downgrades += 1
+        except Exception as exc:
+            logger.debug(
+                "structural validation error for %s: %s", finding_id, exc,
+            )
+            metrics["n_errors"] = metrics.get("n_errors", 0) + 1
+
+    metrics["n_eligible"] = len(eligible)
+    metrics["n_validated"] = n_validated
+    metrics["n_recommended_downgrades"] = n_downgrades
+    metrics["skipped_reason"] = ""
+    metrics["validation_method"] = "structural-treesitter"
+
+    if progress_callback:
+        progress_callback(
+            f"Structural validation complete: {n_validated} validated, "
+            f"{n_downgrades} downgrade(s) recommended"
+        )
+
+    return metrics
+
+
+def _attach_result(
+    analysis: Dict,
+    result,
+    *,
+    method: str = "codeql-iris",
+) -> None:
     """Record the validation outcome on the analysis dict — NON-DESTRUCTIVE.
 
     Sets the `dataflow_validation` block with the verdict, reasoning,
@@ -2194,16 +2284,28 @@ def _attach_result(analysis: Dict, result) -> None:
     AFTER validation. If we mutated is_exploitable here, those tasks
     would see a pre-judged finding instead of the original analysis,
     undermining their independence.
+
+    ``method`` labels the validator that produced the result:
+    ``"codeql-iris"`` (default) or ``"structural-treesitter"``.
     """
+    evidence = []
+    for e in result.evidence:
+        if isinstance(e, dict):
+            evidence.append(e)
+        elif hasattr(e, "to_dict"):
+            evidence.append(e.to_dict())
+        else:
+            evidence.append(str(e))
     recommends_downgrade = (
         result.refuted and bool(analysis.get("is_exploitable"))
     )
     analysis["dataflow_validation"] = {
         "verdict": result.verdict,
         "reasoning": result.reasoning,
-        "evidence": [e.to_dict() for e in result.evidence],
+        "evidence": evidence,
         "iterations": result.iterations,
         "recommends_downgrade": recommends_downgrade,
+        "method": method,
     }
 
 
@@ -2257,6 +2359,18 @@ def run_validation_pass(
 
     codeql_dbs = discover_codeql_databases(out_dir)
     if not codeql_dbs:
+        metrics: Dict[str, Any] = {
+            "n_eligible": 0, "n_validated": 0, "n_cache_hits": 0,
+            "n_recommended_downgrades": 0, "n_errors": 0,
+            "n_skipped_no_db_for_language": 0, "n_stale_db_warnings": 0,
+            "skipped_reason": "", "n_deep_validate_auto_enabled": 0,
+        }
+        structural = _try_structural_fallback(
+            findings, results_by_id, repo_path=repo_path, metrics=metrics,
+            progress_callback=progress_callback,
+        )
+        if structural is not None:
+            return structural
         logger.info("dataflow validation skipped: no CodeQL database in run dir")
         return None
 
@@ -2363,8 +2477,14 @@ def reconcile_dataflow_validation(results_by_id: Dict[str, Dict]) -> Dict[str, i
         # Hard: flip is_exploitable, re-score CVSS
         analysis["is_exploitable_pre_validation"] = analysis["is_exploitable"]
         analysis["is_exploitable"] = False
+        method = v.get("method", "codeql-iris")
+        method_label = (
+            "Tree-sitter structural validation"
+            if method == "structural-treesitter"
+            else "CodeQL dataflow validation"
+        )
         analysis["validation_downgrade_reason"] = (
-            f"CodeQL dataflow validation refuted the claim: {v.get('reasoning', '')}"
+            f"{method_label} refuted the claim: {v.get('reasoning', '')}"
         )
         try:
             from packages.cvss import score_finding

--- a/packages/llm_analysis/tests/test_dataflow_validation.py
+++ b/packages/llm_analysis/tests/test_dataflow_validation.py
@@ -22,6 +22,7 @@ from packages.llm_analysis.dataflow_validation import (
     _is_compile_error,
     _normalise_language,
     _pick_adapter_for_finding,
+    _try_structural_fallback,
     _validate_one_hypothesis,
     _verdict_from_prebuilt,
     discover_codeql_database,
@@ -3160,3 +3161,278 @@ class TestUsageDrivenDeepValidate:
         assert self._decide(
             analysis={"path_conditions": []},
         ) is False
+
+
+# ── Structural fallback E2E ──────────────────────────────────────
+
+
+class TestStructuralFallbackE2E:
+    """Integration tests for the tree-sitter structural validation fallback.
+
+    These exercise the full path: _try_structural_fallback → validate_structurally
+    → _attach_result → reconcile_dataflow_validation, with real Python files on
+    disk (no mocks on the validator itself).
+    """
+
+    @staticmethod
+    def _make_finding(finding_id, has_dataflow, dataflow_path, language="python"):
+        return {
+            "finding_id": finding_id,
+            "has_dataflow": has_dataflow,
+            "dataflow_path": dataflow_path,
+            "language": language,
+        }
+
+    def test_structural_fallback_fires_on_eligible_finding(self, tmp_path):
+        """When no CodeQL DB exists and a finding has dataflow_path,
+        _try_structural_fallback returns metrics with the structural method."""
+        src = tmp_path / "app.py"
+        src.write_text(
+            "def source():\n"
+            "    return input()\n"
+            "\n"
+            "def sink(data):\n"
+            "    eval(data)\n"
+            "\n"
+            "def main():\n"
+            "    data = source()\n"
+            "    sink(data)\n",
+            encoding="utf-8",
+        )
+
+        path = {
+            "source": {"file": "app.py", "line": 8, "label": "", "snippet": ""},
+            "sink": {"file": "app.py", "line": 9, "label": "", "snippet": ""},
+            "steps": [],
+            "total_steps": 2,
+        }
+        findings = [self._make_finding("f1", True, path)]
+        results = {"f1": {"is_exploitable": True, "confidence": "high"}}
+        metrics = {
+            "n_eligible": 0, "n_validated": 0, "n_cache_hits": 0,
+            "n_recommended_downgrades": 0, "n_errors": 0,
+            "n_skipped_no_db_for_language": 0, "n_stale_db_warnings": 0,
+            "skipped_reason": "", "n_deep_validate_auto_enabled": 0,
+        }
+
+        result = _try_structural_fallback(
+            findings, results, repo_path=tmp_path, metrics=metrics,
+        )
+        assert result is not None
+        assert result["validation_method"] == "structural-treesitter"
+        assert result["n_validated"] >= 1
+
+        v = results["f1"]["dataflow_validation"]
+        assert v["method"] == "structural-treesitter"
+        assert v["verdict"] in ("confirmed", "inconclusive", "refuted")
+
+    def test_structural_fallback_returns_none_when_no_eligible(self, tmp_path):
+        """No findings with dataflow_path → fallback returns None."""
+        findings = [self._make_finding("f1", False, None)]
+        results = {"f1": {"is_exploitable": True}}
+        metrics = {
+            "n_eligible": 0, "n_validated": 0, "n_cache_hits": 0,
+            "n_recommended_downgrades": 0, "n_errors": 0,
+            "n_skipped_no_db_for_language": 0, "n_stale_db_warnings": 0,
+            "skipped_reason": "", "n_deep_validate_auto_enabled": 0,
+        }
+
+        result = _try_structural_fallback(
+            findings, results, repo_path=tmp_path, metrics=metrics,
+        )
+        assert result is None
+
+    def test_structural_refuted_triggers_downgrade_recommendation(self, tmp_path):
+        """When the structural validator refutes a path on an exploitable
+        finding, recommends_downgrade=True is set."""
+        src = tmp_path / "a.py"
+        src.write_text(
+            "def handler():\n"
+            "    x = 1\n"
+            "    return x\n"
+            "\n"
+            "def unrelated():\n"
+            "    pass\n",
+            encoding="utf-8",
+        )
+
+        path = {
+            "source": {"file": "a.py", "line": 2, "label": "", "snippet": ""},
+            "sink": {"file": "a.py", "line": 6, "label": "", "snippet": ""},
+            "steps": [],
+            "total_steps": 2,
+        }
+        findings = [self._make_finding("f2", True, path)]
+        results = {"f2": {"is_exploitable": True, "confidence": "high"}}
+        metrics = {
+            "n_eligible": 0, "n_validated": 0, "n_cache_hits": 0,
+            "n_recommended_downgrades": 0, "n_errors": 0,
+            "n_skipped_no_db_for_language": 0, "n_stale_db_warnings": 0,
+            "skipped_reason": "", "n_deep_validate_auto_enabled": 0,
+        }
+
+        _try_structural_fallback(
+            findings, results, repo_path=tmp_path, metrics=metrics,
+        )
+
+        v = results["f2"].get("dataflow_validation", {})
+        if v.get("verdict") == "refuted":
+            assert v["recommends_downgrade"] is True
+            assert metrics["n_recommended_downgrades"] >= 1
+
+    def test_reconcile_labels_structural_method(self):
+        """reconcile_dataflow_validation uses 'Tree-sitter structural validation'
+        in the downgrade reason when method is structural-treesitter."""
+        results = {
+            "f1": {
+                "is_exploitable": True,
+                "confidence": "high",
+                "dataflow_validation": {
+                    "verdict": "refuted",
+                    "reasoning": "Call chain broken",
+                    "evidence": [],
+                    "iterations": 1,
+                    "recommends_downgrade": True,
+                    "method": "structural-treesitter",
+                },
+            },
+        }
+
+        out = reconcile_dataflow_validation(results)
+        assert out["n_hard_downgrades"] == 1
+        assert results["f1"]["is_exploitable"] is False
+        reason = results["f1"]["validation_downgrade_reason"]
+        assert "Tree-sitter structural validation" in reason
+
+    def test_reconcile_labels_codeql_method(self):
+        """reconcile_dataflow_validation uses 'CodeQL dataflow validation'
+        as the default label."""
+        results = {
+            "f1": {
+                "is_exploitable": True,
+                "confidence": "high",
+                "dataflow_validation": {
+                    "verdict": "refuted",
+                    "reasoning": "No taint flow",
+                    "evidence": [],
+                    "iterations": 2,
+                    "recommends_downgrade": True,
+                    "method": "codeql-iris",
+                },
+            },
+        }
+
+        out = reconcile_dataflow_validation(results)
+        assert out["n_hard_downgrades"] == 1
+        reason = results["f1"]["validation_downgrade_reason"]
+        assert "CodeQL dataflow validation" in reason
+
+    def test_attach_result_with_structural_method(self):
+        """_attach_result records the method field from the caller."""
+        from core.dataflow.structural_validator import StructuralResult
+
+        analysis: Dict[str, Any] = {"is_exploitable": True}
+        result = StructuralResult(
+            verdict="confirmed",
+            reasoning="All links verified",
+            evidence=[{"step_index": 0, "file": "a.py", "exists": True}],
+            confidence="high",
+        )
+        _attach_result(analysis, result, method="structural-treesitter")
+
+        v = analysis["dataflow_validation"]
+        assert v["method"] == "structural-treesitter"
+        assert v["verdict"] == "confirmed"
+        assert v["recommends_downgrade"] is False
+
+    def test_validate_dataflow_claims_structural_fallback(self, tmp_path):
+        """Full pipeline: validate_dataflow_claims with no CodeQL DB
+        falls back to structural validation for eligible findings."""
+        src = tmp_path / "app.py"
+        src.write_text(
+            "def source():\n"
+            "    return input()\n"
+            "\n"
+            "def sink(data):\n"
+            "    eval(data)\n"
+            "\n"
+            "def main():\n"
+            "    data = source()\n"
+            "    sink(data)\n",
+            encoding="utf-8",
+        )
+
+        path = {
+            "source": {"file": "app.py", "line": 8, "label": "", "snippet": ""},
+            "sink": {"file": "app.py", "line": 9, "label": "", "snippet": ""},
+            "steps": [],
+            "total_steps": 2,
+        }
+        findings = [{
+            "finding_id": "f1",
+            "has_dataflow": True,
+            "dataflow_path": path,
+            "language": "python",
+            "rule_id": "test-rule",
+        }]
+        results = {"f1": {"is_exploitable": True, "confidence": "high"}}
+
+        metrics = validate_dataflow_claims(
+            findings=findings,
+            results_by_id=results,
+            codeql_db=None,
+            repo_path=tmp_path,
+            llm_client=None,
+        )
+
+        assert metrics["validation_method"] == "structural-treesitter"
+        v = results["f1"]["dataflow_validation"]
+        assert v["method"] == "structural-treesitter"
+
+    def test_run_validation_pass_structural_fallback(self, tmp_path):
+        """run_validation_pass with no CodeQL DB in out_dir falls back
+        to structural validation."""
+        src = tmp_path / "repo" / "app.py"
+        src.parent.mkdir(parents=True)
+        src.write_text(
+            "def source():\n"
+            "    return input()\n"
+            "\n"
+            "def sink(data):\n"
+            "    eval(data)\n"
+            "\n"
+            "def main():\n"
+            "    data = source()\n"
+            "    sink(data)\n",
+            encoding="utf-8",
+        )
+        out_dir = tmp_path / "out"
+        out_dir.mkdir()
+
+        path = {
+            "source": {"file": "app.py", "line": 8, "label": "", "snippet": ""},
+            "sink": {"file": "app.py", "line": 9, "label": "", "snippet": ""},
+            "steps": [],
+            "total_steps": 2,
+        }
+        findings = [{
+            "finding_id": "f1",
+            "has_dataflow": True,
+            "dataflow_path": path,
+            "language": "python",
+        }]
+        results = {"f1": {"is_exploitable": True}}
+
+        metrics = run_validation_pass(
+            findings=findings,
+            results_by_id=results,
+            out_dir=out_dir,
+            repo_path=tmp_path / "repo",
+            dispatch_fn=lambda *a, **kw: None,
+            analysis_model=None,
+            role_resolution={},
+            dispatch_mode="external_llm",
+        )
+
+        assert metrics is not None
+        assert metrics["validation_method"] == "structural-treesitter"

--- a/raptor.py
+++ b/raptor.py
@@ -893,8 +893,17 @@ def mode_agentic(args: list) -> int:
 
     # Enable CodeQL by default for comprehensive agentic mode
     # unless user explicitly specifies --codeql-only or --no-codeql
+    # or CodeQL is disabled via config (tuning.json: codeql_enabled: false)
     if '--codeql' not in args and '--codeql-only' not in args and '--no-codeql' not in args:
-        args = ['--codeql'] + args
+        from core.config import RaptorConfig
+        if RaptorConfig.CODEQL_ENABLED:
+            args = ['--codeql'] + args
+        else:
+            print(
+                "  CodeQL disabled via config (tuning.json). "
+                "Pass --codeql to override for this run.",
+                file=sys.stderr,
+            )
 
     # Re-inject --trust-repo stripped by main(): the agentic child parses it
     # to set the cc_trust + codeql_trust overrides in its own process.


### PR DESCRIPTION
Add a tree-sitter structural dataflow validator that fires when no CodeQL database is available, validating SARIF codeFlows paths (e.g. from Semgrep Pro) by checking call chain existence, sanitizer presence, and branch guards in the AST. This is a stale-path/broken-chain filter, not a taint analyzer — it catches non-existent call chains for free (no LLM, no CodeQL license) but cannot confirm data actually flows.

Priority cascade (hardwired): CodeQL IRIS > structural > SMT Tier 4 > LLM. When CodeQL is available, the structural validator is never invoked.

Add codeql_enabled boolean to tuning.json so users who can't use CodeQL (licensing) can persistently disable it without --no-codeql every run. Default: true. CLI --codeql overrides config for a single run.

Adversarially reviewed: path traversal defense on SARIF step files, extract_functions filepath arg fix, import-before-indirection priority in cross-file call link checking, duplicate branch guard extraction eliminated.

303 tests pass (35 structural + 42 tuning + 199 dataflow validation
+ 8 E2E integration + 19 cvefix), ruff clean.