### PR TITLE
chore: Use correct param for claude code system-prompt 

### DIFF
--- a/core/llm/cc_adapter.py
+++ b/core/llm/cc_adapter.py
@@ -26,7 +26,7 @@ class CCDispatchConfig:
     timeout_s: int = 300
     json_schema: dict[str, Any] | None = None
     capture_json_envelope: bool = True
-    # System prompt passed via the `--system` flag rather than
+    # System prompt passed via the `--system-prompt` flag rather than
     # prepended to the user prompt. Pre-fix `ClaudeCodeLLMProvider`
     # concatenated `f"{system_prompt}\n\n{prompt}"` and sent the
     # combined text as the user message — the model then saw it as
@@ -62,11 +62,11 @@ def build_cc_command(config: CCDispatchConfig) -> list[str]:
         "--max-budget-usd", config.budget_usd,
     ]
     if config.system_prompt is not None and config.system_prompt.strip():
-        # `--system` keeps the system prompt in its own
+        # `--system-prompt` keeps the system prompt in its own
         # role-channel rather than concatenated to the user
         # prompt. See CCDispatchConfig.system_prompt comment for
         # the prompt-injection rationale.
-        cmd.extend(["--system", config.system_prompt])
+        cmd.extend(["--system-prompt", config.system_prompt])
     for d in config.add_dirs:
         cmd.extend(["--add-dir", str(d)])
     if config.capture_json_envelope:

--- a/core/llm/providers.py
+++ b/core/llm/providers.py
@@ -2506,7 +2506,7 @@ class ClaudeCodeLLMProvider(LLMProvider):
         import time as _time
 
         # Pass the user prompt as-is and route the system prompt
-        # through CC's `--system` flag (see CCDispatchConfig.system_prompt
+        # through CC's `--system-prompt` flag (see CCDispatchConfig.system_prompt
         # comment for the prompt-injection rationale).
         full_prompt = prompt
         cc_config = CCDispatchConfig(
@@ -2612,15 +2612,15 @@ class ClaudeCodeLLMProvider(LLMProvider):
         import subprocess
         import time as _time
 
-        # Route system_prompt through CC's `--system` flag instead of
+        # Route system_prompt through CC's `--system-prompt` flag instead of
         # concatenating into the user prompt. Pre-fix this path used
         # `f"{system_prompt}\n\n{prompt}"`, mixing the trusted system
         # message into the same channel as user content. The
         # generate() path above (the freeform sibling of this method)
-        # already uses `--system` correctly. The structured path's
+        # already uses `--system-prompt` correctly. The structured path's
         # f-string concat:
         #
-        #   * Drops the trust separation that CC's `--system` flag
+        #   * Drops the trust separation that CC's `--system-prompt` flag
         #     gives us — operator system instructions and finding
         #     content arrive on the SAME channel from the model's
         #     perspective.
@@ -2632,7 +2632,7 @@ class ClaudeCodeLLMProvider(LLMProvider):
         # Bring this site in line with generate(): full_prompt is
         # the user content; system_prompt routes through
         # CCDispatchConfig.system_prompt (which build_cc_command
-        # converts into a `--system` flag).
+        # converts into a `--system-prompt` flag).
         full_prompt = prompt
         cc_config = CCDispatchConfig(
             claude_bin=self._claude_bin,

--- a/core/llm/tests/test_claude_code_llm_provider.py
+++ b/core/llm/tests/test_claude_code_llm_provider.py
@@ -177,12 +177,12 @@ def test_generate_disables_internal_cc_tools(monkeypatch) -> None:
 
 
 def test_generate_with_system_prompt_uses_system_flag(monkeypatch) -> None:
-    """`system_prompt` flows through CC's --system flag, not via prompt prepend.
+    """`system_prompt` flows through CC's --system-prompt flag, not via prompt prepend.
 
     Pre-cluster-107 the provider concatenated `f"{system_prompt}\\n\\n{prompt}"`
     and sent the combined text as the user message. That folded the
     system instruction into user content, where a hostile user prompt
-    could re-instruct over it. Routing through `--system` keeps the
+    could re-instruct over it. Routing through `--system-prompt` keeps the
     system layer in its own role-channel.
     """
     captured: dict[str, Any] = {}
@@ -197,11 +197,11 @@ def test_generate_with_system_prompt_uses_system_flag(monkeypatch) -> None:
     p.generate("user question", system_prompt="you are helpful")
 
     # User-side input contains only the user prompt — system was
-    # routed through the --system flag.
+    # routed through the --system-prompt flag.
     assert captured["input"] == "user question"
     cmd = captured["cmd"]
-    assert "--system" in cmd
-    sys_idx = cmd.index("--system") + 1
+    assert "--system-prompt" in cmd
+    sys_idx = cmd.index("--system-prompt") + 1
     assert cmd[sys_idx] == "you are helpful"
 
 
@@ -617,12 +617,12 @@ def test_turn_propagates_envelope_cost_to_compute_cost(monkeypatch) -> None:
 
 
 def test_turn_passes_system_through_to_subprocess(monkeypatch) -> None:
-    """``system`` arg goes via the CC `--system` flag.
+    """``system`` arg goes via the CC `--system-prompt` flag.
 
     Pre-cluster-107 system was concatenated into the user prompt so
     the assertion looked for `"be careful"` in the input. Now that
     `ClaudeCodeLLMProvider.generate` routes system through the
-    `--system` argv flag, the assertion checks the cmd argv instead.
+    `--system-prompt` argv flag, the assertion checks the cmd argv instead.
     """
     captured: dict[str, Any] = {}
     monkeypatch.setattr(
@@ -637,8 +637,8 @@ def test_turn_passes_system_through_to_subprocess(monkeypatch) -> None:
         system="be careful",
     )
     cmd = captured["cmd"]
-    assert "--system" in cmd
-    sys_idx = cmd.index("--system") + 1
+    assert "--system-prompt" in cmd
+    sys_idx = cmd.index("--system-prompt") + 1
     # Tool-use fallback wraps the system message with the JSON
     # protocol; the operator's "be careful" must be present
     # inside the system block.


### PR DESCRIPTION
Update the system prompt param for Claude Code. It should be `--system-prompt`. When Anthropic first launched the [Claude Code](https://code.claude.com/docs/en/cli-reference) CLI, `--system` was the original flag used to override the default system prompt. Not supported anymore.

```
vscode ➜ /workspaces/raptor $ claude --help
Usage: claude [options] [command] [prompt]

Claude Code - starts an interactive session by default, use -p/--print for non-interactive output

Arguments:
  prompt                                            Your prompt

Options:
  --add-dir <directories...>                        Additional directories to allow tool access to
  --agent <agent>                                   Agent for the current session. Overrides the 'agent' setting.
(....)
  --system-prompt <prompt>                          System prompt to use for the session
  ```