### PR TITLE
chore: Update Node install instructions in container

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -135,11 +135,11 @@ RUN apt-get update \
 
 # Capture-then-execute the nodesource setup script so a curl failure isn't
 # silently swallowed by the pipeline (curl | bash ignores curl's exit status).
-# Node 22 is the current LTS; Node 20 went EOL April 2026.
-RUN curl -fsSL https://deb.nodesource.com/setup_22.x -o /tmp/nodesource_setup.sh \
+# Node 24 is the current stable release, and is supported by the latest Claude CLI.
+RUN curl -fsSL https://deb.nodesource.com/setup_24.x -o /tmp/nodesource_setup.sh \
     && bash /tmp/nodesource_setup.sh \
     && rm /tmp/nodesource_setup.sh \
-    && apt-get install -y --no-install-recommends nodejs=24.15.0+dfsg+~cs24.12.2-1 \
+    && apt-get install -y --no-install-recommends nodejs=24.15.0-1nodesource1 \
     && apt-get clean && rm -rf /var/lib/apt/lists/* \
     && npm install -g @anthropic-ai/claude-code@2.1.119
 


### PR DESCRIPTION
Building the local dev container was failling due to missmatch of the NodeJS Package version. 

Changes:
* Update to node_24 setup url;
* Updade package version from 24.15.0+dfsg+~cs24.12.2-1 to 24.15.0-1nodesource1

```
4.542 78 packages can be upgraded. Run 'apt list --upgradable' to see them.
4.543 2026-06-16 09:36:18 - Repository configured successfully.
4.544 2026-06-16 09:36:18 - To install Node.js, run: apt install nodejs -y
4.544 2026-06-16 09:36:18 - You can use N|solid Runtime as a node.js alternative
4.545 2026-06-16 09:36:18 - To install N|solid Runtime, run: apt install nsolid -y 
4.545 
4.548 Reading package lists...
4.745 Building dependency tree...
4.805 Reading state information...
4.807 Package nodejs is a virtual package provided by:
4.807   nsolid 22.22.2-ns6.2.5
4.807 
4.808 E: Version '24.15.0+dfsg+~cs24.12.2-1' for 'nodejs' was not found
------
Dockerfile:139
--------------------
 138 |     # Node 22 is the current LTS; Node 20 went EOL April 2026.
 139 | >>> RUN curl -fsSL https://deb.nodesource.com/setup_22.x -o /tmp/nodesource_setup.sh \
 140 | >>>     && bash /tmp/nodesource_setup.sh \
 141 | >>>     && rm /tmp/nodesource_setup.sh \
 142 | >>>     && apt-get install -y --no-install-recommends nodejs=24.15.0+dfsg+~cs24.12.2-1 \
 143 | >>>     && apt-get clean && rm -rf /var/lib/apt/lists/* \
 144 | >>>     && npm install -g @anthropic-ai/claude-code@2.1.119
 145 |     
--------------------
ERROR: failed to build: failed to solve: process "/bin/sh -c curl -fsSL https://deb.nodesource.com/setup_22.x -o /tmp/nodesource_setup.sh     && bash /tmp/nodesource_setup.sh     && rm /tmp/nodesource_setup.sh     && apt-get install -y --no-install-recommends nodejs=24.15.0+dfsg+~cs24.12.2-1     && apt-get clean && rm -rf /var/lib/apt/lists/*     && npm install -g @anthropic-ai/claude-code@2.1.119" did not complete successfully: exit code: 100
```

```
vscode ➜ /workspaces/raptor $ apt-cache madison nodejs
    nodejs | 24.16.0-1nodesource1 | https://deb.nodesource.com/node_24.x nodistro/main arm64 Packages
    nodejs | 24.15.0-1nodesource1 | https://deb.nodesource.com/node_24.x nodistro/main arm64 Packages
    nodejs | 24.14.1-1nodesource1 | https://deb.nodesource.com/node_24.x nodistro/main arm64 Packages
    nodejs | 24.14.0-1nodesource1 | https://deb.nodesource.com/node_24.x nodistro/main arm64 Packages
    nodejs | 24.13.1-1nodesource1 | https://deb.nodesource.com/node_24.x nodistro/main arm64 Packages
    nodejs | 24.13.0-1nodesource1 | https://deb.nodesource.com/node_24.x nodistro/main arm64 Packages
    nodejs | 24.12.0-1nodesource1 | https://deb.nodesource.com/node_24.x nodistro/main arm64 Packages
    nodejs | 24.11.1-1nodesource1 | https://deb.nodesource.com/node_24.x nodistro/main arm64 Packages
    nodejs | 24.11.0-1nodesource1 | https://deb.nodesource.com/node_24.x nodistro/main arm64 Packages
    nodejs | 24.10.0-1nodesource1 | https://deb.nodesource.com/node_24.x nodistro/main arm64 Packages
    nodejs | 24.9.0-1nodesource1 | https://deb.nodesource.com/node_24.x nodistro/main arm64 Packages
    nodejs | 24.8.0-1nodesource1 | https://deb.nodesource.com/node_24.x nodistro/main arm64 Packages
    nodejs | 24.7.0-1nodesource1 | https://deb.nodesource.com/node_24.x nodistro/main arm64 Packages
    nodejs | 24.6.0-1nodesource1 | https://deb.nodesource.com/node_24.x nodistro/main arm64 Packages
    nodejs | 24.5.0-1nodesource1 | https://deb.nodesource.com/node_24.x nodistro/main arm64 Packages
    nodejs | 24.4.1-1nodesource1 | https://deb.nodesource.com/node_24.x nodistro/main arm64 Packages
    nodejs | 24.4.0-1nodesource1 | https://deb.nodesource.com/node_24.x nodistro/main arm64 Packages
    nodejs | 24.3.0-1nodesource1 | https://deb.nodesource.com/node_24.x nodistro/main arm64 Packages
    nodejs | 24.1.0-1nodesource1 | https://deb.nodesource.com/node_24.x nodistro/main arm64 Packages
    nodejs | 24.0.2-1nodesource1 | https://deb.nodesource.com/node_24.x nodistro/main arm64 Packages
    nodejs | 24.0.1-1nodesource1 | https://deb.nodesource.com/node_24.x nodistro/main arm64 Packages
    nodejs | 24.0.0-1nodesource1 | https://deb.nodesource.com/node_24.x nodistro/main arm64 Packages
    nodejs | 18.20.4+dfsg-1~deb12u2 | http://deb.debian.org/debian-security bookworm-security/main arm64 Packages
    nodejs | 18.20.4+dfsg-1~deb12u1 | http://deb.debian.org/debian bookworm/main arm64 Packages
```