### PR TITLE
Feat/wp extraction

### DIFF
--- a/packages/codeql/smt_path_validator.py
+++ b/packages/codeql/smt_path_validator.py
@@ -173,6 +173,21 @@ class PathCondition:
     negated: bool = False
 
 
+# --- Phase 8: weakest-precondition extraction ------------------------------
+# Cap on solver calls in the WP deletion pass.  Each kept-conjunct
+# redundancy test is one ``check()``; real paths carry 1-10 conjuncts and
+# ``_MAX_CONDITIONS_PER_CALL`` caps the input at 64, so 32 covers typical
+# paths fully while bounding worst-case cost on adversarial inputs.
+WP_MAX_SOLVER_CALLS = 32
+
+# The deletion pass visits conjuncts in lexicographic order of their
+# canonicalised text (ties broken by original index).  Recorded on the
+# result so re-runs reproduce the same minimal subset: different visit
+# orders can yield different (equally valid) minimal subsets when
+# conjuncts pairwise imply one another.
+WP_ORDERING = "canonical-text-lexicographic"
+
+
 @dataclass
 class PathSMTResult:
     """Result of SMT feasibility check over a set of path conditions.
@@ -201,6 +216,30 @@ class PathSMTResult:
     reasoning: str
     unknown_reasons: List[Rejection] = field(default_factory=list)
     anon_var_map: Dict[str, str] = field(default_factory=dict)
+
+    # --- Phase 8: weakest-precondition predicate (additive) ---
+    # ``wp_predicate`` is the minimal sat-preserving subset of the pending
+    # path conjuncts, serialised as an SMTLIB s-expression (the conjunction
+    # over the path's symbolic variables).  It is the *weakest predicate
+    # over the current symbolic variables* whose solution set equals the
+    # full path condition's: every kept conjunct is load-bearing (dropping
+    # it would admit inputs that change reachability) and every dropped
+    # conjunct was implied by the kept ones.  ``/exploit`` (Phase 9)
+    # consumes it as a hard constraint on synthesised inputs.  ``None``
+    # when the path is not ``sat``, when there were no pending conjuncts,
+    # or when Z3 is unavailable.  See :func:`_extract_wp`.
+    wp_predicate: Optional[str] = None
+    # The kept (minimal) conjunct texts, in the deterministic extraction
+    # order.  Empty whenever ``wp_predicate`` is ``None``.
+    wp_conjuncts: List[str] = field(default_factory=list)
+    # ``False`` when the deletion pass hit ``WP_MAX_SOLVER_CALLS`` before
+    # every conjunct was tested — ``wp_predicate`` is then a sound
+    # sat-preserving subset but possibly not minimal.
+    wp_complete: bool = True
+    # Names the deterministic conjunct ordering so re-runs reproduce the
+    # same minimal subset.  Always ``WP_ORDERING`` for now; carried
+    # explicitly so a future ordering change is visible to consumers.
+    wp_ordering: str = WP_ORDERING
 
 
 # ---------------------------------------------------------------------------
@@ -953,6 +992,90 @@ def _classify_text_condition(
     return None, (display, final_expr), None
 
 
+def _extract_wp(
+    pending: List[Tuple[str, Any]],
+    *,
+    cap: int = WP_MAX_SOLVER_CALLS,
+) -> Tuple[Optional[str], List[str], bool]:
+    """Extract the weakest-precondition predicate for a *sat* path.
+
+    ``pending`` is the list of ``(text, z3_expr)`` path conjuncts whose
+    conjunction has already been shown satisfiable (we are on the ``sat``
+    branch of :func:`_solve_pending`).  Returns
+    ``(wp_predicate, wp_conjuncts, complete)``:
+
+      * ``wp_predicate`` — SMTLIB s-expression of the conjunction of the
+        *minimal sat-preserving subset* ``W ⊆ pending``, or ``None`` when
+        there is nothing to extract (no conjuncts, Z3 unavailable) or the
+        serialisation fails.
+      * ``wp_conjuncts`` — the kept conjunct texts in extraction order.
+      * ``complete`` — ``False`` if the deletion pass hit ``cap`` before
+        testing every conjunct (``W`` is then sat-preserving but possibly
+        not minimal).
+
+    Primitive — *implication-based redundancy*.  A conjunct ``c_i`` is
+    redundant exactly when the other kept conjuncts already imply it:
+    ``(⋀(kept∖{c_i}) ∧ ¬c_i)`` is unsat.  Dropping only implied conjuncts
+    guarantees ``⋀W`` has the *same* solution set as the full path
+    condition, so ``W`` is the weakest predicate over the path's symbolic
+    variables whose every model reaches the sink.  A conjunct whose
+    negation is still consistent with the rest is load-bearing and kept.
+
+    This is not the literal weakest precondition (that needs symbolic
+    back-substitution through the program); it is the weakest predicate
+    over the *current* symbolic variables, which is what ``/exploit`` PoC
+    synthesis needs because those variables are the attacker-controlled
+    inputs.
+
+    Greedy + deterministic.  Conjuncts are visited in lexicographic order
+    of canonicalised text (:data:`WP_ORDERING`); a conjunct dropped
+    earlier is excluded from later tests, so the result is minimal with
+    respect to that order.  Z3 ``unknown`` (timeout / undecidable) on a
+    redundancy test is treated conservatively as "keep" — a conjunct we
+    cannot *prove* redundant is never dropped, keeping ``W`` sound.
+    """
+    n = len(pending)
+    if n == 0 or not _z3_available():
+        return None, [], True
+
+    order = sorted(range(n), key=lambda i: (_canonicalise(pending[i][0]), i))
+    kept = [True] * n
+    calls = 0
+    complete = True
+    solver = _new_solver()
+    for idx in order:
+        if calls >= cap:
+            complete = False
+            break
+        with _scoped(solver):
+            for j in range(n):
+                if kept[j] and j != idx:
+                    solver.add(pending[j][1])
+            solver.add(z3.Not(pending[idx][1]))
+            calls += 1
+            verdict = solver.check()
+        if verdict == z3.unsat:
+            kept[idx] = False  # implied by the rest → redundant, drop it
+
+    # Serialise + list the kept conjuncts in the deterministic visit order
+    # so the predicate and the conjunct list line up across re-runs.
+    kept_in_order = [i for i in order if kept[i]]
+    kept_exprs = [pending[i][1] for i in kept_in_order]
+    wp_conjuncts = [pending[i][0] for i in kept_in_order]
+
+    if not kept_exprs:
+        # Degenerate — cannot occur for a sat, tautology-filtered pending
+        # set, but stay total rather than index into an empty list.
+        return "true", wp_conjuncts, complete
+
+    expr = kept_exprs[0] if len(kept_exprs) == 1 else z3.And(*kept_exprs)
+    try:
+        wp_predicate = expr.sexpr()
+    except (z3.Z3Exception, AttributeError):
+        wp_predicate = None
+    return wp_predicate, wp_conjuncts, complete
+
+
 def _solve_pending(
     pending: List[Tuple[str, Any]],
     solver: Any,
@@ -1035,6 +1158,10 @@ def _solve_pending(
 
     if result == z3.sat:
         model_dict = _format_witness(solver.model(), signed=profile.signed)
+        # Phase 8: on sat, extract the weakest predicate over the path's
+        # symbolic variables (minimal sat-preserving conjunct subset). Its
+        # own fresh solver — the verdict above is unaffected.
+        wp_predicate, wp_conjuncts, wp_complete = _extract_wp(pending)
         return PathSMTResult(
             feasible=True,
             satisfied=satisfied, unsatisfied=[], unknown=unknown,
@@ -1046,6 +1173,9 @@ def _solve_pending(
                 + (f"; {len(unknown)} unparsed" if unknown else "")
             ),
             anon_var_map=_anon_map,
+            wp_predicate=wp_predicate,
+            wp_conjuncts=wp_conjuncts,
+            wp_complete=wp_complete,
         )
 
     if result == z3.unsat:

--- a/packages/codeql/tests/test_smt_path_validator.py
+++ b/packages/codeql/tests/test_smt_path_validator.py
@@ -1779,3 +1779,104 @@ class TestPreferWitness:
         )
         assert r.feasible is True
         assert r.model.get("count") is not None
+
+
+# ---------------------------------------------------------------------------
+# Phase 8 — weakest-precondition predicate extraction
+# ---------------------------------------------------------------------------
+class TestWeakestPrecondition:
+    """WP extraction: the minimal sat-preserving subset of path conjuncts.
+
+    The properties below use ``check_path_feasibility`` itself as the
+    oracle — ``PathCondition(text, negated=True)`` asserts ``¬text``, so
+    feasibility of ``W + [¬c]`` decides whether ``W`` implies ``c``.
+    """
+
+    @staticmethod
+    def _conds(texts):
+        return [PathCondition(t, step_index=i) for i, t in enumerate(texts)]
+
+    @_requires_z3
+    def test_feasible_path_carries_wp_fields(self):
+        r = check_path_feasibility(self._conds(["size > 5", "size < 100"]))
+        assert r.feasible is True
+        assert r.wp_predicate is not None
+        assert r.wp_complete is True
+        assert r.wp_ordering == "canonical-text-lexicographic"
+
+    @_requires_z3
+    def test_redundant_conjunct_dropped(self):
+        # ``size > 5`` implies ``size > 0`` — the weaker bound is redundant.
+        r = check_path_feasibility(self._conds(["size > 5", "size > 0"]))
+        assert r.feasible is True
+        assert r.wp_conjuncts == ["size > 5"]
+
+    @_requires_z3
+    def test_independent_conjuncts_all_kept(self):
+        r = check_path_feasibility(self._conds(["size > 5", "offset < 3"]))
+        assert r.feasible is True
+        assert set(r.wp_conjuncts) == {"size > 5", "offset < 3"}
+
+    @_requires_z3
+    def test_unsat_path_has_no_wp(self):
+        r = check_path_feasibility(self._conds(["size > 5", "size < 0"]))
+        assert r.feasible is False
+        assert r.wp_predicate is None
+        assert r.wp_conjuncts == []
+
+    def test_no_z3_has_no_wp(self):
+        with patch("packages.codeql.smt_path_validator._z3_available",
+                   return_value=False):
+            r = check_path_feasibility([PathCondition("size > 0", step_index=0)])
+        assert r.wp_predicate is None
+        assert r.wp_conjuncts == []
+
+    @_requires_z3
+    def test_deterministic_across_runs(self):
+        conds = self._conds(["size > 5", "size > 0", "offset < 3"])
+        a = check_path_feasibility(conds)
+        b = check_path_feasibility(conds)
+        assert a.wp_conjuncts == b.wp_conjuncts
+        assert a.wp_predicate == b.wp_predicate
+
+    @_requires_z3
+    def test_wp_equivalent_to_full_path(self):
+        # Sat-preserving: ⋀W ⟹ ⋀C, i.e. for every original conjunct c,
+        # ``(⋀W ∧ ¬c)`` is unsat. With W ⊆ C this makes W ≡ C.
+        originals = ["size > 5", "size > 0", "size < 100", "offset < 3"]
+        r = check_path_feasibility(self._conds(originals))
+        assert r.feasible is True
+        W = r.wp_conjuncts
+        for c in originals:
+            probe = self._conds(W) + [
+                PathCondition(c, step_index=len(W), negated=True)]
+            assert check_path_feasibility(probe).feasible is False, (
+                f"W does not imply original conjunct {c!r}")
+
+    @_requires_z3
+    def test_wp_is_minimal(self):
+        # Minimality: for each c_i ∈ W, ``(⋀(W∖{c_i}) ∧ ¬c_i)`` is sat —
+        # dropping c_i would admit models violating it, so it is
+        # load-bearing and could not have been removed.
+        originals = ["size > 5", "size > 0", "size < 100", "offset < 3"]
+        r = check_path_feasibility(self._conds(originals))
+        W = r.wp_conjuncts
+        assert len(W) >= 1
+        for i, c_i in enumerate(W):
+            rest = [c for j, c in enumerate(W) if j != i]
+            probe = self._conds(rest) + [
+                PathCondition(c_i, step_index=len(rest), negated=True)]
+            assert check_path_feasibility(probe).feasible is True, (
+                f"kept conjunct {c_i!r} is implied by the rest — not minimal")
+
+    @_requires_z3
+    def test_cap_marks_incomplete(self):
+        from packages.codeql.smt_path_validator import WP_MAX_SOLVER_CALLS
+        # More independent conjuncts than the deletion-pass cap: the pass
+        # can't test them all, so it must report wp_complete=False.
+        n = WP_MAX_SOLVER_CALLS + 5
+        conds = [PathCondition(f"v{i} > {i}", step_index=i) for i in range(n)]
+        r = check_path_feasibility(conds)
+        assert r.feasible is True
+        assert r.wp_predicate is not None
+        assert r.wp_complete is False

--- a/packages/exploit_feasibility/smt_path.py
+++ b/packages/exploit_feasibility/smt_path.py
@@ -249,6 +249,17 @@ def validate_path(
           ``kind`` and ``hint`` to drive *targeted* retry of a rejected
           condition rather than guessing what to rephrase.
         - ``smt_available``: whether ``z3-solver`` was loaded.
+        - ``wp_predicate``: SMTLIB s-expression of the weakest-
+          precondition predicate (minimal sat-preserving conjunct
+          subset) when ``feasible=True``; ``None`` otherwise. ``model``
+          is a concrete solution of it. Consumed by ``/exploit`` as a
+          hard constraint on the synthesised input.
+        - ``wp_conjuncts``: the kept conjunct texts behind
+          ``wp_predicate``, in deterministic order.
+        - ``wp_complete``: ``False`` when the extraction pass hit its
+          solver-call cap (predicate is sat-preserving but maybe not
+          minimal).
+        - ``wp_ordering``: the conjunct ordering used, for reproducibility.
     """
     bv = _resolve_profile(profile)
     paths = _normalise_conditions(conditions)
@@ -283,4 +294,16 @@ def validate_path(
         # renderer uses this to surface meaningful labels instead
         # of opaque `_anon_N = V` lines.
         "anon_var_map": dict(smt_result.anon_var_map),
+        # Weakest-precondition predicate (Phase 8): the minimal
+        # sat-preserving subset of the path conjuncts, serialised as an
+        # SMTLIB s-expression. `/exploit` (Phase 9) passes it to the PoC
+        # synthesis prompt as a HARD constraint — the generated input
+        # must satisfy it. `model` above is a concrete solution of this
+        # same predicate (Z3 already solved it), so the LLM gets both
+        # the constraint and a known-valid seed. `None` when the path is
+        # not feasible or Z3 is unavailable.
+        "wp_predicate": smt_result.wp_predicate,
+        "wp_conjuncts": list(smt_result.wp_conjuncts),
+        "wp_complete": smt_result.wp_complete,
+        "wp_ordering": smt_result.wp_ordering,
     }

--- a/packages/exploit_feasibility/tests/test_smt_path.py
+++ b/packages/exploit_feasibility/tests/test_smt_path.py
@@ -141,6 +141,25 @@ class TestEndToEnd:
         assert r["smt_available"] is True
 
     @_requires_z3
+    def test_satisfiable_surfaces_wp_predicate(self):
+        # Phase 9: the wrapper exposes the WP fields for /exploit's
+        # hard-constraint prompt. ``x > 5`` implies ``x > 0`` so the
+        # redundant weaker bound is dropped from the predicate.
+        r = validate_path(["x > 5", "x > 0"])
+        assert r["feasible"] is True
+        assert r["wp_predicate"] is not None
+        assert r["wp_conjuncts"] == ["x > 5"]
+        assert r["wp_complete"] is True
+        assert r["wp_ordering"]
+
+    @_requires_z3
+    def test_unsatisfiable_has_no_wp_predicate(self):
+        r = validate_path(["x > 100", "x < 50"])
+        assert r["feasible"] is False
+        assert r["wp_predicate"] is None
+        assert r["wp_conjuncts"] == []
+
+    @_requires_z3
     def test_unsatisfiable_names_conflict(self):
         r = validate_path(["x > 100", "x < 50"])
         assert r["feasible"] is False

--- a/packages/llm_analysis/dataflow_validation.py
+++ b/packages/llm_analysis/dataflow_validation.py
@@ -1413,6 +1413,16 @@ def _tier4_smt_refine(
                 # anything actionable. Empty dict when no
                 # substitution happened (named-locals conditions).
                 "anon_var_map": dict(smt.get("anon_var_map") or {}),
+                # Phase 9: the weakest-precondition predicate (Phase 8).
+                # `model` is one concrete solution; `wp_predicate` is the
+                # full constraint every valid trigger must satisfy. The
+                # /exploit prompt renders it as a HARD constraint so the
+                # LLM can generalise the seed (e.g. fuzz around it) while
+                # staying on the dangerous path. `None`/absent when the
+                # substrate didn't compute one (older substrate, no z3).
+                "wp_predicate": smt.get("wp_predicate"),
+                "wp_conjuncts": list(smt.get("wp_conjuncts") or []),
+                "wp_complete": smt.get("wp_complete", True),
             })
         refined = ValidationResult(
             verdict=result.verdict,

--- a/packages/llm_analysis/prompts/exploit.py
+++ b/packages/llm_analysis/prompts/exploit.py
@@ -46,7 +46,7 @@ Create a WORKING proof-of-concept exploit that:
 
 If the user message includes EXPLOITATION CONSTRAINTS blocks listing chain breaks (techniques verified not to work) or what-would-help notes, respect them: do not attempt blocked techniques; favour the suggested viable approaches.
 
-If the user message includes an SMT WITNESS block, the values listed there are guaranteed by the Z3 solver to make the program take the dangerous code path. Use them as your PoC's concrete inputs (argv values, struct fields, etc.) rather than reasoning out trigger values from scratch. The solver has already done that work.
+If the user message includes an SMT WITNESS block, the values listed there are guaranteed by the Z3 solver to make the program take the dangerous code path. Use them as your PoC's concrete inputs (argv values, struct fields, etc.) rather than reasoning out trigger values from scratch. The solver has already done that work. If that block also lists a HARD CONSTRAINT predicate, treat it as inviolable: every concrete input your PoC uses must satisfy it. The witness values are one valid solution; you may choose different inputs (e.g. to make the PoC clearer or to amplify the effect) only as long as they still satisfy the predicate.
 
 When the witness model uses an opaque placeholder name like `_anon_0` or `_anon_N`, the Z3 parser substituted it for a function-call subexpression that couldn't be encoded directly (e.g. `strlen(...)`, `sizeof(...)`, `getenv(...)`). The renderer usually decodes this for you in the form `_anon_0 (= strlen(argv[1])) = 32` — when the decoded form is shown, treat the value as the result of that expression (so `strlen(argv[1]) = 32` means "supply an argv[1] whose strlen is 32"). When only the bare `_anon_N = V` is shown (renderer couldn't disambiguate), look at the SMT WITNESS path conditions list in the same block to find the unique function-call expression — usually only one appears in the conditions, and that's what the placeholder stands for.
 
@@ -128,6 +128,30 @@ def _format_smt_witness(witness: Dict[str, Any]) -> str:
         parts.append("")
         parts.append("Path conditions Z3 satisfied:")
         parts.extend(f"  - {c}" for c in conditions)
+    # Phase 9: the weakest-precondition predicate. The witness model
+    # above is ONE solution; `wp_predicate` is the full constraint every
+    # valid trigger satisfies. Surfacing it lets the LLM generalise the
+    # seed (vary fields, fuzz around it) without leaving the dangerous
+    # path. `wp_conjuncts` is the human-readable form of the same.
+    wp_predicate = witness.get("wp_predicate")
+    if wp_predicate:
+        wp_conjuncts = witness.get("wp_conjuncts") or []
+        complete = witness.get("wp_complete", True)
+        parts.append("")
+        parts.append(
+            "HARD CONSTRAINT — every input you generate MUST satisfy this "
+            "predicate (the witness above is one solution; you may vary the "
+            "inputs as long as the predicate still holds):"
+        )
+        if wp_conjuncts:
+            parts.extend(f"  - {c}" for c in wp_conjuncts)
+        parts.append(f"  SMTLIB: {wp_predicate}")
+        if not complete:
+            parts.append(
+                "  (note: predicate is sat-preserving but extraction hit its "
+                "solver-call cap, so it may not be fully minimal — it is still "
+                "a sound constraint to satisfy.)"
+            )
     return "\n".join(parts)
 
 

--- a/packages/llm_analysis/tests/test_smt_witness_poc_seed.py
+++ b/packages/llm_analysis/tests/test_smt_witness_poc_seed.py
@@ -387,3 +387,97 @@ class TestSmtPathValidatorAnonMap:
         assert len(r.anon_var_map) == 2
         assert r.anon_var_map["_anon_0"] == "strlen(input)"
         assert r.anon_var_map["_anon_1"] == "strlen(other)"
+
+
+# -- Phase 9: weakest-precondition predicate as a hard constraint ----------
+
+class TestWpPredicateInWitness:
+    """The WP predicate (Phase 8) rides on the smt_witness record and is
+    rendered as a HARD CONSTRAINT in the exploit prompt: the witness
+    model is one solution; the predicate is what every valid trigger
+    must satisfy, so the LLM can generalise the seed without leaving the
+    dangerous path."""
+
+    def test_predicate_renders_as_hard_constraint(self):
+        out = _format_smt_witness({
+            "model": {"count": 268435457},
+            "path_conditions": ["count > 0x10000000"],
+            "path_profile": "uint32",
+            "wp_predicate": "(bvugt count #x10000000)",
+            "wp_conjuncts": ["count > 0x10000000"],
+            "wp_complete": True,
+        })
+        assert "HARD CONSTRAINT" in out
+        assert "(bvugt count #x10000000)" in out
+
+    def test_no_predicate_no_hard_constraint(self):
+        """Backwards-compatible: a witness without wp_predicate (older
+        substrate, or no z3) renders exactly as before — no constraint
+        block."""
+        out = _format_smt_witness({
+            "model": {"x": 1},
+            "path_conditions": ["x > 0"],
+        })
+        assert "HARD CONSTRAINT" not in out
+
+    def test_incomplete_predicate_carries_caveat(self):
+        out = _format_smt_witness({
+            "model": {"x": 1},
+            "wp_predicate": "(bvugt x #x00000000)",
+            "wp_conjuncts": ["x > 0"],
+            "wp_complete": False,
+        })
+        assert "HARD CONSTRAINT" in out
+        assert "cap" in out.lower()  # the not-minimal caveat
+
+    def test_tier4_attaches_wp_fields(self):
+        """validate_path's wp_* fields flow through _tier4_smt_refine
+        onto analysis['smt_witness']."""
+        from packages.llm_analysis.dataflow_validation import _tier4_smt_refine
+        from packages.hypothesis_validation.result import ValidationResult
+
+        analysis = {"path_conditions": ["x > 5"], "path_profile": "uint32"}
+        finding = {"finding_id": "f1"}
+        confirmed = ValidationResult(verdict="confirmed", evidence=[], iterations=1)
+
+        with patch(
+            "packages.exploit_feasibility.smt_path.validate_path"
+        ) as mock_validate:
+            mock_validate.return_value = {
+                "feasible": True,
+                "smt_available": True,
+                "model": {"x": 6},
+                "reasoning": "satisfiable",
+                "satisfied": [],
+                "unsatisfied": [],
+                "unknown": [],
+                "unknown_reasons": [],
+                "wp_predicate": "(bvugt x #x00000005)",
+                "wp_conjuncts": ["x > 5"],
+                "wp_complete": True,
+            }
+            _, outcome = _tier4_smt_refine(confirmed, finding, analysis)
+
+        assert outcome == "smt_witness"
+        sw = analysis["smt_witness"]
+        assert sw["wp_predicate"] == "(bvugt x #x00000005)"
+        assert sw["wp_conjuncts"] == ["x > 5"]
+        assert sw["wp_complete"] is True
+
+    def test_predicate_reaches_exploit_prompt_end_to_end(self):
+        """The predicate surfaces in the assembled exploit prompt text."""
+        bundle = build_exploit_prompt_bundle(
+            rule_id="r1", file_path="/x.c", start_line=42, level="warning",
+            analysis={
+                "is_exploitable": True,
+                "smt_witness": {
+                    "model": {"count": 268435457},
+                    "wp_predicate": "(bvugt count #x10000000)",
+                    "wp_conjuncts": ["count > 0x10000000"],
+                    "wp_complete": True,
+                },
+            },
+        )
+        text = "\n".join(m.content for m in bundle.messages)
+        assert "(bvugt count #x10000000)" in text
+        assert "HARD CONSTRAINT" in text


### PR DESCRIPTION
## Weakest-Precondition (WP) extraction

Phases 8–9 of the aggregation/dominators/WP arc (`docs/design-aggregation-dominators-wp.md`). Independent of Projects A #793 and #794. Two commits, one per phase.

### WP predicate on sat paths (`packages/codeql/smt_path_validator.py`)
On a feasible (sat) dataflow path, emit the **weakest predicate over the path's current symbolic variables**: the minimal sat-preserving subset `W` of the path conjuncts, serialised as an SMTLIB s-expression on `PathSMTResult.wp_predicate`.

- **Primitive: implication-based redundancy.** A conjunct is dropped iff the remaining kept conjuncts already imply it (`(⋀(kept∖{cᵢ}) ∧ ¬cᵢ)` unsat). Dropping only implied conjuncts guarantees `⋀W ≡ ⋀C` — same reachability, minimal form. (This sharpens the design doc's looser "sink-relevant vars unconstrained-or-equal" wording into a well-defined, testable check.)
- Greedy + deterministic (lexicographic canonical-text ordering, recorded in `wp_ordering`); capped at 32 solver calls (`wp_complete=False`when the cap trips); conservative on Z3 `unknown` (keep).
- New `PathSMTResult` fields all defaulted → **backward compatible**. Runs on its own fresh solver; the feasibility verdict is untouched.
- Property tests: minimality (every kept conjunct load-bearing) + sat-preservation/equivalence (`⋀W ⟹ ⋀C`), plus redundancy/independence/determinism/unsat/no-z3/cap.

### Phase 9 — `/exploit` consumes the predicate
- `smt_path.validate_path` surfaces the WP fields.
- Tier 4 (`dataflow_validation`) carries them onto `analysis["smt_witness"]` beside the witness model.
- The exploit prompt renders the predicate as a **HARD CONSTRAINT**: the witness model is one solution, but every input the LLM generates must satisfy the predicate, so it can generalise/fuzz the seed without leaving the dangerous path. No constraint block when `wp_predicate` is absent (older substrate / no z3 / unsat).
- The concrete-byte pre-flight is structural: Z3 already solved the full path (⊇ `W`), so the LLM gets a known-valid seed *with* the constraint rather than being asked to find one.

### Tests
160 (phase 8 validator) + 257/211 (phase 9 wiring) passing locally; ruff-pr clean. No regressions.

### Not included
The doc's E2E *measurement* (regenerate 3 historical findings' `/exploit` output with/without the WP flow, compare PoC validity rate) needs LLM calls + historical findings — an operator-run validation, not an automated test.