### PR TITLE
feat: /frida dynamic instrumentation, CLI QoL, and code-review hardening

### DIFF
--- a/.claude/commands/frida.md
+++ b/.claude/commands/frida.md
@@ -1,0 +1,76 @@
+---
+description: Dynamic instrumentation with Frida (function trace, Stalker coverage)
+dispatch: skill
+---
+
+# /frida - Dynamic Instrumentation (Frida)
+
+Spawn an operator-chosen binary under Frida and instrument it: trace function
+entry/arguments, or collect Stalker basic-block coverage that flows into
+RAPTOR's coverage store (and thus `/project coverage` and the binary-oracle
+reachability view). This is the dynamic complement to the static analysis,
+binary-oracle, and fuzzing surfaces.
+
+**Authorization & safety:** `/frida` is **spawn-only by default** - RAPTOR
+instruments a binary it launches, not arbitrary already-running PIDs. The
+target runs under the sandbox (network blocked, credentials unreadable) using
+the `debug` profile (ptrace-permitted). Only instrument targets you are
+authorized to test, same as `/fuzz` and `/crash-analysis`.
+
+**`--help`:** run `CLAUDECODE=1 libexec/raptor-frida probe` to check whether
+Frida is available on this host (no spawn, no side effects).
+
+## Your task
+
+1. **Identify the target binary** (full path) and what the operator wants:
+   - function/argument **trace** of specific symbols, or
+   - **coverage** (which basic blocks / source lines executed).
+   Ask if unclear. Note any target arguments (passed after `--`).
+
+2. **Check capability** - run `libexec/raptor-frida probe`. If Frida isn't
+   available, tell the operator to `pipx install frida-tools` and stop.
+
+3. **Start the run** (RUN LIFECYCLE in CLAUDE.md):
+   ```
+   libexec/raptor-run-lifecycle start frida --target <binary>
+   ```
+   Use the printed `OUTPUT_DIR=<path>` for `--out`.
+
+4. **Run the operation** via the shim (EXECUTION RULES: run verbatim, no pipes):
+   - Trace:
+     ```
+     libexec/raptor-frida trace <binary> --symbols func1,func2 --out $OUTPUT_DIR
+     ```
+   - Coverage (feeds the store; pass the debug binary for DWARF resolution
+     via `/project binary add` or `--out` of a run that has the inventory):
+     ```
+     libexec/raptor-frida coverage <binary> --out $OUTPUT_DIR
+     ```
+   Target arguments go after a trailing `--`.
+
+5. **Present results** concisely: for trace, the per-call argument records and
+   any unresolved symbols; for coverage, the basic-block count and the drcov
+   path. If the run fell back to `profile=none` (host without working mount
+   namespaces), say so - network isolation was not applied that run.
+
+6. **Ingest coverage into the store** (optional, for `/project coverage`):
+   ```
+   libexec/raptor-coverage-summary <run_or_project_dir> --import $OUTPUT_DIR/frida.drcov --format drcov --binary <binary>
+   ```
+
+7. **Complete the run:** `libexec/raptor-run-lifecycle complete "$OUTPUT_DIR"`
+   (or `fail` with a reason).
+
+## Skills
+
+Detailed procedure in `.claude/skills/dynamic-instrumentation/`:
+- `SKILL.md` - model, isolation, gates
+- `trace/SKILL.md` - function/argument tracing
+- `coverage/SKILL.md` - Stalker coverage → drcov → store
+
+## Notes
+
+- Coverage starts at the target's `main` (resolved via DWARF) and follows that
+  thread with Stalker; binaries without a resolvable `main` won't collect
+  coverage (a `no_main` note is emitted).
+- The drcov output is standard format - usable in Lighthouse/IDA too.

--- a/.claude/skills/dynamic-instrumentation/SKILL.md
+++ b/.claude/skills/dynamic-instrumentation/SKILL.md
@@ -1,0 +1,57 @@
+# Dynamic Instrumentation (Frida) - SKILL
+
+Spawn-and-instrument support for `/frida`. Backend: Frida (the `frida` Python
+binding + agent JS). The deterministic mechanics live in
+`packages/dynamic_instrumentation/` and are reached through
+`libexec/raptor-frida` so this skill stays declarative.
+
+## Execution model (read before running)
+
+- **Spawn, not attach.** The driver (`frida_driver.py`) runs *inside* the
+  sandbox as the parent and `frida.spawn()`s the target as a descendant, so
+  `ptrace_scope=1` authorises the trace - the same model gdb/rr use under
+  `/crash-analysis`. Attaching to a pre-existing PID is **not** the default
+  (and does not work under the namespace sandbox).
+- **Isolation.** Default sandbox profile is `debug` (full Landlock + seccomp
+  *with ptrace* + network block). Frida's spawn loader reads
+  `/proc/<pid>/auxv`, which needs `/proc` correctly remounted in the PID
+  namespace; on hosts where the mount namespace can't be set up the runner
+  detects the failure and transparently falls back to `profile="none"` (no
+  isolation) with a warning. The fallback loses network isolation only; the
+  target is still operator-chosen and spawn-only.
+- **The agent JS is RAPTOR's; the target is untrusted.** Credentials are
+  protected by the sandbox (restrict_reads / fake_home semantics of the
+  profile); network is blocked by default so an instrumented target can't
+  phone home.
+
+## Capability gate
+
+Always probe first - Frida is an optional (`degrades`) dependency:
+```
+libexec/raptor-frida probe
+```
+`available: false` → tell the operator `pipx install frida-tools` and stop.
+
+## Sub-skills
+
+- `trace/SKILL.md` - hook named functions, capture entry arguments.
+- `coverage/SKILL.md` - Stalker basic-block coverage → drcov → CoverageStore.
+
+## Reuse (don't reinvent)
+
+| Need | Use |
+|------|-----|
+| Output dir + status | `libexec/raptor-run-lifecycle start/complete/fail` |
+| Sandboxed spawn + ptrace | `packages/dynamic_instrumentation/runner.py` (`core.sandbox`, profile `debug`) |
+| drcov → source coverage | `core.coverage.collect.import_drcov` (Frida-aware) |
+| Coverage store / `/project coverage` | `core.coverage.store.CoverageStore` |
+| Debug binary for DWARF | `/project binary add <path>` persisted list |
+| Capability + `/doctor` | `RaptorConfig.TOOL_DEPS["frida"]` |
+
+## Programmatic API
+
+```python
+from packages.dynamic_instrumentation.api import trace_functions, collect_coverage
+trace_functions(binary, ["func"], output_dir=OUT)         # → {trace, unresolved, ...}
+collect_coverage(binary, output_dir=OUT, store=store, checklist=cl)  # → marks store
+```

--- a/.claude/skills/dynamic-instrumentation/coverage/SKILL.md
+++ b/.claude/skills/dynamic-instrumentation/coverage/SKILL.md
@@ -1,0 +1,52 @@
+# Frida coverage - SKILL
+
+Collect Stalker basic-block coverage from a spawned target, write a standard
+**drcov** file, and resolve it to source through RAPTOR's existing coverage
+pipeline (`import_drcov`) so it lands in the same store as gcov/lcov/AFL - and
+shows up in `/project coverage` and the binary-oracle reachability view.
+
+## Run
+
+```
+libexec/raptor-frida coverage <binary> --out $OUTPUT_DIR [--timeout 30] [--modules name1,name2] [-- <target args>]
+```
+
+- Coverage starts at the target's `main` (resolved via DWARF) and follows that
+  thread with Stalker. Binaries without a resolvable `main` won't collect
+  coverage (a `no_main` note appears in the result).
+- `--modules` - restrict to module-name substrings; default covers the main
+  module (the target binary).
+
+## Output (JSON on stdout)
+
+```json
+{"drcov_path": "<OUTPUT_DIR>/frida.drcov", "basic_blocks": 16, "profile_used": "debug"}
+```
+
+## Ingest into the coverage store
+
+drcov is address-based, so resolution needs the binary (DWARF). Use the debug
+binary persisted via `/project binary add`, or the binary you instrumented:
+
+```
+libexec/raptor-coverage-summary <run_or_project_dir> --import $OUTPUT_DIR/frida.drcov --format drcov --binary <binary>
+```
+
+Then `raptor project coverage` reflects the executed source lines, attributed
+to the `frida` tool label (distinct from `drcov`/`afl`/`sancov`).
+
+## Programmatic (one step)
+
+`api.collect_coverage(binary, output_dir=OUT, store=store, checklist=checklist)`
+runs the spawn + writes drcov + marks the store in a single call and returns
+`lines_marked`.
+
+## Notes
+
+- The agent deduplicates block starts in-process to keep the Frida bridge
+  traffic bounded on hot loops.
+- The drcov file is standard format - also loadable in Lighthouse/IDA for
+  manual review.
+- Very short-lived targets may under-report (Stalker drains asynchronously);
+  the agent sets an aggressive `queueDrainInterval`, but a target that exits in
+  microseconds before any block executes in `main` yields little.

--- a/.claude/skills/dynamic-instrumentation/trace/SKILL.md
+++ b/.claude/skills/dynamic-instrumentation/trace/SKILL.md
@@ -1,0 +1,43 @@
+# Frida trace - SKILL
+
+Hook named functions in a spawned target and capture entry + the first four
+integer-width arguments.
+
+## Run
+
+```
+libexec/raptor-frida trace <binary> --symbols funcA,funcB --out $OUTPUT_DIR [--timeout 30] [-- <target args>]
+```
+
+- `--symbols` - comma-separated function names. Resolved via DWARF
+  (`DebugSymbol.fromName`, works for `-g` static symbols) then exported name.
+- `-- <target args>` - everything after `--` is passed to the spawned target.
+- `--profile` - sandbox profile (`debug` default; `none` / `network-only`).
+
+## Output (JSON on stdout)
+
+```json
+{
+  "trace": [{"fn": "secret", "args": [0, ...], "addr": "0x..."}],
+  "unresolved": ["names that couldn't be resolved"],
+  "call_count": 3,
+  "profile_used": "debug",
+  "events_path": "<OUTPUT_DIR>/frida-events.jsonl"
+}
+```
+
+## Presenting
+
+- Summarise `call_count` and show the per-call argument records.
+- List `unresolved` symbols explicitly (e.g. typo, stripped binary, or a
+  symbol only present in a shared library - try the library's name).
+- If `profile_used` is `none`, note the host lacked working mount namespaces
+  so the trace ran without network isolation.
+
+## Notes
+
+- Argument width is integer (`args[i].toInt32()`); pointer/string arguments
+  show as their integer value - dereference in a follow-up hook if needed.
+- For deeper instrumentation (return values, memory reads, replacement),
+  extend `packages/dynamic_instrumentation/agents.py` with a new agent
+  template rather than hand-writing JS inline.

--- a/.github/scripts/check_command_metadata.py
+++ b/.github/scripts/check_command_metadata.py
@@ -146,10 +146,23 @@ def main() -> int:
             "lint or restore the sentence."
         )
     else:
-        excluded_in_index = set(re.findall(r"raptor-[\w-]+|\b\w[\w-]+\b", m.group(0)))
+        # Scan ONLY the part after the "e.g.," marker so the anchor word
+        # "commands" (from "internal/duplicate commands") isn't tokenised as
+        # a listed name - that coincidentally matched commands.md's stem and
+        # let the parity pass by accident. Splitting on "e.g.," scopes the
+        # capture to the actual listed names.
+        span = m.group(0)
+        _eg = re.split(r"e\.g\.,?", span, maxsplit=1, flags=re.IGNORECASE)
+        scan_text = _eg[1] if len(_eg) > 1 else span
+        excluded_in_index = set(re.findall(r"raptor-[\w-]+|\b\w[\w-]+\b", scan_text))
         # Drop noise tokens; only keep names that correspond to .md files.
         md_names = {p.stem for p in md_files}
         excluded_in_index = excluded_in_index & md_names
+
+        # The index file itself (commands.md) carries exclude_from_listing -
+        # it shouldn't list itself in its own exclusion sentence - so don't
+        # require its stem to appear in the index text.
+        excluded_via_frontmatter = excluded_via_frontmatter - {COMMANDS_INDEX.stem}
 
         missing_in_md = excluded_in_index - excluded_via_frontmatter
         missing_in_index = excluded_via_frontmatter - excluded_in_index

--- a/.github/tests/test_libexec_marker_coverage.py
+++ b/.github/tests/test_libexec_marker_coverage.py
@@ -1,17 +1,25 @@
-"""Verify every libexec script has the inline trust-marker check.
+"""Verify every libexec script wires the trust-marker check.
 
 Why this test exists
 --------------------
-The trust-marker check is intentionally inlined in every libexec
-script (not factored into a shared helper) so it cannot be subverted
-by a single helper-module compromise and so it remains visible at the
-top of every script during code review.
+Every libexec/raptor-* script must refuse to run unless reached through
+the trusted launcher (CLAUDECODE / _RAPTOR_TRUSTED). That check is wired
+one of two ways:
 
-The cost of that decision is that future contributors who add a new
-libexec script could forget to paste in the block. This test catches
-that — every libexec/raptor-* file must contain the sentinel comment
-``# ─── trust-marker check`` near the top, and the marker must
-gate on at least one of the trusted-caller env vars.
+* Standard scripts call the shared ``core.security._trust_guard``
+  helper (``require_trusted_caller()``) on the first lines after the
+  repo root is added to ``sys.path`` -- dependency-free, in the tiny
+  ``core.security`` package, so it still runs before any heavy import.
+* A handful of special shims (pid1/seatbelt, ``python3 -I`` isolated
+  launchers) keep the check INLINED, marked by the box-drawing sentinel
+  comment ``# ─── trust-marker check``, because they run before any
+  ``sys.path`` manipulation by design.
+
+The cost of either approach is that a future contributor adding a new
+libexec script could forget to wire it. This test catches that: every
+script must carry one of the two markers near the top, and the trust
+vars must be referenced wherever the gate actually lives (inline in the
+shim, or in the shared helper module).
 """
 
 from __future__ import annotations
@@ -20,13 +28,18 @@ import unittest
 from pathlib import Path
 
 
-# parents[2] = .github/tests → .github → repo root. Anchor to this
+# parents[2] = .github/tests -> .github -> repo root. Anchor to this
 # file, not $RAPTOR_DIR, so the test inspects libexec/ in its own
 # worktree (RAPTOR_DIR may point at a different checkout).
 REPO = Path(__file__).resolve().parents[2]
 LIBEXEC = REPO / "libexec"
+TRUST_GUARD = REPO / "core" / "security" / "_trust_guard.py"
 
+# Inline sentinel (special shims) and the shared-helper call (standard
+# scripts). A script is covered if it carries either one. The sentinel
+# uses box-drawing rules (U+2500), matching the literal text in the shims.
 _SENTINEL = "# ─── trust-marker check"
+_HELPER_MARKER = "require_trusted_caller"
 _TRUST_VARS = ("CLAUDECODE", "_RAPTOR_TRUSTED")
 
 
@@ -40,74 +53,88 @@ def _libexec_scripts() -> list[Path]:
     return out
 
 
+def _first_marker_line(text: str) -> int | None:
+    """1-based line of the first trust-marker (inline sentinel or helper
+    call), or None if neither is present."""
+    for i, line in enumerate(text.splitlines(), 1):
+        if _SENTINEL in line or _HELPER_MARKER in line:
+            return i
+    return None
+
+
 class LibexecMarkerCoverageTests(unittest.TestCase):
-    """Every libexec/raptor-* script must inline the trust-marker check."""
+    """Every libexec/raptor-* script must wire the trust-marker check."""
 
     def test_at_least_one_libexec_script_exists(self):
-        """Sanity — guards against the test silently passing on a broken
+        """Sanity -- guards against the test silently passing on a broken
         worktree where libexec/ is empty.
         """
         self.assertGreater(len(_libexec_scripts()), 0,
                            msg="no libexec scripts discovered")
 
-    def test_every_script_has_sentinel_comment(self):
-        """The sentinel comment opens (and closes) the check block."""
+    def test_every_script_wires_trust_check(self):
+        """Each script carries either the inline sentinel or the shared
+        require_trusted_caller() helper call."""
         missing = []
         for path in _libexec_scripts():
             text = path.read_text(encoding="utf-8", errors="replace")
-            if _SENTINEL not in text:
+            if _SENTINEL not in text and _HELPER_MARKER not in text:
                 missing.append(path.name)
         self.assertEqual(
             missing, [],
             msg=(
-                "These libexec scripts are missing the inline trust-marker "
-                "check. Paste the block from any existing script (search "
-                "for `# ─── trust-marker check`).\nMissing: "
-                + ", ".join(missing)
+                "These libexec scripts are missing the trust-marker check. "
+                "Add the helper (`from core.security._trust_guard import "
+                "require_trusted_caller; require_trusted_caller()`) near the "
+                "top, or paste the inline sentinel block from a special "
+                "shim.\nMissing: " + ", ".join(missing)
             ),
         )
 
-    def test_check_references_all_trust_vars(self):
-        """The check must gate on every documented trust marker.
+    def test_helper_references_all_trust_vars(self):
+        """The shared helper -- the gate for standard scripts -- must check
+        every documented trust marker. (Inline shims are checked below.)"""
+        text = TRUST_GUARD.read_text(encoding="utf-8", errors="replace")
+        missing_vars = [v for v in _TRUST_VARS if v not in text]
+        self.assertEqual(
+            missing_vars, [],
+            msg=f"{TRUST_GUARD} does not reference {missing_vars}",
+        )
 
-        Catches drift like: someone adds a new marker to docs/CONTRIBUTING
-        but forgets to update some scripts. All scripts must check the
-        same set.
-        """
+    def test_inline_checks_reference_all_trust_vars(self):
+        """Special shims that inline the check must gate on every documented
+        trust marker. Helper-based scripts delegate to the shared module
+        (covered by test_helper_references_all_trust_vars)."""
         problems = []
         for path in _libexec_scripts():
             text = path.read_text(encoding="utf-8", errors="replace")
             if _SENTINEL not in text:
-                continue  # covered by the sentinel test above
+                continue  # delegates to the shared helper
             missing_vars = [v for v in _TRUST_VARS if v not in text]
             if missing_vars:
                 problems.append(f"{path.name}: missing {missing_vars}")
         self.assertEqual(
             problems, [],
-            msg="trust-marker checks reference incomplete env-var sets:\n"
-                + "\n".join(problems),
+            msg="inline trust-marker checks reference incomplete env-var "
+                "sets:\n" + "\n".join(problems),
         )
 
     def test_check_appears_near_top(self):
-        """The check must run before any meaningful work — i.e., before
+        """The check must run before any meaningful work -- i.e., before
         ``sys.path`` is mutated (if any) and before non-stdlib imports.
 
-        Heuristic: the sentinel must appear within the first 100 lines.
-        That's loose enough to permit long module docstrings (raptor-
-        pid1-shim has a 60-line one and lands at line ~72) but tight
-        enough to catch a check accidentally pushed to the bottom of
-        the file.
+        Heuristic: the marker (inline sentinel or helper call) must appear
+        within the first 100 lines. That's loose enough to permit long
+        module docstrings (raptor-pid1-shim has a 60-line one and lands at
+        line ~72) but tight enough to catch a check accidentally pushed to
+        the bottom of the file.
         """
         late = []
         for path in _libexec_scripts():
-            lines = path.read_text(
-                encoding="utf-8", errors="replace",
-            ).splitlines()
-            for i, line in enumerate(lines, 1):
-                if _SENTINEL in line:
-                    if i > 100:
-                        late.append(f"{path.name}: line {i}")
-                    break
+            text = path.read_text(encoding="utf-8", errors="replace")
+            line = _first_marker_line(text)
+            if line is not None and line > 100:
+                late.append(f"{path.name}: line {line}")
         self.assertEqual(
             late, [],
             msg="trust-marker checks appear too late in these scripts "

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,6 +40,7 @@ When a `/command` fires:
 
 /project - Project management: create, list, status, coverage, findings, diff, merge, report, clean, export
 /scan /fuzz /web /agentic /codeql /analyze - Security testing
+/frida - Dynamic instrumentation: function/argument trace + Stalker coverage (spawn-only, sandboxed)
 /exploit /patch - Generate PoCs and fixes (beta)
 /validate - Exploitability validation pipeline (see below)
 /understand - Code understanding: map attack surface, trace flows, hunt variants (see below)

--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ Once inside, just say "hi" to get started, or jump straight to a command.
 | `/exploit` | Generate proof-of-concept exploit code | Beta |
 | `/patch` | Generate secure patches for confirmed vulnerabilities | Beta |
 | `/fuzz` | Binary fuzzing with AFL++ and crash analysis | Stable |
+| `/frida` | Dynamic instrumentation: spawn-only function/argument trace and Stalker coverage | Beta |
 | `/crash-analysis` | Autonomous root-cause analysis for C/C++ crashes | Stable |
 | `/oss-forensics` | Evidence-backed forensic investigation for GitHub repositories | Stable |
 | `/project` | Named workspaces to organise runs and track findings over time | Stable |
@@ -349,6 +350,7 @@ Tell Claude which one to use, e.g. "Use the Binary Exploitation Specialist".
 | `docs/PYTHON_CLI.md` | Python CLI reference for scripting and CI |
 | `docs/sca.md` | Software composition analysis reference |
 | `docs/FUZZING_QUICKSTART.md` | Binary fuzzing guide |
+| `docs/DYNAMIC_INSTRUMENTATION_QUICKSTART.md` | Frida dynamic instrumentation guide (/frida) |
 | `docs/ARCHITECTURE.md` | Technical architecture detail |
 | `docs/EXTENDING_LAUNCHER.md` | How to add new capabilities |
 | `docs/DEPENDENCIES.md` | External tools, versions, and licences |

--- a/bin/cve-diff
+++ b/bin/cve-diff
@@ -9,11 +9,23 @@ set -euo pipefail
 
 # Resolve symlinks to find the real script location
 SCRIPT="$0"
+# Hop bound: a bare `while [ -L "$SCRIPT" ]` has no termination guard, so
+# a symlink cycle (A → B → A) in a poisoned ~/bin layout loops forever.
+# 32 matches Linux's MAXSYMLINKS; real layouts rarely exceed 2-3 hops.
+# Mirrors the guard already in libexec/raptor-cc-trust-check.
+_symhops=0
 while [ -L "$SCRIPT" ]; do
+    _symhops=$((_symhops + 1))
+    if [ "$_symhops" -gt 32 ]; then
+        echo "$(basename "$0"): symlink hop limit exceeded resolving $0" >&2
+        echo "  (likely a symlink cycle; refusing to resolve further)" >&2
+        exit 1
+    fi
     DIR="$(cd "$(dirname "$SCRIPT")" && pwd)"
     SCRIPT="$(readlink "$SCRIPT")"
     [[ "$SCRIPT" != /* ]] && SCRIPT="$DIR/$SCRIPT"
 done
+unset _symhops
 RAPTOR_DIR="$(cd "$(dirname "$SCRIPT")/.." && pwd)"
 
 if [ ! -d "$RAPTOR_DIR/core" ]; then

--- a/bin/raptor
+++ b/bin/raptor
@@ -9,11 +9,23 @@ set -euo pipefail
 
 # Resolve symlinks to find the real script location
 SCRIPT="$0"
+# Hop bound: a bare `while [ -L "$SCRIPT" ]` has no termination guard, so
+# a symlink cycle (A → B → A) in a poisoned ~/bin layout loops forever.
+# 32 matches Linux's MAXSYMLINKS; real layouts rarely exceed 2-3 hops.
+# Mirrors the guard already in libexec/raptor-cc-trust-check.
+_symhops=0
 while [ -L "$SCRIPT" ]; do
+    _symhops=$((_symhops + 1))
+    if [ "$_symhops" -gt 32 ]; then
+        echo "$(basename "$0"): symlink hop limit exceeded resolving $0" >&2
+        echo "  (likely a symlink cycle; refusing to resolve further)" >&2
+        exit 1
+    fi
     DIR="$(cd "$(dirname "$SCRIPT")" && pwd)"
     SCRIPT="$(readlink "$SCRIPT")"
     [[ "$SCRIPT" != /* ]] && SCRIPT="$DIR/$SCRIPT"
 done
+unset _symhops
 RAPTOR_DIR="$(cd "$(dirname "$SCRIPT")/.." && pwd)"
 
 if [ ! -d "$RAPTOR_DIR/core" ]; then

--- a/bin/raptor-sca
+++ b/bin/raptor-sca
@@ -19,11 +19,23 @@ set -euo pipefail
 
 # Resolve symlinks to find the real script location
 SCRIPT="$0"
+# Hop bound: a bare `while [ -L "$SCRIPT" ]` has no termination guard, so
+# a symlink cycle (A → B → A) in a poisoned ~/bin layout loops forever.
+# 32 matches Linux's MAXSYMLINKS; real layouts rarely exceed 2-3 hops.
+# Mirrors the guard already in libexec/raptor-cc-trust-check.
+_symhops=0
 while [ -L "$SCRIPT" ]; do
+    _symhops=$((_symhops + 1))
+    if [ "$_symhops" -gt 32 ]; then
+        echo "$(basename "$0"): symlink hop limit exceeded resolving $0" >&2
+        echo "  (likely a symlink cycle; refusing to resolve further)" >&2
+        exit 1
+    fi
     DIR="$(cd "$(dirname "$SCRIPT")" && pwd)"
     SCRIPT="$(readlink "$SCRIPT")"
     [[ "$SCRIPT" != /* ]] && SCRIPT="$DIR/$SCRIPT"
 done
+unset _symhops
 RAPTOR_DIR="$(cd "$(dirname "$SCRIPT")/.." && pwd)"
 
 if [ ! -f "$RAPTOR_DIR/libexec/raptor-sca-run" ]; then

--- a/completions/_raptor.zsh
+++ b/completions/_raptor.zsh
@@ -1,0 +1,58 @@
+#compdef raptor raptor.py
+#
+# Zsh completion for RAPTOR. Install by adding the completions/ dir to your
+# fpath before `compinit`, e.g. in ~/.zshrc:
+#   fpath=(/path/to/raptor/completions $fpath)
+#   autoload -Uz compinit && compinit
+#
+# Mirrors completions/raptor.bash: top-level modes, `project` subcommands,
+# and path/flag completion. Static (no RAPTOR import) so it loads instantly.
+
+_raptor() {
+    local -a modes project_subs
+    modes=(scan sca fuzz web agentic codeql analyze describe doctor help version)
+    project_subs=(create list use none status coverage findings correlate diff
+                  merge report clean export binary annotations notes add remove
+                  rename description import help)
+
+    if (( CURRENT == 2 )); then
+        _describe -t modes 'raptor mode' modes
+        return
+    fi
+
+    case "${words[2]}" in
+        project)
+            if (( CURRENT == 3 )); then
+                _describe -t subcommands 'project subcommand' project_subs
+                return
+            fi
+            ;;
+        help)
+            if (( CURRENT == 3 )); then
+                _describe -t modes 'mode' modes
+                return
+            fi
+            ;;
+    esac
+
+    # Path/flag fallback.
+    case "${words[CURRENT-1]}" in
+        --repo|-r|--out|-o|--binary|-b|--sarif|--target|-t)
+            _files
+            return
+            ;;
+        --sandbox)
+            compadd full debug network-only none
+            return
+            ;;
+    esac
+
+    if [[ "${words[CURRENT]}" == -* ]]; then
+        compadd -- --repo --out --version --help --sandbox --no-sandbox \
+                   --audit --reanalyze --model --max-cost-usd --max-findings
+    else
+        _files
+    fi
+}
+
+_raptor "$@"

--- a/completions/raptor.bash
+++ b/completions/raptor.bash
@@ -1,0 +1,67 @@
+# Bash completion for RAPTOR (the `raptor` / `bin/raptor` launcher).
+#
+# Install:
+#   source /path/to/raptor/completions/raptor.bash
+# or symlink into your bash-completion.d:
+#   ln -s "$PWD/completions/raptor.bash" /etc/bash_completion.d/raptor
+#
+# Covers top-level modes, `project` subcommands, and the most common flags.
+# Path-valued flags (--repo/--out/--binary/--sarif/--url) fall back to file
+# completion. Kept as a static list (no argparse introspection) so it loads
+# instantly and works without importing RAPTOR.
+
+_raptor_complete() {
+    local cur prev words cword
+    _init_completion 2>/dev/null || {
+        cur="${COMP_WORDS[COMP_CWORD]}"
+        prev="${COMP_WORDS[COMP_CWORD-1]}"
+        cword=$COMP_CWORD
+    }
+
+    local modes="scan sca fuzz web agentic codeql analyze describe doctor help version --version --help"
+    local project_subs="create list use none status coverage findings correlate diff merge report clean export binary annotations notes add remove rename description import help"
+
+    # Flags that take a filesystem path → delegate to default file completion.
+    case "$prev" in
+        --repo|-r|--out|-o|--binary|-b|--sarif|--target|-t|--findings|--checklist)
+            COMPREPLY=( $(compgen -f -- "$cur") )
+            return 0
+            ;;
+        --sandbox)
+            COMPREPLY=( $(compgen -W "full debug network-only none" -- "$cur") )
+            return 0
+            ;;
+    esac
+
+    # Top-level mode (first non-flag word after the program name).
+    if [[ $cword -eq 1 ]]; then
+        COMPREPLY=( $(compgen -W "$modes" -- "$cur") )
+        return 0
+    fi
+
+    local mode="${COMP_WORDS[1]}"
+
+    # `raptor project <subcommand>`
+    if [[ "$mode" == "project" && $cword -eq 2 ]]; then
+        COMPREPLY=( $(compgen -W "$project_subs" -- "$cur") )
+        return 0
+    fi
+    if [[ "$mode" == "help" && $cword -eq 2 ]]; then
+        COMPREPLY=( $(compgen -W "$modes" -- "$cur") )
+        return 0
+    fi
+
+    # Common flags for the analysis modes.
+    local common_flags="--repo -r --out -o --version --help --sandbox --no-sandbox --audit --reanalyze --model --max-cost-usd --max-findings"
+    if [[ "$cur" == -* ]]; then
+        COMPREPLY=( $(compgen -W "$common_flags" -- "$cur") )
+        return 0
+    fi
+
+    # Otherwise default to file completion.
+    COMPREPLY=( $(compgen -f -- "$cur") )
+    return 0
+}
+
+complete -F _raptor_complete raptor
+complete -F _raptor_complete raptor.py

--- a/core/build/toolchain.py
+++ b/core/build/toolchain.py
@@ -91,8 +91,10 @@ def detect_JAVA_HOME() -> Optional[str]:
         if os.path.isfile(macos_helper) and os.access(macos_helper, os.X_OK):
             try:
                 import subprocess
+                from core.config import RaptorConfig
                 r = subprocess.run(
                     [macos_helper], capture_output=True, text=True, timeout=5,
+                    env=RaptorConfig.get_safe_env(),
                 )
                 if r.returncode == 0 and r.stdout.strip():
                     candidate = r.stdout.strip()
@@ -176,9 +178,18 @@ def detect_RUSTUP_HOME() -> Optional[str]:
     if rustup_bin:
         try:
             import subprocess
+            from core.config import RaptorConfig
+            # Safe env strips exec-hijack vars (LD_PRELOAD, DYLD_*, …) but
+            # also drops RUSTUP_HOME; preserve the operator's own
+            # RUSTUP_HOME so `rustup show home` still reports a custom
+            # toolchain location rather than silently defaulting to ~/.rustup.
+            _env = RaptorConfig.get_safe_env()
+            if os.environ.get("RUSTUP_HOME"):
+                _env["RUSTUP_HOME"] = os.environ["RUSTUP_HOME"]
             r = subprocess.run(
                 [rustup_bin, "show", "home"],
                 capture_output=True, text=True, timeout=5,
+                env=_env,
             )
             if r.returncode == 0 and r.stdout.strip():
                 candidate = r.stdout.strip()

--- a/core/config/__init__.py
+++ b/core/config/__init__.py
@@ -103,6 +103,7 @@ class RaptorConfig:
         # /agentic"), not internal subsystem axes. ``source_intel`` /
         # ``verdict-active`` mean nothing to an operator reading /doctor.
         "coccinelle":   {"binary": "spatch",    "severity": "degrades", "affects": "/codeql, /agentic (C/C++ semantic-patch verification)"},
+        "frida":        {"binary": "frida",     "severity": "degrades", "affects": "/frida (dynamic instrumentation: trace, coverage)"},
         "gdb":          {"binary": "gdb",       "severity": "required", "affects": "/crash-analysis, /fuzz"},
         "rr":           {"binary": "rr",        "severity": "degrades", "affects": "/crash-analysis"},
         "semgrep":      {"binary": "semgrep",   "group": "scanner",     "affects": "/scan, /agentic"},

--- a/core/coverage/importer.py
+++ b/core/coverage/importer.py
@@ -505,11 +505,24 @@ def mark_runtime(
 def import_runtime(
     store: CoverageStore, path, checklist: Dict[str, Any],
     fmt: Optional[str] = None, tool: Optional[str] = None,
+    binary: Optional[str] = None,
 ) -> int:
-    """Import external runtime coverage (gcov / lcov / coverage.py) into the
-    store (Phase 4). Detects the format (unless ``fmt`` given), parses executed
-    source lines, and marks them under the runtime ``tool`` label. Returns
-    marks made."""
+    """Import external runtime coverage into the store (Phase 4). Detects the
+    format (unless ``fmt`` given), parses executed source lines, and marks them
+    under the runtime ``tool`` label. Returns marks made.
+
+    Source-level formats (gcov / lcov / coverage.py) resolve directly. The
+    binary format ``drcov`` (DynamoRIO / Frida / AFL-QEMU) is address-based and
+    needs ``binary`` for DWARF resolution - it routes through ``import_drcov``
+    rather than the source parsers."""
+    if fmt == "drcov":
+        if not binary:
+            raise ValueError(
+                "import_runtime: --format drcov requires --binary for DWARF "
+                "address resolution")
+        from .collect import import_drcov
+        return import_drcov(store, path, binary, checklist, tool=tool or "drcov")
+
     from .parsers import default_tool, detect_format, parse
 
     fmt = fmt or detect_format(path)

--- a/core/inventory/_reach_cache.py
+++ b/core/inventory/_reach_cache.py
@@ -93,9 +93,10 @@ _CACHE_DIR = Path.home() / ".cache" / "raptor" / "reachability"
 # A short header sentinel prefixed to each pickle. Lets us version-
 # bump the on-disk format without colliding with a stale pickle of
 # the same name. Also doubles as a cheap "is this a raptor cache
-# file" check before handing bytes to ``pickle.load``. The numeric
-# suffix tracks ``_CACHE_VERSION``.
-_HEADER_MAGIC = b"RAPTOR-REACHABILITY-CACHE-V5\n"
+# file" check before handing bytes to ``pickle.load``. Derived from
+# ``_CACHE_VERSION`` so the documented "numeric suffix tracks
+# _CACHE_VERSION" invariant can't silently drift.
+_HEADER_MAGIC = f"RAPTOR-REACHABILITY-CACHE-V{_CACHE_VERSION}\n".encode()
 
 # Hard cap on cache-file size. A genuine reachability index for a
 # kernel-scale target weighs in the low MB; anything past this is

--- a/core/inventory/binary_oracle.py
+++ b/core/inventory/binary_oracle.py
@@ -33,9 +33,11 @@ classifier is the consumer-facing contract, not the parsing details.
 from __future__ import annotations
 
 import logging
+import os
 import re
 import shutil
 import subprocess
+import tempfile
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -44,6 +46,26 @@ from typing import (
 )
 
 logger = logging.getLogger(__name__)
+
+# Warn at most once per process when namespace isolation is unavailable and
+# the binutils parsers fall back to the rlimits-only (run_trusted) path.
+_warned_no_sandbox = False
+
+
+def _argv_target_dir(argv: List[str]) -> Optional[str]:
+    """Directory of the ELF being parsed - the last argv element that is an
+    existing file (binutils takes the binary as a positional). Used as the
+    sandbox ``target`` so the tool can read the binary while Landlock denies
+    everything else (``$HOME``, credentials, the rest of the tree). Returns
+    ``None`` when no path-like argument exists (e.g. ``c++filt`` reading
+    stdin), in which case the caller keeps the trusted rlimits-only path."""
+    for tok in reversed(argv[1:]):
+        try:
+            if Path(tok).is_file():
+                return str(Path(tok).parent)
+        except (OSError, ValueError):
+            continue
+    return None
 
 
 Classification = Literal["symbol_present", "inlined", "absent", "folded"]
@@ -90,19 +112,44 @@ def _run(argv: List[str], timeout: int = 60) -> str:
     """Capture stdout from a system tool; return ``''`` on any failure
     rather than raise — the classifier is best-effort and surface-only.
 
-    Uses ``core.sandbox.run_trusted`` (matches the existing pattern for
-    ELF/binutils tools in ``exploit_feasibility``/``binary_analysis``):
-    applies ``RaptorConfig.get_safe_env()`` + resource rlimits to keep
-    the tool's ambient state hostile-input-resistant. Read-only tools
-    (readelf, nm, objdump, c++filt) are RAPTOR-picked even when the
-    binary path is operator-supplied.
+    When the argv names a target binary (readelf/nm/objdump on a file)
+    the *content* is attacker-controlled even though RAPTOR picked the
+    tool - binutils/libbfd have a long RCE-on-malformed-input history.
+    Those calls run with ``block_network=True`` (network-namespace
+    isolation), so a code-exec in the parser cannot phone home or
+    exfiltrate over the network - the highest-value mitigation that is
+    reliably available. (Filesystem read-restriction needs Landlock,
+    which is host-dependent and, where the mount namespace can't be set
+    up, breaks the parser entirely; network isolation is robust and is
+    what we depend on here.) When no path argument exists (``c++filt``
+    reading stdin) the rlimits-only ``run_trusted`` path is kept. If
+    unprivileged user namespaces are unavailable, ``run`` raises
+    ``SandboxSetupError`` and we fall back to ``run_trusted`` (warning
+    once) rather than disabling the oracle.
     """
+    global _warned_no_sandbox
     # Lazy import — keep the classifier independently importable in
     # unit tests that stub the sandbox module.
-    from core.sandbox import run_trusted
+    from core.sandbox import run, run_trusted, SandboxSetupError
+    target_dir = _argv_target_dir(argv)
     try:
-        proc = run_trusted(argv, capture_output=True, text=True,
-                           check=False, timeout=timeout)
+        if target_dir is not None:
+            try:
+                proc = run(argv, block_network=True, capture_output=True,
+                           text=True, check=False, timeout=timeout)
+            except SandboxSetupError as e:
+                if not _warned_no_sandbox:
+                    _warned_no_sandbox = True
+                    logger.warning(
+                        "binary_oracle: namespace sandbox unavailable (%s); "
+                        "binutils parsers run with rlimits only - untrusted "
+                        "ELF parsing is not network-isolated on this host", e,
+                    )
+                proc = run_trusted(argv, capture_output=True, text=True,
+                                   check=False, timeout=timeout)
+        else:
+            proc = run_trusted(argv, capture_output=True, text=True,
+                               check=False, timeout=timeout)
     except (OSError, subprocess.TimeoutExpired) as e:
         logger.debug("binary_oracle: %s failed: %s", argv[0], e)
         return ""
@@ -118,15 +165,50 @@ def _stream(argv: List[str], timeout: int) -> Iterator[str]:
     binary produces 1-3 GB of text); ``_run`` would buffer it all into
     memory and OOM. Yields each line stripped of its trailing newline.
 
-    Manual ``get_safe_env`` application — ``run_trusted`` is one-shot
-    (capture_output=True) and would defeat the memory-bounded streaming
-    we need here. Same env hygiene as ``_run`` (no namespace/Landlock —
-    that's the ``run_trusted`` protection level: env + rlimits only).
+    When the argv names a target binary, the parser (objdump --dwarf on
+    an attacker-controlled ELF - a real libbfd RCE surface) runs with
+    ``block_network=True`` and its stdout redirected to a temp file,
+    which is then stream-read. This keeps memory bounded (disk-backed,
+    not buffered) AND adds network-namespace isolation so a code-exec in
+    the parser cannot exfiltrate over the network. (No mount-ns/Landlock
+    here - that path is host-fragile and would break the parser; network
+    isolation is the robust mitigation.) If user namespaces are
+    unavailable the call falls back to the prior rlimits-only streaming
+    ``Popen``.
 
     On any failure (tool missing, non-zero rc with no output, timeout)
     yields nothing — same swallow-and-degrade contract as ``_run``.
     """
+    global _warned_no_sandbox
     from core.config import RaptorConfig
+    target_dir = _argv_target_dir(argv)
+    if target_dir is not None:
+        from core.sandbox import run, SandboxSetupError
+        try:
+            with tempfile.TemporaryDirectory(prefix="raptor-bo-dwarf-") as td:
+                dump = os.path.join(td, "dump.txt")
+                with open(dump, "wb") as fh:
+                    # The already-open fd is inherited across exec; stdout
+                    # of the sandboxed child writes to our temp file.
+                    run(argv, block_network=True, check=False,
+                        timeout=timeout, stdout=fh,
+                        stderr=subprocess.DEVNULL)
+                with open(dump, "r", errors="replace") as fh:
+                    for line in fh:
+                        yield line.rstrip("\n")
+            return
+        except SandboxSetupError as e:
+            if not _warned_no_sandbox:
+                _warned_no_sandbox = True
+                logger.warning(
+                    "binary_oracle: namespace sandbox unavailable (%s); "
+                    "objdump runs with rlimits only - untrusted ELF parsing "
+                    "is not network-isolated on this host", e,
+                )
+            # fall through to the rlimits-only streaming path
+        except (OSError, subprocess.TimeoutExpired) as e:
+            logger.debug("binary_oracle: %s failed: %s", argv[0], e)
+            return
     deadline = time.monotonic() + timeout
     try:
         proc = subprocess.Popen(
@@ -615,6 +697,13 @@ def _parse_dwarf(binary_path: Path) -> Tuple[Dict[int, _SubprogramDIE], List[int
                 if not cur_die.name:
                     cur_die.name = linkage
             elif attr == "low_pc":
+                # A bare "DW_AT_low_pc : 0" (no 0x prefix) is left unparsed
+                # on purpose. In a linked binary (the only input this oracle
+                # parses) a zero low_pc means the function was garbage-
+                # collected (--gc-sections), i.e. genuinely absent; parsing
+                # it as a real address would flip a GC'd function to
+                # symbol_present. A real function at address 0 only occurs
+                # in relocatable .o files, out of scope here.
                 ma2 = addr_re.search(value)
                 if ma2:
                     cur_die.low_pc = int(ma2.group(1), 16)
@@ -1122,10 +1211,18 @@ def enrich_inventory_with_binary_oracle(
         # downgrade is the safety net) and only on projects wide
         # enough for the floor to be meaningful.
         any_full = any(w.tier == "full" for w in verdicts.values())
-        if (any_full
-                and n_project >= SRC_FLOOR_MIN_PROJECT_NAMES
-                and (matched < SRC_COVERAGE_MIN_MATCHED
-                     or ratio < SRC_COVERAGE_FLOOR)):
+        # Absolute floor at any project size: a wrong / planted binary
+        # unrelated to this source tree matches zero project names, so
+        # require at least one match even on a 1-7 function module. Only
+        # matched >= 1 (not the full count) so a legit small binary with
+        # some genuinely-dead functions isn't over-dropped. The stronger
+        # ratio + min-3 floor still applies once the project is wide enough
+        # for the percentage to carry signal.
+        ratio_floor_active = n_project >= SRC_FLOOR_MIN_PROJECT_NAMES
+        floor = (SRC_COVERAGE_MIN_MATCHED if ratio_floor_active else 1)
+        if any_full and n_project > 0 and (
+                matched < floor
+                or (ratio_floor_active and ratio < SRC_COVERAGE_FLOOR)):
             logger.warning(
                 "binary_oracle: dropping %s — only %d of %d project source "
                 "names matched (%.1f%%, floor %.0f%% / min %d). Likely the "
@@ -1133,7 +1230,7 @@ def enrich_inventory_with_binary_oracle(
                 "vendored test binary, or planted ELF). Pass --binary "
                 "explicitly to override.",
                 bp.name, matched, n_project, ratio * 100,
-                SRC_COVERAGE_FLOOR * 100, SRC_COVERAGE_MIN_MATCHED,
+                SRC_COVERAGE_FLOOR * 100, floor,
             )
             continue
         kept.append((bp, build_id, verdicts))

--- a/core/inventory/reach_audit.py
+++ b/core/inventory/reach_audit.py
@@ -71,6 +71,16 @@ def _stage_binary_oracle_absent(ctx: "_ClassifyCtx", R) -> Optional[str]:
     if R.binary_oracle_absent(
         ctx.inventory, ctx.file_path, ctx.name, ctx.line,
     ):
+        # Affirmative reachability evidence beats a name-lookup "absent":
+        # an incoming direct call edge proves the function exists and is
+        # called, so the name-based absent verdict (which can miss a
+        # function under a C++ demangling / ICF spelling mismatch) must not
+        # hard-suppress it. _stage_binary_call_edge runs later in
+        # PRECEDENCE, so check it here before suppressing.
+        if R.binary_call_edge_present(
+            ctx.inventory, ctx.file_path, ctx.name, ctx.line,
+        ):
+            return None
         return "binary_oracle_absent"
     return None
 

--- a/core/inventory/reachability.py
+++ b/core/inventory/reachability.py
@@ -2474,9 +2474,12 @@ def binary_oracle_absent(
                 enclosing,
                 key=lambda it: int(it.get("line_start") or 0),
             )]
-        else:
-            candidates = candidates[:1]
-    for item in candidates:
+        # else: line provided but matched no enclosing range - fall
+        # through and require unanimity below rather than picking the
+        # first item (a dead namesake at index 0 must not suppress a
+        # live overload).
+
+    def _item_absent(item: Dict[str, Any]) -> bool:
         meta = item.get("metadata")
         if not isinstance(meta, dict):
             return False
@@ -2499,7 +2502,13 @@ def binary_oracle_absent(
                for b in per_binary):
             return False
         return True
-    return False
+
+    # When we could NOT disambiguate to a single candidate (line==0, or
+    # a line that matched no enclosing range), require UNANIMITY: suppress
+    # only if EVERY same-name candidate is independently absent. Deciding
+    # on candidates[0] alone let a dead namesake suppress a live overload
+    # when the finding carried no line (adversarial review P0-C-3).
+    return all(_item_absent(it) for it in candidates)
 
 
 def is_lexically_dead(

--- a/core/llm/client.py
+++ b/core/llm/client.py
@@ -145,6 +145,11 @@ def _sanitize_log_message(msg: str) -> str:
         msg,
         flags=re.IGNORECASE,
     )
+    # Patterns above redact secrets but preserve hostnames/IPs; a raw
+    # connection error embeds the remote Ollama host:port, so mask it here
+    # (CLAUDE.md: never disclose the remote OLLAMA server location).
+    from core.security.redaction import mask_ollama_endpoint
+    msg = mask_ollama_endpoint(msg)
     return msg
 
 
@@ -211,7 +216,9 @@ def _is_quota_error(error: Exception) -> bool:
 
     error_str = str(error).lower()
     return any([
-        "429" in error_str,
+        # \b so a model id / echoed prompt containing "4290" or "x429"
+        # doesn't read as an HTTP 429.
+        bool(re.search(r"\b429\b", error_str)),
         "quota exceeded" in error_str,
         "quota" in error_str and "exceeded" in error_str,
         "rate limit" in error_str,
@@ -226,22 +233,37 @@ def _is_retryable_error(error: Exception) -> bool:
     Non-retryable: schema validation, auth errors (401/403), bad request (400),
     Instructor failures, Pydantic validation errors.
     """
+    error_type = type(error).__name__
+
+    # Definitive non-retryable SDK exception types win before any
+    # body-substring matching. A 400/401/403/404/422 must not be flipped
+    # to retryable just because its echoed-back body (e.g. a quoted prompt
+    # or model id) contains "rate limit" / "429" / "timeout".
+    non_retryable_types = ("BadRequestError", "AuthenticationError",
+                           "PermissionDeniedError", "NotFoundError",
+                           "UnprocessableEntityError", "ValidationError")
+    if any(t in error_type for t in non_retryable_types):
+        return False
+
     # Rate limits are retryable (with backoff)
     if _is_quota_error(error):
         return True
 
     # Check exception types
-    error_type = type(error).__name__
     retryable_types = ("Timeout", "ConnectionError", "APIConnectionError",
                        "InternalServerError", "ServiceUnavailableError")
     if any(t in error_type for t in retryable_types):
         return True
 
-    # Check error message for retryable patterns
+    # Check error message for retryable patterns. Numeric status codes use
+    # \b so they match "HTTP 503" / "status 503" but not a "5031" build id
+    # or a port number echoed in the body.
     error_str = str(error).lower()
-    retryable_patterns = ("timeout", "connection", "502", "503", "504",
+    retryable_patterns = ("timeout", "connection",
                           "internal server error", "service unavailable")
     if any(p in error_str for p in retryable_patterns):
+        return True
+    if re.search(r"\b50[234]\b", error_str):
         return True
 
     # Everything else is non-retryable (schema errors, 400, 401, 403, 404,
@@ -1426,8 +1448,13 @@ class LLMClient:
                         )
                         from core.security.redaction import (
                             redact_secrets as _redact,
+                            mask_ollama_endpoint as _mask_ollama,
                         )
-                        _safe_e = _esc_np(_redact(str(e)))[:1024]
+                        # redact_secrets preserves hostnames, so for the
+                        # Ollama tier mask the remote host/IP that would
+                        # otherwise survive in the connection error (no-op
+                        # for cloud providers / loopback Ollama).
+                        _safe_e = _esc_np(_mask_ollama(_redact(str(e))))[:1024]
                         logger.warning(
                             f"Attempt {attempt + 1}/{self.config.max_retries} "
                             f"failed for {model.provider}/{model.model_name}: "
@@ -1726,8 +1753,13 @@ class LLMClient:
                         )
                         from core.security.redaction import (
                             redact_secrets as _redact,
+                            mask_ollama_endpoint as _mask_ollama,
                         )
-                        _safe_e = _esc_np(_redact(str(e)))[:1024]
+                        # redact_secrets preserves hostnames, so for the
+                        # Ollama tier mask the remote host/IP that would
+                        # otherwise survive in the connection error (no-op
+                        # for cloud providers / loopback Ollama).
+                        _safe_e = _esc_np(_mask_ollama(_redact(str(e))))[:1024]
                         logger.warning(
                             f"Structured generation attempt {attempt + 1} "
                             f"failed: {_safe_e}"

--- a/core/llm/detection.py
+++ b/core/llm/detection.py
@@ -110,8 +110,12 @@ def _get_available_ollama_models() -> List[str]:
             _cached_ollama_models = [model['name'] for model in data.get('models', [])]
             return _cached_ollama_models
     except Exception as e:
+        from core.security.redaction import mask_ollama_endpoint
         ollama_display = RaptorConfig.OLLAMA_HOST if 'localhost' in RaptorConfig.OLLAMA_HOST or '127.0.0.1' in RaptorConfig.OLLAMA_HOST else '[REMOTE-OLLAMA]'
-        logger.debug(f"Could not connect to Ollama at {ollama_display}: {e}")
+        # The raw exception embeds the real remote host:port (e.g.
+        # HTTPConnectionPool(host='10.x.x.x', port=11434)), which would
+        # defeat the ollama_display mask on the same line - scrub it.
+        logger.debug(f"Could not connect to Ollama at {ollama_display}: {mask_ollama_endpoint(e)}")
     _cached_ollama_models = []
     return []
 

--- a/core/llm/egress.py
+++ b/core/llm/egress.py
@@ -244,9 +244,13 @@ def enable_llm_egress(config: "LLMConfig") -> None:
     os.environ["no_proxy"] = new_no_proxy
 
     _enabled = True
+    # The allowlist may contain the remote Ollama host - mask it (CLAUDE.md)
+    # while leaving non-secret cloud hosts (api.anthropic.com, etc.) visible.
+    from core.security.redaction import mask_ollama_endpoint
+    _allowlist_display = mask_ollama_endpoint(", ".join(sorted(remote_hosts)))
     logger.debug(
-        "LLM egress enabled: HTTPS_PROXY=127.0.0.1:%d, allowlist=%s",
-        proxy.port, sorted(remote_hosts),
+        "LLM egress enabled: HTTPS_PROXY=127.0.0.1:%d, allowlist=[%s]",
+        proxy.port, _allowlist_display,
     )
 
 

--- a/core/project/cli.py
+++ b/core/project/cli.py
@@ -137,6 +137,31 @@ def _emit_json_payload(payload) -> None:
     sys.stdout.buffer.write(b"\n")
 
 
+def _nonneg_int(value):
+    """argparse type: a non-negative int. Rejects negatives (and non-ints)
+    with a usage error (exit 2) rather than silently accepting a value that
+    would delete more runs than intended."""
+    try:
+        n = int(value)
+    except (TypeError, ValueError):
+        raise argparse.ArgumentTypeError(f"expected an integer, got {value!r}")
+    if n < 0:
+        raise argparse.ArgumentTypeError(f"must be >= 0, got {n}")
+    return n
+
+
+def _pct_float(value):
+    """argparse type: a percentage in [0, 100]. A threshold outside that
+    range can never be met (or is trivially met), so reject it up front."""
+    try:
+        f = float(value)
+    except (TypeError, ValueError):
+        raise argparse.ArgumentTypeError(f"expected a number, got {value!r}")
+    if not (0.0 <= f <= 100.0):
+        raise argparse.ArgumentTypeError(f"must be between 0 and 100, got {f}")
+    return f
+
+
 def _detect_target_type(target_path: str):
     """Best-effort catalog detection for project-create. Returns
     a ``CatalogEntry`` or None — substrate failures (catalog
@@ -306,24 +331,28 @@ def main():
 
     # status
     p_status = sub.add_parser("status", help="Show project summary",
-                              usage="raptor project status [<name>]", **_F)
+                              usage="raptor project status [<name>] [--json]", **_F)
     p_status.add_argument("name", nargs="?", help="Project name")
+    p_status.add_argument("--json", action="store_true",
+                          help="Emit a machine-readable report (for CI parsing)")
 
     # coverage
     p_cov = sub.add_parser(
         "coverage",
         help="Show coverage summary",
-        usage="raptor project coverage [<name>] [--detailed] [--fail-under <pct>]",
+        usage="raptor project coverage [<name>] [--detailed] [--fail-under <pct>] [--json]",
         **_F,
     )
     p_cov.add_argument("name", nargs="?", help="Project name")
     p_cov.add_argument("--detailed", action="store_true", help="Per-file breakdown")
     p_cov.add_argument(
         "--fail-under",
-        type=float,
+        type=_pct_float,
         metavar="<pct>",
-        help="Exit non-zero unless LLM item coverage is at least this percentage",
+        help="Exit non-zero unless LLM item coverage is at least this percentage (0-100)",
     )
+    p_cov.add_argument("--json", action="store_true",
+                       help="Emit a machine-readable report (for CI parsing)")
 
     # provenance
     p_prov = sub.add_parser(
@@ -341,14 +370,16 @@ def main():
         usage="raptor project show <run> [<name>]",
         **_F,
     )
-    p_show.add_argument("run", help="Run directory name (or unique substring)")
+    p_show.add_argument("run", help="Run directory name, unique substring, or 'last'/'latest'")
     p_show.add_argument("name", nargs="?", help="Project name")
 
     # findings
     p_findings = sub.add_parser("findings", help="Show merged findings across all runs",
-                                usage="raptor project findings [<name>] [--detailed]", **_F)
+                                usage="raptor project findings [<name>] [--detailed] [--json]", **_F)
     p_findings.add_argument("name", nargs="?", help="Project name")
     p_findings.add_argument("--detailed", action="store_true", help="Per-finding detail (reasoning, proof, PoC)")
+    p_findings.add_argument("--json", action="store_true",
+                            help="Emit a machine-readable report (for CI parsing)")
 
     # annotations
     p_anns = sub.add_parser(
@@ -430,7 +461,7 @@ def main():
     p_remove = sub.add_parser("remove", help="Move a run out of the project",
                               usage="raptor project remove <name> <run> --to <path>", **_F)
     p_remove.add_argument("name", help="Project name")
-    p_remove.add_argument("run", help="Run directory name")
+    p_remove.add_argument("run", help="Run: dir name, unique substring, or 'last'/'latest'")
     p_remove.add_argument("--to", required=True, metavar="<path>", help="Destination path")
 
     # report
@@ -446,16 +477,16 @@ def main():
               "[--name <project>]",
         **_F,
     )
-    p_anndiff.add_argument("run_a", help="First run dir or run name")
-    p_anndiff.add_argument("run_b", help="Second run dir or run name")
+    p_anndiff.add_argument("run_a", help="First run: dir name, unique substring, or 'last'/'latest'")
+    p_anndiff.add_argument("run_b", help="Second run: dir name, unique substring, or 'last'/'latest'")
     p_anndiff.add_argument("--name", help="Project name (default: active)")
 
     # diff
     p_diff = sub.add_parser("diff", help="Compare findings between two runs",
                             usage="raptor project diff <name> <run1> <run2>", **_F)
     p_diff.add_argument("name", help="Project name")
-    p_diff.add_argument("run1", help="Baseline run")
-    p_diff.add_argument("run2", help="Comparison run")
+    p_diff.add_argument("run1", help="Baseline run: dir name, unique substring, or 'last'/'latest'")
+    p_diff.add_argument("run2", help="Comparison run: dir name, unique substring, or 'last'/'latest'")
 
     # merge
     p_merge = sub.add_parser("merge", help="Merge runs per command type (destructive)",
@@ -468,9 +499,9 @@ def main():
     p_clean = sub.add_parser("clean", help="Delete old runs, keep latest n",
                              usage="raptor project clean [<name>] [--keep <n>] [--dedup] [--dry-run] [--yes]", **_F)
     p_clean.add_argument("name", nargs="?", help="Project name")
-    p_clean.add_argument("--keep", type=int, default=1, metavar="<n>",
+    p_clean.add_argument("--keep", type=_nonneg_int, default=1, metavar="<n>",
                          help="Runs to keep per type (default: 1; 0 keeps only "
-                              "the newest — the last run is never deleted)")
+                              "the newest - the last run is never deleted)")
     p_clean.add_argument("--dedup", action="store_true",
                          help="Coverage-aware: drop only runs fully subsumed by a survivor "
                               "(provably lossless), ignoring --keep")
@@ -653,7 +684,10 @@ def main():
             if not p:
                 print(f"Project '{name}' not found.")
                 return
-            _print_status(p)
+            if getattr(args, "json", False):
+                _emit_json_payload(_status_payload(p))
+            else:
+                _print_status(p)
 
         elif args.subcommand == "coverage":
             name = args.name or _get_active_project()
@@ -664,9 +698,15 @@ def main():
             if not p:
                 print(f"Project '{name}' not found.")
                 return
-            result = _print_coverage(p, detailed=args.detailed, fail_under=args.fail_under)
-            if result is False:
-                sys.exit(1)
+            if getattr(args, "json", False):
+                payload, met = _coverage_payload(p, fail_under=args.fail_under)
+                _emit_json_payload(payload)
+                if met is False:
+                    sys.exit(1)
+            else:
+                result = _print_coverage(p, detailed=args.detailed, fail_under=args.fail_under)
+                if result is False:
+                    sys.exit(1)
 
         elif args.subcommand == "provenance":
             name = args.name or _get_active_project()
@@ -699,7 +739,10 @@ def main():
             if not p:
                 print(f"Project '{name}' not found.")
                 return
-            _print_findings(p, detailed=args.detailed)
+            if getattr(args, "json", False):
+                _emit_json_payload(_findings_payload(p))
+            else:
+                _print_findings(p, detailed=args.detailed)
 
         elif args.subcommand == "annotations":
             name = args.name or _get_active_project()
@@ -877,6 +920,25 @@ def main():
                         file=sys.stderr,
                     )
                     return
+                # The basename allowlist alone does NOT close the vector the
+                # comment above describes: `EDITOR='vim -c ":!cmd"'` has an
+                # allowlisted argv[0] but vim's -c executes the command. Allow
+                # only -w/--wait (the common GUI-editor "block until closed"
+                # flag for code/subl); reject any other extra argument, which
+                # for vim (-c/--cmd/-S/+), emacs (--eval/-f/-l) and friends
+                # can run arbitrary commands.
+                _SAFE_EDITOR_FLAGS = {"-w", "--wait"}
+                _extra = [a for a in editor_argv[1:] if a not in _SAFE_EDITOR_FLAGS]
+                if _extra:
+                    print(
+                        f"Refusing to launch editor: $EDITOR carries "
+                        f"arguments {_extra!r} beyond -w/--wait. Flags like "
+                        "vim -c / emacs --eval can execute arbitrary commands; "
+                        "set $EDITOR to a bare editor name (optionally with "
+                        "-w/--wait) and try again.",
+                        file=sys.stderr,
+                    )
+                    return
                 # Capture tf_path BEFORE tf.write so a failing write (disk
                 # full, etc.) still leaves tf_path set and the finally can
                 # unlink the stub. Keep tempfile creation inside the try so
@@ -933,8 +995,15 @@ def main():
                 print(f"No new runs added (already present or none found in {args.directory})")
 
         elif args.subcommand == "remove":
-            mgr.remove_run(args.name, args.run, to_path=args.to)
-            print(f"Removed '{args.run}' from project '{args.name}'")
+            p = mgr.load(args.name)
+            if not p:
+                print(f"Project '{args.name}' not found.")
+                return
+            d = _resolve_run(p, args.run)
+            if d is None:
+                return
+            mgr.remove_run(args.name, d.name, to_path=args.to)
+            print(f"Removed '{d.name}' from project '{args.name}'")
 
         elif args.subcommand == "correlate":
             name = args.name or _get_active_project()
@@ -953,16 +1022,14 @@ def main():
             if not p:
                 print(f"Project '{args.name}' not found.")
                 return
-            dir1 = p.output_path / args.run1
-            dir2 = p.output_path / args.run2
-            if not dir1.exists():
-                print(f"Run not found: {args.run1}")
+            dir1 = _resolve_run(p, args.run1)
+            if dir1 is None:
                 return
-            if not dir2.exists():
-                print(f"Run not found: {args.run2}")
+            dir2 = _resolve_run(p, args.run2)
+            if dir2 is None:
                 return
             result = diff_runs(dir1, dir2)
-            print(f"Diff: {args.run1} (baseline) → {args.run2}")
+            print(f"Diff: {dir1.name} (baseline) -> {dir2.name}")
             _print_diff(result)
 
         elif args.subcommand == "annotations-diff":
@@ -975,13 +1042,11 @@ def main():
             if not p:
                 print(f"Project '{name}' not found.")
                 return
-            dir1 = p.output_path / args.run_a
-            dir2 = p.output_path / args.run_b
-            if not dir1.exists():
-                print(f"Run not found: {args.run_a}")
+            dir1 = _resolve_run(p, args.run_a)
+            if dir1 is None:
                 return
-            if not dir2.exists():
-                print(f"Run not found: {args.run_b}")
+            dir2 = _resolve_run(p, args.run_b)
+            if dir2 is None:
                 return
             result = diff_annotations(dir1, dir2)
             print(format_diff(result), end="")
@@ -1374,6 +1439,116 @@ def _handle_threat_model(mgr, args) -> None:
         print(f"  - {item}")
 
 
+def _status_payload(project):
+    """Machine-readable counterpart of :func:`_print_status` - the same facts
+    (identity, threat-model presence, per-run metadata, disk usage) as a
+    JSON-serializable dict."""
+    from core.run import load_run_metadata
+    from core.run.provenance import format_repro_short, format_sha_short
+    from core.threat_model import (
+        _project_threat_model_json_path,
+        load_model,
+        project_threat_model_paths,
+    )
+
+    tm_path = _project_threat_model_json_path(project) or (
+        project_threat_model_paths(project)[0]
+    )
+    tm = None
+    if tm_path.exists():
+        model = load_model(tm_path)
+        tm = {"path": str(tm_path),
+              "focus_areas": len(model.focus_areas) if model else 0}
+
+    runs = project.get_run_dirs(sweep=False)
+    run_records = []
+    total_size = 0
+    import stat as _stat
+    for d in runs:
+        meta = load_run_metadata(d) or {}
+        manifest = meta.get("manifest")
+        run_records.append({
+            "name": d.name,
+            "command": meta.get("command", "?"),
+            "status": meta.get("status", "?"),
+            "summary": _get_output_summary(d, meta),
+            "sha": format_sha_short(manifest) or None,
+            "repro": format_repro_short(manifest) or None,
+        })
+        for root, _dirs, files in os.walk(d, followlinks=False):
+            for fname in files:
+                try:
+                    st = os.lstat(os.path.join(root, fname))
+                except OSError:
+                    continue
+                if _stat.S_ISREG(st.st_mode):
+                    total_size += st.st_size
+
+    return {
+        "name": project.name,
+        "description": project.description or None,
+        "target": project.target,
+        "output_dir": str(project.output_dir),
+        "created": project.created or None,
+        "notes": project.notes or None,
+        "threat_model": tm,
+        "run_count": len(runs),
+        "runs": run_records,
+        "disk_bytes": total_size,
+    }
+
+
+def _findings_payload(project):
+    """Machine-readable merged findings: code findings and SCA findings as
+    JSON-serializable lists (the same data :func:`_print_findings` renders)."""
+    from .merge import merge_findings
+    from .findings_utils import merge_sca_findings
+
+    run_dirs = project.get_run_dirs(sweep=False)
+    return {
+        "name": project.name,
+        "findings": merge_findings(run_dirs),
+        "sca_findings": merge_sca_findings(run_dirs),
+    }
+
+
+def _coverage_payload(project, fail_under=None):
+    """Machine-readable coverage: the store-backed view, plus the threshold
+    result when --fail-under is set. Returns (payload, met) where met is
+    True/False/None (None = no threshold requested)."""
+    from core.json import load_json
+    from core.coverage.store_summary import (
+        coverage_view,
+        store_coverage_threshold_met,
+    )
+
+    base = Path(project.output_dir)
+    try:
+        run_dirs = list(project.get_run_dirs(sweep=False))
+    except Exception:
+        run_dirs = []
+    checklist = load_json(base / "checklist.json")
+    if not checklist:
+        for d in run_dirs:
+            cl = load_json(d / "checklist.json")
+            if cl:
+                checklist = cl
+                break
+    view = coverage_view(run_dirs, checklist, base / "coverage.json",
+                         base / "annotations")
+    payload = {"name": project.name, "coverage": view}
+    met = None
+    if fail_under is not None:
+        if view is None:
+            payload["threshold"] = {"fail_under": fail_under, "met": False,
+                                    "reason": "no function inventory"}
+            met = False
+        else:
+            met = store_coverage_threshold_met(view, fail_under)
+            payload["threshold"] = {"fail_under": fail_under, "met": bool(met)}
+    return payload, met
+
+
 def _print_status(project):
     """Print project status."""
     from core.run import load_run_metadata
@@ -1457,6 +1632,12 @@ def _print_status(project):
         else:
             print(f"\nDisk usage: {total_size}B")
 
+        # Surface the drill-in verbs here: a run table alone doesn't tell a
+        # new operator what to do next.
+        print("\nTip: 'raptor project show <run>' (or 'last') for run detail, "
+              "'raptor project findings' for merged findings, "
+              "'raptor project coverage' for tool coverage.")
+
     else:
         print("\nNo runs.")
 
@@ -1472,25 +1653,39 @@ def _print_provenance(project):
     print(format_provenance_rollup(aggregate_provenance(metadatas)))
 
 
-def _print_run_provenance(project, run_query):
-    """Print one run's provenance detail. ``run_query`` matches a run dir by
-    exact name, else by unique substring."""
-    from core.run import load_run_metadata
-    from core.run.provenance import format_manifest_block
-
+def _resolve_run(project, run_query):
+    """Resolve a run-dir query to a single run Path. Accepts an exact dir
+    name, a unique substring, or 'last'/'latest' (most recent by mtime).
+    Returns the Path, or None after printing a diagnostic (no runs / not
+    found / ambiguous) so callers can just `return` on None."""
     runs = project.get_run_dirs(sweep=False)
+    if run_query in ("last", "latest"):
+        if not runs:
+            print(f"No runs in project '{project.name}'.")
+            return None
+        return max(runs, key=lambda p: p.stat().st_mtime)
     exact = [d for d in runs if d.name == run_query]
     matches = exact or [d for d in runs if run_query in d.name]
     if not matches:
         print(f"No run matching '{run_query}' in project '{project.name}'.")
-        return
+        return None
     if len(matches) > 1:
-        print(f"Ambiguous '{run_query}' — matches {len(matches)} runs:")
+        print(f"Ambiguous '{run_query}' - matches {len(matches)} runs:")
         for d in matches:
             print(f"  {d.name}")
-        return
+        return None
+    return matches[0]
 
-    d = matches[0]
+
+def _print_run_provenance(project, run_query):
+    """Print one run's provenance detail. ``run_query`` matches a run dir by
+    exact name, unique substring, or 'last'/'latest'."""
+    from core.run import load_run_metadata
+    from core.run.provenance import format_manifest_block
+
+    d = _resolve_run(project, run_query)
+    if d is None:
+        return
     meta = load_run_metadata(d) or {}
     print(f"Run: {d.name}")
     print(f"  Command: {meta.get('command', '?')}")

--- a/core/run/tests/test_max_cost_usd_lifecycle_gate.py
+++ b/core/run/tests/test_max_cost_usd_lifecycle_gate.py
@@ -76,33 +76,33 @@ class TestExtractAndStrip:
         )
         assert cap == pytest.approx(0.0042)
 
-    def test_non_numeric_value_warns_and_returns_unchanged(self, capsys):
+    def test_non_numeric_value_fails_closed(self, capsys):
         raptor = _import_raptor()
-        cap, out = raptor._extract_and_strip_max_cost_usd(
-            ["--max-cost-usd", "lots", "--repo", "/x"],
-        )
-        # Bad value → no cap applied; args returned UNCHANGED so
-        # the lifecycle doesn't silently lose context.
-        assert cap is None
-        assert out == ["--max-cost-usd", "lots", "--repo", "/x"]
-        captured = capsys.readouterr()
-        assert "not a number" in captured.err
+        # QoL #14: a malformed cap FAILS CLOSED (exit 2) rather than silently
+        # running UNCAPPED - the operator passed the flag because they want a
+        # ceiling, so a typo must refuse to start.
+        import pytest
+        with pytest.raises(SystemExit) as exc:
+            raptor._extract_and_strip_max_cost_usd(
+                ["--max-cost-usd", "lots", "--repo", "/x"],
+            )
+        assert exc.value.code == 2
+        assert "not a number" in capsys.readouterr().err
 
-    def test_zero_value_warns_and_returns_unchanged(self, capsys):
+    def test_zero_value_fails_closed(self, capsys):
         raptor = _import_raptor()
-        cap, out = raptor._extract_and_strip_max_cost_usd(
-            ["--max-cost-usd", "0"],
-        )
-        assert cap is None
-        assert out == ["--max-cost-usd", "0"]
+        import pytest
+        with pytest.raises(SystemExit) as exc:
+            raptor._extract_and_strip_max_cost_usd(["--max-cost-usd", "0"])
+        assert exc.value.code == 2
         assert "> 0" in capsys.readouterr().err
 
-    def test_negative_value_warns(self, capsys):
+    def test_negative_value_fails_closed(self, capsys):
         raptor = _import_raptor()
-        cap, _ = raptor._extract_and_strip_max_cost_usd(
-            ["--max-cost-usd=-5"],
-        )
-        assert cap is None
+        import pytest
+        with pytest.raises(SystemExit) as exc:
+            raptor._extract_and_strip_max_cost_usd(["--max-cost-usd=-5"])
+        assert exc.value.code == 2
         assert "> 0" in capsys.readouterr().err
 
 

--- a/core/sandbox/context.py
+++ b/core/sandbox/context.py
@@ -715,6 +715,14 @@ def sandbox(block_network: bool = False, target: str = None, output: str = None,
             output = None
             allowed_tcp_ports = None
     strict_required = profile == "strict"
+    # RAPTOR_REQUIRE_SANDBOX=1 makes the call fail closed when no isolation
+    # backend is available, instead of silently degrading to rlimits-only
+    # (the `not use_sandbox` branch below). Scoped to the full no-isolation
+    # case only: it does not force the mount-ns/strict requirement, and an
+    # explicit per-call/CLI disable is still respected.
+    _require_sandbox = os.environ.get(
+        "RAPTOR_REQUIRE_SANDBOX", "").strip().lower() in (
+        "1", "true", "yes", "on")
     # Explicitly disabled: no seccomp either (rlimits-only contract).
     if effectively_disabled:
         seccomp_profile = None
@@ -753,6 +761,15 @@ def sandbox(block_network: bool = False, target: str = None, output: str = None,
     if effectively_disabled and not state._cli_sandbox_disabled:
         logger.info("Sandbox disabled for this call")
     elif not use_sandbox:
+        if _require_sandbox:
+            from .errors import SandboxSetupError
+            raise SandboxSetupError(
+                "RAPTOR_REQUIRE_SANDBOX is set but no platform isolation "
+                "backend is available (no unprivileged user namespaces / "
+                "seatbelt). Refusing to run subprocesses without namespace "
+                "isolation. Unset RAPTOR_REQUIRE_SANDBOX or pass "
+                "disabled=True to opt out deliberately."
+            )
         if state.warn_once("_sandbox_unavailable_warned"):
             logger.warning(
                 "Sandbox unavailable — subprocesses run without namespace isolation"

--- a/core/security/_trust_guard.py
+++ b/core/security/_trust_guard.py
@@ -1,0 +1,40 @@
+"""Shared trust-marker guard for ``libexec/`` dispatch scripts.
+
+Centralises the check that was previously inlined (near byte-for-byte) into
+~40 ``libexec/`` scripts: an internal dispatch script must be reached through
+the ``bin/raptor`` launcher (which exports ``CLAUDECODE`` / ``_RAPTOR_TRUSTED``)
+rather than run directly, so a stray ``PATH`` entry or a copy-pasted invocation
+can't drive RAPTOR's internals with an unexpected environment.
+
+Deliberately kept dependency-free and in the tiny ``core.security`` package
+(an 8-line ``__init__`` with no imports), so importing it costs ~3 ms and still
+runs BEFORE any heavy ``core.*`` import - preserving the original
+"guard before real work" property the inline block had. Callers must add the
+repo root to ``sys.path`` first (the standard
+``sys.path.insert(0, str(Path(__file__).resolve().parents[1]))`` line) and then::
+
+    from core.security._trust_guard import require_trusted_caller
+    require_trusted_caller()
+
+The genuinely-special shims (``raptor-pid1-shim``, ``raptor-seatbelt-shim``,
+and the ``python3 -I`` isolated launchers) keep their inline check - they run
+before any ``sys.path`` manipulation by design.
+"""
+
+import os
+import sys
+
+
+def require_trusted_caller() -> None:
+    """Exit(2) unless invoked via ``bin/raptor`` (CLAUDECODE / _RAPTOR_TRUSTED).
+
+    No-op when trusted; writes the standard guidance to stderr and exits with
+    status 2 otherwise (matching the historical inline behaviour)."""
+    if os.environ.get("CLAUDECODE") or os.environ.get("_RAPTOR_TRUSTED"):
+        return
+    sys.stderr.write(
+        f"{sys.argv[0]}: internal dispatch script.\n"
+        "  Run via 'bin/raptor' instead.\n"
+        "  Tests / power users: set _RAPTOR_TRUSTED=1 to bypass.\n"
+    )
+    sys.exit(2)

--- a/core/security/redaction.py
+++ b/core/security/redaction.py
@@ -252,3 +252,41 @@ def redact_url_secrets_only(value: object, *, reveal_secrets: bool = False) -> s
     # tail visible in logs.
     text = re.sub(r"https?://[^\s'\"<>()]{1,8192}", _redact_url, text)
     return text
+
+
+def mask_ollama_endpoint(value: object) -> str:
+    """Replace the configured *remote* Ollama host/IP (and ``host:port`` and
+    full-URL forms) in ``value`` with ``[REMOTE-OLLAMA]``.
+
+    CLAUDE.md forbids disclosing the remote Ollama server location in code,
+    comments, or logs. The standard secret redactors (``redact_secrets`` /
+    ``_redact_url``) deliberately PRESERVE hostnames, and a raw
+    ``requests``/SDK connection error embeds the host as
+    ``HTTPConnectionPool(host='10.x.x.x', port=11434)`` - so any log/error
+    string for the Ollama tier must pass through here. Loopback endpoints
+    (localhost / 127.0.0.1) are not secrets and are left intact. No-ops
+    safely when the config can't be read or the endpoint is loopback, so it
+    is safe to apply unconditionally."""
+    text = value if isinstance(value, str) else str(value)
+    try:
+        from core.config import RaptorConfig
+        host_url = str(RaptorConfig.OLLAMA_HOST or "")
+    except Exception:
+        return text
+    if not host_url:
+        return text
+    lowered = host_url.lower()
+    if "localhost" in lowered or "127.0.0.1" in lowered:
+        return text
+    from urllib.parse import urlparse
+    parsed = urlparse(host_url if "://" in host_url else "//" + host_url)
+    host = parsed.hostname
+    if not host:
+        return text
+    # Longest/most-specific forms first so a bare-host replace doesn't
+    # leave a dangling ":port" or URL scheme behind.
+    text = text.replace(host_url, "[REMOTE-OLLAMA]")
+    if parsed.port:
+        text = text.replace(f"{host}:{parsed.port}", "[REMOTE-OLLAMA]")
+    text = text.replace(host, "[REMOTE-OLLAMA]")
+    return text

--- a/core/startup/doctor.py
+++ b/core/startup/doctor.py
@@ -52,9 +52,10 @@ from core.security.log_sanitisation import escape_nonprintable
 
 
 _USAGE = (
-    "usage: raptor doctor [--strict] [--verbose]\n"
+    "usage: raptor doctor [--strict] [--verbose] [--json]\n"
     "  --strict     non-zero exit on warnings too (CI gate)\n"
     "  --verbose    include passing checks in the output\n"
+    "  --json       emit a machine-readable report (for CI parsing)\n"
 )
 
 
@@ -309,12 +310,15 @@ def main(argv: Optional[List[str]] = None) -> int:
     argv = list(argv or [])
     strict = False
     verbose = False
+    as_json = False
     while argv:
         a = argv.pop(0)
         if a == "--strict":
             strict = True
         elif a in ("--verbose", "-v"):
             verbose = True
+        elif a == "--json":
+            as_json = True
         elif a in ("--help", "-h"):
             # `--help` is a help request, not a usage error: print usage to
             # stdout and exit 0, matching every other raptor.py mode. Pre-fix
@@ -340,8 +344,30 @@ def main(argv: Optional[List[str]] = None) -> int:
         )
         return 1
 
+    (tool_results, tool_warnings, llm_lines, llm_warnings,
+     env_parts, env_warnings, lang_line, project_line) = gathered
     text, n_fail, n_warn = _render(*gathered, verbose=verbose)
-    print(text)
+
+    if as_json:
+        import json as _json
+        payload = {
+            "tools": {name: ok for name, ok in tool_results},
+            "tool_warnings": list(tool_warnings),
+            "llm": list(llm_lines),
+            "llm_warnings": list(llm_warnings),
+            "env": list(env_parts),
+            "env_warnings": list(env_warnings),
+            "lang": lang_line,
+            "project": project_line,
+            "summary": {
+                "failures": n_fail,
+                "warnings": n_warn,
+                "passed": sum(1 for _, ok in tool_results if ok),
+            },
+        }
+        print(_json.dumps(payload, indent=2))
+    else:
+        print(text)
     if n_fail:
         return 1
     if strict and n_warn:

--- a/core/startup/tests/test_doctor.py
+++ b/core/startup/tests/test_doctor.py
@@ -176,10 +176,21 @@ class TestMainExitCodes:
 
 class TestUsage:
     def test_unknown_flag_returns_two(self, capsys):
-        rc = main(["--json"])
+        rc = main(["--bogus-flag"])
         captured = capsys.readouterr()
         assert rc == 2
         assert "usage: raptor doctor" in captured.err
+
+    def test_json_flag_emits_valid_json(self, capsys):
+        import json
+        rc = main(["--json"])
+        captured = capsys.readouterr()
+        # rc is 0/1 depending on host tool availability, never a usage error
+        assert rc in (0, 1)
+        payload = json.loads(captured.out)
+        assert "tools" in payload and isinstance(payload["tools"], dict)
+        assert "summary" in payload
+        assert set(payload["summary"]) == {"failures", "warnings", "passed"}
 
     def test_help_flag_returns_zero_on_stdout(self, capsys):
         """`--help` is a help request: usage to stdout, exit 0.

--- a/docs/DEPENDENCIES.md
+++ b/docs/DEPENDENCIES.md
@@ -69,6 +69,13 @@ For example CodeQL does not allow commerical use.
 - Usage: RAPTOR uses for deterministic debugging in /crash-analysis command
 - Note: User installs separately, Linux only (x86_64)
 
+**Frida** (Dynamic instrumentation toolkit)
+- Install: `pipx install frida-tools` (or `pip install frida-tools`)
+- License: wxWindows Library Licence (LGPL-compatible)
+- Source: https://frida.re
+- Usage: RAPTOR calls Frida for the /frida command (spawn-only function/argument tracing and Stalker basic-block coverage)
+- Note: User installs separately, optional. Degrades gracefully when absent (the capability probe reports unavailable and /doctor shows a soft warning)
+
 **gcov** (Code coverage tool)
 - Install: Bundled with gcc (no separate install needed)
 - License: GPL (part of GCC)
@@ -127,6 +134,7 @@ For example CodeQL does not allow commerical use.
 - Semgrep (LGPL 2.1) - User installs
 - AFL++ (Apache 2.0) - User installs
 - CodeQL (GitHub Terms) - User installs
+- Frida (wxWindows Library Licence) - User installs
 - Python packages (various open source) - User installs via pip
 - System tools (GPL v3, Apache 2.0) - Pre-installed on OS
 

--- a/docs/DYNAMIC_INSTRUMENTATION_QUICKSTART.md
+++ b/docs/DYNAMIC_INSTRUMENTATION_QUICKSTART.md
@@ -1,0 +1,115 @@
+# RAPTOR Dynamic Instrumentation (Frida) - Quick Start Guide
+
+## What It Does
+
+The `/frida` command drives [Frida](https://frida.re) to observe a binary at
+runtime, complementing RAPTOR's static analysis:
+
+1. **Function/argument tracing** - hook named functions and capture their
+   entry arguments and addresses.
+2. **Stalker coverage** - record executed basic blocks and emit a standard
+   `drcov` file (loadable in Lighthouse/IDA, and ingested into RAPTOR's
+   coverage store alongside gcov/lcov/AFL).
+
+It is **spawn-only by default**: RAPTOR launches the target itself rather than
+attaching to a running PID, and the target is always operator-chosen. Runs are
+sandboxed; see [Sandbox profiles](#sandbox-profiles).
+
+## Prerequisites
+
+### Install Frida
+
+```bash
+# Recommended (isolated CLI install)
+pipx install frida-tools
+
+# or
+pip install frida-tools
+
+# Verify
+frida --version
+```
+
+Frida is **optional**. When it is absent, the capability probe reports
+unavailable and `/doctor` shows a soft warning - no other command is affected.
+
+### Check capability
+
+```bash
+libexec/raptor-frida probe
+```
+
+This reports the Frida Python binding, the `frida` CLI, the platform/arch, and
+the kernel `ptrace_scope` setting. `ptrace_scope=1` is sufficient for
+spawn-only operation (the same model gdb/rr use).
+
+## Quick Test
+
+### 1. Compile a test binary
+
+```bash
+cat > /tmp/demo.c <<'EOF'
+#include <stdio.h>
+int add(int a, int b){ return a + b; }
+int main(void){ printf("sum=%d\n", add(2, 3)); return 0; }
+EOF
+cc -O0 -g -o /tmp/demo /tmp/demo.c
+```
+
+### 2. Trace a function
+
+```bash
+libexec/raptor-frida trace /tmp/demo --symbols add --out /tmp/frida-out
+```
+
+Output is JSON: each hooked call records the function name, its entry
+arguments, and address; plus an `events_path` to the per-event JSONL log.
+
+### 3. Collect coverage
+
+```bash
+libexec/raptor-frida coverage /tmp/demo --out /tmp/frida-cov
+```
+
+Writes `frida.drcov` (DynamoRIO coverage format) and reports the basic-block
+count. The drcov file routes through `import_drcov` into the same coverage
+store as gcov/lcov/AFL.
+
+## Usage
+
+```
+raptor-frida probe
+raptor-frida trace    <binary> --symbols <fn1,fn2,...> [--out DIR] [--timeout S] [--profile P]
+raptor-frida coverage <binary> [--modules <substr,...>] [--out DIR] [--timeout S] [--profile P]
+```
+
+- `--symbols` - comma-separated function names. Resolved via DWARF; a symbol
+  only present in a shared library may need the library's name.
+- `--modules` - restrict coverage to module-name substrings; default covers
+  the main module.
+- `--out` - output directory for the JSON/JSONL/drcov artifacts.
+- `--timeout` - seconds before the spawned target is killed.
+- `--profile` - sandbox profile (see below).
+
+## Sandbox profiles
+
+| Profile | Isolation |
+|---|---|
+| `debug` (default) | full namespace isolation (mount/PID/network) where the host supports it |
+| `network-only` | network denied; filesystem unrestricted |
+| `none` | no isolation (Landlock disabled) |
+
+On a host without working mount namespaces, the `debug` profile degrades to no
+isolation for the spawn with an explicit warning (network is not blocked, but
+the target is still operator-chosen and spawn-only). For full isolation, run on
+a host with working user/mount namespaces.
+
+## Notes
+
+- Pointer arguments show as their integer value; dereference in a follow-up
+  hook if you need the pointed-to data.
+- Stalker cannot enumerate a spawned target's threads until the loader has run,
+  so very early startup blocks may be missed.
+- See the LLM-facing skills for deeper detail:
+  `.claude/skills/dynamic-instrumentation/SKILL.md` (gates, model, isolation),
+  `.../trace/SKILL.md`, and `.../coverage/SKILL.md`.

--- a/libexec/raptor-annotate
+++ b/libexec/raptor-annotate
@@ -52,18 +52,10 @@ import sys
 from pathlib import Path
 from typing import List, Optional
 
-# ─── trust-marker check (do not import; inline by design) ───
-if not (os.environ.get("CLAUDECODE")
-        or os.environ.get("_RAPTOR_TRUSTED")):
-    sys.stderr.write(
-        f"{sys.argv[0]}: internal dispatch script.\n"
-        "  Run via 'bin/raptor' instead.\n"
-        "  Tests / power users: set _RAPTOR_TRUSTED=1 to bypass.\n"
-    )
-    sys.exit(2)
-# ─── end trust-marker check ─────────────────────────────────
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from core.security._trust_guard import require_trusted_caller
+require_trusted_caller()
 
 from core.annotations import (  # noqa: E402
     Annotation,

--- a/libexec/raptor-ast
+++ b/libexec/raptor-ast
@@ -23,19 +23,10 @@ inventory substrate. See the ``core/ast/`` package for the API.
 import sys
 from pathlib import Path
 
-# ─── trust-marker check (do not import; inline by design) ───
-import os
-if not (os.environ.get("CLAUDECODE")
-        or os.environ.get("_RAPTOR_TRUSTED")):
-    sys.stderr.write(
-        f"{sys.argv[0]}: internal dispatch script.\n"
-        "  Run via 'bin/raptor' instead.\n"
-        "  Tests / power users: set _RAPTOR_TRUSTED=1 to bypass.\n"
-    )
-    sys.exit(2)
-# ─── end trust-marker check ─────────────────────────────────
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from core.security._trust_guard import require_trusted_caller
+require_trusted_caller()
 
 import argparse
 import json

--- a/libexec/raptor-binary-oracle-precision
+++ b/libexec/raptor-binary-oracle-precision
@@ -8,18 +8,10 @@ import os
 import sys
 from pathlib import Path
 
-# ─── trust-marker check (do not import; inline by design) ───
-if not (os.environ.get("CLAUDECODE")
-        or os.environ.get("_RAPTOR_TRUSTED")):
-    sys.stderr.write(
-        f"{sys.argv[0]}: internal dispatch script.\n"
-        "  Run via 'bin/raptor' instead.\n"
-        "  Tests / power users: set _RAPTOR_TRUSTED=1 to bypass.\n"
-    )
-    sys.exit(2)
-# ─── end trust-marker check ─────────────────────────────────
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from core.security._trust_guard import require_trusted_caller
+require_trusted_caller()
 
 from core.inventory.binary_oracle_precision import main  # noqa: E402
 

--- a/libexec/raptor-build-checklist
+++ b/libexec/raptor-build-checklist
@@ -11,19 +11,10 @@ and their coverage marks cleared.
 import sys
 from pathlib import Path
 
-# ─── trust-marker check (do not import; inline by design) ───
-import os
-if not (os.environ.get("CLAUDECODE")
-        or os.environ.get("_RAPTOR_TRUSTED")):
-    sys.stderr.write(
-        f"{sys.argv[0]}: internal dispatch script.\n"
-        "  Run via 'bin/raptor' instead.\n"
-        "  Tests / power users: set _RAPTOR_TRUSTED=1 to bypass.\n"
-    )
-    sys.exit(2)
-# ─── end trust-marker check ─────────────────────────────────
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from core.security._trust_guard import require_trusted_caller
+require_trusted_caller()
 
 
 def main():

--- a/libexec/raptor-coverage-summary
+++ b/libexec/raptor-coverage-summary
@@ -10,8 +10,9 @@ Usage:
   raptor-coverage-summary [<dir>] --mark-file <json>    Mark functions from JSON file
   raptor-coverage-summary [<dir>] --unmark <file:item>  Remove item from reviewed
   raptor-coverage-summary [<dir>] --import <path>       Ingest external runtime
-      [--format gcov|lcov|coverage.py] [--tool <label>] coverage (gcov/lcov/
-                                                        coverage.py) into the store
+      [--format gcov|lcov|coverage.py|drcov]            coverage into the store.
+      [--tool <label>] [--binary <path>]                drcov (DynamoRIO/Frida/
+                                                        AFL-QEMU) needs --binary
 
 If <dir> is omitted, uses the active project.
 Accepts: project output dir, run dir, target path, or project name.
@@ -19,19 +20,10 @@ Accepts: project output dir, run dir, target path, or project name.
 import sys
 from pathlib import Path
 
-# ─── trust-marker check (do not import; inline by design) ───
-import os
-if not (os.environ.get("CLAUDECODE")
-        or os.environ.get("_RAPTOR_TRUSTED")):
-    sys.stderr.write(
-        f"{sys.argv[0]}: internal dispatch script.\n"
-        "  Run via 'bin/raptor' instead.\n"
-        "  Tests / power users: set _RAPTOR_TRUSTED=1 to bypass.\n"
-    )
-    sys.exit(2)
-# ─── end trust-marker check ─────────────────────────────────
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from core.security._trust_guard import require_trusted_caller
+require_trusted_caller()
 
 
 def _is_project_dir(d: Path) -> bool:
@@ -250,15 +242,22 @@ def _cmd_unmark(unmark_targets, run_dir):
     print(f"Removed {removed} item{'s' if removed != 1 else ''} from reviewed in {run_dir.name}")
 
 
-def _cmd_import(import_path, fmt, tool, args):
-    """Ingest external runtime coverage (gcov/lcov/coverage.py) into the target's
-    durable store. The positional <dir> (if any) resolves the project/run store;
+def _cmd_import(import_path, fmt, tool, args, binary=None):
+    """Ingest external runtime coverage into the target's durable store. Source
+    formats (gcov/lcov/coverage.py) resolve directly; the binary ``drcov``
+    format (DynamoRIO / Frida / AFL-QEMU) needs ``--binary`` for DWARF address
+    resolution. The positional <dir> (if any) resolves the project/run store;
     --import names the coverage artifact. Persists under the store lock."""
     from core.coverage.importer import import_runtime
     from core.coverage.store import CoverageStore, coverage_store_lock
 
     if not Path(import_path).exists():
         print(f"ERROR: coverage path not found: {import_path}", file=sys.stderr)
+        sys.exit(1)
+    if fmt == "drcov" and not binary:
+        print("ERROR: --format drcov requires --binary <path> (drcov is "
+              "address-based; DWARF resolution needs the binary).",
+              file=sys.stderr)
         sys.exit(1)
     checklist, _run_dirs, store_path, _ann = _store_inputs(args)
     if not checklist or not store_path:
@@ -268,7 +267,8 @@ def _cmd_import(import_path, fmt, tool, args):
         sys.exit(1)
     with coverage_store_lock(store_path):
         store = CoverageStore(store_path)
-        n = import_runtime(store, import_path, checklist, fmt=fmt, tool=tool)
+        n = import_runtime(store, import_path, checklist, fmt=fmt, tool=tool,
+                           binary=binary)
         store.save()
     print(f"Imported {n} runtime coverage range(s) from {import_path} -> {store_path}")
 
@@ -288,6 +288,7 @@ def main():
     import_path, argv = _take_opt("--import", argv)
     import_fmt, argv = _take_opt("--format", argv)
     import_tool, argv = _take_opt("--tool", argv)
+    import_binary, argv = _take_opt("--binary", argv)
 
     detailed = "--detailed" in argv
     show_gaps = "--gaps" in argv
@@ -382,7 +383,8 @@ def main():
         return
 
     if import_path:
-        _cmd_import(import_path, import_fmt, import_tool, args)
+        _cmd_import(import_path, import_fmt, import_tool, args,
+                    binary=import_binary)
         return
 
     # All report views go through the unified store-backed renderer. `--store`

--- a/libexec/raptor-describe
+++ b/libexec/raptor-describe
@@ -15,19 +15,10 @@ import argparse
 import sys
 from pathlib import Path
 
-# ─── trust-marker check (do not import; inline by design) ───
-import os
-if not (os.environ.get("CLAUDECODE")
-        or os.environ.get("_RAPTOR_TRUSTED")):
-    sys.stderr.write(
-        f"{sys.argv[0]}: internal dispatch script.\n"
-        "  Run via 'bin/raptor' instead.\n"
-        "  Tests / power users: set _RAPTOR_TRUSTED=1 to bypass.\n"
-    )
-    sys.exit(2)
-# ─── end trust-marker check ─────────────────────────────────
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from core.security._trust_guard import require_trusted_caller
+require_trusted_caller()
 
 
 def main(argv=None):

--- a/libexec/raptor-enrich-context-map-ast-view
+++ b/libexec/raptor-enrich-context-map-ast-view
@@ -16,19 +16,10 @@ import argparse
 import sys
 from pathlib import Path
 
-# ─── trust-marker check (do not import; inline by design) ───
-import os
-if not (os.environ.get("CLAUDECODE")
-        or os.environ.get("_RAPTOR_TRUSTED")):
-    sys.stderr.write(
-        f"{sys.argv[0]}: internal dispatch script.\n"
-        "  Run via 'bin/raptor' instead.\n"
-        "  Tests / power users: set _RAPTOR_TRUSTED=1 to bypass.\n"
-    )
-    sys.exit(2)
-# ─── end trust-marker check ─────────────────────────────────
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from core.security._trust_guard import require_trusted_caller
+require_trusted_caller()
 
 from core.json import load_json, save_json
 from core.orchestration.context_map_ast_view import enrich_with_ast_view

--- a/libexec/raptor-enrich-context-map-callgraph
+++ b/libexec/raptor-enrich-context-map-callgraph
@@ -15,19 +15,10 @@ import argparse
 import sys
 from pathlib import Path
 
-# ─── trust-marker check (do not import; inline by design) ───
-import os
-if not (os.environ.get("CLAUDECODE")
-        or os.environ.get("_RAPTOR_TRUSTED")):
-    sys.stderr.write(
-        f"{sys.argv[0]}: internal dispatch script.\n"
-        "  Run via 'bin/raptor' instead.\n"
-        "  Tests / power users: set _RAPTOR_TRUSTED=1 to bypass.\n"
-    )
-    sys.exit(2)
-# ─── end trust-marker check ─────────────────────────────────
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from core.security._trust_guard import require_trusted_caller
+require_trusted_caller()
 
 from core.json import load_json, save_json
 from core.orchestration.context_map_callgraph import (

--- a/libexec/raptor-enrich-context-map-sites
+++ b/libexec/raptor-enrich-context-map-sites
@@ -18,19 +18,10 @@ import argparse
 import sys
 from pathlib import Path
 
-# ─── trust-marker check (do not import; inline by design) ───
-import os
-if not (os.environ.get("CLAUDECODE")
-        or os.environ.get("_RAPTOR_TRUSTED")):
-    sys.stderr.write(
-        f"{sys.argv[0]}: internal dispatch script.\n"
-        "  Run via 'bin/raptor' instead.\n"
-        "  Tests / power users: set _RAPTOR_TRUSTED=1 to bypass.\n"
-    )
-    sys.exit(2)
-# ─── end trust-marker check ─────────────────────────────────
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from core.security._trust_guard import require_trusted_caller
+require_trusted_caller()
 
 from core.json import load_json, save_json
 

--- a/libexec/raptor-enrich-flow-trace-ast-view
+++ b/libexec/raptor-enrich-flow-trace-ast-view
@@ -18,19 +18,10 @@ import argparse
 import sys
 from pathlib import Path
 
-# ─── trust-marker check (do not import; inline by design) ───
-import os
-if not (os.environ.get("CLAUDECODE")
-        or os.environ.get("_RAPTOR_TRUSTED")):
-    sys.stderr.write(
-        f"{sys.argv[0]}: internal dispatch script.\n"
-        "  Run via 'bin/raptor' instead.\n"
-        "  Tests / power users: set _RAPTOR_TRUSTED=1 to bypass.\n"
-    )
-    sys.exit(2)
-# ─── end trust-marker check ─────────────────────────────────
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from core.security._trust_guard import require_trusted_caller
+require_trusted_caller()
 
 from core.json import load_json, save_json
 from core.orchestration.flow_trace_ast_view import enrich_with_ast_view

--- a/libexec/raptor-frida
+++ b/libexec/raptor-frida
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""raptor-frida - dynamic instrumentation (Frida) dispatch shim.
+
+Thin CLI over ``packages.dynamic_instrumentation.api`` so the ``/frida`` skill
+(and operators) can run the deterministic operations without writing Python.
+Spawn-only by design: RAPTOR instruments a binary it launches, under the
+sandbox, network blocked by default (see runner.py for the isolation model).
+
+Usage:
+  raptor-frida probe
+  raptor-frida trace  <binary> --symbols a,b,c [--out DIR] [--timeout S] [-- ARGS...]
+  raptor-frida coverage <binary> [--out DIR] [--timeout S] [--binary-for-dwarf P]
+                                 [--modules m1,m2] [-- ARGS...]
+"""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from core.security._trust_guard import require_trusted_caller
+require_trusted_caller()
+
+import argparse
+import json
+
+
+def _positive_float(value):
+    """argparse type: a strictly positive timeout (seconds). A zero/negative
+    timeout would kill the target before it runs, so fail closed (exit 2)."""
+    try:
+        f = float(value)
+    except (TypeError, ValueError):
+        raise argparse.ArgumentTypeError(f"expected a number, got {value!r}")
+    if f <= 0:
+        raise argparse.ArgumentTypeError(f"must be > 0, got {f}")
+    return f
+
+
+def _split_args(argv):
+    """Split off a trailing ``-- <target args>`` section."""
+    if "--" in argv:
+        i = argv.index("--")
+        return argv[:i], argv[i + 1:]
+    return argv, []
+
+
+def main() -> int:
+    pre, target_args = _split_args(sys.argv[1:])
+    ap = argparse.ArgumentParser(prog="raptor-frida")
+    sub = ap.add_subparsers(dest="cmd", required=True)
+
+    p_probe = sub.add_parser("probe", help="Report Frida capability (no spawn)")
+
+    p_trace = sub.add_parser("trace", help="Trace function entry + arguments")
+    p_trace.add_argument("binary")
+    p_trace.add_argument("--symbols", required=True,
+                         help="Comma-separated function names to hook")
+    p_trace.add_argument("--out", default=None, help="Output directory")
+    p_trace.add_argument("--timeout", type=_positive_float, default=30.0)
+    p_trace.add_argument("--profile", default="debug",
+                         help="Sandbox profile (debug|none|network-only)")
+
+    p_cov = sub.add_parser("coverage", help="Stalker block coverage → drcov → store")
+    p_cov.add_argument("binary")
+    p_cov.add_argument("--out", default=None, help="Output directory")
+    p_cov.add_argument("--timeout", type=_positive_float, default=30.0)
+    p_cov.add_argument("--modules", default=None,
+                       help="Comma-separated module substrings to cover")
+    p_cov.add_argument("--profile", default="debug")
+
+    args = ap.parse_args(pre)
+
+    from packages.dynamic_instrumentation import api
+    from packages.dynamic_instrumentation.capability import probe
+
+    if args.cmd == "probe":
+        rep = probe()
+        print(json.dumps({
+            "available": rep.available, "frida_python": rep.frida_python,
+            "frida_cli": rep.frida_cli, "ptrace_scope": rep.ptrace_scope,
+            "platform": rep.platform, "arch": rep.arch, "notes": rep.notes,
+            "summary": rep.summary(),
+        }, indent=2))
+        return 0 if rep.available else 1
+
+    if not probe().available:
+        print("frida not available - install with: pipx install frida-tools",
+              file=sys.stderr)
+        return 1
+
+    out_dir = args.out
+    if not out_dir:
+        from core.config import RaptorConfig
+        out_dir = str(RaptorConfig.get_out_dir() / "frida")
+
+    if args.cmd == "trace":
+        symbols = [s.strip() for s in args.symbols.split(",") if s.strip()]
+        res = api.trace_functions(
+            args.binary, symbols, output_dir=out_dir, timeout=args.timeout,
+            spawn_args=target_args, profile=args.profile)
+        print(json.dumps(res, indent=2))
+        return 0
+
+    if args.cmd == "coverage":
+        modules = ([m.strip() for m in args.modules.split(",") if m.strip()]
+                   if args.modules else None)
+        res = api.collect_coverage(
+            args.binary, output_dir=out_dir, timeout=args.timeout,
+            modules=modules, spawn_args=target_args, profile=args.profile)
+        print(json.dumps(res, indent=2))
+        return 0
+
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/libexec/raptor-normalize-context-map
+++ b/libexec/raptor-normalize-context-map
@@ -18,19 +18,10 @@ import sys
 from pathlib import Path
 
 # libexec/raptor-normalize-context-map -> repo root (parents[1])
-# ─── trust-marker check (do not import; inline by design) ───
-import os
-if not (os.environ.get("CLAUDECODE")
-        or os.environ.get("_RAPTOR_TRUSTED")):
-    sys.stderr.write(
-        f"{sys.argv[0]}: internal dispatch script.\n"
-        "  Run via 'bin/raptor' instead.\n"
-        "  Tests / power users: set _RAPTOR_TRUSTED=1 to bypass.\n"
-    )
-    sys.exit(2)
-# ─── end trust-marker check ─────────────────────────────────
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from core.security._trust_guard import require_trusted_caller
+require_trusted_caller()
 
 from core.json import load_json, save_json
 from core.orchestration.understand_bridge import normalize_context_map

--- a/libexec/raptor-pick-strategies
+++ b/libexec/raptor-pick-strategies
@@ -32,19 +32,10 @@ Exit codes:
 import sys
 from pathlib import Path
 
-# ─── trust-marker check (do not import; inline by design) ───
-import os
-if not (os.environ.get("CLAUDECODE")
-        or os.environ.get("_RAPTOR_TRUSTED")):
-    sys.stderr.write(
-        f"{sys.argv[0]}: internal dispatch script.\n"
-        "  Run via 'bin/raptor' instead.\n"
-        "  Tests / power users: set _RAPTOR_TRUSTED=1 to bypass.\n"
-    )
-    sys.exit(2)
-# ─── end trust-marker check ─────────────────────────────────
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from core.security._trust_guard import require_trusted_caller
+require_trusted_caller()
 
 import argparse
 

--- a/libexec/raptor-project-manager
+++ b/libexec/raptor-project-manager
@@ -10,19 +10,10 @@ Called by:
 import sys
 from pathlib import Path
 
-# ─── trust-marker check (do not import; inline by design) ───
-import os
-if not (os.environ.get("CLAUDECODE")
-        or os.environ.get("_RAPTOR_TRUSTED")):
-    sys.stderr.write(
-        f"{sys.argv[0]}: internal dispatch script.\n"
-        "  Run via 'bin/raptor' instead.\n"
-        "  Tests / power users: set _RAPTOR_TRUSTED=1 to bypass.\n"
-    )
-    sys.exit(2)
-# ─── end trust-marker check ─────────────────────────────────
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from core.security._trust_guard import require_trusted_caller
+require_trusted_caller()
 
 from core.project.cli import main
 

--- a/libexec/raptor-render-diagrams
+++ b/libexec/raptor-render-diagrams
@@ -6,19 +6,10 @@ Usage: raptor-render-diagrams <output_dir> [--target <name>] [--force]
 import sys
 from pathlib import Path
 
-# ─── trust-marker check (do not import; inline by design) ───
-import os
-if not (os.environ.get("CLAUDECODE")
-        or os.environ.get("_RAPTOR_TRUSTED")):
-    sys.stderr.write(
-        f"{sys.argv[0]}: internal dispatch script.\n"
-        "  Run via 'bin/raptor' instead.\n"
-        "  Tests / power users: set _RAPTOR_TRUSTED=1 to bypass.\n"
-    )
-    sys.exit(2)
-# ─── end trust-marker check ─────────────────────────────────
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from core.security._trust_guard import require_trusted_caller
+require_trusted_caller()
 
 
 def main():

--- a/libexec/raptor-run-feasibility
+++ b/libexec/raptor-run-feasibility
@@ -9,19 +9,10 @@ to all findings that reference this binary. Updates findings.json in place.
 import sys
 from pathlib import Path
 
-# ─── trust-marker check (do not import; inline by design) ───
-import os
-if not (os.environ.get("CLAUDECODE")
-        or os.environ.get("_RAPTOR_TRUSTED")):
-    sys.stderr.write(
-        f"{sys.argv[0]}: internal dispatch script.\n"
-        "  Run via 'bin/raptor' instead.\n"
-        "  Tests / power users: set _RAPTOR_TRUSTED=1 to bypass.\n"
-    )
-    sys.exit(2)
-# ─── end trust-marker check ─────────────────────────────────
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from core.security._trust_guard import require_trusted_caller
+require_trusted_caller()
 
 from core.json import load_json, save_json
 

--- a/libexec/raptor-run-lifecycle
+++ b/libexec/raptor-run-lifecycle
@@ -18,19 +18,10 @@ are handled by their respective tools.
 import sys
 from pathlib import Path
 
-# ─── trust-marker check (do not import; inline by design) ───
-import os
-if not (os.environ.get("CLAUDECODE")
-        or os.environ.get("_RAPTOR_TRUSTED")):
-    sys.stderr.write(
-        f"{sys.argv[0]}: internal dispatch script.\n"
-        "  Run via 'bin/raptor' instead.\n"
-        "  Tests / power users: set _RAPTOR_TRUSTED=1 to bypass.\n"
-    )
-    sys.exit(2)
-# ─── end trust-marker check ─────────────────────────────────
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from core.security._trust_guard import require_trusted_caller
+require_trusted_caller()
 
 from core.run.output import get_output_dir, TargetMismatchError
 from core.run.metadata import start_run, complete_run, fail_run

--- a/libexec/raptor-sandbox-calibrate
+++ b/libexec/raptor-sandbox-calibrate
@@ -21,18 +21,10 @@ import os
 import sys
 from pathlib import Path
 
-# ─── trust-marker check (do not import; inline by design) ───
-if not (os.environ.get("CLAUDECODE")
-        or os.environ.get("_RAPTOR_TRUSTED")):
-    sys.stderr.write(
-        f"{sys.argv[0]}: internal dispatch script.\n"
-        "  Run via 'bin/raptor' instead.\n"
-        "  Tests / power users: set _RAPTOR_TRUSTED=1 to bypass.\n"
-    )
-    sys.exit(2)
-# ─── end trust-marker check ─────────────────────────────────
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from core.security._trust_guard import require_trusted_caller
+require_trusted_caller()
 
 from core.sandbox.calibrate_cli import _cli_main  # noqa: E402
 

--- a/libexec/raptor-sandbox-observe
+++ b/libexec/raptor-sandbox-observe
@@ -16,18 +16,10 @@ import os
 import sys
 from pathlib import Path
 
-# ─── trust-marker check (do not import; inline by design) ───
-if not (os.environ.get("CLAUDECODE")
-        or os.environ.get("_RAPTOR_TRUSTED")):
-    sys.stderr.write(
-        f"{sys.argv[0]}: internal dispatch script.\n"
-        "  Run via 'bin/raptor' instead.\n"
-        "  Tests / power users: set _RAPTOR_TRUSTED=1 to bypass.\n"
-    )
-    sys.exit(2)
-# ─── end trust-marker check ─────────────────────────────────
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from core.security._trust_guard import require_trusted_caller
+require_trusted_caller()
 
 from core.sandbox.observe_cli import _cli_main  # noqa: E402
 

--- a/libexec/raptor-sandbox-summary
+++ b/libexec/raptor-sandbox-summary
@@ -22,19 +22,10 @@ core.sandbox.summary via observe.py before runpy executes it as __main__.
 import sys
 from pathlib import Path
 
-# ─── trust-marker check (do not import; inline by design) ───
-import os
-if not (os.environ.get("CLAUDECODE")
-        or os.environ.get("_RAPTOR_TRUSTED")):
-    sys.stderr.write(
-        f"{sys.argv[0]}: internal dispatch script.\n"
-        "  Run via 'bin/raptor' instead.\n"
-        "  Tests / power users: set _RAPTOR_TRUSTED=1 to bypass.\n"
-    )
-    sys.exit(2)
-# ─── end trust-marker check ─────────────────────────────────
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from core.security._trust_guard import require_trusted_caller
+require_trusted_caller()
 
 from core.sandbox.summary import _cli_main  # noqa: E402
 

--- a/libexec/raptor-smt-check-null-deref
+++ b/libexec/raptor-smt-check-null-deref
@@ -27,19 +27,10 @@ import json
 import sys
 from pathlib import Path
 
-# ─── trust-marker check (do not import; inline by design) ───
-import os
-if not (os.environ.get("CLAUDECODE")
-        or os.environ.get("_RAPTOR_TRUSTED")):
-    sys.stderr.write(
-        f"{sys.argv[0]}: internal dispatch script.\n"
-        "  Run via 'bin/raptor' instead.\n"
-        "  Tests / power users: set _RAPTOR_TRUSTED=1 to bypass.\n"
-    )
-    sys.exit(2)
-# ─── end trust-marker check ─────────────────────────────────
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from core.security._trust_guard import require_trusted_caller
+require_trusted_caller()
 
 from packages.exploit_feasibility.smt_verbs import check_null_deref
 

--- a/libexec/raptor-smt-check-oob
+++ b/libexec/raptor-smt-check-oob
@@ -31,19 +31,10 @@ import json
 import sys
 from pathlib import Path
 
-# ─── trust-marker check (do not import; inline by design) ───
-import os
-if not (os.environ.get("CLAUDECODE")
-        or os.environ.get("_RAPTOR_TRUSTED")):
-    sys.stderr.write(
-        f"{sys.argv[0]}: internal dispatch script.\n"
-        "  Run via 'bin/raptor' instead.\n"
-        "  Tests / power users: set _RAPTOR_TRUSTED=1 to bypass.\n"
-    )
-    sys.exit(2)
-# ─── end trust-marker check ─────────────────────────────────
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from core.security._trust_guard import require_trusted_caller
+require_trusted_caller()
 
 from packages.exploit_feasibility.smt_verbs import check_oob
 

--- a/libexec/raptor-smt-check-overflow
+++ b/libexec/raptor-smt-check-overflow
@@ -43,19 +43,10 @@ import sys
 from pathlib import Path
 
 # libexec/<this> -> repo root
-# ─── trust-marker check (do not import; inline by design) ───
-import os
-if not (os.environ.get("CLAUDECODE")
-        or os.environ.get("_RAPTOR_TRUSTED")):
-    sys.stderr.write(
-        f"{sys.argv[0]}: internal dispatch script.\n"
-        "  Run via 'bin/raptor' instead.\n"
-        "  Tests / power users: set _RAPTOR_TRUSTED=1 to bypass.\n"
-    )
-    sys.exit(2)
-# ─── end trust-marker check ─────────────────────────────────
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from core.security._trust_guard import require_trusted_caller
+require_trusted_caller()
 
 from packages.exploit_feasibility.smt_verbs import check_overflow
 

--- a/libexec/raptor-smt-check-overflow-to-oob
+++ b/libexec/raptor-smt-check-overflow-to-oob
@@ -36,19 +36,10 @@ import json
 import sys
 from pathlib import Path
 
-# ─── trust-marker check (do not import; inline by design) ───
-import os
-if not (os.environ.get("CLAUDECODE")
-        or os.environ.get("_RAPTOR_TRUSTED")):
-    sys.stderr.write(
-        f"{sys.argv[0]}: internal dispatch script.\n"
-        "  Run via 'bin/raptor' instead.\n"
-        "  Tests / power users: set _RAPTOR_TRUSTED=1 to bypass.\n"
-    )
-    sys.exit(2)
-# ─── end trust-marker check ─────────────────────────────────
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from core.security._trust_guard import require_trusted_caller
+require_trusted_caller()
 
 from packages.exploit_feasibility.smt_verbs import check_overflow_to_oob
 

--- a/libexec/raptor-smt-validate-path
+++ b/libexec/raptor-smt-validate-path
@@ -65,19 +65,10 @@ import sys
 from pathlib import Path
 
 # libexec/<this> -> repo root
-# ─── trust-marker check (do not import; inline by design) ───
-import os
-if not (os.environ.get("CLAUDECODE")
-        or os.environ.get("_RAPTOR_TRUSTED")):
-    sys.stderr.write(
-        f"{sys.argv[0]}: internal dispatch script.\n"
-        "  Run via 'bin/raptor' instead.\n"
-        "  Tests / power users: set _RAPTOR_TRUSTED=1 to bypass.\n"
-    )
-    sys.exit(2)
-# ─── end trust-marker check ─────────────────────────────────
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from core.security._trust_guard import require_trusted_caller
+require_trusted_caller()
 
 from packages.exploit_feasibility.smt_path import validate_path
 

--- a/libexec/raptor-startup-check
+++ b/libexec/raptor-startup-check
@@ -14,19 +14,10 @@ Exit 0 on success (continue to claude), non-zero on abort.
 import sys
 from pathlib import Path
 
-# ─── trust-marker check (do not import; inline by design) ───
-import os
-if not (os.environ.get("CLAUDECODE")
-        or os.environ.get("_RAPTOR_TRUSTED")):
-    sys.stderr.write(
-        f"{sys.argv[0]}: internal dispatch script.\n"
-        "  Run via 'bin/raptor' instead.\n"
-        "  Tests / power users: set _RAPTOR_TRUSTED=1 to bypass.\n"
-    )
-    sys.exit(2)
-# ─── end trust-marker check ─────────────────────────────────
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from core.security._trust_guard import require_trusted_caller
+require_trusted_caller()
 
 
 def _find_project_for(directory, exclude=None):

--- a/libexec/raptor-strategy-eval
+++ b/libexec/raptor-strategy-eval
@@ -24,19 +24,10 @@ Exit codes:
 import sys
 from pathlib import Path
 
-# ─── trust-marker check (do not import; inline by design) ───
-import os
-if not (os.environ.get("CLAUDECODE")
-        or os.environ.get("_RAPTOR_TRUSTED")):
-    sys.stderr.write(
-        f"{sys.argv[0]}: internal dispatch script.\n"
-        "  Run via 'bin/raptor' instead.\n"
-        "  Tests / power users: set _RAPTOR_TRUSTED=1 to bypass.\n"
-    )
-    sys.exit(2)
-# ─── end trust-marker check ─────────────────────────────────
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from core.security._trust_guard import require_trusted_caller
+require_trusted_caller()
 
 import argparse
 

--- a/libexec/raptor-tune
+++ b/libexec/raptor-tune
@@ -12,18 +12,10 @@ import os
 import sys
 from pathlib import Path
 
-# ─── trust-marker check (do not import; inline by design) ───
-if not (os.environ.get("CLAUDECODE")
-        or os.environ.get("_RAPTOR_TRUSTED")):
-    sys.stderr.write(
-        f"{sys.argv[0]}: internal dispatch script.\n"
-        "  Run via 'bin/raptor' instead.\n"
-        "  Tests / power users: set _RAPTOR_TRUSTED=1 to bypass.\n"
-    )
-    sys.exit(2)
-# ─── end trust-marker check ─────────────────────────────────
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from core.security._trust_guard import require_trusted_caller
+require_trusted_caller()
 
 from core.json import load_json_with_comments
 from core.tuning import load_tuning, _DEFAULTS, _detect_available_cpus

--- a/libexec/raptor-understand
+++ b/libexec/raptor-understand
@@ -27,18 +27,10 @@ import os
 import sys
 from pathlib import Path
 
-# ─── trust-marker check (do not import; inline by design) ───
-if not (os.environ.get("CLAUDECODE")
-        or os.environ.get("_RAPTOR_TRUSTED")):
-    sys.stderr.write(
-        f"{sys.argv[0]}: internal dispatch script.\n"
-        "  Run via 'bin/raptor' instead.\n"
-        "  Tests / power users: set _RAPTOR_TRUSTED=1 to bypass.\n"
-    )
-    sys.exit(2)
-# ─── end trust-marker check ─────────────────────────────────
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from core.security._trust_guard import require_trusted_caller
+require_trusted_caller()
 
 
 # Per-model cost floor. Each model gets at LEAST this much budget so

--- a/libexec/raptor-understand-annotate
+++ b/libexec/raptor-understand-annotate
@@ -16,18 +16,10 @@ import os
 import sys
 from pathlib import Path
 
-# ─── trust-marker check (do not import; inline by design) ───
-if not (os.environ.get("CLAUDECODE")
-        or os.environ.get("_RAPTOR_TRUSTED")):
-    sys.stderr.write(
-        f"{sys.argv[0]}: internal dispatch script.\n"
-        "  Run via 'bin/raptor' instead.\n"
-        "  Tests / power users: set _RAPTOR_TRUSTED=1 to bypass.\n"
-    )
-    sys.exit(2)
-# ─── end trust-marker check ─────────────────────────────────
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from core.security._trust_guard import require_trusted_caller
+require_trusted_caller()
 
 
 def main() -> int:

--- a/libexec/raptor-validate-schema
+++ b/libexec/raptor-validate-schema
@@ -21,19 +21,10 @@ import hashlib
 import sys
 from pathlib import Path
 
-# ─── trust-marker check (do not import; inline by design) ───
-import os
-if not (os.environ.get("CLAUDECODE")
-        or os.environ.get("_RAPTOR_TRUSTED")):
-    sys.stderr.write(
-        f"{sys.argv[0]}: internal dispatch script.\n"
-        "  Run via 'bin/raptor' instead.\n"
-        "  Tests / power users: set _RAPTOR_TRUSTED=1 to bypass.\n"
-    )
-    sys.exit(2)
-# ─── end trust-marker check ─────────────────────────────────
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from core.security._trust_guard import require_trusted_caller
+require_trusted_caller()
 
 from core.json import load_json, save_json
 

--- a/libexec/raptor-validation-helper
+++ b/libexec/raptor-validation-helper
@@ -15,19 +15,10 @@ import sys
 from collections import defaultdict
 from pathlib import Path
 
-# ─── trust-marker check (do not import; inline by design) ───
-import os
-if not (os.environ.get("CLAUDECODE")
-        or os.environ.get("_RAPTOR_TRUSTED")):
-    sys.stderr.write(
-        f"{sys.argv[0]}: internal dispatch script.\n"
-        "  Run via 'bin/raptor' instead.\n"
-        "  Tests / power users: set _RAPTOR_TRUSTED=1 to bypass.\n"
-    )
-    sys.exit(2)
-# ─── end trust-marker check ─────────────────────────────────
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from core.security._trust_guard import require_trusted_caller
+require_trusted_caller()
 
 import hashlib
 from core.json import load_json, save_json

--- a/libexec/raptor-verified-outcomes
+++ b/libexec/raptor-verified-outcomes
@@ -12,22 +12,13 @@ rather than leaving verified status scattered across per-producer fields.
 import sys
 from pathlib import Path
 
-# ─── trust-marker check (do not import; inline by design) ───
-import os
-if not (os.environ.get("CLAUDECODE")
-        or os.environ.get("_RAPTOR_TRUSTED")):
-    sys.stderr.write(
-        f"{sys.argv[0]}: internal dispatch script.\n"
-        "  Run via 'bin/raptor' instead.\n"
-        "  Tests / power users: set _RAPTOR_TRUSTED=1 to bypass.\n"
-    )
-    sys.exit(2)
-# ─── end trust-marker check ─────────────────────────────────
 
 import argparse
 import json
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from core.security._trust_guard import require_trusted_caller
+require_trusted_caller()
 
 
 def main(argv=None) -> int:

--- a/libexec/raptor-zkpox
+++ b/libexec/raptor-zkpox
@@ -20,22 +20,13 @@ the package docstring (packages/zkpox/__init__.py).
 import sys
 from pathlib import Path
 
-# ─── trust-marker check (do not import; inline by design) ───
-import os
-if not (os.environ.get("CLAUDECODE")
-        or os.environ.get("_RAPTOR_TRUSTED")):
-    sys.stderr.write(
-        f"{sys.argv[0]}: internal dispatch script.\n"
-        "  Run via 'bin/raptor' instead.\n"
-        "  Tests / power users: set _RAPTOR_TRUSTED=1 to bypass.\n"
-    )
-    sys.exit(2)
-# ─── end trust-marker check ─────────────────────────────────
 
 import argparse
 import json
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from core.security._trust_guard import require_trusted_caller
+require_trusted_caller()
 
 
 def _cmd_bundle(args) -> int:

--- a/packages/codeql/database_manager.py
+++ b/packages/codeql/database_manager.py
@@ -805,12 +805,45 @@ class DatabaseManager:
         try:
             from core.sandbox import run as sandbox_run
             from core.sandbox.fingerprint import HOST_CPU_COUNT
+            # `codeql database create` runs the target repo's autobuild /
+            # --command build (attacker-controlled), which by default has
+            # full $HOME read access and could stage ~/.ssh, ~/.aws, etc.
+            # into the build outputs RAPTOR later collects. Opt-in
+            # (RAPTOR_CODEQL_RESTRICT_READS=1) because read-restriction can
+            # starve $HOME toolchains: when enabled, keep common build caches
+            # readable (Maven/Gradle/cargo/codeql) while denying credential
+            # dirs (~/.ssh, ~/.aws, ~/.config, ~/.gnupg, ~/.docker, ~/.kube,
+            # ~/.netrc). Writes stay unrestricted, so the build still writes
+            # its staging/db normally; no-op on hosts without Landlock (network stays
+            # blocked).
+            _restrict = os.environ.get(
+                "RAPTOR_CODEQL_RESTRICT_READS", ""
+            ).strip().lower() in ("1", "true", "yes", "on")
+            _hardening: Dict = {}
+            if _restrict:
+                _home = Path.home()
+                _cache_names = (
+                    ".codeql", ".m2", ".gradle", ".sbt", ".ivy2", ".cargo",
+                    ".rustup", ".cache", ".npm", ".nvm", ".yarn", "go",
+                    ".pyenv", ".local", ".conan", ".conan2", ".cmake",
+                    ".swiftpm", ".dotnet", ".nuget",
+                )
+                _readable = [
+                    str(_home / n) for n in _cache_names
+                    if (_home / n).exists()
+                ]
+                _hardening = dict(
+                    restrict_reads=True,
+                    target=str(working_dir),
+                    readable_paths=_readable,
+                )
             result = sandbox_run(
                 cmd,
                 block_network=True,
                 cwd=working_dir,
                 env=env,
                 tool_paths=self._sandbox_tool_paths(),
+                **_hardening,
                 # Audit JSONL home (only used when --audit is engaged).
                 # Decoupled from output= because the build subprocess
                 # writes to working_dir / db_path / ~/.codeql, none of

--- a/packages/dynamic_instrumentation/__init__.py
+++ b/packages/dynamic_instrumentation/__init__.py
@@ -1,0 +1,19 @@
+"""RAPTOR dynamic instrumentation (Frida).
+
+Spawn-and-instrument support for ``/frida``: function tracing and Stalker
+basic-block coverage that feeds the existing drcov → CoverageStore pipeline.
+Backend-agnostic package name so a second backend could slot in behind the
+same API.
+
+Public surface::
+
+    from packages.dynamic_instrumentation.api import (
+        trace_functions, collect_coverage, is_available,
+    )
+    from packages.dynamic_instrumentation.capability import probe
+"""
+
+from .api import collect_coverage, is_available, trace_functions
+from .capability import probe
+
+__all__ = ["trace_functions", "collect_coverage", "is_available", "probe"]

--- a/packages/dynamic_instrumentation/agents.py
+++ b/packages/dynamic_instrumentation/agents.py
@@ -1,0 +1,136 @@
+"""RAPTOR-authored Frida agent (JS) templates.
+
+The agent scripts are RAPTOR's own code (the *target* is the untrusted
+party); they are rendered with operator/skill-supplied parameters injected
+as JSON literals so target-derived strings never reach ``eval``.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import List, Optional
+
+
+def trace_agent(symbols: List[str]) -> str:
+    """JS that hooks each named function and ``send()``s its first four
+    integer-width arguments on entry. Resolves by debug symbol first (works
+    for static, ``-g`` symbols), then by exported name. Unresolved symbols
+    report a one-shot ``error`` so the operator sees "not found" rather than
+    silent absence."""
+    syms_json = json.dumps(list(symbols))
+    return """
+'use strict';
+var SYMBOLS = %s;
+function resolve(name) {
+    try {
+        var s = DebugSymbol.fromName(name);
+        if (s && s.address && !s.address.isNull()) return s.address;
+    } catch (e) {}
+    try {
+        var a = Module.findGlobalExportByName(name);  // Frida 17 API
+        if (a && !a.isNull()) return a;
+    } catch (e) {}
+    return null;
+}
+SYMBOLS.forEach(function (name) {
+    var addr = resolve(name);
+    if (!addr) { send({ fn: name, error: 'symbol not found' }); return; }
+    try {
+        Interceptor.attach(addr, {
+            onEnter: function (args) {
+                var a = [];
+                for (var i = 0; i < 4; i++) {
+                    try { a.push(args[i].toInt32()); } catch (e) { a.push(null); }
+                }
+                send({ fn: name, addr: addr.toString(), args: a });
+            }
+        });
+    } catch (e) {
+        send({ fn: name, error: 'attach failed: ' + e });
+    }
+});
+""" % syms_json
+
+
+def coverage_agent(modules: Optional[List[str]] = None) -> str:
+    """JS that enumerates loaded modules (so Python can build the drcov module
+    table) and follows the main thread with Stalker, emitting basic-block
+    start/end addresses. ``modules`` (substrings) optionally restricts which
+    modules are reported/instrumented; ``None`` = the main module only (the
+    common "cover the target binary" case).
+
+    Emits:
+      * ``{kind:'modules', modules:[{name,base,size,path}]}`` once at load
+      * ``{kind:'blocks', blocks:[[startHex,endHex],...]}`` per Stalker batch
+        (deduplicated agent-side to keep bridge traffic bounded)
+    Python (``coverage.py``) turns these into a drcov file.
+
+    Coverage starts at ``main`` (resolved via DWARF) and follows that thread
+    with Stalker - a spawned target's threads aren't enumerable while
+    suspended and its entry hook (``__libc_start_main``) has already run by
+    resume, so we hook the target's own ``main`` and call ``Stalker.follow``
+    from inside it (runs on the target main thread). Requires a resolvable
+    ``main`` symbol (the DWARF-present context this feature targets); reports
+    a ``no_main`` error otherwise.
+    """
+    mods_json = json.dumps(modules) if modules else "null"
+    return """
+'use strict';
+var WANT = %s;
+function moduleMatches(m) {
+    if (WANT === null) return true;
+    for (var i = 0; i < WANT.length; i++) {
+        if (m.name.indexOf(WANT[i]) !== -1 || m.path.indexOf(WANT[i]) !== -1)
+            return true;
+    }
+    return false;
+}
+var mods = Process.enumerateModules().filter(moduleMatches).map(function (m) {
+    return { name: m.name, base: m.base.toString(), size: m.size, path: m.path };
+});
+send({ kind: 'modules', modules: mods });
+
+// Cover the main module by default (the target binary) when WANT is null.
+var mainMod = Process.enumerateModules()[0];
+var lo = WANT === null ? ptr(mainMod.base) : null;
+var hi = WANT === null ? ptr(mainMod.base).add(mainMod.size) : null;
+
+// Drain the Stalker event queue aggressively so short-lived targets flush
+// their blocks before exit (default interval can outlive a fast target).
+try { Stalker.queueDrainInterval = 5; } catch (e) {}
+var SEEN = {};   // agent-side dedup: block-start string -> 1
+function onBlocks(events) {
+    var parsed = Stalker.parse(events, { annotate: false, stringify: false });
+    var blocks = [];
+    for (var i = 0; i < parsed.length; i++) {
+        var start = parsed[i][0];
+        if (lo !== null && (start.compare(lo) < 0 || start.compare(hi) >= 0))
+            continue;
+        var key = start.toString();
+        if (SEEN[key]) continue;
+        SEEN[key] = 1;
+        blocks.push([key, parsed[i][1].toString()]);
+    }
+    if (blocks.length) send({ kind: 'blocks', blocks: blocks });
+}
+var mainAddr = null;
+try {
+    var s = DebugSymbol.fromName('main');
+    if (s && s.address && !s.address.isNull()) mainAddr = s.address;
+} catch (e) {}
+if (!mainAddr) {
+    try { mainAddr = Module.findGlobalExportByName('main'); } catch (e) {}
+}
+if (!mainAddr) {
+    send({ kind: 'blocks', error: 'no_main: cannot resolve main to start coverage' });
+} else {
+    var started = false;
+    Interceptor.attach(mainAddr, { onEnter: function () {
+        if (started) return;
+        started = true;
+        Stalker.follow(this.threadId, {
+            events: { block: true }, onReceive: onBlocks,
+        });
+    }});
+}
+""" % mods_json

--- a/packages/dynamic_instrumentation/api.py
+++ b/packages/dynamic_instrumentation/api.py
@@ -1,0 +1,118 @@
+"""Programmatic API for RAPTOR dynamic instrumentation (Frida).
+
+Callable both from the ``/frida`` skill (``python3 -c "from
+packages.dynamic_instrumentation.api import ..."``) and from other packages
+(fuzzing crash triage, exploit_feasibility runtime confirmation). Mirrors the
+``packages/exploit_feasibility/api.py`` shape: small, well-typed entry points
+that hide the sandbox/driver mechanics.
+
+Posture: targets are spawned (RAPTOR launches them), not attached to arbitrary
+running PIDs - RAPTOR instruments binaries the operator chose, under the
+sandbox, network blocked by default. See ``runner.py`` for the isolation model.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from . import agents, coverage as _coverage, runner
+
+logger = logging.getLogger(__name__)
+
+
+def is_available() -> bool:
+    """True when Frida instrumentation can run on this host (binding present)."""
+    from .capability import probe
+    return probe().available
+
+
+def trace_functions(
+    binary: str,
+    symbols: List[str],
+    *,
+    output_dir: str,
+    timeout: float = 30.0,
+    spawn_args: Optional[List[str]] = None,
+    profile: str = "debug",
+) -> Dict[str, Any]:
+    """Spawn ``binary`` and trace entry into each named function, capturing the
+    first four integer-width arguments. Returns a dict with ``trace`` (one
+    record per call), ``unresolved`` symbols, ``events_path``, ``profile_used``
+    and the raw driver ``result``."""
+    if not symbols:
+        raise ValueError("trace_functions: at least one symbol required")
+    agent_js = agents.trace_agent(symbols)
+    run = runner.run_agent(
+        binary, agent_js, output_dir=output_dir, timeout=timeout,
+        spawn_args=spawn_args, profile=profile,
+    )
+    trace: List[dict] = []
+    unresolved: List[str] = []
+    try:
+        for line in Path(run["events_path"]).read_text().splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            msg = json.loads(line)
+            if msg.get("type") != "send":
+                continue
+            p = msg.get("payload") or {}
+            if p.get("error"):
+                unresolved.append(p.get("fn", "?"))
+            elif "fn" in p:
+                trace.append({"fn": p["fn"], "args": p.get("args", []),
+                              "addr": p.get("addr")})
+    except (OSError, ValueError):
+        pass
+    return {
+        "binary": binary,
+        "trace": trace,
+        "unresolved": sorted(set(unresolved)),
+        "call_count": len(trace),
+        "events_path": run["events_path"],
+        "profile_used": run["profile_used"],
+        "result": run["result"],
+    }
+
+
+def collect_coverage(
+    binary: str,
+    *,
+    output_dir: str,
+    modules: Optional[List[str]] = None,
+    timeout: float = 30.0,
+    spawn_args: Optional[List[str]] = None,
+    profile: str = "debug",
+    store: Any = None,
+    checklist: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    """Spawn ``binary`` under Stalker block-coverage, write a drcov file, and
+    (when ``store`` is given) resolve it to source and mark the CoverageStore
+    via the existing ``import_drcov`` path. Returns drcov path, record count
+    and (if marked) source-line count.
+
+    ``store``/``checklist`` are the standard ``core.coverage`` objects; omit
+    them to just produce the drcov file (e.g. for Lighthouse/IDA)."""
+    agent_js = agents.coverage_agent(modules)
+    run = runner.run_agent(
+        binary, agent_js, output_dir=output_dir,
+        events_name="frida-coverage-events.jsonl", agent_name="coverage.js",
+        timeout=timeout, spawn_args=spawn_args, profile=profile,
+    )
+    drcov_path = str(Path(output_dir) / "frida.drcov")
+    n_bbs = _coverage.write_drcov(run["events_path"], drcov_path)
+    out: Dict[str, Any] = {
+        "binary": binary,
+        "drcov_path": drcov_path if n_bbs else None,
+        "basic_blocks": n_bbs,
+        "events_path": run["events_path"],
+        "profile_used": run["profile_used"],
+        "result": run["result"],
+    }
+    if n_bbs and store is not None:
+        out["lines_marked"] = _coverage.import_to_store(
+            store, drcov_path, binary, checklist or {}, tool="frida")
+    return out

--- a/packages/dynamic_instrumentation/capability.py
+++ b/packages/dynamic_instrumentation/capability.py
@@ -1,0 +1,81 @@
+"""Frida / dynamic-instrumentation capability detection.
+
+Probes the host for the pieces ``/frida`` needs - the ``frida`` Python
+binding, the ``frida`` CLI, and the kernel ``ptrace_scope`` setting - and
+reports them rather than failing mid-run with a cryptic error. Mirrors the
+``packages/fuzzing/capability.py`` ``CapabilityReport`` pattern.
+
+Backend-agnostic naming (``dynamic_instrumentation``, not ``frida``) so a
+second backend could slot in behind the same report, the way ``fuzzing``
+abstracts AFL++/libFuzzer.
+"""
+
+from __future__ import annotations
+
+import logging
+import platform
+import shutil
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class CapabilityReport:
+    """What dynamic instrumentation can do on this host."""
+
+    platform: str
+    arch: str
+    frida_python: Optional[str] = None   # frida.__version__ or None
+    frida_cli: Optional[str] = None      # path to `frida` CLI or None
+    ptrace_scope: Optional[int] = None   # /proc/sys/kernel/yama/ptrace_scope
+    notes: List[str] = field(default_factory=list)
+
+    @property
+    def available(self) -> bool:
+        """True when the Python binding is importable - the embedded driver
+        (spawn + Stalker) only needs the binding, not the CLI."""
+        return self.frida_python is not None
+
+    def summary(self) -> str:
+        if not self.available:
+            return ("frida Python binding not importable - /frida unavailable. "
+                    "Install with: pipx install frida-tools  (or "
+                    "pip install frida-tools)")
+        bits = [f"frida {self.frida_python}"]
+        if self.frida_cli:
+            bits.append("CLI present")
+        if self.ptrace_scope is not None:
+            bits.append(f"ptrace_scope={self.ptrace_scope}")
+        return ", ".join(bits)
+
+
+def _read_ptrace_scope() -> Optional[int]:
+    try:
+        with open("/proc/sys/kernel/yama/ptrace_scope") as fh:
+            return int(fh.read().strip())
+    except (OSError, ValueError):
+        return None
+
+
+def probe() -> CapabilityReport:
+    """Static capability probe - no process is spawned (cheap, safe to call
+    from ``/doctor``). Runtime spawn-vs-namespace fallback is handled by the
+    runner, not here."""
+    rep = CapabilityReport(
+        platform=platform.system(),
+        arch=platform.machine(),
+        frida_cli=shutil.which("frida"),
+        ptrace_scope=_read_ptrace_scope(),
+    )
+    try:
+        import frida  # noqa: F401
+        rep.frida_python = getattr(frida, "__version__", "unknown")
+    except Exception as e:  # noqa: BLE001 - probe must never raise
+        rep.notes.append(f"frida import failed: {type(e).__name__}: {e}")
+    if rep.ptrace_scope is not None and rep.ptrace_scope >= 2:
+        rep.notes.append(
+            "ptrace_scope >= 2: attach-to-PID is restricted; spawn-mode "
+            "(the /frida default) is unaffected.")
+    return rep

--- a/packages/dynamic_instrumentation/coverage.py
+++ b/packages/dynamic_instrumentation/coverage.py
@@ -1,0 +1,119 @@
+"""Frida Stalker coverage → drcov → RAPTOR CoverageStore.
+
+The coverage agent (``agents.coverage_agent``) emits a module table and
+basic-block start/end addresses as ``send()`` events. This module turns those
+into a standard **drcov** file (the format ``core.coverage.collect.parse_drcov``
+already ingests - its docstring names Frida as a producer) and then resolves
+it to source via the existing ``import_drcov`` path. No new resolver is
+written: Frida coverage rides the same DWARF-resolution + store-marking
+machinery as DynamoRIO/AFL-QEMU drcov.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import struct
+from pathlib import Path
+from typing import Any, Dict, List, Tuple
+
+logger = logging.getLogger(__name__)
+
+
+def _load_events(events_path: str) -> Tuple[List[dict], List[Tuple[int, int]]]:
+    """Return (modules, block_addrs) from the driver's JSONL event file.
+
+    ``modules`` = [{name, base(int), size(int), path}]; ``block_addrs`` =
+    list of (start_addr, end_addr) ints (absolute)."""
+    modules: List[dict] = []
+    blocks: List[Tuple[int, int]] = []
+    try:
+        text = Path(events_path).read_text()
+    except OSError:
+        return modules, blocks
+    for line in text.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            msg = json.loads(line)
+        except ValueError:
+            continue
+        if msg.get("type") != "send":
+            continue
+        payload = msg.get("payload") or {}
+        kind = payload.get("kind")
+        if kind == "modules":
+            for m in payload.get("modules", []):
+                try:
+                    modules.append({
+                        "name": m["name"],
+                        "base": int(m["base"], 0) if isinstance(m["base"], str)
+                        else int(m["base"]),
+                        "size": int(m["size"]),
+                        "path": m["path"],
+                    })
+                except (KeyError, ValueError, TypeError):
+                    continue
+        elif kind == "blocks":
+            for pair in payload.get("blocks", []):
+                try:
+                    start = int(pair[0], 0) if isinstance(pair[0], str) else int(pair[0])
+                    end = int(pair[1], 0) if isinstance(pair[1], str) else int(pair[1])
+                    blocks.append((start, end))
+                except (ValueError, TypeError, IndexError):
+                    continue
+    return modules, blocks
+
+
+def write_drcov(events_path: str, drcov_path: str) -> int:
+    """Serialise the Frida coverage events to a drcov-v2 file. Returns the
+    number of basic-block records written (0 if nothing was collected)."""
+    modules, blocks = _load_events(events_path)
+    if not modules:
+        logger.debug("frida coverage: no module table in %s", events_path)
+        return 0
+
+    # Stable module ids by load order; resolve each block to (module_id, off).
+    mod_ranges = [
+        (i, m["base"], m["base"] + m["size"]) for i, m in enumerate(modules)
+    ]
+    records: List[Tuple[int, int, int]] = []  # (offset_u32, size_u16, mid_u16)
+    seen = set()
+    for start, end in blocks:
+        for mid, lo, hi in mod_ranges:
+            if lo <= start < hi:
+                off = start - lo
+                size = max(0, min(end - start, 0xFFFF))
+                key = (mid, off)
+                if key not in seen:
+                    seen.add(key)
+                    records.append((off & 0xFFFFFFFF, size, mid & 0xFFFF))
+                break
+
+    lines = [
+        "DRCOV VERSION: 2",
+        "DRCOV FLAVOR: frida",
+        f"Module Table: version 2, count {len(modules)}",
+        "Columns: id, base, end, entry, path",
+    ]
+    for i, m in enumerate(modules):
+        lines.append(
+            f"{i}, {hex(m['base'])}, {hex(m['base'] + m['size'])}, 0, {m['path']}"
+        )
+    header = ("\n".join(lines) + "\n").encode("utf-8")
+    bb_header = f"BB Table: {len(records)} bbs\n".encode("utf-8")
+    blob = b"".join(struct.pack("<IHH", off, size, mid) for off, size, mid in records)
+
+    Path(drcov_path).write_bytes(header + bb_header + blob)
+    return len(records)
+
+
+def import_to_store(store, drcov_path: str, binary: str,
+                    checklist: Dict[str, Any], tool: str = "frida") -> int:
+    """Resolve the drcov file to source and mark ``store`` - thin wrapper over
+    the existing ``core.coverage.collect.import_drcov`` so Frida coverage flows
+    into the same store as every other runtime source (visible in
+    ``/project coverage``). Returns the number of source lines marked."""
+    from core.coverage.collect import import_drcov
+    return import_drcov(store, drcov_path, binary, checklist, tool=tool)

--- a/packages/dynamic_instrumentation/frida_driver.py
+++ b/packages/dynamic_instrumentation/frida_driver.py
@@ -1,0 +1,101 @@
+"""In-sandbox Frida driver - runs as the PARENT that spawns the target.
+
+Invoked by ``runner.py`` *inside* the sandbox namespace so that the driver
+and the target it spawns live in the same process tree (ptrace_scope=1
+authorises a parent→descendant trace, the same model gdb/rr use under
+``/crash-analysis``). Reads a RAPTOR-authored agent script, spawns the
+target suspended, loads the agent, resumes, and streams ``send()`` messages
+to a JSONL file until the target exits or the timeout fires.
+
+stdout contract (parsed by the runner):
+  ``FRIDA_RESULT=<json>`` - one line with {events, exit, error}.
+
+This file is intentionally dependency-free (only ``frida`` + stdlib) so it
+runs under the sandbox's restricted environment.
+"""
+
+import argparse
+import json
+import sys
+import time
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="RAPTOR in-sandbox Frida driver")
+    ap.add_argument("--agent", required=True, help="Path to the Frida agent JS")
+    ap.add_argument("--events-out", required=True, help="JSONL output path")
+    ap.add_argument("--timeout", type=float, default=30.0)
+    ap.add_argument("cmd", nargs=argparse.REMAINDER,
+                    help="target binary + args (after --)")
+    args = ap.parse_args()
+
+    cmd = args.cmd
+    if cmd and cmd[0] == "--":
+        cmd = cmd[1:]
+    if not cmd:
+        print('FRIDA_RESULT=' + json.dumps({"error": "no target command"}))
+        return 2
+
+    try:
+        import frida
+    except Exception as e:  # noqa: BLE001
+        print('FRIDA_RESULT=' + json.dumps(
+            {"error": f"frida import failed: {e}"}))
+        return 3
+
+    try:
+        agent_src = open(args.agent).read()
+    except OSError as e:
+        print('FRIDA_RESULT=' + json.dumps({"error": f"agent read: {e}"}))
+        return 4
+
+    events = []
+
+    def on_message(message, data):
+        # 'send' → payload from the agent; 'error' → JS exception. Keep both
+        # so the caller can see agent-side failures rather than silent zero.
+        events.append(message)
+
+    detached = {"flag": False}
+
+    try:
+        pid = frida.spawn(cmd)
+        session = frida.attach(pid)
+        session.on("detached", lambda *a: detached.update(flag=True))
+        script = session.create_script(agent_src)
+        script.on("message", on_message)
+        script.load()
+        frida.resume(pid)
+    except Exception as e:  # noqa: BLE001 - spawn/attach can fail (namespace,
+        # ptrace_scope, missing target). Report so the runner can fall back.
+        print('FRIDA_RESULT=' + json.dumps(
+            {"error": f"{type(e).__name__}: {e}"}))
+        return 5
+
+    deadline = time.monotonic() + args.timeout
+    while time.monotonic() < deadline and not detached["flag"]:
+        time.sleep(0.05)
+
+    try:
+        frida.kill(pid)
+    except Exception:  # noqa: BLE001 - already dead is fine
+        pass
+
+    try:
+        with open(args.events_out, "w") as fh:
+            for e in events:
+                fh.write(json.dumps(e) + "\n")
+    except OSError as e:
+        print('FRIDA_RESULT=' + json.dumps({"error": f"events write: {e}"}))
+        return 6
+
+    n_send = sum(1 for e in events if e.get("type") == "send")
+    n_err = sum(1 for e in events if e.get("type") == "error")
+    print('FRIDA_RESULT=' + json.dumps(
+        {"events": len(events), "send": n_send, "errors": n_err,
+         "exited": detached["flag"]}))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/packages/dynamic_instrumentation/runner.py
+++ b/packages/dynamic_instrumentation/runner.py
@@ -1,0 +1,117 @@
+"""Sandboxed execution glue for Frida.
+
+The only module that talks to ``core.sandbox``. It runs ``frida_driver.py``
+*inside* the sandbox so the driver and the target it spawns share one
+process tree (parent→descendant ptrace, authorised by ptrace_scope=1 - the
+same model ``/crash-analysis`` uses for gdb/rr).
+
+Default profile is ``debug`` (full Landlock + seccomp-with-ptrace + network
+block). Empirically, Frida's spawn loader reads ``/proc/<pid>/auxv``, which
+needs ``/proc`` correctly remounted inside the PID namespace; on hosts where
+the mount namespace can't be set up that read fails, so the runner detects
+the failure signature and transparently falls back to ``profile="none"``
+(no isolation) with a loud warning - rather than leaving the operator with a
+cryptic ``NotSupportedError``. Network isolation is the property lost in the
+fallback; the target is still operator-chosen and spawn-only.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+_DRIVER = Path(__file__).resolve().parent / "frida_driver.py"
+
+# Stderr/stdout signatures that mean "spawn failed because the PID namespace's
+# /proc isn't usable" - the documented fall-back-to-no-isolation trigger.
+_NS_SPAWN_FAIL = (
+    "auxv", "No such process", "NotSupportedError",
+    "unable to find process", "ptrace",
+)
+
+
+def _parse_result(stdout: str) -> Optional[dict]:
+    for line in stdout.splitlines():
+        if line.startswith("FRIDA_RESULT="):
+            try:
+                return json.loads(line[len("FRIDA_RESULT="):])
+            except ValueError:
+                return None
+    return None
+
+
+def run_agent(
+    target: str,
+    agent_js: str,
+    *,
+    output_dir: str,
+    events_name: str = "frida-events.jsonl",
+    agent_name: str = "agent.js",
+    timeout: float = 30.0,
+    spawn_args: Optional[List[str]] = None,
+    profile: str = "debug",
+    _allow_fallback: bool = True,
+) -> Dict[str, Any]:
+    """Spawn ``target`` under Frida with ``agent_js`` attached, inside the
+    sandbox. Returns a dict with ``events_path``, ``result`` (the driver's
+    summary), ``profile_used``, ``returncode`` and trailing ``stderr``.
+
+    Never raises on instrumentation failure - a failed run is reported via the
+    ``result.error`` field so callers (skill, api) can surface it cleanly.
+    """
+    out = Path(output_dir)
+    out.mkdir(parents=True, exist_ok=True)
+    agent_path = out / agent_name
+    agent_path.write_text(agent_js)
+    events_path = out / events_name
+
+    cmd = [
+        sys.executable, str(_DRIVER),
+        "--agent", str(agent_path),
+        "--events-out", str(events_path),
+        "--timeout", str(timeout),
+        "--", str(target),
+    ] + [str(a) for a in (spawn_args or [])]
+
+    from core.sandbox import sandbox, SandboxSetupError
+
+    def _fallback(reason: str) -> Dict[str, Any]:
+        logger.warning(
+            "frida: %s under profile %r - retrying with NO isolation "
+            "(network not blocked; target is still operator-chosen + "
+            "spawn-only). Pass profile='debug' on a host with working "
+            "mount namespaces for full isolation.", reason, profile,
+        )
+        return run_agent(
+            target, agent_js, output_dir=output_dir, events_name=events_name,
+            agent_name=agent_name, timeout=timeout, spawn_args=spawn_args,
+            profile="none", _allow_fallback=False,
+        )
+
+    try:
+        with sandbox(profile=profile, output=str(out)) as run:
+            proc = run(cmd, capture_output=True, text=True, check=False,
+                       timeout=timeout + 30)
+    except SandboxSetupError as e:
+        if _allow_fallback and profile != "none":
+            return _fallback(f"sandbox unavailable ({e})")
+        raise
+
+    result = _parse_result(proc.stdout) or {}
+    combined = f"{result.get('error', '')} {proc.stderr or ''}"
+    if (_allow_fallback and profile != "none"
+            and any(sig in combined for sig in _NS_SPAWN_FAIL)):
+        return _fallback("spawn failed (PID-namespace / proc-remount)")
+
+    return {
+        "events_path": str(events_path),
+        "result": result,
+        "profile_used": profile,
+        "returncode": proc.returncode,
+        "stderr": (proc.stderr or "")[-2000:],
+    }

--- a/packages/dynamic_instrumentation/tests/test_agents.py
+++ b/packages/dynamic_instrumentation/tests/test_agents.py
@@ -1,0 +1,37 @@
+"""Agent JS generation - parameters must be injected as JSON literals (never
+raw string interpolation) so target-derived names can't break out of the JS."""
+
+import json
+
+from packages.dynamic_instrumentation import agents
+
+
+def test_trace_agent_embeds_symbols_as_json():
+    js = agents.trace_agent(["foo", "bar"])
+    assert '["foo", "bar"]' in js
+    assert "Interceptor.attach" in js
+    assert "DebugSymbol.fromName" in js
+    # Frida 17 API (not the removed Module.findExportByName(null, ...)).
+    assert "findGlobalExportByName" in js
+
+
+def test_trace_agent_quote_injection_is_neutralised():
+    # A symbol containing a quote must be JSON-escaped, not break the JS.
+    evil = 'x"); doSomethingEvil(("'
+    js = agents.trace_agent([evil])
+    assert json.dumps([evil]) in js
+    # the raw unescaped payload must not appear verbatim as JS
+    assert 'doSomethingEvil((")' not in js.replace(json.dumps([evil]), "")
+
+
+def test_coverage_agent_hooks_main_and_follows_stalker():
+    js = agents.coverage_agent()
+    assert "Stalker.follow" in js
+    assert "DebugSymbol.fromName('main')" in js
+    assert "enumerateModules" in js
+    assert "null" in js  # WANT defaults to null (cover main module)
+
+
+def test_coverage_agent_module_filter_is_json():
+    js = agents.coverage_agent(["libssl", "libcrypto"])
+    assert json.dumps(["libssl", "libcrypto"]) in js

--- a/packages/dynamic_instrumentation/tests/test_capability.py
+++ b/packages/dynamic_instrumentation/tests/test_capability.py
@@ -1,0 +1,27 @@
+"""Capability probe - must never raise and must report a stable shape,
+whether or not Frida is installed on the test host."""
+
+from packages.dynamic_instrumentation.capability import CapabilityReport, probe
+
+
+def test_probe_returns_report():
+    rep = probe()
+    assert isinstance(rep, CapabilityReport)
+    assert isinstance(rep.platform, str) and rep.platform
+    # available iff the binding imported
+    assert rep.available == (rep.frida_python is not None)
+    assert isinstance(rep.summary(), str) and rep.summary()
+
+
+def test_unavailable_summary_has_install_hint():
+    rep = CapabilityReport(platform="Linux", arch="x86_64", frida_python=None)
+    assert not rep.available
+    assert "pipx install frida-tools" in rep.summary()
+
+
+def test_high_ptrace_scope_noted():
+    rep = CapabilityReport(platform="Linux", arch="x86_64",
+                           frida_python="17.0", ptrace_scope=3)
+    # probe() adds the note; construct-and-call path is exercised in probe(),
+    # here we assert the field is carried.
+    assert rep.ptrace_scope == 3

--- a/packages/dynamic_instrumentation/tests/test_coverage.py
+++ b/packages/dynamic_instrumentation/tests/test_coverage.py
@@ -1,0 +1,68 @@
+"""drcov serialisation round-trip: the file written by coverage.write_drcov
+must be readable by core.coverage.collect.parse_drcov (the existing,
+Frida-aware ingest path). No Frida required."""
+
+import json
+
+from core.coverage.collect import parse_drcov
+from packages.dynamic_instrumentation import coverage
+
+
+def _write_events(path, modules, blocks):
+    with open(path, "w") as fh:
+        fh.write(json.dumps({"type": "send",
+                             "payload": {"kind": "modules", "modules": modules}}) + "\n")
+        fh.write(json.dumps({"type": "send",
+                             "payload": {"kind": "blocks", "blocks": blocks}}) + "\n")
+
+
+def test_drcov_round_trip(tmp_path):
+    events = tmp_path / "events.jsonl"
+    drcov = tmp_path / "out.drcov"
+    base = 0x400000
+    modules = [{"name": "target", "base": hex(base), "size": 0x2000,
+                "path": "/tmp/target"}]
+    # three blocks inside the module
+    blocks = [[hex(base + 0x100), hex(base + 0x110)],
+              [hex(base + 0x200), hex(base + 0x208)],
+              [hex(base + 0x300), hex(base + 0x320)]]
+    _write_events(str(events), modules, blocks)
+
+    n = coverage.write_drcov(str(events), str(drcov))
+    assert n == 3
+
+    parsed = parse_drcov(str(drcov))
+    assert "/tmp/target" in parsed
+    entry = parsed["/tmp/target"]
+    assert entry["base"] == base
+    assert entry["offsets"] == {0x100, 0x200, 0x300}
+
+
+def test_blocks_outside_modules_are_dropped(tmp_path):
+    events = tmp_path / "e.jsonl"
+    drcov = tmp_path / "o.drcov"
+    base = 0x400000
+    modules = [{"name": "t", "base": hex(base), "size": 0x1000, "path": "/t"}]
+    blocks = [[hex(base + 0x10), hex(base + 0x20)],   # in
+              [hex(0x900000), hex(0x900010)]]          # out of range
+    _write_events(str(events), modules, blocks)
+    n = coverage.write_drcov(str(events), str(drcov))
+    assert n == 1
+    assert parse_drcov(str(drcov))["/t"]["offsets"] == {0x10}
+
+
+def test_no_modules_writes_nothing(tmp_path):
+    events = tmp_path / "e.jsonl"
+    events.write_text(json.dumps({"type": "send",
+                                  "payload": {"kind": "blocks", "blocks": []}}) + "\n")
+    assert coverage.write_drcov(str(events), str(tmp_path / "o.drcov")) == 0
+
+
+def test_duplicate_blocks_deduplicated(tmp_path):
+    events = tmp_path / "e.jsonl"
+    drcov = tmp_path / "o.drcov"
+    base = 0x400000
+    modules = [{"name": "t", "base": hex(base), "size": 0x1000, "path": "/t"}]
+    blocks = [[hex(base + 0x10), hex(base + 0x20)]] * 5
+    _write_events(str(events), modules, blocks)
+    assert coverage.write_drcov(str(events), str(drcov)) == 1

--- a/packages/dynamic_instrumentation/tests/test_runner.py
+++ b/packages/dynamic_instrumentation/tests/test_runner.py
@@ -1,0 +1,57 @@
+"""End-to-end runner/api test - gated on Frida + a C compiler being present
+(skipped in their absence so CI without Frida stays green)."""
+
+import shutil
+import subprocess
+
+import pytest
+
+from packages.dynamic_instrumentation import api
+from packages.dynamic_instrumentation.capability import probe
+
+_FRIDA = probe().available
+_CC = shutil.which("gcc") or shutil.which("cc")
+
+pytestmark = pytest.mark.skipif(
+    not (_FRIDA and _CC), reason="needs frida binding + a C compiler")
+
+_SRC = r"""
+#include <stdio.h>
+int secret(int x){ return x*3+1; }
+int main(){ for(int i=0;i<3;i++){ printf("%d\n", secret(i)); } return 0; }
+"""
+
+
+@pytest.fixture(scope="module")
+def target(tmp_path_factory):
+    d = tmp_path_factory.mktemp("frida_target")
+    src = d / "t.c"
+    src.write_text(_SRC)
+    binp = d / "t"
+    rc = subprocess.run([_CC, "-O0", "-g", "-o", str(binp), str(src)],
+                        capture_output=True, text=True)
+    if rc.returncode != 0:
+        pytest.skip(f"compile failed: {rc.stderr[:200]}")
+    return str(binp)
+
+
+def test_trace_captures_calls(target, tmp_path):
+    res = api.trace_functions(target, ["secret"],
+                              output_dir=str(tmp_path / "trace"), timeout=20)
+    # secret() is called 3 times with args 0,1,2
+    assert res["call_count"] == 3
+    assert res["unresolved"] == []
+    first_args = [r["args"][0] for r in res["trace"]]
+    assert first_args == [0, 1, 2]
+
+
+def test_coverage_marks_drcov(target, tmp_path):
+    res = api.collect_coverage(target, output_dir=str(tmp_path / "cov"),
+                               timeout=20)
+    # tiny target - may collect few blocks, but the main module must register
+    assert res["basic_blocks"] >= 1
+    assert res["drcov_path"]
+    # the produced drcov resolves to source via the existing pipeline
+    from core.coverage.collect import collect_drcov
+    src = collect_drcov(res["drcov_path"], target)
+    assert any(p.endswith("t.c") for p in src)

--- a/packages/llm_analysis/dispatch.py
+++ b/packages/llm_analysis/dispatch.py
@@ -308,6 +308,11 @@ def dispatch_task(
           + f" (max {max_parallel} parallel)")
 
     results = []
+    # Terminal (item_id, model_key) pairs: the unit of work is the
+    # (model, item) pair, not the item, so the abort back-fill can record a
+    # cancelled model's contribution to an item another model already
+    # completed (else multi-model correlation under-counts contributors).
+    _completed_pairs: set = set()
     completed = 0
     running_cost = 0.0
     abort = False
@@ -350,6 +355,17 @@ def dispatch_task(
         futures = {}
         for model, item in work:
             def _do_one(m=model, it=item):
+                # Stop spending budget on a model already declared dead (3
+                # consecutive failures): all (model, item) futures are
+                # submitted up front, so without this guard its remaining
+                # items keep calling the provider. Best-effort read of
+                # _per_model_dead; routes through the per-future error
+                # handler so the (item, model) pair is recorded and the
+                # abort back-fill stays consistent.
+                if _model_key(m) in _per_model_dead:
+                    raise RuntimeError(
+                        "model marked dead (consecutive failures) - "
+                        "skipping dispatch")
                 # Prefilter hook (fast-tier scorecard) — fires before
                 # prompt build and full dispatch so we don't pay for
                 # token-heavy work when the cheap-tier verdict is
@@ -396,6 +412,7 @@ def dispatch_task(
                 item_cost = processed.get("cost_usd", 0)
                 running_cost += item_cost
                 results.append(processed)
+                _completed_pairs.add((item_id, model_key))
                 # Reset this model's consecutive-failure counter
                 # — successful response means we're not in a
                 # death spiral for this model.
@@ -482,6 +499,7 @@ def dispatch_task(
                 error_type = _classify_error(err_str)
                 results.append({"finding_id": item_id, "error": err_str,
                                 "error_type": error_type})
+                _completed_pairs.add((item_id, model_key))
                 display = task.get_item_display(item)
                 print(f"  [{completed}/{total} {_format_elapsed(elapsed)} ${running_cost:.2f}] "
                       f"{display} FAILED — {err_str}")
@@ -565,11 +583,16 @@ def dispatch_task(
                         break
 
     if abort:
-        completed_ids = {r.get("finding_id") for r in results}
-        for item in selected:
+        # Back-fill over (model, item) WORK pairs, not items: in multi-model
+        # mode an item completed by one model must still get an error record
+        # for every other model whose future was cancelled, else that model
+        # silently drops out of the per-finding contributor set.
+        for model, item in work:
             item_id = task.get_item_id(item)
-            if item_id not in completed_ids:
-                results.append({"finding_id": item_id, "error": "aborted (auth failure)"})
+            mk = _model_key(model)
+            if (item_id, mk) not in _completed_pairs:
+                results.append({"finding_id": item_id, "analysed_by": mk,
+                                "error": "aborted (auth failure)"})
 
     # Finalize (e.g. consensus verdict rules)
     results = task.finalize(results, prior_results)

--- a/packages/llm_analysis/orchestrator.py
+++ b/packages/llm_analysis/orchestrator.py
@@ -371,6 +371,14 @@ def build_llm_config_from_flags(
         for role, model_name in role_flags:
             if not model_name:
                 continue
+            # --aggregate synthesises across multiple analysis models; with
+            # fewer than two it has nothing to synthesise, so drop it with a
+            # warning rather than billing an aggregate model for a no-op.
+            if role == "aggregate" and n_analysis < 2:
+                print("\n  Warning: --aggregate requires at least two --model "
+                      "values (it synthesises across multiple models); "
+                      "ignoring --aggregate")
+                continue
             llm_config.fallback_models = [
                 m for m in llm_config.fallback_models if m.role != role
             ]

--- a/raptor.py
+++ b/raptor.py
@@ -90,13 +90,12 @@ def _extract_and_strip_max_cost_usd(args: list) -> tuple[float | None, list]:
     forwarding so downstream scripts (scanner, agentic, codeql)
     don't have to recognise the flag.
 
-    Invalid values (non-numeric, zero, negative) print a stderr
-    warning and return ``(None, args)`` unchanged — operator's
-    typo doesn't silently uncap the run, but the run also doesn't
-    refuse to start over a bad cap value. (A hard error here
-    would force every operator typo through a full lifecycle
-    failure, which is more brittle than this warn-and-skip
-    fallback.)
+    Invalid values (non-numeric, zero, negative) FAIL CLOSED: the
+    operator passed ``--max-cost-usd`` precisely because they want a
+    cost ceiling, so a typo must refuse to start (exit 2) rather than
+    silently uncap the run - silently removing a budget cap is the
+    worst-case failure for a cost control (QoL #14). Omitting the flag
+    entirely (cap_str is None) is the normal uncapped path and is fine.
     """
     flag = "--max-cost-usd"
     prefix = f"{flag}="
@@ -121,18 +120,20 @@ def _extract_and_strip_max_cost_usd(args: list) -> tuple[float | None, list]:
         cap = float(cap_str)
     except ValueError:
         print(
-            f"WARNING: --max-cost-usd value {cap_str!r} is not a number; "
-            "ignoring cap for this run",
+            f"✗ --max-cost-usd value {cap_str!r} is not a number. Refusing to "
+            "start: a malformed cost cap must not silently run UNCAPPED. "
+            "Fix the value or omit --max-cost-usd to run without a cap.",
             file=sys.stderr,
         )
-        return (None, args)
+        sys.exit(2)
     if cap <= 0:
         print(
-            f"WARNING: --max-cost-usd must be > 0 (got {cap}); "
-            "ignoring cap for this run",
+            f"✗ --max-cost-usd must be > 0 (got {cap}). Refusing to start: a "
+            "malformed cost cap must not silently run UNCAPPED. Fix the value "
+            "or omit --max-cost-usd to run without a cap.",
             file=sys.stderr,
         )
-        return (None, args)
+        sys.exit(2)
     return (cap, out)
 
 
@@ -308,7 +309,16 @@ def _run_with_lifecycle(command: str, script_path: Path, args: list,
     # the dispatcher resolved the output dir correctly but never
     # forwarded the target into the downstream script's args.
     # Explicit --repo from args always wins (per the override pattern).
-    if target is None:
+    # EXCEPTION: --reanalyze carries its own target (the previous run's
+    # recorded target_path). Back-filling --repo from the active project /
+    # caller-dir here would make agentic's reanalyze logic see a non-empty
+    # args.repo that differs from the recorded target and discard the
+    # correct one (SARIF then rebases against the wrong tree). Leave target
+    # unset so the child resolves it from the prior run.
+    _reanalyze_mode = any(
+        a == "--reanalyze" or a.startswith("--reanalyze=") for a in args
+    )
+    if target is None and not _reanalyze_mode:
         target = resolve_default_target()
         if target is not None:
             args = args + ["--repo", target]
@@ -589,16 +599,36 @@ def _run_with_lifecycle(command: str, script_path: Path, args: list,
         # Engine versions + deterministically_reproducible are filled by the
         # lifecycle itself now (core.run.complete_run), uniformly for every
         # command — no per-command manifest wiring here.
-        complete_run(out_dir)
-        # Print a coverage summary at the end of /agentic (after complete_run,
-        # so the scanner + codeql + llm-read records are all materialised).
-        # /scan and /validate print their own; this closes the agentic gap.
+        #
+        # EXCEPTION: agentic self-finalizes inside raptor_agentic.main()
+        # with a richer extra/manifest (findings_count, models, …). Calling
+        # complete_run again here would re-run the finalize side-effects
+        # (coverage snapshot, sandbox summary) and log a spurious "refusing
+        # to overwrite terminal status" warning on every successful run.
+        # Every real agentic path self-seals (normal run + threat-model-only),
+        # so the launcher only finalizes the other modes.
+        if command != "agentic":
+            complete_run(out_dir)
+        # Print a coverage summary at the end of /agentic (after the run is
+        # finalized, so the scanner + codeql + llm-read records are all
+        # materialised). /scan and /validate print their own; this closes
+        # the agentic gap.
         if command == "agentic":
             try:
                 from core.coverage.store_summary import render_run_coverage
                 summary = render_run_coverage(out_dir)
                 if summary:
                     print("\n" + summary)
+            except Exception:
+                pass
+        # Point the one-shot scanners at the verbs to triage what the run
+        # produced, rather than leaving the operator with a bare path.
+        if command in ("scan", "codeql"):
+            try:
+                print("\nNext steps:")
+                print(f"  python3 raptor.py agentic --reanalyze {out_dir}   # LLM triage of these findings")
+                print("  raptor project findings                            # merged findings (in a project)")
+                print("  raptor project coverage                            # tool coverage")
             except Exception:
                 pass
     else:
@@ -1077,16 +1107,26 @@ def show_mode_help(mode: str, preamble: bool = True) -> None:
     help, with nothing above it.
     """
     mode_scripts = _mode_help_scripts()
+    # Modes handled in-process by raptor.py (no child script) that parse
+    # their own --help: render their help by re-invoking raptor.py itself.
+    inprocess_modes = {"doctor", "describe", "sca"}
 
-    if mode not in mode_scripts:
+    if mode not in mode_scripts and mode not in inprocess_modes:
         print(f"✗ Unknown mode: {mode}", file=sys.stderr)
-        print(f"Available modes: {', '.join(mode_scripts.keys())}")
+        available = sorted(set(mode_scripts) | inprocess_modes)
+        print(f"Available modes: {', '.join(available)}")
         return
 
-    script_path = mode_scripts[mode]
-    if not script_path.exists():
-        print(f"✗ Script not found: {script_path}", file=sys.stderr)
-        return
+    if mode in mode_scripts:
+        script_path = mode_scripts[mode]
+        if not script_path.exists():
+            print(f"✗ Script not found: {script_path}", file=sys.stderr)
+            return
+        help_cmd = [sys.executable, str(script_path), "--help"]
+    else:
+        # In-process mode: re-invoke raptor.py <mode> --help (the handler
+        # parses --help itself, side-effect-free).
+        help_cmd = [sys.executable, str(Path(__file__)), mode, "--help"]
 
     if preamble:
         # flush=True so the header lands ABOVE the child's help. Without
@@ -1107,7 +1147,7 @@ def show_mode_help(mode: str, preamble: bool = True) -> None:
     try:
         from core.config import RaptorConfig
         subprocess.run(
-            [sys.executable, str(script_path), "--help"],
+            help_cmd,
             env=RaptorConfig.get_safe_env(),
             timeout=10,
         )
@@ -1129,6 +1169,8 @@ Available Modes:
   agentic     - Full autonomous workflow (Semgrep + CodeQL + LLM analysis)
   codeql      - CodeQL-only analysis
   analyze     - LLM-powered vulnerability analysis (requires SARIF input)
+  describe    - Pre-flight target inspection: language mix, build system,
+                cost estimate (read-only, no LLM cost)
   doctor      - Status report for local setup (no claude needed)
 
 Examples:
@@ -1314,7 +1356,15 @@ if __name__ == "__main__":
         print("\n\nInterrupted by user")
         sys.exit(130)
     except Exception as e:
-        print(f"\n✗ Fatal error: {e}")
-        import traceback
-        traceback.print_exc()
+        print(f"\n✗ Fatal error: {e}", file=sys.stderr)
+        # A bare traceback is noise for the common operator-facing causes
+        # (missing API key, unreadable repo, absent tool). Gate the full
+        # traceback behind RAPTOR_DEBUG and point the operator at it.
+        if os.environ.get("RAPTOR_DEBUG"):
+            import traceback
+            traceback.print_exc()
+        else:
+            print("  Run with RAPTOR_DEBUG=1 for a full traceback, or "
+                  "'python3 raptor.py doctor' to check tool + LLM setup.",
+                  file=sys.stderr)
         sys.exit(1)

--- a/raptor_agentic.py
+++ b/raptor_agentic.py
@@ -997,6 +997,25 @@ def _build_completion_manifest(orch_meta, import_result, import_sarif_files,
     return manifest
 
 
+def _recent_run_dirs(limit: int = 10):
+    """Prior run directories (those containing ``.raptor-run.json``), newest
+    first. Scans the output root one and two levels deep so both the
+    ``out/<run>`` and ``out/<project>/<run>`` (active-project) layouts are
+    covered. Used by ``--reanalyze last`` and the not-found hint (QoL #4/#13)."""
+    from core.config import RaptorConfig
+    found = set()
+    try:
+        root = RaptorConfig.get_out_dir()
+    except Exception:
+        return []
+    if not root or not Path(root).is_dir():
+        return []
+    for depth in ("*/.raptor-run.json", "*/*/.raptor-run.json"):
+        for meta in Path(root).glob(depth):
+            found.add(meta.parent)
+    return sorted(found, key=lambda p: p.stat().st_mtime, reverse=True)[:limit]
+
+
 def main():
     parser = argparse.ArgumentParser(
         description="RAPTOR Agentic Security Testing - Scan, Analyse, Exploit, Patch",
@@ -1052,8 +1071,13 @@ Examples:
         """
     )
 
+    from core.config import RaptorConfig as _RC
     parser.add_argument(
-        "--repo", default=os.environ.get("RAPTOR_CALLER_DIR"),
+        "--version", action="version", version=_RC.effective_version(),
+        help="Print the RAPTOR version and exit",
+    )
+    parser.add_argument(
+        "-r", "--repo", default=os.environ.get("RAPTOR_CALLER_DIR"),
         help=(
             "Path to repository to analyse (default: $RAPTOR_CALLER_DIR "
             "— set by the bin/raptor wrapper to the operator's cwd at "
@@ -1091,7 +1115,8 @@ Examples:
     parser.add_argument(
         "--reanalyze", metavar="DIR",
         help=(
-            "Re-run analysis on a previous run's output directory. "
+            "Re-run analysis on a previous run's output directory (or "
+            "'last'/'latest' for the most recent run). "
             "Reads .raptor-run.json to recover target path and SARIF files, "
             "skips scanning. Equivalent to --sarif <previous SARIFs> --repo <previous target>."
         ),
@@ -1144,7 +1169,7 @@ Examples:
         action="store_true",
         help="Skip per-finding annotation emission (default: emit)",
     )
-    parser.add_argument("--out", help="Output directory")
+    parser.add_argument("-o", "--out", help="Output directory")
     parser.add_argument("--mode", choices=["fast", "thorough"], default="thorough",
                        help="fast: quick scan, thorough: detailed analysis")
 
@@ -1471,10 +1496,28 @@ Examples:
     # --reanalyze: seed --sarif and --repo from a previous run's metadata
     if getattr(args, "reanalyze", None):
         from core.run.metadata import load_run_metadata
-        reanalyze_dir = Path(args.reanalyze).resolve()
-        args.reanalyze = str(reanalyze_dir)
+        # 'last'/'latest' resolves to the most recent prior run dir.
+        if args.reanalyze in ("last", "latest"):
+            _recent = _recent_run_dirs()
+            if not _recent:
+                parser.error("--reanalyze last: no prior runs found under the "
+                             "output directory")
+            reanalyze_dir = _recent[0]
+            args.reanalyze = str(reanalyze_dir)
+            logger.info("--reanalyze last → %s", reanalyze_dir)
+        else:
+            reanalyze_dir = Path(args.reanalyze).resolve()
+            args.reanalyze = str(reanalyze_dir)
         if not reanalyze_dir.is_dir():
-            parser.error(f"--reanalyze directory does not exist: {args.reanalyze}")
+            # List recent candidates so a fat-fingered dir name has a next
+            # step instead of a dead error.
+            _recent = _recent_run_dirs(limit=3)
+            _hint = ""
+            if _recent:
+                _hint = "\n  Recent runs (or use --reanalyze last):\n" + \
+                    "\n".join(f"    {d}" for d in _recent)
+            parser.error(
+                f"--reanalyze directory does not exist: {args.reanalyze}{_hint}")
         prev_meta = load_run_metadata(reanalyze_dir)
         if not prev_meta:
             parser.error(f"--reanalyze: no .raptor-run.json in {reanalyze_dir}")
@@ -2583,6 +2626,21 @@ Examples:
                 print(f"    Error: {stderr[:500]}")
             logger.warning(f"Phase 3 failed - rc={rc}, stderr={stderr[:200]}")
             analysis = {}
+            if rc != 0:
+                # The prep/analysis subprocess errored or timed out
+                # (run_command_streaming returns rc=-1 on timeout) and
+                # wrote no report. Do NOT fall through to the unconditional
+                # complete_run at the end of main(), which would seal a
+                # failed run as a green 'completed'. Fail loudly - mirrors
+                # the SANDBOX_ENGAGE_EXIT_CODE handling above. (rc==0 with
+                # no report is left as-is: it can be a legitimate
+                # zero-finding prep, not a failure.)
+                from core.run import fail_run
+                fail_run(
+                    out_dir,
+                    f"analysis subprocess failed (rc={rc}) with no report",
+                )
+                sys.exit(1)
 
     # ========================================================================
     # PHASE 4: AGENTIC ORCHESTRATION
@@ -3376,6 +3434,18 @@ Examples:
         ))
     except Exception as e:
         logger.debug(f"Run metadata: {e}")  # Optional — don't fail the pipeline
+
+    # After a long autonomous run, point the operator at the verbs to
+    # inspect/re-run rather than leaving them with a bare path.
+    try:
+        _run_name = Path(out_dir).name
+        print("\n  Next steps:")
+        print(f"    • Inspect findings:   raptor project show {_run_name}")
+        print("    • Merged findings:    raptor project findings")
+        print(f"    • Re-analyse (no rescan): python3 raptor.py agentic --reanalyze {out_dir}")
+        print(f"    • Open report:        {md_path}")
+    except Exception:
+        pass
 
     # Clean up temporary git copy (if we created one for a non-git target)
     if _git_temp_dir and _git_temp_dir.exists():

--- a/raptor_codeql.py
+++ b/raptor_codeql.py
@@ -286,10 +286,15 @@ Examples:
         """
     )
 
-    parser.add_argument("--repo", required=True, help="Repository path")
+    from core.config import RaptorConfig as _RC
+    parser.add_argument(
+        "--version", action="version", version=_RC.effective_version(),
+        help="Print the RAPTOR version and exit",
+    )
+    parser.add_argument("-r", "--repo", required=True, help="Repository path")
     parser.add_argument("--languages", help="Comma-separated languages")
     parser.add_argument("--build-command", help="Custom build command")
-    parser.add_argument("--out", help="Output directory")
+    parser.add_argument("-o", "--out", help="Output directory")
     parser.add_argument(
         "--force", action="store_true",
         help="Delete and recreate the CodeQL database from scratch. Slow — "

--- a/raptor_fuzzing.py
+++ b/raptor_fuzzing.py
@@ -38,6 +38,19 @@ from packages.autonomous import (
 logger = get_logger()
 
 
+def _positive_int(value):
+    """argparse type: a strictly positive int. A zero/negative per-exec
+    timeout would disable the watchdog or be rejected by AFL, so fail closed
+    (usage error, exit 2) rather than launching a misconfigured campaign."""
+    try:
+        n = int(value)
+    except (TypeError, ValueError):
+        raise argparse.ArgumentTypeError(f"expected an integer, got {value!r}")
+    if n <= 0:
+        raise argparse.ArgumentTypeError(f"must be > 0, got {n}")
+    return n
+
+
 def main() -> None:
     # So much more needed here but this is a start for us. :-)
     ap = argparse.ArgumentParser(
@@ -61,7 +74,12 @@ Examples:
 """,
     )
 
-    ap.add_argument("--binary", help="Path to binary to fuzz")
+    from core.config import RaptorConfig as _RC
+    ap.add_argument(
+        "--version", action="version", version=_RC.effective_version(),
+        help="Print the RAPTOR version and exit",
+    )
+    ap.add_argument("-b", "--binary", help="Path to binary to fuzz")
     ap.add_argument("--corpus", help="Path to seed corpus directory (optional)")
     ap.add_argument(
         "--prepare-corpus",
@@ -86,8 +104,8 @@ Examples:
     ap.add_argument("--duration", type=int, default=3600, help="Fuzzing duration in seconds (default: 3600)")
     ap.add_argument("--parallel", type=int, default=1, help="Number of parallel AFL instances (default: 1, ceiling: tuning.json)")
     ap.add_argument("--max-crashes", type=int, default=10, help="Maximum crashes to analyse (default: 10)")
-    ap.add_argument("--timeout", type=int, default=1000, help="Timeout per execution in ms (default: 1000)")
-    ap.add_argument("--out", help="Output directory (default: out/fuzz_<binary_name>)")
+    ap.add_argument("--timeout", type=_positive_int, default=1000, help="Timeout per execution in ms (default: 1000)")
+    ap.add_argument("-o", "--out", help="Output directory (default: out/fuzz_<binary_name>)")
     ap.add_argument("--dict", help="Path to AFL dictionary file for structured input fuzzing")
     ap.add_argument("--input-mode", choices=["stdin", "file"], default="stdin", help="Input mode: stdin (default) or file (uses @@)")
     ap.add_argument("--check-sanitizers", action="store_true", help="Check if binary is compiled with sanitizers (ASAN, etc.)")

--- a/requirements.txt
+++ b/requirements.txt
@@ -62,6 +62,12 @@ packaging==25.0
 # Optional: For SMT-based constraint analysis (one-gadget feasibility, etc.)
 # z3-solver==4.15.4.0  # see requirements-dev.txt for bookworm/aarch64 cap
 
+# Optional: For dynamic instrumentation (/frida - function trace, Stalker
+# coverage). The `frida` Python binding drives the embedded spawn loader;
+# `frida-tools` adds the CLI. Degrades gracefully when absent (capability
+# probe reports unavailable, /doctor shows a soft warning).
+# frida-tools>=13.0.0
+
 # Optional: For web scanning package
 # beautifulsoup4>=4.12.0
 # playwright>=1.40.0


### PR DESCRIPTION
Dynamic instrumentation
- New /frida command: spawn-only Frida function/argument tracing and Stalker basic-block coverage (drcov), sandboxed and degrading gracefully when the frida binding is absent. Documented in docs/DYNAMIC_INSTRUMENTATION_QUICKSTART.md + DEPENDENCIES + README.

CLI quality-of-life
- daily-loop helpers: 'last'/'latest' run tokens, agentic next-steps hints, --version, doctor --json, describe visibility, short flags, cleaner errors.
- Shared run-resolver: 'last'/'latest'/unique-substring now work uniformly across project show / diff / annotations-diff / remove.
- --json output for project status / findings / coverage (joining doctor and describe) for CI parsing.
- Next-steps hints after /scan and /codeql.
- Fail-closed flag validation: malformed/out-of-range --max-cost-usd, project clean --keep, project coverage --fail-under, and fuzz/frida --timeout now exit 2 instead of running with a bad value.

Refactor
- Factor the duplicated libexec trust-guard into core.security._trust_guard; add bash/zsh completion.

Security & correctness fixes
- Mask the remote Ollama endpoint in logs and errors.
- Close the $EDITOR argument-injection vector (allow only -w/--wait).
- Bound bin/ symlink resolution with a 32-hop guard.
- Spawn JDK/rustup probes with get_safe_env.
- Opt-in CodeQL credential isolation for untrusted builds.
- Sandbox binutils ELF parsers; planted-binary source-coverage floor at any project size.
- reachability: require unanimity for line-less same-name suppression; an affirmative binary call-edge beats a name-lookup 'absent'.
- dispatch: stop spending on a model declared dead; back-fill aborted work by (item, model) pair; tighten retry/quota error classification.
- orchestrator: --aggregate requires >=2 analysis models.
- agentic: fail the run on analysis failure; single finalize owner; reanalyze uses the prior run's recorded target.
- reach-cache: derive header magic from _CACHE_VERSION.
- sandbox: RAPTOR_REQUIRE_SANDBOX fail-closed kill-switch.

Credit to @Splinters-io for original Frida wiring idea