### PR TITLE
fix(qol): portability and test-guard improvements

### DIFF
--- a/core/binary/tests/test_elf.py
+++ b/core/binary/tests/test_elf.py
@@ -92,10 +92,17 @@ class TestNegativeCases:
 class TestRealBinaryParse:
     @pytest.fixture(autouse=True)
     def _require_elf_host(self):
-        """All tests in this class need a Linux-shaped host with
-        /bin/ls. macOS test runners (Mach-O coreutils) skip."""
-        if not Path("/bin/ls").exists():
-            pytest.skip("/bin/ls not present on host")
+        """All tests in this class need a Linux-shaped host with an
+        ELF /bin/ls. macOS test runners (Mach-O coreutils) skip — the
+        old guard only checked existence, so it failed to skip on a
+        host where /bin/ls exists but is Mach-O."""
+        p = Path("/bin/ls")
+        try:
+            is_elf = p.is_file() and p.read_bytes()[:4] == b"\x7fELF"
+        except OSError:
+            is_elf = False
+        if not is_elf:
+            pytest.skip("/bin/ls is not an ELF binary on this host")
 
     def test_parse_bin_ls(self):
         """Parser doesn't crash on a real binary; the metadata
@@ -167,8 +174,13 @@ class TestRadare2Parity:
         )
         if not probe_capability().get("available"):
             pytest.skip("radare2 stack not available")
-        if not Path("/bin/ls").exists():
-            pytest.skip("/bin/ls not present")
+        p = Path("/bin/ls")
+        try:
+            is_elf = p.is_file() and p.read_bytes()[:4] == b"\x7fELF"
+        except OSError:
+            is_elf = False
+        if not is_elf:
+            pytest.skip("/bin/ls is not an ELF binary on this host")
 
     def test_imports_match_radare2_ls(self):
         """Native ELF parser must produce the exact same import

--- a/core/dataflow/tests/test_cvefix_pipeline_codeql_e2e.py
+++ b/core/dataflow/tests/test_cvefix_pipeline_codeql_e2e.py
@@ -39,6 +39,33 @@ _HOST_ALLOWED_GUARD = (
 pytestmark = pytest.mark.skipif(_CODEQL is None, reason="codeql CLI not installed")
 
 
+def _query_pack_available() -> bool:
+    """True only if the prebuilt ``codeql/python-queries`` pack the
+    pipeline test runs is actually resolvable.
+
+    Having ``codeql`` on PATH is not enough — that pack must be
+    downloaded (``codeql pack download``), which needs network. In
+    offline / sandboxed environments (and CI without the pack) it is
+    absent and ``codeql database analyze`` hard-fails with "Query pack
+    ... cannot be found". Skip there instead, in the spirit of "only
+    run CodeQL when real CodeQL will run". The synthesized-barrier test
+    below resolves ``codeql/python-all`` (the library pack, bundled) and
+    so does not depend on this.
+    """
+    if _CODEQL is None:
+        return False
+    try:
+        return subprocess.run(
+            [_CODEQL, "resolve", "queries", _QUERY],
+            capture_output=True, text=True, timeout=120,
+        ).returncode == 0
+    except (OSError, subprocess.SubprocessError):
+        return False
+
+
+_QUERY_PACK_AVAILABLE = _query_pack_available()
+
+
 def _build_db(src: Path, db: Path) -> None:
     subprocess.run(
         [_CODEQL, "database", "create", str(db), "--language=python",
@@ -57,6 +84,10 @@ def codeql_dbs(tmp_path_factory):
     return before_db, after_db
 
 
+@pytest.mark.skipif(
+    not _QUERY_PACK_AVAILABLE,
+    reason="codeql/python-queries pack not downloaded (needs `codeql pack download`)",
+)
 def test_pipeline_labels_post_fix_finding_as_missing_sanitizer_fp(codeql_dbs, tmp_path):
     before_db, after_db = codeql_dbs
     pairs = generate_corpus_for_pair(

--- a/core/llm/tests/conftest.py
+++ b/core/llm/tests/conftest.py
@@ -23,16 +23,31 @@ import pytest
 
 _PROXY_VARS = ("HTTPS_PROXY", "https_proxy", "NO_PROXY", "no_proxy")
 
+# Pin OLLAMA_HOST to the documented default so these tests are hermetic
+# against a developer's ambient env. A dev running Ollama exports the
+# canonical schemeless ``OLLAMA_HOST=127.0.0.1:11434`` (or a remote
+# host), which otherwise leaks into LLMClient/detection and makes the
+# suite's outcome host-dependent. A test that genuinely exercises a
+# specific host overrides this with its own ``monkeypatch.setenv``,
+# which runs after this autouse setup and wins.
+_DEFAULT_OLLAMA_HOST = "http://localhost:11434"
+
 
 @pytest.fixture(autouse=True)
 def _reset_llm_egress_state():
-    """Reset egress module flag + clear proxy env vars before AND
-    after every test in this directory."""
+    """Reset egress module flag, clear proxy env vars, and pin
+    OLLAMA_HOST before AND after every test in this directory."""
     from core.llm import egress
+    _saved_ollama = os.environ.get("OLLAMA_HOST")
     egress._reset_for_tests()
     for var in _PROXY_VARS:
         os.environ.pop(var, None)
+    os.environ["OLLAMA_HOST"] = _DEFAULT_OLLAMA_HOST
     yield
     egress._reset_for_tests()
     for var in _PROXY_VARS:
         os.environ.pop(var, None)
+    if _saved_ollama is None:
+        os.environ.pop("OLLAMA_HOST", None)
+    else:
+        os.environ["OLLAMA_HOST"] = _saved_ollama

--- a/core/llm/tests/test_config_file.py
+++ b/core/llm/tests/test_config_file.py
@@ -648,7 +648,11 @@ class TestWarnUnusableKeys:
         with patch.dict(os.environ, {}, clear=False), \
              patch("core.llm.detection.OPENAI_SDK_AVAILABLE", False), \
              patch("core.llm.detection.logger") as mock_logger:
-            os.environ.pop("OPENAI_API_KEY", None)
+            # Clear every provider key _warn_unusable_keys inspects so the
+            # "no key present" precondition holds regardless of a dev's
+            # ambient env (patch.dict restores the full environ on exit).
+            for _k in ("ANTHROPIC_API_KEY", "OPENAI_API_KEY", "GEMINI_API_KEY"):
+                os.environ.pop(_k, None)
             _warn_unusable_keys()
         mock_logger.warning.assert_not_called()
 

--- a/core/run/tests/test_metadata.py
+++ b/core/run/tests/test_metadata.py
@@ -126,6 +126,8 @@ class TestRunLifecycle(unittest.TestCase):
         import os
         if not os.environ.get("CLAUDECODE"):
             self.skipTest("Requires CLAUDECODE environment")
+        if not Path("/proc").is_dir():
+            self.skipTest("_find_claude_ancestor walks /proc — Linux only")
         from core.json import save_json
         with TemporaryDirectory() as d:
             project = Path(d) / "project"
@@ -157,6 +159,8 @@ class TestRunLifecycle(unittest.TestCase):
         import os
         if not os.environ.get("CLAUDECODE"):
             self.skipTest("Requires CLAUDECODE environment")
+        if not Path("/proc").is_dir():
+            self.skipTest("_find_claude_ancestor walks /proc — Linux only")
         with TemporaryDirectory() as d:
             project = Path(d) / "project"
             project.mkdir()
@@ -176,6 +180,8 @@ class TestRunLifecycle(unittest.TestCase):
         import os
         if not os.environ.get("CLAUDECODE"):
             self.skipTest("Requires CLAUDECODE environment")
+        if not Path("/proc").is_dir():
+            self.skipTest("_find_claude_ancestor walks /proc — Linux only")
         with TemporaryDirectory() as d:
             project = Path(d) / "project"
             project.mkdir()
@@ -194,6 +200,8 @@ class TestFindClaudeAncestor(unittest.TestCase):
         import os
         if not os.environ.get("CLAUDECODE"):
             self.skipTest("Requires CLAUDECODE environment")
+        if not Path("/proc").is_dir():
+            self.skipTest("_find_claude_ancestor walks /proc — Linux only")
         from core.run.metadata import _find_claude_ancestor
         pid = _find_claude_ancestor()
         self.assertIsNotNone(pid)
@@ -205,6 +213,8 @@ class TestFindClaudeAncestor(unittest.TestCase):
         import os
         if not os.environ.get("CLAUDECODE"):
             self.skipTest("Requires CLAUDECODE environment")
+        if not Path("/proc").is_dir():
+            self.skipTest("_find_claude_ancestor walks /proc — Linux only")
         from core.run.metadata import _find_claude_ancestor
         pid1 = _find_claude_ancestor()
         pid2 = _find_claude_ancestor()
@@ -215,6 +225,8 @@ class TestFindClaudeAncestor(unittest.TestCase):
         import os
         if not os.environ.get("CLAUDECODE"):
             self.skipTest("Requires CLAUDECODE environment")
+        if not Path("/proc").is_dir():
+            self.skipTest("_find_claude_ancestor walks /proc — Linux only")
         from core.run.metadata import _find_claude_ancestor
         with TemporaryDirectory() as d:
             out = Path(d) / "test-run"

--- a/core/sandbox/fingerprint.py
+++ b/core/sandbox/fingerprint.py
@@ -91,6 +91,21 @@ logger = logging.getLogger(__name__)
 HOST_CPU_COUNT = -1
 
 
+def _host_cpu_count() -> int:
+    """Schedulable CPU count, portable across platforms.
+
+    Linux exposes the cpuset-aware count via ``os.sched_getaffinity``;
+    on platforms without it (macOS, Windows) fall back to
+    ``os.cpu_count()``. Mirrors the guard in ``core.tuning`` so
+    ``build_persona(cpu_count=HOST_CPU_COUNT)`` does not raise
+    ``AttributeError`` off Linux.
+    """
+    getaff = getattr(os, "sched_getaffinity", None)
+    if getaff is not None:
+        return len(getaff(0))
+    return os.cpu_count() or 1
+
+
 # === Persona constants ===
 
 # Hostname / domainname — applied via sethostname() / setdomainname()
@@ -244,7 +259,7 @@ def build_persona(tmpdir: Path, cpu_count: int) -> Persona:
     gracefully (tools fall back to default code paths).
     """
     if cpu_count == HOST_CPU_COUNT:
-        cpu_count = len(os.sched_getaffinity(0))
+        cpu_count = _host_cpu_count()
     if cpu_count < 1:
         raise ValueError(
             f"cpu_count must be >= 1 or HOST_CPU_COUNT, got {cpu_count}"
@@ -484,6 +499,8 @@ def set_cpu_affinity(cpu_count: int) -> int:
     """
     if cpu_count < 1:
         raise ValueError(f"cpu_count must be >= 1, got {cpu_count}")
+    if not hasattr(os, "sched_getaffinity"):
+        raise NotImplementedError("set_cpu_affinity requires Linux (sched_setaffinity syscall)")
     available = os.sched_getaffinity(0)
     effective = min(cpu_count, len(available))
     if effective < cpu_count:

--- a/core/sandbox/tests/test_fingerprint.py
+++ b/core/sandbox/tests/test_fingerprint.py
@@ -19,6 +19,7 @@ import pytest
 
 from core.sandbox.fingerprint import (
     HOST_CPU_COUNT,
+    _host_cpu_count,
     _HOSTNAME,
     _DOMAINNAME,
     _MACHINE_ID,
@@ -37,7 +38,7 @@ def test_host_cpu_count_sentinel_resolves_to_host(tmp_path):
     """build_persona(cpu_count=HOST_CPU_COUNT) must resolve to the
     host's actual schedulable CPU count via os.sched_getaffinity(0).
     Persona.cpu_count is the resolved int, not the sentinel."""
-    expected = len(os.sched_getaffinity(0))
+    expected = _host_cpu_count()
     persona = build_persona(tmp_path, cpu_count=HOST_CPU_COUNT)
     assert persona.cpu_count == expected, (
         f"sentinel resolved to {persona.cpu_count}, expected {expected}"
@@ -48,7 +49,7 @@ def test_host_cpu_count_sentinel_yields_n_cpuinfo_blocks(tmp_path):
     """With the sentinel, /proc/cpuinfo claims as many processors as
     the host has available — preserves capability surface for callers
     that need real parallelism (codeql, parallel builds)."""
-    expected = len(os.sched_getaffinity(0))
+    expected = _host_cpu_count()
     build_persona(tmp_path, cpu_count=HOST_CPU_COUNT)
     content = (tmp_path / "cpuinfo").read_text()
     indices = [

--- a/core/tuning/tests/test_tuning.py
+++ b/core/tuning/tests/test_tuning.py
@@ -111,7 +111,10 @@ class TestLoadTuning(unittest.TestCase):
                 "max_codeql_workers": "auto",
                 "max_fuzz_parallel": "auto",
             }))
-            with patch("core.tuning.os.sched_getaffinity", None, create=True), patch("core.tuning.os.cpu_count", return_value=8):
+            # Mock RAM too: max_codeql_workers is RAM-capped (it's memory-
+            # heavy), so without this the test is non-hermetic and resolves
+            # to 3 on a low-RAM CI runner (~7 GB) instead of the cpu-bound 4.
+            with patch("core.tuning.os.sched_getaffinity", None, create=True), patch("core.tuning.os.cpu_count", return_value=8), patch("core.tuning._detect_total_ram_mb", return_value=98304), patch("core.tuning._detect_ram_mb", return_value=16384):
                 t = load_tuning(p)
             self.assertEqual(t.max_semgrep_workers, 4)
             self.assertEqual(t.max_codeql_workers, 4)

--- a/packages/sca/tests/test_fingerprint_cli.py
+++ b/packages/sca/tests/test_fingerprint_cli.py
@@ -11,14 +11,26 @@ from core.binary.fingerprint import FINGERPRINT_SCHEMA_VERSION
 from packages.sca import fingerprint_cli
 
 
+def _is_elf(path: str = "/bin/ls") -> bool:
+    """True only when ``path`` is a real ELF binary. These tests
+    fingerprint ELF binaries; on macOS /bin/ls and /usr/bin/python3
+    exist but are Mach-O, so an existence check alone failed to skip.
+    Gate on the ELF magic instead."""
+    p = Path(path)
+    try:
+        return p.is_file() and p.read_bytes()[:4] == b"\x7fELF"
+    except OSError:
+        return False
+
+
 class TestCliBasics:
     def test_print_fingerprint_of_real_binary(
         self, tmp_path, capsys,
     ):
         """``fingerprint /bin/ls`` prints JSON to stdout when the
         host has a real ELF binary at that path."""
-        if not Path("/bin/ls").exists():
-            pytest.skip("/bin/ls not present on host")
+        if not _is_elf():
+            pytest.skip("/bin/ls is not an ELF binary on this host")
         rc = fingerprint_cli.main([
             "/bin/ls", "--cache-root", str(tmp_path),
         ])
@@ -39,8 +51,8 @@ class TestCliBasics:
         # Stub fetch_image_binary to return a real file path
         real_bin = tmp_path / "fake.bin"
         # An ELF file so capability_fingerprint succeeds
-        if not Path("/bin/ls").is_file():
-            pytest.skip("/bin/ls not present on host")
+        if not _is_elf():
+            pytest.skip("/bin/ls is not an ELF binary on this host")
         real_bin.write_bytes(Path("/bin/ls").read_bytes())
 
         def fake_fetch(ref, *, client, **kwargs):
@@ -67,8 +79,8 @@ class TestCliBasics:
 
 class TestSaveBaseline:
     def test_save_writes_baseline(self, tmp_path, capsys):
-        if not Path("/bin/ls").exists():
-            pytest.skip("/bin/ls not present on host")
+        if not _is_elf():
+            pytest.skip("/bin/ls is not an ELF binary on this host")
         cache_root = tmp_path / "cache"
         rc = fingerprint_cli.main([
             "/bin/ls",
@@ -86,8 +98,8 @@ class TestSaveBaseline:
         assert loaded.binary_format == "elf"
 
     def test_save_uses_target_as_default_ref(self, tmp_path):
-        if not Path("/bin/ls").exists():
-            pytest.skip("/bin/ls not present on host")
+        if not _is_elf():
+            pytest.skip("/bin/ls is not an ELF binary on this host")
         cache_root = tmp_path / "cache"
         rc = fingerprint_cli.main([
             "/bin/ls", "--save", "--cache-root", str(cache_root),
@@ -102,8 +114,8 @@ class TestSaveBaseline:
 
 class TestCheckDrift:
     def test_check_no_baseline_exits_zero(self, tmp_path, capsys):
-        if not Path("/bin/ls").exists():
-            pytest.skip("/bin/ls not present on host")
+        if not _is_elf():
+            pytest.skip("/bin/ls is not an ELF binary on this host")
         rc = fingerprint_cli.main([
             "/bin/ls", "--check",
             "--ref", "never-seen",
@@ -116,8 +128,8 @@ class TestCheckDrift:
     def test_check_baseline_matches_exits_zero(
         self, tmp_path, capsys,
     ):
-        if not Path("/bin/ls").exists():
-            pytest.skip("/bin/ls not present on host")
+        if not _is_elf():
+            pytest.skip("/bin/ls is not an ELF binary on this host")
         cache_root = tmp_path / "cache"
         # Seed baseline
         fingerprint_cli.main([
@@ -135,8 +147,8 @@ class TestCheckDrift:
         """Mock the fingerprint primitive to return a different
         fingerprint than the baseline → drift detected → exit 1
         (CI gate semantic: build fails on drift)."""
-        if not Path("/bin/ls").exists():
-            pytest.skip("/bin/ls not present on host")
+        if not _is_elf():
+            pytest.skip("/bin/ls is not an ELF binary on this host")
         cache_root = tmp_path / "cache"
         # Save real baseline of /bin/ls
         fingerprint_cli.main([
@@ -184,8 +196,8 @@ class TestOutFlag:
     def test_out_to_directory_exits_three(self, tmp_path, capsys):
         """``--out <dir>`` (instead of <file>) → exit 3 with a
         readable error, not a Python traceback."""
-        if not Path("/usr/bin/python3").is_file():
-            pytest.skip("/usr/bin/python3 not present")
+        if not _is_elf("/usr/bin/python3"):
+            pytest.skip("/usr/bin/python3 is not an ELF binary on this host")
         # Point --out at an existing directory
         rc = fingerprint_cli.main([
             "/usr/bin/python3",
@@ -199,8 +211,8 @@ class TestOutFlag:
         assert "Traceback" not in err
 
     def test_out_writes_file(self, tmp_path):
-        if not Path("/usr/bin/python3").is_file():
-            pytest.skip("/usr/bin/python3 not present")
+        if not _is_elf("/usr/bin/python3"):
+            pytest.skip("/usr/bin/python3 is not an ELF binary on this host")
         out = tmp_path / "fp.json"
         rc = fingerprint_cli.main([
             "/usr/bin/python3",


### PR DESCRIPTION
Follow up on https://github.com/gadievron/raptor/pull/815 submitting split out pull request with QoL improvements separately for review, will split out others too and open PRs

Portability:
- shellcode_emulator: resolve AArch64 via getattr fallback (capstone >=5 renamed CS_ARCH_ARM64 -> CS_ARCH_AARCH64); eager dict broke x86/x64 too
- sandbox/fingerprint: portable _host_cpu_count() (sched_getaffinity is Linux-only) so build_persona(HOST_CPU_COUNT) does not crash off Linux
- pwntools_scaffold: drop stray f-prefixes (F541)

Test guards:
- gate Linux-only tests on the real precondition: ELF magic (not /bin/ls), /proc, and the codeql/python-queries pack being resolvable
- make core/llm tests hermetic (pin OLLAMA_HOST, clear provider keys)
- tuning: mock RAM in the cpu-backed worker-limit test (non-hermetic on low-RAM CI runners)
- codeql e2e: skip when pack is not resolvable

