### PR TITLE
fix(config/llm): harden path guard, Ollama URL normalisation, host_is_local

### DIFF
--- a/core/config/__init__.py
+++ b/core/config/__init__.py
@@ -699,16 +699,24 @@ class RaptorConfig:
             return RaptorConfig.BASE_OUT_DIR
         resolved = Path(base).resolve()
         forbidden = ("/etc", "/usr", "/bin", "/sbin", "/boot", "/dev", "/proc", "/sys")
-        resolved_str = str(resolved)
-        for prefix in forbidden:
-            # Component-boundary match: equals or starts with `prefix/`.
-            if resolved_str == prefix or resolved_str.startswith(prefix + "/"):
-                raise ValueError(
-                    f"RAPTOR_OUT_DIR={resolved!r} resolves under system "
-                    f"path {prefix!r}. Refusing to create output there. "
-                    f"Set RAPTOR_OUT_DIR to a path under your home or a "
-                    f"dedicated work directory."
-                )
+        # Check BOTH the lexically-normalised input and the symlink-
+        # resolved path. On macOS /etc, /var and /tmp are symlinks into
+        # /private, so a literal RAPTOR_OUT_DIR=/etc resolves to
+        # /private/etc and would slip past a resolved-only check — catch
+        # the operator-typed system path via os.path.normpath too. The
+        # resolved check still guards against a symlink that points into
+        # a (Linux-named) system directory.
+        candidates = (os.path.normpath(base), str(resolved))
+        for path_str in candidates:
+            for prefix in forbidden:
+                # Component-boundary match: equals or starts with `prefix/`.
+                if path_str == prefix or path_str.startswith(prefix + "/"):
+                    raise ValueError(
+                        f"RAPTOR_OUT_DIR={base!r} resolves under system "
+                        f"path {prefix!r}. Refusing to create output there. "
+                        f"Set RAPTOR_OUT_DIR to a path under your home or a "
+                        f"dedicated work directory."
+                    )
         # Validate the parent exists. `mkdir(parents=True)` would
         # silently create a deep directory tree under what may be a
         # typo (`RAPTOR_OUT_DIR=/home/raptr/out` — note the missing

--- a/core/llm/client.py
+++ b/core/llm/client.py
@@ -294,9 +294,9 @@ def _ollama_check_url() -> str:
     matching the convention already used by ``core.llm.detection``.
     """
     from core.config import RaptorConfig
+    from core.llm.detection import _host_is_local
     host = RaptorConfig.OLLAMA_HOST.rstrip("/")
-    is_local = "localhost" in host or "127.0.0.1" in host
-    base = host if is_local else "[REMOTE-OLLAMA]"
+    base = host if _host_is_local(host) else "[REMOTE-OLLAMA]"
     return f"{base}/api/tags"
 
 

--- a/core/llm/detection.py
+++ b/core/llm/detection.py
@@ -73,11 +73,35 @@ class LLMAvailability:
 
 
 def _validate_ollama_url(url: str) -> str:
-    """Validate and normalize Ollama URL."""
-    url = url.rstrip('/')
+    """Validate and normalise an Ollama URL.
+
+    Ollama's own canonical ``OLLAMA_HOST`` is a schemeless ``host:port``
+    (e.g. ``127.0.0.1:11434``), so a missing scheme is the common,
+    *valid* case rather than an error — we default it to ``http://``.
+    An empty value is still rejected so a genuinely unset/blank config
+    surfaces loudly instead of becoming ``http:///api/tags``.
+    """
+    url = url.strip().rstrip('/')
+    if not url:
+        raise ValueError("Ollama URL is empty (set OLLAMA_HOST)")
     if not url.startswith(('http://', 'https://')):
-        raise ValueError(f"Invalid Ollama URL (must start with http:// or https://): {url}")
+        url = f"http://{url}"
     return url
+
+
+def _host_is_local(raw: str) -> bool:
+    """True if ``raw`` (a URL or bare ``host[:port]``) points at the
+    local machine.
+
+    Parses the hostname instead of substring-matching so a remote host
+    such as ``localhost.attacker.example`` or ``127.0.0.1.evil`` is not
+    mis-classified as local (which would disclose a remote OLLAMA host
+    in logs — CLAUDE.md: "never disclose remote OLLAMA server location").
+    """
+    from urllib.parse import urlparse
+    candidate = raw if "://" in raw else f"//{raw}"
+    host = (urlparse(candidate).hostname or "").lower()
+    return host in ("localhost", "127.0.0.1", "::1")
 
 
 _cached_ollama_models: Optional[List[str]] = None
@@ -110,7 +134,7 @@ def _get_available_ollama_models() -> List[str]:
             _cached_ollama_models = [model['name'] for model in data.get('models', [])]
             return _cached_ollama_models
     except Exception as e:
-        ollama_display = RaptorConfig.OLLAMA_HOST if 'localhost' in RaptorConfig.OLLAMA_HOST or '127.0.0.1' in RaptorConfig.OLLAMA_HOST else '[REMOTE-OLLAMA]'
+        ollama_display = RaptorConfig.OLLAMA_HOST if _host_is_local(RaptorConfig.OLLAMA_HOST) else '[REMOTE-OLLAMA]'
         logger.debug(f"Could not connect to Ollama at {ollama_display}: {e}")
     _cached_ollama_models = []
     return []


### PR DESCRIPTION
Security fixes split per https://github.com/gadievron/raptor/pull/815

- get_out_dir: check both os.path.normpath(input) and resolved path so a literal RAPTOR_OUT_DIR=/etc doesn't slip the system-path guard on macOS where /etc is a symlink into /private/etc.
- _validate_ollama_url: accept schemeless host:port (Ollama's canonical 127.0.0.1:11434) by defaulting the scheme to http://; reject empty.
- _host_is_local: parse the hostname with urllib.parse instead of substring-matching so localhost.attacker.example and 127.0.0.1.evil are not mis-classified as local hosts.
- client.py: replace the same substring check with _host_is_local.