### PR TITLE
feat/frida integration

### DIFF
--- a/.claude/commands/frida.md
+++ b/.claude/commands/frida.md
@@ -1,0 +1,9 @@
+---
+description: Dynamic instrumentation via Frida (alpha) - attach or spawn, hook with JS templates, capture runtime events
+---
+
+# /frida - RAPTOR Frida Dynamic Instrumentation (alpha)
+
+Alias for /raptor-frida
+
+See: raptor-frida.md

--- a/.claude/commands/frida.md
+++ b/.claude/commands/frida.md
@@ -1,5 +1,6 @@
 ---
 description: Dynamic instrumentation via Frida (alpha) - attach or spawn, hook with JS templates, capture runtime events
+dispatch: skill
 ---
 
 # /frida - RAPTOR Frida Dynamic Instrumentation (alpha)

--- a/.claude/commands/raptor-frida.md
+++ b/.claude/commands/raptor-frida.md
@@ -1,5 +1,6 @@
 ---
 description: Dynamic instrumentation via Frida (alpha) - attach or spawn, hook with JS templates, capture runtime events
+dispatch: libexec/raptor-frida
 ---
 
 # /raptor-frida - Frida Dynamic Instrumentation (alpha)

--- a/.claude/commands/raptor-frida.md
+++ b/.claude/commands/raptor-frida.md
@@ -1,0 +1,101 @@
+---
+description: Dynamic instrumentation via Frida (alpha) - attach or spawn, hook with JS templates, capture runtime events
+---
+
+# /raptor-frida - Frida Dynamic Instrumentation (alpha)
+
+Runtime instrumentation substrate. Attach to (or spawn) a target, load a hook script (bundled template or operator-supplied), capture `send(...)` events into a lifecycle-managed run directory.
+
+## Usage
+
+```
+/raptor-frida --target <pid|name|bundle-id|binary>
+              (--template <name> | --script <path>)
+              [--host HOST[:PORT]] [--usb]
+              [--duration N] [--spawn] [--unsafe-attach]
+```
+
+Equivalent shell:
+
+```
+raptor frida --target ... --template ...
+# or directly:
+libexec/raptor-frida --target ... --template ...
+```
+
+## What This Does
+
+1. Resolves the target (PID, process name, bundle id, or binary path).
+2. Resolves the device - local, `--usb`-attached, or remote `--host`.
+3. Loads the hook script (template by name or `--script` JS file).
+4. For spawn-and-attach: calls `device.spawn`, attaches, loads the script, *then* resumes - so hooks are in place before `main()` runs.
+5. Runs for `--duration` seconds (default 60), capturing every `send(...)` from the script into `events.jsonl`.
+6. Detaches cleanly on time-up or SIGINT; writes `metadata.json` + `frida-report.md`.
+
+## Bundled Templates
+
+| Name | Purpose |
+|------|---------|
+| `api-trace` | libc/syscall surface: `open`, `read`, `write`, `connect`, `fork`, `execve`, etc. |
+| `ssl-unpin` | iOS/macOS Security.framework, OpenSSL `SSL_get_verify_result`, Android `X509TrustManager`. |
+
+List dynamically: `raptor frida --list-templates`.
+
+## Examples
+
+```bash
+# Trace local PID for 30 seconds
+/raptor-frida --target 1234 --template api-trace --duration 30
+
+# Spawn and watch
+/raptor-frida --target ./victim --template api-trace --duration 60
+
+# Bypass mobile SSL pinning via USB (spawn by bundle id - attach-by-name needs the running process name, not the bundle id)
+/raptor-frida --target com.example.app --template ssl-unpin --usb --spawn --duration 120
+
+# Remote frida-server
+/raptor-frida --target target-proc --host 10.10.20.1 --template api-trace
+
+# Operator-supplied hook
+/raptor-frida --target Safari --script ./my-hook.js --duration 30
+```
+
+## Output
+
+Resolved by `libexec/raptor-run-lifecycle`:
+- Active project: `out/projects/<name>/frida-<timestamp>/`
+- Otherwise: `out/frida_<timestamp>/`
+
+Artefacts:
+- `events.jsonl` - one JSON object per `send(...)`.
+- `metadata.json` - target, host info, timings, errors.
+- `script.js` - the script that ran.
+- `frida-report.md` - human-readable summary.
+
+## Requirements
+
+- **Host:** `frida` CLI on PATH and the `frida` Python module importable by raptor's Python 3 interpreter.
+  - `pipx install frida-tools` puts the CLI on PATH but isolates the Python binding - `raptor frida` will report `FridaUnavailable` until the module is also installed.
+  - Add the module with: `python3 -m pip install --user --break-system-packages frida`.
+- **Target:** for remote / mobile targets, run the matching `frida-server`. Bind to `0.0.0.0:27042` (default builds bind to localhost only - `raptor doctor` won't tell you this, but `metadata.json` will record the connect failure).
+
+See `docs/frida/QUICKSTART.md`, `docs/frida/SETUP_MACOS.md`, `docs/frida/SETUP_LINUX.md`.
+
+## Failure Modes
+
+Read `metadata.json` first. Common patterns:
+
+| Error fragment | Cause |
+|---|---|
+| `ptrace denied` (Linux) | `kernel.yama.ptrace_scope` ≥ 1. Lower it, or spawn-and-attach instead. |
+| `task_for_pid` (macOS) | Hardened-runtime target / system process. SIP-disabled or `get-task-allow` signing required. |
+| `unable to connect to remote frida-server` | frida-server not running, or bound to localhost only. SSH-forward 27042 or rebind. |
+| `frida-python not installed` | Install per "Requirements" above. |
+
+## Status
+
+Alpha. Two templates ship; richer set in progress (collab with @Splinters-io after his abandoned PR #57). Integration into `/validate --runtime` and `/crash-analysis` on macOS is planned - see `docs/frida-integration-proposal.md`.
+
+The runner currently does **not** wrap frida in `core/sandbox/`; the `--unsafe-attach` flag is forward-looking and logged into `metadata.json` for when the sandbox envelope lands.
+
+---

--- a/.claude/skills/frida/SKILL.md
+++ b/.claude/skills/frida/SKILL.md
@@ -1,0 +1,113 @@
+---
+name: frida
+description: Dynamic instrumentation via Frida - attach to or spawn a process, load a JS hook script, capture send() events into a lifecycle-managed run directory. Supports local, USB-attached, and remote frida-server targets.
+---
+
+# Frida - dynamic instrumentation (alpha)
+
+Hook a target at runtime to confirm LLM-flagged sinks actually execute, trace API calls, bypass SSL pinning, scan memory for secrets.
+
+## When to use
+
+- `/scan` or `/agentic` flagged a sink and you want to confirm it fires at runtime before treating it as exploitable.
+- A binary or mobile app is doing something opaque and a few minutes of API-trace would reveal the shape.
+- A pinned mobile app is blocking your MITM proxy.
+- A crash you can't `rr`-record (macOS) needs a function-call trace.
+
+## Install
+
+```bash
+pipx install frida-tools                       # host CLI + python bindings
+raptor doctor                                  # confirms frida is detected
+```
+
+For remote / mobile targets, install the matching `frida-server` on the target side. See `docs/frida/SETUP_MACOS.md`, `SETUP_LINUX.md`. Note: most `frida-server` binaries bind to `127.0.0.1` by default - start with `-l 0.0.0.0:27042` or SSH-forward port 27042.
+
+## Invocation
+
+The slash command surfaces the libexec wrapper; run it as Bash. Lifecycle (output dir, run state) is handled by the wrapper.
+
+```
+libexec/raptor-frida --target <pid|name|bundle-id|binary>
+                     (--template <name> | --script <path>)
+                     [--host HOST[:PORT]] [--usb]
+                     [--duration N] [--spawn] [--unsafe-attach]
+```
+
+Equivalent CLI without a Claude session: `raptor frida ...`.
+
+## Templates
+
+```bash
+raptor frida --list-templates
+```
+
+| Name | Purpose |
+|------|---------|
+| `api-trace` | Hooks `open`/`read`/`write`/`connect`/`fork`/`execve` etc. Most useful default. |
+| `ssl-unpin` | Bypasses iOS/macOS Security.framework, OpenSSL `SSL_get_verify_result`, and Android `X509TrustManager`. |
+
+Operator-supplied scripts via `--script ./hook.js` - same `send(...)` capture path.
+
+## Examples
+
+```bash
+# Trace API calls in a local PID for 30s
+raptor frida --target 1234 --template api-trace --duration 30
+
+# Spawn a binary and watch its first minute
+raptor frida --target ./victim --template api-trace --duration 60
+
+# Bypass SSL pinning on a USB-attached mobile target. Spawn by bundle id (frida resolves bundle ids for spawn); attach-by-name needs the running process's name, not the bundle id, so --spawn is the reliable form.
+raptor frida --target com.example.app --template ssl-unpin --usb --spawn --duration 120
+
+# Connect to remote frida-server
+raptor frida --target target-proc --host 10.10.20.1 --template api-trace
+
+# Operator-supplied hook
+raptor frida --target Safari --script ./my-hook.js --duration 30
+```
+
+## Output layout
+
+```
+<run-dir>/
+  events.jsonl       # one JSON object per send() from the script
+  metadata.json      # target, host info, timings, errors
+  script.js          # copy of the script that ran
+  frida-report.md    # short human-readable summary
+```
+
+`<run-dir>` is resolved by `libexec/raptor-run-lifecycle`:
+- Active `/project`: `out/projects/<name>/frida-<timestamp>/`
+- Otherwise: `out/frida_<timestamp>/`
+
+## Failure modes (read `metadata.json` first)
+
+| Error fragment | Likely cause |
+|---|---|
+| `ptrace denied` | Linux `kernel.yama.ptrace_scope` ≥ 1. Lower it or spawn-and-attach. |
+| `task_for_pid` | macOS hardened-runtime target or system process - needs SIP-disabled or signed-with-`get-task-allow`. |
+| `unable to connect to remote frida-server` | Target not running, or bound to localhost only. SSH-forward 27042 or rebind. |
+| `frida-python not installed` | `pipx install frida-tools`. |
+
+## Threat model
+
+Frida-instrumented targets are **untrusted** - that's the whole point. The current runner does **not** wrap frida in `core/sandbox/`; that's tracked for a follow-up. Treat the host you run frida from accordingly. `--unsafe-attach` is a forward-looking flag (logged into `metadata.json`) for when the sandbox envelope lands; it doesn't change behaviour today.
+
+## Related: pipeline-side frida
+
+This skill is the **operator-facing** frida tool: you pick a target and a hook, it captures `send(...)` events into a run dir. It is distinct from `packages/dynamic_analysis/frida_local.py`, the **pipeline library** the fuzzing/coverage stages call programmatically:
+
+| | This skill (`core/dynamic/frida/`) | `packages/dynamic_analysis/frida_local.py` |
+|---|---|---|
+| Audience | operator, interactive | called by harness/coverage code |
+| Interface | `/frida`, `raptor frida`, JS templates | `enumerate_exports` / `stalk_coverage` / `probe_function` |
+| Targets | local, USB, remote frida-server | local spawn only |
+| Output | `events.jsonl` + report in a run dir | structured dataclasses |
+
+They share no code (separate packages, separate frida-unavailable shims) by design - don't fold one into the other. If you need block coverage or argument-shape probing for harness generation, reach for `packages/dynamic_analysis`, not this skill.
+
+## Status
+
+Alpha. Two templates ship; richer set in progress (collab with @Splinters-io). Integration into `/validate --runtime` and `/crash-analysis` on macOS is in `docs/frida-integration-proposal.md`. The autonomous LLM-guided mode from the abandoned PR #57 is intentionally **not** in this slice. Pipeline-side block coverage / argument probing already landed separately in `packages/dynamic_analysis/` (see *Related* above).

--- a/bin/raptor
+++ b/bin/raptor
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# raptor — launch RAPTOR via Claude Code
+# raptor - launch RAPTOR via Claude Code
 #
 # Install: add this directory to PATH, or symlink to a directory already on PATH.
 #
@@ -29,7 +29,7 @@ case "${1:-}" in
 esac
 
 # Strip env vars that would inject code into the launcher's own exec
-# chain — the Python parent (libseccomp/ctypes loads) and the Claude
+# chain - the Python parent (libseccomp/ctypes loads) and the Claude
 # Code Node process that replaces this bash shell via exec. A hostile
 # parent env (malicious .envrc + direnv, compromised shell rc) could
 # otherwise inject a fake shared library or Python module BEFORE any
@@ -39,9 +39,9 @@ esac
 # code INSIDE the launcher→Python→Claude Code chain. Variables that
 # only affect *subprocesses* (git config, JAVA_TOOL_OPTIONS, shell rc
 # vars, editor/pager, Kerberos, etc.) are handled by
-# core.config.get_safe_env() when we spawn children — stripping them
+# core.config.get_safe_env() when we spawn children - stripping them
 # here would needlessly break the user's legitimate environment.
-# Sourced from core/security/_dangerous_env_strip.sh — single
+# Sourced from core/security/_dangerous_env_strip.sh - single
 # source of truth shared with bin/cve-diff. Lives next to its
 # Python siblings (core/config.RaptorConfig.DANGEROUS_ENV_VARS
 # + core/security/env_sanitisation.strip_env_vars) so a single
@@ -51,17 +51,17 @@ esac
 # point), so we resolve the strip-list path relative to this script.
 . "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")/../core/security/_dangerous_env_strip.sh"
 # Added by batch 581:
-#   * LD_DEBUG / LD_PROFILE / LD_PROFILE_OUTPUT — glibc loader
+#   * LD_DEBUG / LD_PROFILE / LD_PROFILE_OUTPUT - glibc loader
 #     diagnostic env vars that write profile data to operator-
 #     readable paths, can be abused to enumerate libraries
 #     loaded by the launcher and to write to predictable
 #     filesystem locations during dynamic linking.
-#   * MALLOC_CONF / JE_MALLOC_CONF — jemalloc config; lets an
+#   * MALLOC_CONF / JE_MALLOC_CONF - jemalloc config; lets an
 #     attacker enable heap profiling, redirect profile writes
 #     to attacker-readable paths (e.g.
 #     `prof:true,prof_prefix:/tmp/x`), or trigger predictable
 #     allocator behaviour useful for exploit construction.
-#   * MALLOC_CHECK_ / MALLOC_PERTURB_ — glibc allocator
+#   * MALLOC_CHECK_ / MALLOC_PERTURB_ - glibc allocator
 #     diagnostics: high MALLOC_CHECK_ values print verbose
 #     allocator state to stderr (operator log capture leaks
 #     internal state); MALLOC_PERTURB_ stabilises
@@ -126,7 +126,7 @@ if [[ "${1:-}" == "project" ]]; then
     exec "$RAPTOR_DIR/libexec/raptor-project-manager" "$@"
 fi
 
-# Route doctor directly (no Claude needed) — the doctor is a status
+# Route doctor directly (no Claude needed) - the doctor is a status
 # report on local setup, and `raptor doctor` is precisely the
 # command an operator runs when claude itself is missing.
 # Export RAPTOR_DIR + _RAPTOR_TRUSTED here because the main path's
@@ -138,6 +138,20 @@ if [[ "${1:-}" == "doctor" ]]; then
     export RAPTOR_DIR
     export _RAPTOR_TRUSTED=1
     exec python3 -m core.startup.doctor "$@"
+fi
+
+# Route frida directly (no Claude needed) - dynamic instrumentation
+# doesn't depend on a claude session. libexec/raptor-frida handles
+# its own lifecycle + python dispatch. Deliberately do NOT cd into
+# $RAPTOR_DIR: the operator's cwd must survive so a relative
+# --target (e.g. ./victim) resolves against where they ran the
+# command. The wrapper exports PYTHONPATH=$RAPTOR_DIR so the python
+# `-m` dispatch still works from any cwd.
+if [[ "${1:-}" == "frida" ]]; then
+    shift
+    export RAPTOR_DIR
+    export _RAPTOR_TRUSTED=1
+    exec "$RAPTOR_DIR/libexec/raptor-frida" "$@"
 fi
 
 # Claude required for everything else
@@ -152,20 +166,20 @@ fi
 # project paths in subcommands). Reject control bytes
 # (newlines, tabs, NULs, escape) so a pathologically-crafted
 # pwd value can't smuggle CLI-arg / line-injection payloads
-# downstream — a directory path SHOULD never contain
+# downstream - a directory path SHOULD never contain
 # whitespace control chars on a healthy filesystem.
 _caller_dir="$(pwd)"
 case "$_caller_dir" in
     *[$'\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f\x1b']*)
-        echo "raptor: RAPTOR_CALLER_DIR contains control bytes — refusing" >&2
-        echo "  (\$PWD has chars in the C0 control range; this is suspicious — bailing safely)" >&2
+        echo "raptor: RAPTOR_CALLER_DIR contains control bytes - refusing" >&2
+        echo "  (\$PWD has chars in the C0 control range; this is suspicious - bailing safely)" >&2
         exit 1
         ;;
 esac
 export RAPTOR_CALLER_DIR="$_caller_dir"
 unset _caller_dir
 export RAPTOR_DIR
-# Trust marker — libexec/ scripts refuse to run without one of
+# Trust marker - libexec/ scripts refuse to run without one of
 # CLAUDECODE, _RAPTOR_TRUSTED, or RAPTOR_DIR. We've stripped env above
 # and resolved RAPTOR_DIR; mark this invocation as trusted.
 export _RAPTOR_TRUSTED=1
@@ -185,7 +199,7 @@ while [[ $# -gt 0 ]]; do
             ;;
         --project=*)
             # `--project=foo` form. Pre-fix only `--project foo`
-            # (separate args) was accepted — the `--project=foo`
+            # (separate args) was accepted - the `--project=foo`
             # convention is standard for GNU long-options and
             # operators familiar with it (gcc, find, grep) hit
             # "unknown option" on the launcher when they used it.
@@ -220,7 +234,7 @@ while [[ $# -gt 0 ]]; do
             ;;
         -h|--help|help)
             # The early help check at the top of this script only
-            # tests `${1:-}` — so `raptor <target> -h` (help requested
+            # tests `${1:-}` - so `raptor <target> -h` (help requested
             # AFTER a positional target) never reached the early
             # branch, fell through `-*)` here, and got forwarded to
             # Claude Code as a flag, which then complained about
@@ -244,10 +258,10 @@ done
 
 # Build initial prompt: /raptor [target]. Escape TARGET
 # before interpolating into the prompt string. Pre-fix `"/raptor
-# $TARGET"` interpolated `$TARGET` raw — for legitimate paths
+# $TARGET"` interpolated `$TARGET` raw - for legitimate paths
 # this was harmless, but TARGET is operator-supplied:
 #   * Path with embedded newlines (`/foo$'\n'/extra`) split
-#     the prompt into multiple lines downstream — the second
+#     the prompt into multiple lines downstream - the second
 #     line was treated by Claude Code as a new instruction.
 #   * Path with embedded backticks / `$()` was preserved
 #     verbatim into the prompt (Claude Code receives a
@@ -259,7 +273,7 @@ done
 # legitimate path components don't contain them.
 _target_clean=$(printf '%s' "$TARGET" | tr -d '\000-\010\013-\037')
 if [ "$_target_clean" != "$TARGET" ]; then
-    echo "raptor: TARGET contained control bytes — stripped before use" >&2
+    echo "raptor: TARGET contained control bytes - stripped before use" >&2
 fi
 if [[ -n "$_target_clean" && -n "$INITIAL_PROMPT" ]]; then
     INITIAL_PROMPT="/raptor $_target_clean"
@@ -278,12 +292,12 @@ fi
 # error output from `raptor-cc-trust-check` or
 # `raptor-startup-check` stays visible to the operator. Pre-fix
 # the `clear` call lived AFTER the pre-flight checks (just before
-# `exec claude`), wiping every line they emitted to stderr —
+# `exec claude`), wiping every line they emitted to stderr -
 # trust-check warnings about untrusted target repos, startup-check
 # diagnostics about API key configuration, project-mismatch
 # prompts. The operator launched what looked like a clean Claude
 # session unaware that the launcher had flagged a problem.
-# Moving `clear` here keeps the visual reset (legitimate UX —
+# Moving `clear` here keeps the visual reset (legitimate UX -
 # operators expect a fresh screen on every `raptor` launch)
 # without erasing actionable diagnostics from the gates that
 # decide WHETHER to launch.
@@ -296,7 +310,7 @@ if [ -n "$CHECK_TARGET" ]; then
     # `-` (rare but legitimate: someone scanning a sibling
     # checkout named `--branch-foo/`) was interpreted by the
     # cc-trust-check arg parser as a flag, triggering "unknown
-    # option" + exit 2 — which the launcher then treated as
+    # option" + exit 2 - which the launcher then treated as
     # "refused to launch", failing the run on a path the
     # operator never intended as a flag.
     if [ -n "$TRUST_REPO_ARG" ]; then
@@ -339,7 +353,7 @@ fi
 # of the other vars in the strip-list affect Python / glibc / Node
 # loaders, not the bash shell that wraps a launched binary. The
 # four here are the ones that bash itself reads from the env at
-# startup (BASH_ENV, ENV, SHELLOPTS, BASHOPTS) — if claude
+# startup (BASH_ENV, ENV, SHELLOPTS, BASHOPTS) - if claude
 # happens to be a bash wrapper script (some package-manager installs
 # of claude are wrapper scripts that exec node with the right
 # args), these are the vars that influence its startup before

--- a/core/config/__init__.py
+++ b/core/config/__init__.py
@@ -106,6 +106,10 @@ class RaptorConfig:
         "gdb":          {"binary": "gdb",       "severity": "required", "affects": "/crash-analysis, /fuzz"},
         "rr":           {"binary": "rr",        "severity": "degrades", "affects": "/crash-analysis"},
         "semgrep":      {"binary": "semgrep",   "group": "scanner",     "affects": "/scan, /agentic"},
+        # Dynamic analysis tools
+        "frida":        {"binary": "frida",       "severity": "degrades", "affects": "/frida, dynamic analysis, /fuzz harness probe"},
+        "frida-trace":  {"binary": "frida-trace", "severity": "degrades", "affects": "dynamic tracing"},
+        "jadx":         {"binary": "jadx",        "severity": "degrades", "affects": "Android/APK reverse engineering"},
     }
 
     TOOL_GROUPS = {

--- a/core/dynamic/frida/__init__.py
+++ b/core/dynamic/frida/__init__.py
@@ -1,0 +1,16 @@
+"""Frida dynamic-instrumentation substrate for RAPTOR.
+
+Hosts the host-side runner, CLI, and curated hook templates. The
+runner attaches to (or spawns) a target via the frida Python bindings,
+loads a JS hook script, captures events emitted via ``send(...)`` into
+``events.jsonl``, and renders a short ``frida-report.md`` summary into
+a lifecycle-managed run directory.
+
+Not in scope:
+  * Vendoring ``frida-server`` for any target architecture - the
+    operator installs frida-server on the target; ``raptor doctor``
+    reports availability of the host-side ``frida`` CLI.
+  * LLM-autonomous instrumentation. A later integration plugs this
+    substrate into ``/agentic`` and ``/validate``; the standalone
+    runner is the prerequisite, not the consumer.
+"""

--- a/core/dynamic/frida/cli.py
+++ b/core/dynamic/frida/cli.py
@@ -1,0 +1,132 @@
+"""CLI entry point for ``raptor frida``.
+
+Invoked as ``python3 -m core.dynamic.frida.cli`` from the libexec
+wrapper (which also handles the run-lifecycle output directory). The
+``--out`` flag is injected by the lifecycle layer, so this module
+treats it as a required input rather than constructing one itself.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from .runner import (
+    RunConfig,
+    list_templates,
+    load_script_source,
+    parse_target,
+    run,
+    FridaUnavailable,
+)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="raptor frida",
+        description=("Dynamic instrumentation via Frida. Attach to or spawn "
+                     "a target, load a hook script, capture events."),
+    )
+    parser.add_argument("--target", required=True,
+                        help="PID (digits), process name, bundle id, "
+                             "or path to a binary to spawn.")
+    parser.add_argument("--out", required=True,
+                        help="Lifecycle-managed output directory "
+                             "(injected by libexec/raptor-frida).")
+
+    src = parser.add_mutually_exclusive_group(required=True)
+    src.add_argument("--template", metavar="NAME",
+                     help=("Bundled hook template name. Use --list-templates "
+                           "to see options."))
+    src.add_argument("--script", metavar="PATH",
+                     help="Path to an operator-supplied JS hook file.")
+
+    dev = parser.add_mutually_exclusive_group()
+    dev.add_argument("--host", metavar="HOST[:PORT]",
+                     help=("Connect to a remote frida-server. Default "
+                           "port 27042 if not specified."))
+    dev.add_argument("--usb", action="store_true",
+                     help="Connect to the first USB-attached device.")
+
+    parser.add_argument("--duration", type=float, default=60.0,
+                        help="Seconds to run before detaching. Default 60.")
+    parser.add_argument("--spawn", action="store_true",
+                        help=("Force spawn-and-attach. Implied when --target "
+                              "is an existing file path."))
+    parser.add_argument("--unsafe-attach", action="store_true",
+                        help=("Required for templates / attach modes needing "
+                              "PTRACE_ATTACH or task_for_pid. Logged in "
+                              "metadata."))
+    parser.add_argument("--list-templates", action="store_true",
+                        help="Print bundled template names and exit.")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    # --list-templates is a query mode; skip the required flags by
+    # short-circuiting before parse_args's required-arg check.
+    if argv is None:
+        argv = sys.argv[1:]
+    if "--list-templates" in argv:
+        for name in list_templates():
+            print(name)
+        return 0
+
+    args = parser.parse_args(argv)
+
+    try:
+        target = parse_target(args.target)
+    except ValueError as e:
+        print(f"frida: invalid --target: {e}", file=sys.stderr)
+        return 2
+
+    # A PID identifies an already-running process; you cannot spawn it.
+    # Without this guard the runner would fall into the spawn branch and
+    # try to launch a program literally named after the PID - a confusing
+    # failure. Reject it up front instead.
+    if target.kind == "pid" and args.spawn:
+        print("frida: --spawn is incompatible with a PID target "
+              "(a PID is already running; pass a binary path or name to "
+              "spawn).", file=sys.stderr)
+        return 2
+
+    try:
+        source, origin = load_script_source(args.template, args.script)
+    except (FileNotFoundError, ValueError) as e:
+        print(f"frida: {e}", file=sys.stderr)
+        return 2
+
+    cfg = RunConfig(
+        target=target,
+        out_dir=Path(args.out),
+        script_source=source,
+        script_origin=origin,
+        duration_sec=args.duration,
+        host=args.host,
+        use_usb=args.usb,
+        spawn=args.spawn,
+        unsafe_attach=args.unsafe_attach,
+    )
+
+    try:
+        result = run(cfg)
+    except FridaUnavailable as e:
+        print(f"frida: {e}", file=sys.stderr)
+        return 3
+
+    if not result.ok:
+        # Detail already in metadata.json + frida-report.md; the CLI
+        # prints a one-liner so a caller wrapping us in a shell knows
+        # what happened without parsing JSON.
+        print(f"frida: run failed: {result.error}", file=sys.stderr)
+        return 1
+
+    print(f"frida: ok - {result.events_captured} events captured in "
+          f"{result.duration_actual_sec:.1f}s → {args.out}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/core/dynamic/frida/platform.py
+++ b/core/dynamic/frida/platform.py
@@ -1,0 +1,77 @@
+"""Platform detection for Frida runs.
+
+Frida's behaviour differs meaningfully across host platforms - most
+notably, macOS attach to system-owned processes requires SIP-disabled
+or task_for_pid entitlements, while Linux attach needs ptrace
+permission (kernel.yama.ptrace_scope). We surface these in the
+metadata.json a run drops so an operator looking at a failed attach
+later can see *why*.
+
+The helpers here are deliberately small - no platform-specific code
+paths in the runner itself; just labels and reachability checks.
+"""
+
+from __future__ import annotations
+
+import os
+import platform
+import shutil
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class HostInfo:
+    """Snapshot of host-side preconditions for a Frida run.
+
+    Persisted into ``metadata.json`` so post-hoc inspection of a
+    failed attach has the host posture without needing to re-derive
+    it. ``frida_version`` is best-effort - falls back to "unknown"
+    if the binding isn't importable.
+    """
+    system: str            # "Darwin", "Linux", "Windows"
+    arch: str              # "arm64", "x86_64", etc.
+    frida_version: str     # frida-python version
+    frida_bin: str | None  # resolved path to `frida` CLI, if any
+    sip_status: str | None # macOS only: "enabled" / "disabled" / "unknown"
+    ptrace_scope: int | None  # Linux only: /proc/sys/kernel/yama/ptrace_scope
+
+
+def detect_host() -> HostInfo:
+    """Snapshot the host. Pure read; never raises."""
+    sys_name = platform.system()
+    arch = platform.machine()
+
+    try:
+        import frida  # type: ignore
+        version = getattr(frida, "__version__", "unknown")
+    except Exception:
+        version = "unavailable"
+
+    return HostInfo(
+        system=sys_name,
+        arch=arch,
+        frida_version=version,
+        frida_bin=shutil.which("frida"),
+        sip_status=_macos_sip_status() if sys_name == "Darwin" else None,
+        ptrace_scope=_linux_ptrace_scope() if sys_name == "Linux" else None,
+    )
+
+
+def _macos_sip_status() -> str:
+    # `csrutil status` is the canonical query but exits non-zero on
+    # some restricted environments. We don't shell out - the rare
+    # information is "we couldn't tell". `nvram` reflection of csr is
+    # also restricted on modern macOS. Return "unknown" and let the
+    # operator check manually if a system-process attach fails.
+    return "unknown"
+
+
+def _linux_ptrace_scope() -> int | None:
+    path = "/proc/sys/kernel/yama/ptrace_scope"
+    if not os.path.exists(path):
+        return None
+    try:
+        with open(path, "r") as f:
+            return int(f.read().strip())
+    except (OSError, ValueError):
+        return None

--- a/core/dynamic/frida/runner.py
+++ b/core/dynamic/frida/runner.py
@@ -1,0 +1,397 @@
+"""Frida session runner.
+
+Wraps the frida-python API into a single ``run()`` entry point:
+
+  * Resolve the device (local / USB / remote frida-server).
+  * Resolve the target (PID, name, bundle id, or binary path).
+  * Spawn or attach.
+  * Load the hook script (template or operator-supplied JS).
+  * Capture ``send(...)`` messages into ``events.jsonl``.
+  * Run for ``duration`` seconds, detach cleanly, write
+    ``metadata.json`` + ``frida-report.md``.
+
+The frida import is deferred so a) ``raptor doctor`` and the SKILL.md
+remain usable on a host without frida-python installed and b) unit
+tests can monkey-patch frida.* without import-time side effects.
+"""
+
+from __future__ import annotations
+
+import json
+import signal
+import threading
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, Optional
+
+from .platform import HostInfo, detect_host
+
+
+TEMPLATES_DIR = Path(__file__).parent / "templates"
+
+
+class FridaUnavailable(RuntimeError):
+    """Raised when frida-python isn't installed.
+
+    Kept as a distinct exception so callers (CLI, libexec wrapper)
+    can give an actionable error rather than a bare ImportError.
+    """
+
+
+@dataclass
+class TargetSpec:
+    """Parsed target descriptor.
+
+    ``raw`` is what the operator typed; ``pid``, ``name``, ``binary``
+    are the resolved interpretations. Exactly one of pid/name/binary
+    is set after :func:`parse_target`.
+    """
+    raw: str
+    pid: Optional[int] = None
+    name: Optional[str] = None         # process name OR bundle id
+    binary: Optional[str] = None       # filesystem path → spawn
+
+    @property
+    def kind(self) -> str:
+        if self.pid is not None:
+            return "pid"
+        if self.binary is not None:
+            return "binary"
+        return "name"
+
+
+def parse_target(raw: str) -> TargetSpec:
+    """Classify a ``--target`` value.
+
+    Order: numeric → PID; existing file → binary (spawn); else name
+    (process name or bundle id, distinguished by frida at attach time).
+    """
+    raw = raw.strip()
+    if not raw:
+        raise ValueError("empty target")
+    if raw.isdigit():
+        return TargetSpec(raw=raw, pid=int(raw))
+    p = Path(raw)
+    if p.exists() and p.is_file():
+        return TargetSpec(raw=raw, binary=str(p.resolve()))
+    return TargetSpec(raw=raw, name=raw)
+
+
+@dataclass
+class RunConfig:
+    """Inputs to one :func:`run` invocation.
+
+    All fields besides ``target`` and ``out_dir`` have sensible
+    defaults; the CLI populates from argparse.
+    """
+    target: TargetSpec
+    out_dir: Path
+    script_source: str
+    script_origin: str                  # "template:<name>" or "file:<path>"
+    duration_sec: float = 60.0
+    host: Optional[str] = None          # frida-server host[:port]
+    use_usb: bool = False
+    spawn: bool = False
+    unsafe_attach: bool = False         # informational; logged in metadata
+
+
+@dataclass
+class RunResult:
+    """Outcome of a run. Populated incrementally; the JSON-serialisable
+    fields are what gets written to ``metadata.json``.
+    """
+    ok: bool = False
+    error: Optional[str] = None
+    events_captured: int = 0
+    duration_actual_sec: float = 0.0
+    resolved_pid: Optional[int] = None
+    device_id: Optional[str] = None
+    host_info: Optional[HostInfo] = None
+
+
+def resolve_template(name: str) -> Path:
+    """Map a ``--template`` name to its on-disk JS file.
+
+    Restricts to ``[a-zA-Z0-9_-]`` to defend against ``--template
+    ../../../etc/passwd``. The eventual real path must live inside
+    TEMPLATES_DIR; symlink-escape is rejected via ``.resolve()``
+    comparison against the templates root.
+    """
+    if not name or not all(c.isalnum() or c in "-_" for c in name):
+        raise ValueError(f"invalid template name: {name!r}")
+    candidate = (TEMPLATES_DIR / f"{name}.js").resolve()
+    root = TEMPLATES_DIR.resolve()
+    try:
+        candidate.relative_to(root)
+    except ValueError:
+        raise ValueError(f"template path escaped templates dir: {name!r}")
+    if not candidate.is_file():
+        raise FileNotFoundError(f"template not found: {name}")
+    return candidate
+
+
+def list_templates() -> list[str]:
+    """Names of the bundled hook templates (sans .js)."""
+    if not TEMPLATES_DIR.is_dir():
+        return []
+    return sorted(p.stem for p in TEMPLATES_DIR.glob("*.js"))
+
+
+def load_script_source(template: Optional[str],
+                      script_path: Optional[str]) -> tuple[str, str]:
+    """Return (source, origin_label). Exactly one input must be set."""
+    if bool(template) == bool(script_path):
+        raise ValueError("specify exactly one of --template or --script")
+    if template:
+        path = resolve_template(template)
+        return path.read_text(encoding="utf-8"), f"template:{template}"
+    assert script_path is not None
+    p = Path(script_path).resolve()
+    if not p.is_file():
+        raise FileNotFoundError(f"script not found: {script_path}")
+    return p.read_text(encoding="utf-8"), f"file:{p}"
+
+
+def _import_frida():
+    """Late-bind frida-python with a useful error.
+
+    Returning the module rather than importing at module-scope keeps
+    this whole package importable on hosts without frida - important
+    for `raptor doctor` and for unit tests that inject a fake.
+    """
+    try:
+        import frida  # type: ignore
+        return frida
+    except ImportError as e:
+        raise FridaUnavailable(
+            "frida-python not installed. Install via: "
+            "pipx install frida-tools  (or pip install --user frida-tools)"
+        ) from e
+
+
+def _resolve_device(frida_mod: Any, cfg: RunConfig):
+    """Pick the device per the CLI flags.
+
+    Mutually exclusive with --usb / --host already enforced at parse
+    time in cli.py; here we just translate to frida-API calls.
+    """
+    if cfg.host:
+        return frida_mod.get_device_manager().add_remote_device(cfg.host)
+    if cfg.use_usb:
+        return frida_mod.get_usb_device(timeout=5)
+    return frida_mod.get_local_device()
+
+
+def _attach_or_spawn(frida_mod: Any, device: Any, cfg: RunConfig
+                     ) -> tuple[Any, int]:
+    """Return (session, pid). Spawned processes start suspended;
+    caller must ``device.resume(pid)`` after script load.
+    """
+    t = cfg.target
+    if t.binary or cfg.spawn:
+        # Spawn: argv0 = binary. No further args supported in v1 -
+        # operator can wrap with a shell script if they need them.
+        binary = t.binary or t.raw
+        pid = device.spawn([binary])
+        session = device.attach(pid)
+        return session, pid
+    if t.pid is not None:
+        session = device.attach(t.pid)
+        return session, t.pid
+    # name or bundle id
+    session = device.attach(t.name)
+    # Pid resolution after attach: frida exposes session.pid only
+    # since 16.x; fall back to None if absent for older bindings.
+    return session, int(getattr(session, "pid", 0) or 0)
+
+
+def run(cfg: RunConfig,
+        on_event: Optional[Callable[[dict], None]] = None,
+        frida_mod_override: Any = None) -> RunResult:
+    """Execute one Frida session.
+
+    Side effects in ``cfg.out_dir``:
+      * ``events.jsonl`` - one JSON object per ``send()`` from the script
+      * ``script.js`` - copy of the script source (template or file)
+      * ``metadata.json`` - run shape, host info, target, timings
+      * ``frida-report.md`` - human-readable summary
+
+    ``on_event`` is called for every message in addition to being
+    serialised - used by tests to assert events without parsing the
+    jsonl file.
+    """
+    cfg.out_dir.mkdir(parents=True, exist_ok=True)
+    (cfg.out_dir / "script.js").write_text(cfg.script_source, encoding="utf-8")
+
+    host_info = detect_host()
+    result = RunResult(host_info=host_info)
+
+    frida_mod = frida_mod_override or _import_frida()
+
+    events_path = cfg.out_dir / "events.jsonl"
+    # Create up-front so the file frida-report.md points to always
+    # exists - even for a run that captures zero events or fails
+    # before the first send().
+    events_path.touch()
+    events_lock = threading.Lock()
+    event_count = {"n": 0}
+
+    def _message_cb(message: dict, data: Optional[bytes]) -> None:
+        """Frida's on('message') callback. Both ``send()`` payloads
+        (type='send') and uncaught script errors (type='error')
+        flow through here. We persist both so a hook crashing
+        mid-run leaves a trail.
+        """
+        record: dict[str, Any] = {
+            "ts": time.time(),
+            "type": message.get("type"),
+        }
+        if message.get("type") == "send":
+            record["payload"] = message.get("payload")
+        elif message.get("type") == "error":
+            record["error"] = {
+                "description": message.get("description"),
+                "stack": message.get("stack"),
+                "fileName": message.get("fileName"),
+                "lineNumber": message.get("lineNumber"),
+            }
+        else:
+            record["raw"] = message
+        if data is not None:
+            # Binary blobs (rare; emitted via send(payload, data) in JS)
+            # are summarised, not embedded - JSONL stays line-grep-able.
+            record["binary_len"] = len(data)
+        with events_lock:
+            with events_path.open("a", encoding="utf-8") as f:
+                f.write(json.dumps(record, default=str) + "\n")
+            event_count["n"] += 1
+        if on_event is not None:
+            try:
+                on_event(record)
+            except Exception:
+                pass  # never let a test callback break the run
+
+    started = time.monotonic()
+    session = None
+    device = None
+    pid: Optional[int] = None
+
+    try:
+        device = _resolve_device(frida_mod, cfg)
+        result.device_id = getattr(device, "id", None) or str(device)
+        session, pid = _attach_or_spawn(frida_mod, device, cfg)
+        result.resolved_pid = pid
+
+        script = session.create_script(cfg.script_source)
+        script.on("message", _message_cb)
+        script.load()
+
+        # If we spawned, the process is suspended pre-load. Resume it
+        # AFTER load so hooks are in place before main() runs.
+        if cfg.target.binary or cfg.spawn:
+            device.resume(pid)
+
+        # Sleep loop with SIGINT trap so Ctrl-C in the operator's shell
+        # terminates the run cleanly rather than orphaning the script.
+        stop = threading.Event()
+
+        def _on_sigint(_signum, _frame):
+            stop.set()
+
+        prev_handler = signal.signal(signal.SIGINT, _on_sigint)
+        try:
+            deadline = started + cfg.duration_sec
+            while time.monotonic() < deadline and not stop.is_set():
+                time.sleep(0.1)
+        finally:
+            signal.signal(signal.SIGINT, prev_handler)
+
+        result.ok = True
+    except FridaUnavailable:
+        raise
+    except Exception as e:
+        result.ok = False
+        result.error = f"{type(e).__name__}: {e}"
+    finally:
+        try:
+            if session is not None:
+                session.detach()
+        except Exception:
+            pass
+        result.duration_actual_sec = round(time.monotonic() - started, 3)
+        result.events_captured = event_count["n"]
+        _write_metadata(cfg, result)
+        _write_report(cfg, result)
+
+    return result
+
+
+def _write_metadata(cfg: RunConfig, result: RunResult) -> None:
+    payload = {
+        "ok": result.ok,
+        "error": result.error,
+        "target": {
+            "raw": cfg.target.raw,
+            "kind": cfg.target.kind,
+            "pid": cfg.target.pid,
+            "name": cfg.target.name,
+            "binary": cfg.target.binary,
+        },
+        "script_origin": cfg.script_origin,
+        "duration_requested_sec": cfg.duration_sec,
+        "duration_actual_sec": result.duration_actual_sec,
+        "events_captured": result.events_captured,
+        "device": {
+            "id": result.device_id,
+            "host": cfg.host,
+            "usb": cfg.use_usb,
+        },
+        "host": {
+            "system": result.host_info.system if result.host_info else None,
+            "arch": result.host_info.arch if result.host_info else None,
+            "frida_version": (result.host_info.frida_version
+                              if result.host_info else None),
+            "frida_bin": (result.host_info.frida_bin
+                          if result.host_info else None),
+            "sip_status": (result.host_info.sip_status
+                           if result.host_info else None),
+            "ptrace_scope": (result.host_info.ptrace_scope
+                             if result.host_info else None),
+        },
+        "spawn": cfg.spawn or bool(cfg.target.binary),
+        "unsafe_attach": cfg.unsafe_attach,
+        "resolved_pid": result.resolved_pid,
+    }
+    (cfg.out_dir / "metadata.json").write_text(
+        json.dumps(payload, indent=2, default=str), encoding="utf-8")
+
+
+def _write_report(cfg: RunConfig, result: RunResult) -> None:
+    lines: list[str] = []
+    lines.append("# RAPTOR Frida Run")
+    lines.append("")
+    status = "OK" if result.ok else "FAILED"
+    lines.append(f"**Status:** {status}")
+    if result.error:
+        lines.append(f"**Error:** `{result.error}`")
+    lines.append(f"**Target:** `{cfg.target.raw}` ({cfg.target.kind})")
+    if result.resolved_pid:
+        lines.append(f"**PID:** {result.resolved_pid}")
+    lines.append(f"**Script:** `{cfg.script_origin}`")
+    lines.append(f"**Events captured:** {result.events_captured}")
+    lines.append(
+        f"**Duration:** {result.duration_actual_sec:.2f}s "
+        f"(requested {cfg.duration_sec:.0f}s)"
+    )
+    if cfg.host:
+        lines.append(f"**Remote frida-server:** `{cfg.host}`")
+    if cfg.use_usb:
+        lines.append("**Device:** USB")
+    if cfg.unsafe_attach:
+        lines.append("**Mode:** `--unsafe-attach` (sandbox bypass)")
+    lines.append("")
+    lines.append("Raw events: see `events.jsonl`. Run metadata: see "
+                 "`metadata.json`. Script as executed: see `script.js`.")
+    (cfg.out_dir / "frida-report.md").write_text(
+        "\n".join(lines) + "\n", encoding="utf-8")

--- a/core/dynamic/frida/templates/api-trace.js
+++ b/core/dynamic/frida/templates/api-trace.js
@@ -1,0 +1,95 @@
+// api-trace.js - trace common syscalls + libc functions.
+//
+// Originally drafted by @ZephrFish for the v2 Frida integration
+// (gadievron/raptor PR forthcoming). Intentionally minimal - Splinters
+// will land a richer version in the same templates dir; this one is
+// the starter that proves the runner's send()-capture path.
+//
+// Hooks: open(2)/openat(2), read(2)/write(2), connect(2),
+// fork(2)/execve(2). Each hit emits a {category, fn, args} record
+// via send() so the runner persists it to events.jsonl.
+//
+// Use:
+//   raptor frida --target <pid|name|binary> --template api-trace
+//
+// Scope choices:
+//   * libc-level (Module.findExportByName('libc', ...)) rather than
+//     raw syscall numbers - portable enough between glibc/musl/macOS
+//     libSystem for the common cases.
+//   * No string-content capture beyond first 256 bytes of read/write
+//     buffers - keeps events.jsonl line-grep-friendly; an operator
+//     hunting for credentials will hook ssl-trace separately.
+
+'use strict';
+
+function safeStr(ptr, maxLen) {
+  // NULL or unreadable pointers return '<null>' / '<unreadable>'
+  // rather than crashing the agent. Defensive because attacker-
+  // controlled input is reaching libc here.
+  if (ptr.isNull()) return '<null>';
+  try {
+    return Memory.readUtf8String(ptr, maxLen || 256);
+  } catch (_e) {
+    return '<unreadable>';
+  }
+}
+
+function emit(category, fn, args) {
+  send({ category: category, fn: fn, args: args, tid: Process.getCurrentThreadId() });
+}
+
+// Resolve a symbol from any loaded module. Frida 17 removed the
+// `Module.findExportByName(null, name)` global-search form; the
+// replacement is `Module.findGlobalExportByName(name)`. We probe for
+// both so the template stays usable on Frida 16 and 17.
+function findGlobalExport(name) {
+  if (typeof Module.findGlobalExportByName === 'function') {
+    return Module.findGlobalExportByName(name);
+  }
+  if (typeof Module.findExportByName === 'function') {
+    try { return Module.findExportByName(null, name); } catch (_e) { return null; }
+  }
+  return null;
+}
+
+function hook(name, category, argHandler) {
+  // findGlobalExport returns null when the symbol isn't in any loaded
+  // module on this platform (e.g. openat missing on older macOS, or
+  // a statically-linked Go binary that doesn't pull libc).
+  const addr = findGlobalExport(name);
+  if (addr === null) return;
+  Interceptor.attach(addr, {
+    onEnter: function (args) {
+      try {
+        this.captured = argHandler(args);
+      } catch (e) {
+        this.captured = { _err: String(e) };
+      }
+    },
+    onLeave: function (retval) {
+      emit(category, name, Object.assign({ ret: retval.toInt32() }, this.captured));
+    },
+  });
+}
+
+// File I/O
+hook('open',   'file', a => ({ path: safeStr(a[0]), flags: a[1].toInt32() }));
+hook('openat', 'file', a => ({ dirfd: a[0].toInt32(), path: safeStr(a[1]), flags: a[2].toInt32() }));
+hook('read',   'file', a => ({ fd: a[0].toInt32(), count: a[2].toInt32() }));
+hook('write',  'file', a => ({ fd: a[0].toInt32(), count: a[2].toInt32() }));
+hook('close',  'file', a => ({ fd: a[0].toInt32() }));
+
+// Process
+hook('fork',   'process', _a => ({}));
+hook('execve', 'process', a => ({ path: safeStr(a[0]) }));
+hook('exit',   'process', a => ({ status: a[0].toInt32() }));
+
+// Network - sockaddr inspection is platform-specific; emit just the fd
+// and let the operator correlate via /proc or lsof if they need more.
+hook('connect', 'network', a => ({ fd: a[0].toInt32() }));
+hook('bind',    'network', a => ({ fd: a[0].toInt32() }));
+hook('accept',  'network', a => ({ fd: a[0].toInt32() }));
+
+send({ _meta: 'api-trace loaded', hooks: ['open', 'openat', 'read', 'write', 'close',
+                                          'fork', 'execve', 'exit',
+                                          'connect', 'bind', 'accept'] });

--- a/core/dynamic/frida/templates/ssl-unpin.js
+++ b/core/dynamic/frida/templates/ssl-unpin.js
@@ -1,0 +1,110 @@
+// ssl-unpin.js - bypass common SSL/TLS certificate pinning paths.
+//
+// Originally drafted by @ZephrFish for the v2 Frida integration.
+// Splinters will likely supersede with a richer version pulling
+// from his closed PR #57; this is the starter.
+//
+// Targets covered:
+//   * iOS:     SecTrustEvaluateWithError / SecTrustGetTrustResult
+//              (Security.framework - modern path)
+//   * macOS:   same as iOS via Security.framework
+//   * OpenSSL: SSL_get_verify_result, SSL_CTX_set_verify
+//   * Android: javax.net.ssl.X509TrustManager.checkServerTrusted
+//              (only if a Java VM is attached)
+//
+// Each bypass emits a {category, fn, before, after} record so the
+// operator sees *which* pinning layer fired and was overridden.
+//
+// Use:
+//   raptor frida --target com.example.app --template ssl-unpin --usb
+//   raptor frida --target Safari --template ssl-unpin
+
+'use strict';
+
+function emit(category, fn, detail) {
+  send({ category: category, fn: fn, detail: detail });
+}
+
+// ─── Security.framework (iOS / macOS) ───────────────────────────────
+(function patchSecurityFramework() {
+  const symbols = [
+    // newer API, returns bool
+    { name: 'SecTrustEvaluateWithError', retType: 'bool' },
+    // older API, returns OSStatus
+    { name: 'SecTrustEvaluate', retType: 'OSStatus' },
+  ];
+  for (const sym of symbols) {
+    const addr = Module.findExportByName('Security', sym.name);
+    if (addr === null) continue;
+    Interceptor.attach(addr, {
+      onLeave: function (retval) {
+        if (sym.retType === 'bool') {
+          // SecTrustEvaluateWithError returns true on success
+          if (retval.toInt32() === 0) {
+            emit('ssl-unpin', sym.name, { forced: 'true' });
+            retval.replace(1);
+          }
+        } else {
+          // SecTrustEvaluate returns errSecSuccess (0) on success.
+          // Force result to kSecTrustResultProceed (1) via out-param -
+          // here we just zero the return code which is sufficient for
+          // most NSURLSession pinning paths.
+          if (retval.toInt32() !== 0) {
+            emit('ssl-unpin', sym.name, {
+              forced: 'errSecSuccess', original: retval.toInt32(),
+            });
+            retval.replace(0);
+          }
+        }
+      },
+    });
+    emit('ssl-unpin', '_hook_installed', { sym: sym.name });
+  }
+})();
+
+// ─── OpenSSL ────────────────────────────────────────────────────────
+(function patchOpenSSL() {
+  // Frida 17 removed Module.findExportByName(null, ...). Use the
+  // global search helper when present.
+  const findGlobal = (typeof Module.findGlobalExportByName === 'function')
+    ? Module.findGlobalExportByName.bind(Module)
+    : function (n) { try { return Module.findExportByName(null, n); } catch (_e) { return null; } };
+  const addr = findGlobal('SSL_get_verify_result');
+  if (addr === null) return;
+  Interceptor.attach(addr, {
+    onLeave: function (retval) {
+      // X509_V_OK is 0; force pass.
+      if (retval.toInt32() !== 0) {
+        emit('ssl-unpin', 'SSL_get_verify_result', {
+          forced: 'X509_V_OK', original: retval.toInt32(),
+        });
+        retval.replace(0);
+      }
+    },
+  });
+  emit('ssl-unpin', '_hook_installed', { sym: 'SSL_get_verify_result' });
+})();
+
+// ─── Android JSSE (only if Java is available) ───────────────────────
+if (typeof Java !== 'undefined' && Java.available) {
+  Java.perform(function () {
+    try {
+      const X509TM = Java.use('javax.net.ssl.X509TrustManager');
+      X509TM.checkServerTrusted.overload(
+        '[Ljava.security.cert.X509Certificate;', 'java.lang.String'
+      ).implementation = function (chain, authType) {
+        emit('ssl-unpin', 'X509TrustManager.checkServerTrusted', {
+          authType: authType, chainLen: chain.length,
+        });
+        // Return without throwing → certificate accepted.
+      };
+      emit('ssl-unpin', '_hook_installed', {
+        sym: 'X509TrustManager.checkServerTrusted',
+      });
+    } catch (e) {
+      emit('ssl-unpin', '_hook_failed', { err: String(e) });
+    }
+  });
+}
+
+send({ _meta: 'ssl-unpin loaded' });

--- a/core/dynamic/frida/tests/test_cli.py
+++ b/core/dynamic/frida/tests/test_cli.py
@@ -1,0 +1,173 @@
+"""CLI tests for core.dynamic.frida.cli.
+
+These exercise argument parsing and the wiring from CLI flags to
+``runner.RunConfig``. The actual frida call is mocked via the same
+``frida_mod_override`` injection point used in test_runner.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from core.dynamic.frida import cli, runner
+
+
+class _FakeDevice:
+    def __init__(self):
+        self.id = "local"
+        self.attach_calls: list = []
+        self.spawn_calls: list = []
+        self.resume_calls: list = []
+
+    def attach(self, target):
+        self.attach_calls.append(target)
+        return _FakeSession()
+
+    def spawn(self, argv):
+        self.spawn_calls.append(argv)
+        return 9999
+
+    def resume(self, pid):
+        self.resume_calls.append(pid)
+
+
+class _FakeSession:
+    def __init__(self):
+        self.pid = 1234
+        self.detached = False
+
+    def create_script(self, src):
+        return _FakeScript()
+
+    def detach(self):
+        self.detached = True
+
+
+class _FakeScript:
+    def on(self, ev, cb):
+        pass
+
+    def load(self):
+        pass
+
+
+def _fake_frida():
+    dev = _FakeDevice()
+    return dev, SimpleNamespace(
+        __version__="test",
+        get_local_device=lambda: dev,
+        get_device_manager=lambda: SimpleNamespace(
+            add_remote_device=lambda h: dev),
+        get_usb_device=lambda timeout=5: dev,
+    )
+
+
+def test_list_templates_exits_zero(capsys):
+    rc = cli.main(["--list-templates"])
+    assert rc == 0
+    out = capsys.readouterr().out.strip().splitlines()
+    # At minimum, api-trace and ssl-unpin ship with the package.
+    assert "api-trace" in out
+    assert "ssl-unpin" in out
+
+
+def test_cli_requires_target_and_source():
+    # Missing --target should exit non-zero (argparse 2).
+    with pytest.raises(SystemExit) as exc:
+        cli.main(["--template", "api-trace", "--out", "/tmp/x"])
+    assert exc.value.code == 2
+
+
+def test_cli_template_and_script_mutually_exclusive():
+    with pytest.raises(SystemExit) as exc:
+        cli.main([
+            "--target", "1",
+            "--out", "/tmp/x",
+            "--template", "api-trace",
+            "--script", "/tmp/h.js",
+        ])
+    assert exc.value.code == 2
+
+
+def test_cli_host_and_usb_mutually_exclusive():
+    with pytest.raises(SystemExit) as exc:
+        cli.main([
+            "--target", "1",
+            "--out", "/tmp/x",
+            "--template", "api-trace",
+            "--host", "10.0.0.1",
+            "--usb",
+        ])
+    assert exc.value.code == 2
+
+
+def test_cli_happy_path_runs(tmp_path: Path, monkeypatch):
+    dev, fake_frida = _fake_frida()
+    # Patch the runner's frida-import to return our fake.
+    monkeypatch.setattr(runner, "_import_frida", lambda: fake_frida)
+
+    rc = cli.main([
+        "--target", "1234",
+        "--out", str(tmp_path),
+        "--template", "api-trace",
+        "--duration", "0.05",
+    ])
+    assert rc == 0
+    # The runner produces these three artefacts on success.
+    assert (tmp_path / "metadata.json").is_file()
+    assert (tmp_path / "frida-report.md").is_file()
+    assert (tmp_path / "script.js").is_file()
+    meta = json.loads((tmp_path / "metadata.json").read_text())
+    assert meta["ok"] is True
+    assert meta["target"]["pid"] == 1234
+
+
+def test_cli_invalid_template_name(tmp_path: Path):
+    rc = cli.main([
+        "--target", "1234",
+        "--out", str(tmp_path),
+        "--template", "../../etc/passwd",
+        "--duration", "0.05",
+    ])
+    assert rc == 2  # parse_target succeeds; template validation fails
+
+
+def test_cli_missing_script_file(tmp_path: Path):
+    rc = cli.main([
+        "--target", "1234",
+        "--out", str(tmp_path),
+        "--script", str(tmp_path / "nonexistent.js"),
+        "--duration", "0.05",
+    ])
+    assert rc == 2
+
+
+def test_cli_spawn_with_pid_rejected(tmp_path: Path):
+    # --spawn names a program to launch; a PID is already running, so the
+    # combination is contradictory and must be rejected (exit 2) rather
+    # than silently trying to spawn a program named after the PID.
+    rc = cli.main([
+        "--target", "1234",
+        "--out", str(tmp_path),
+        "--template", "api-trace",
+        "--spawn",
+        "--duration", "0.05",
+    ])
+    assert rc == 2
+
+
+def test_cli_frida_unavailable_exit_3(tmp_path: Path, monkeypatch):
+    def boom():
+        raise runner.FridaUnavailable("missing")
+    monkeypatch.setattr(runner, "_import_frida", boom)
+    rc = cli.main([
+        "--target", "1234",
+        "--out", str(tmp_path),
+        "--template", "api-trace",
+        "--duration", "0.05",
+    ])
+    assert rc == 3

--- a/core/dynamic/frida/tests/test_runner.py
+++ b/core/dynamic/frida/tests/test_runner.py
@@ -1,0 +1,395 @@
+"""Unit tests for core.dynamic.frida.runner.
+
+The runner integrates with the real frida-python binding when present,
+but the binding requires a running target to attach to and shells out
+to platform-specific binaries - neither suitable for CI. We inject a
+fake frida module with the minimal API surface the runner touches
+(get_local_device / get_device_manager.add_remote_device /
+get_usb_device, device.attach / spawn / resume, session.create_script /
+detach, script.on / load) and assert the runner orchestrates them
+correctly.
+
+Coverage:
+  * Target parsing: PID, name, binary-path.
+  * Template name validation (path-traversal defence).
+  * Script source loading from template OR file (xor).
+  * Run with attach-by-pid emits events.jsonl + metadata.json + report.
+  * Run with spawn calls device.spawn + device.resume in correct order.
+  * Remote --host routes via get_device_manager().add_remote_device.
+  * --usb routes via get_usb_device.
+  * Script error messages get written to events.jsonl.
+  * Frida ImportError is mapped to FridaUnavailable.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from core.dynamic.frida import runner
+
+
+class FakeScript:
+    """Stand-in for frida.Script with the runner-touched surface."""
+    def __init__(self):
+        self._cb = None
+        self.loaded = False
+
+    def on(self, event: str, cb):
+        assert event == "message"
+        self._cb = cb
+
+    def load(self):
+        self.loaded = True
+
+    def fire(self, message: dict, data: bytes | None = None):
+        """Test helper - simulate a message from the JS side."""
+        assert self._cb is not None, "load() must be called first"
+        self._cb(message, data)
+
+
+class FakeSession:
+    def __init__(self, pid: int):
+        self.pid = pid
+        self.detached = False
+        self.script = FakeScript()
+
+    def create_script(self, source: str):
+        self.last_source = source
+        return self.script
+
+    def detach(self):
+        self.detached = True
+
+
+class FakeDevice:
+    def __init__(self, id_: str = "local"):
+        self.id = id_
+        self.spawn_calls: list[list[str]] = []
+        self.resume_calls: list[int] = []
+        self.attach_calls: list[Any] = []
+        self._next_spawn_pid = 9999
+
+    def spawn(self, argv: list[str]) -> int:
+        self.spawn_calls.append(argv)
+        return self._next_spawn_pid
+
+    def resume(self, pid: int):
+        self.resume_calls.append(pid)
+
+    def attach(self, target) -> FakeSession:
+        self.attach_calls.append(target)
+        # PID-by-int when target is int; else use a placeholder.
+        pid = target if isinstance(target, int) else 7777
+        return FakeSession(pid=pid)
+
+
+class FakeDeviceManager:
+    def __init__(self, remote_device: FakeDevice):
+        self._remote = remote_device
+        self.add_remote_calls: list[str] = []
+
+    def add_remote_device(self, host: str) -> FakeDevice:
+        self.add_remote_calls.append(host)
+        return self._remote
+
+
+def _fake_frida(local_device: FakeDevice,
+               remote_device: FakeDevice | None = None,
+               usb_device: FakeDevice | None = None):
+    """Build a minimal fake frida module."""
+    rdev = remote_device or FakeDevice("remote")
+    udev = usb_device or FakeDevice("usb")
+    return SimpleNamespace(
+        __version__="test-fake",
+        get_local_device=lambda: local_device,
+        get_device_manager=lambda: FakeDeviceManager(rdev),
+        get_usb_device=lambda timeout=5: udev,
+    )
+
+
+# --- parse_target ----------------------------------------------------
+
+def test_parse_target_pid():
+    t = runner.parse_target("1234")
+    assert t.pid == 1234 and t.binary is None and t.name is None
+    assert t.kind == "pid"
+
+
+def test_parse_target_binary(tmp_path: Path):
+    binary = tmp_path / "victim"
+    binary.write_text("#!/bin/sh\n")
+    t = runner.parse_target(str(binary))
+    assert t.binary == str(binary.resolve())
+    assert t.kind == "binary"
+
+
+def test_parse_target_name():
+    t = runner.parse_target("Safari")
+    assert t.name == "Safari" and t.pid is None and t.binary is None
+    assert t.kind == "name"
+
+
+def test_parse_target_empty_rejected():
+    with pytest.raises(ValueError):
+        runner.parse_target("")
+
+
+# --- resolve_template ------------------------------------------------
+
+def test_resolve_template_traversal_rejected():
+    with pytest.raises(ValueError):
+        runner.resolve_template("../../../etc/passwd")
+
+
+def test_resolve_template_disallowed_chars():
+    with pytest.raises(ValueError):
+        runner.resolve_template("api trace")  # space
+
+
+def test_resolve_template_missing():
+    with pytest.raises(FileNotFoundError):
+        runner.resolve_template("does-not-exist-zzz")
+
+
+def test_resolve_template_real_one_exists():
+    # api-trace.js ships with the package - sanity-check the lookup.
+    p = runner.resolve_template("api-trace")
+    assert p.is_file() and p.name == "api-trace.js"
+
+
+# --- load_script_source ----------------------------------------------
+
+def test_load_script_xor_required():
+    with pytest.raises(ValueError):
+        runner.load_script_source(None, None)
+    with pytest.raises(ValueError):
+        runner.load_script_source("api-trace", "/tmp/foo.js")
+
+
+def test_load_script_from_template():
+    src, origin = runner.load_script_source("api-trace", None)
+    assert origin == "template:api-trace"
+    assert "send(" in src or "Interceptor" in src  # smoke
+
+
+def test_load_script_from_file(tmp_path: Path):
+    js = tmp_path / "h.js"
+    js.write_text("send({hello: 'world'});\n")
+    src, origin = runner.load_script_source(None, str(js))
+    assert origin == f"file:{js.resolve()}"
+    assert "hello" in src
+
+
+# --- run() with attach-by-PID ----------------------------------------
+
+def test_run_attach_pid_writes_outputs(tmp_path: Path):
+    device = FakeDevice("local")
+    fake = _fake_frida(device)
+    cfg = runner.RunConfig(
+        target=runner.parse_target("1234"),
+        out_dir=tmp_path,
+        script_source="send({hi: 1});",
+        script_origin="file:test.js",
+        duration_sec=0.05,        # tiny - test stays fast
+    )
+
+    # Fire one message during the sleep window.
+    events: list[dict] = []
+    def on_event(rec: dict):
+        events.append(rec)
+
+    # Patch threading.Event-wait pattern by firing inside a thread
+    # once the script's loaded.
+    original_load = FakeScript.load
+    def load_and_fire(self):
+        original_load(self)
+        threading.Timer(0.01, lambda: self.fire(
+            {"type": "send", "payload": {"hi": 1}})).start()
+    FakeScript.load = load_and_fire
+    try:
+        result = runner.run(cfg, on_event=on_event, frida_mod_override=fake)
+    finally:
+        FakeScript.load = original_load
+
+    assert result.ok is True
+    assert result.resolved_pid == 1234
+    assert device.attach_calls == [1234]
+    assert device.spawn_calls == []  # attach mode → no spawn
+    assert (tmp_path / "events.jsonl").is_file()
+    assert (tmp_path / "metadata.json").is_file()
+    assert (tmp_path / "frida-report.md").is_file()
+    assert (tmp_path / "script.js").read_text() == "send({hi: 1});"
+    # Event captured?
+    lines = (tmp_path / "events.jsonl").read_text().strip().splitlines()
+    assert len(lines) >= 1
+    parsed = json.loads(lines[0])
+    assert parsed["type"] == "send"
+    assert parsed["payload"] == {"hi": 1}
+    # Metadata
+    meta = json.loads((tmp_path / "metadata.json").read_text())
+    assert meta["ok"] is True
+    assert meta["target"]["pid"] == 1234
+
+
+def test_run_spawn_resumes_after_load(tmp_path: Path):
+    device = FakeDevice("local")
+    fake = _fake_frida(device)
+    binary = tmp_path / "victim"
+    binary.write_text("#!/bin/sh\necho hi\n")
+    cfg = runner.RunConfig(
+        target=runner.parse_target(str(binary)),
+        out_dir=tmp_path,
+        script_source="// noop",
+        script_origin="file:noop.js",
+        duration_sec=0.02,
+    )
+    result = runner.run(cfg, frida_mod_override=fake)
+    assert result.ok is True
+    assert device.spawn_calls == [[str(binary.resolve())]]
+    assert device.resume_calls == [9999]   # spawn returned 9999 above
+    # Attach must be called with the spawn PID.
+    assert device.attach_calls == [9999]
+    assert result.resolved_pid == 9999
+
+
+def test_run_zero_events_still_creates_events_jsonl(tmp_path: Path):
+    # frida-report.md unconditionally points at events.jsonl, so the file
+    # must exist even when the script emits nothing during the window.
+    device = FakeDevice("local")
+    fake = _fake_frida(device)
+    cfg = runner.RunConfig(
+        target=runner.parse_target("1"),
+        out_dir=tmp_path,
+        script_source="// emits nothing",
+        script_origin="file:noop.js",
+        duration_sec=0.02,
+    )
+    result = runner.run(cfg, frida_mod_override=fake)
+    assert result.ok is True
+    assert result.events_captured == 0
+    events = tmp_path / "events.jsonl"
+    assert events.is_file()
+    assert events.read_text() == ""   # created, but empty
+
+
+def test_run_remote_host_routes_correctly(tmp_path: Path):
+    local = FakeDevice("local")
+    remote = FakeDevice("remote-host")
+    fake = _fake_frida(local, remote_device=remote)
+    cfg = runner.RunConfig(
+        target=runner.parse_target("victim-proc"),
+        out_dir=tmp_path,
+        script_source="// noop",
+        script_origin="file:noop.js",
+        duration_sec=0.02,
+        host="10.10.20.1",
+    )
+    result = runner.run(cfg, frida_mod_override=fake)
+    assert result.ok is True
+    # Local device must NOT have been used.
+    assert local.attach_calls == []
+    # Remote device was used; attach by name.
+    assert remote.attach_calls == ["victim-proc"]
+
+
+def test_run_usb_routes_correctly(tmp_path: Path):
+    local = FakeDevice("local")
+    usb = FakeDevice("usb-dev")
+    fake = _fake_frida(local, usb_device=usb)
+    cfg = runner.RunConfig(
+        target=runner.parse_target("com.example.app"),
+        out_dir=tmp_path,
+        script_source="// noop",
+        script_origin="file:noop.js",
+        duration_sec=0.02,
+        use_usb=True,
+    )
+    result = runner.run(cfg, frida_mod_override=fake)
+    assert result.ok is True
+    assert local.attach_calls == []
+    assert usb.attach_calls == ["com.example.app"]
+
+
+def test_run_script_error_persisted(tmp_path: Path):
+    device = FakeDevice("local")
+    fake = _fake_frida(device)
+    cfg = runner.RunConfig(
+        target=runner.parse_target("1"),
+        out_dir=tmp_path,
+        script_source="// crash",
+        script_origin="file:crash.js",
+        duration_sec=0.05,
+    )
+
+    original_load = FakeScript.load
+    def load_and_error(self):
+        original_load(self)
+        threading.Timer(0.005, lambda: self.fire({
+            "type": "error",
+            "description": "ReferenceError: blah is not defined",
+            "stack": "...",
+            "fileName": "/agent/script1.js",
+            "lineNumber": 3,
+        })).start()
+    FakeScript.load = load_and_error
+    try:
+        result = runner.run(cfg, frida_mod_override=fake)
+    finally:
+        FakeScript.load = original_load
+
+    assert result.ok is True   # run completes; error logged not raised
+    body = (tmp_path / "events.jsonl").read_text()
+    assert "ReferenceError" in body
+
+
+def test_run_attach_failure_marks_failed(tmp_path: Path):
+    class BrokenDevice(FakeDevice):
+        def attach(self, target):
+            raise RuntimeError("ptrace denied")
+    device = BrokenDevice("local")
+    fake = _fake_frida(device)
+    cfg = runner.RunConfig(
+        target=runner.parse_target("1"),
+        out_dir=tmp_path,
+        script_source="// noop",
+        script_origin="file:noop.js",
+        duration_sec=0.02,
+    )
+    result = runner.run(cfg, frida_mod_override=fake)
+    assert result.ok is False
+    assert "ptrace denied" in (result.error or "")
+    # metadata + report still written so the operator has a trail.
+    meta = json.loads((tmp_path / "metadata.json").read_text())
+    assert meta["ok"] is False
+    assert "ptrace denied" in (meta["error"] or "")
+    report = (tmp_path / "frida-report.md").read_text()
+    assert "FAILED" in report
+    # events.jsonl is created up-front, so it exists even on a failed run.
+    assert (tmp_path / "events.jsonl").is_file()
+
+
+def test_frida_unavailable_raises(monkeypatch, tmp_path: Path):
+    """When frida-python isn't installed, _import_frida must raise
+    FridaUnavailable rather than the bare ImportError so the CLI can
+    print an actionable message."""
+    # Force _import_frida to raise ImportError by stubbing the inner
+    # ``import frida``. We do that by monkey-patching the helper itself
+    # - simpler than swapping sys.modules.
+    def _boom():
+        raise runner.FridaUnavailable("frida-python not installed")
+    monkeypatch.setattr(runner, "_import_frida", _boom)
+    cfg = runner.RunConfig(
+        target=runner.parse_target("1"),
+        out_dir=tmp_path,
+        script_source="// noop",
+        script_origin="file:noop.js",
+        duration_sec=0.02,
+    )
+    with pytest.raises(runner.FridaUnavailable):
+        runner.run(cfg)

--- a/docs/frida-integration-proposal.md
+++ b/docs/frida-integration-proposal.md
@@ -1,0 +1,259 @@
+# Frida integration - design proposal (v2)
+
+**Status:** Proposal · **Audience:** @Splinters-io (+ @grokjc / @gadievron) · **Author:** @ZephrFish (collaborator)
+**Context:** PR #57 was closed with the author's note "we might have to trash this one." PR #496 (`raptor doctor`) cherry-picked the self-check shape from #57 cleanly. Frida itself is unowned upstream; this doc proposes how a v2 lands without re-creating #57's scope problems.
+
+This is a **proposal**, not a finished design. Where the right call is unclear it's marked **OPEN**. Edit freely.
+
+---
+
+## Goals
+
+1. **Dynamic confirmation of LLM-flagged sinks.** RAPTOR's biggest signal-loss happens when the LLM marks a finding `is_exploitable: true` for a sink that never executes at runtime. Frida is the substrate that closes that gap.
+2. **Native macOS dynamic analysis.** `rr` only exists on Linux; macOS users today have no equivalent for `/crash-analysis` or function tracing. Frida fills it.
+3. **Mobile / remote targets.** SSL pinning bypass, API tracing, secret hunting in mobile apps and embedded Linux - first-class targets, not afterthoughts.
+4. **No vendored binaries.** Frida is large and architecture-specific; require the operator to install `frida-tools` (host) and `frida-server` (target). `raptor doctor` reports availability.
+
+## Non-goals (v1)
+
+- Replacing `rr` or AFL++ - Frida is complementary, not a substitute.
+- Building an LLM-driven autonomous instrumentation loop on day one. (#57's `autonomous.py` was 732 lines of agent code that didn't integrate with `raptor_agentic`'s dispatch; v2 should reuse `core/orchestration/` infrastructure.)
+- Vendoring or shipping Frida binaries.
+
+---
+
+## What to lift from PR #57 (with attribution)
+
+| File | Verdict | Why |
+|------|---------|-----|
+| `packages/frida/templates/api-trace.js` | **Keep, light revision** | General-purpose, the most-used hook pattern. |
+| `packages/frida/templates/ssl-unpin.js` | **Keep** | Mobile pinning bypass is table stakes. |
+| `packages/frida/templates/memory-scan.js` | **Keep** | Useful with `/validate --runtime` confirming a "secret leaks" finding. |
+| `packages/frida/templates/crypto-trace.js` | **Keep** | Detects weak-crypto findings dynamically. |
+| `packages/frida/templates/anti-debug.js` | **Keep, gate behind `--unsafe-attach`** | Useful but easy to misuse. |
+| `packages/frida/templates/binary-environment.js` | **OPEN** | Overlap with the existing `core/binary/` substrate (cap-fingerprinting in PR #545). Decide whether to keep or fold into core/binary. |
+| `packages/frida/scanner.py` | **Rewrite small** | Good shape; doesn't use `libexec/raptor-run-lifecycle` or active-project resolution. |
+| `packages/frida/autonomous.py` (732 lines) | **Defer** | Replace with `core/orchestration/agentic_passes.py`-style integration into `/agentic` and `/validate`. Don't ship an independent agent loop. |
+| `packages/frida/interactive.py` | **Defer / drop** | Frida already has a REPL (`frida -p PID`); a RAPTOR-flavoured REPL is low value vs. the cost of maintaining a TTY-aware Python loop. |
+| `packages/frida/methodology.py` | **Fold into SKILL.md** | Prose belongs in the skill doc, not Python. |
+| `packages/frida/platform.py` | **Keep, simplify** | Platform detection is fine; cut the Windows/iOS branches you don't test. |
+| `packages/frida/binary_context_analyzer.py` | **OPEN** | Possibly redundant with `packages/exploit_feasibility/` - review for overlap. |
+| `docs/frida/SETUP_*.md` | **Keep** | Setup docs per platform are useful as-is. |
+| `docs/frida/FRIDA_INTEGRATION.md`, `INTEGRATION_ARCHITECTURE.md`, `QUICKSTART.md` | **Rewrite** to match v2 shape | Originals assume `raptor-cli`, hardcoded paths. |
+
+**Lift mechanism:** When v2 lands, the JS templates carry `// Originally authored by @Splinters-io (PR #57)` headers; Python files credit in commit body. No silent reuse.
+
+---
+
+## v2 architecture - fits current RAPTOR conventions
+
+Follows the pattern proven by `raptor doctor` (PR #496): a thin shell entry, a Python module, a slash-command skill, and `libexec/` orchestration with lifecycle management.
+
+```
+bin/raptor frida ...                # shell route, no claude required
+  → libexec/raptor-frida             # lifecycle: raptor-run-lifecycle start/complete/fail
+      → python3 -m core.dynamic.frida.cli ...
+
+raptor.py mode "frida"               # internal dispatch (libexec wrapper calls this)
+
+.claude/skills/frida/SKILL.md        # /frida slash command, documents templates + workflow
+
+core/dynamic/frida/                  # the substrate
+  __init__.py
+  cli.py                             # argparse + dispatch
+  runner.py                          # spawn / attach / remote, event capture, output
+  templates/                         # JS templates lifted from #57
+    api-trace.js
+    ssl-unpin.js
+    memory-scan.js
+    crypto-trace.js
+    anti-debug.js
+  platform.py                        # platform detection (simplified)
+  tests/
+    test_runner.py                   # unit tests with mocked frida.core
+    test_cli.py
+    fixtures/
+
+core/config/__init__.py              # add "frida" to RaptorConfig.TOOL_DEPS
+core/startup/init.py                 # check_tools picks it up automatically
+
+docs/frida/                          # operator-facing docs (lifted from #57, revised)
+  QUICKSTART.md
+  SETUP_MACOS.md
+  SETUP_LINUX.md
+  SETUP_ANDROID.md
+  SETUP_IOS.md
+  SETUP_WINDOWS.md                   # OPEN - only if you actually test on Windows
+```
+
+**Output layout** (lifecycle-managed):
+```
+out/projects/<project>/frida-<timestamp>/      # if active project
+out/frida_<timestamp>/                         # otherwise
+
+  events.jsonl                                 # one JSON event per line
+  frida-report.md                              # operator summary
+  metadata.json                                # target, template, host, duration
+  script.js                                    # the actual script that ran (template or user)
+  annotations/                                 # per-function annotations if integrated with /annotate
+```
+
+---
+
+## CLI surface (v1)
+
+```
+raptor frida --target <pid|name|bundle-id|binary> [--template <name> | --script <path>]
+             [--host <ip>[:port]] [--duration <seconds>] [--spawn] [--unsafe-attach]
+```
+
+- `--target` accepts:
+  - integer PID
+  - process name (e.g. `Safari`)
+  - bundle ID (iOS/Android, requires `--host` or USB device)
+  - filesystem path (implies `--spawn`)
+- `--template <name>` - one of the curated templates above.
+- `--script <path>` - operator-supplied JS file.
+- `--host <ip>[:port]` - connect to a remote `frida-server` (default port 27042).
+- `--duration <seconds>` - run for N seconds then detach cleanly (default: 60).
+- `--spawn` - explicitly spawn-and-attach when `--target` is a binary path.
+- `--unsafe-attach` - required for templates / modes that need PTRACE_ATTACH or `task_for_pid` on macOS. Off by default. Logs an audit line. The eventual sandbox envelope (see below) is bypassed when this is set.
+
+**Examples:**
+```bash
+# Local: trace API calls in a process by name
+raptor frida --target Safari --template api-trace --duration 30
+
+# Mobile: bypass SSL pinning via USB device (spawn by bundle id)
+raptor frida --target com.example.app --template ssl-unpin --usb --spawn --duration 120
+
+# Remote frida-server on the LAN
+raptor frida --target target-binary --template api-trace --host 10.10.20.1
+
+# Spawn a local binary with a custom script
+raptor frida --target ./vulnerable-bin --script ./my-hook.js --spawn
+```
+
+---
+
+## Integration points with existing pipelines
+
+The single most valuable bit isn't the standalone `/frida` command - it's the integration. Roadmap, post-v1:
+
+### `/validate --runtime` (largest payoff)
+
+`/validate` Stage C ("sanity check") today asks the LLM "does the code match? is the flow real? is it reachable?" - but "reachable" is inferred, not observed. With Frida:
+
+- Stage C2 (new): for findings where the sink is a hookable function (open/exec/sql/etc.), launch a frida session, trigger the suspected attack path, observe whether the sink fires.
+- Result: a `runtime_confirmed: true|false|unreachable` field per finding. Turns "LLM thinks this is exploitable" into "we watched the sink execute."
+
+### `/crash-analysis` on macOS
+
+`rr` is Linux-only. macOS users have no record-replay debugger; `/crash-analysis` is currently `gdb` + symbolicated cores. With Frida:
+
+- `function-trace-generator-agent` gets a Frida backend on macOS (Linux still prefers `rr` for determinism).
+- Output format matches the existing `function-tracing` skill - same downstream consumer.
+
+### `/agentic` dynamic verification
+
+Post-analysis, optional pass: for every finding where `is_exploitable: true` AND the binary is available, run a frida confirmation against the suspected sink. Mirrors the existing `--validate` flag pattern.
+
+### `/exploit` PoC introspection
+
+For generated PoCs, attach frida to the target during PoC execution and capture: leaked addresses, gadget hits, control-flow at the moment of corruption. Goes into the PoC report as evidence.
+
+---
+
+## Threat model - Frida + RAPTOR's sandbox
+
+Frida-instrumented targets are **untrusted** by definition (we're analysing them to find bugs). The existing `core/sandbox/` substrate (Landlock + seccomp on Linux, seatbelt on macOS, egress allowlist via proxy) needs to extend to Frida sessions.
+
+| Mode | Sandbox posture |
+|------|-----------------|
+| Spawn local binary with template | Run frida + target inside `run_untrusted_networked` envelope; egress allowlist; no `$HOME` access. |
+| Attach to local PID | Same envelope; the PID must already be running outside our control, so we just observe. |
+| Remote frida-server (`--host`) | The target's already remote; envelope still applies to local frida client process to constrain *its* egress. |
+| `--unsafe-attach` | Bypasses sandbox; logs an audit line; required for system-process attach (PTRACE/task_for_pid). |
+
+**OPEN:** Whether `frida-server` on the target host should be RAPTOR-managed (start/stop via SSH) or always operator-managed (we just connect). I lean operator-managed for v1 - RAPTOR-managed adds an SSH key and remote-exec surface that doesn't pay for itself yet.
+
+---
+
+## Doctor / banner signalling
+
+Already wired in this proposal's accompanying patch:
+
+```python
+# core/config/__init__.py TOOL_DEPS
+"frida":    {"binary": "frida",     "severity": "required", "affects": "/frida"},
+```
+
+`raptor doctor` and the SessionStart banner now show frida availability. `/frida` lists as "unavailable" when the binary is missing; lifecycle still creates the run dir + fails with a clear message rather than crashing on import.
+
+---
+
+## Phasing - three landable PRs
+
+Don't repeat #57's mistake of one 18K-line bundled PR. Three reviewable chunks:
+
+### PR 1 - Scaffolding (~600 LOC, lands first)
+
+- `core/config/__init__.py`: add `frida` to TOOL_DEPS *(done in this proposal's patch)*
+- `.claude/skills/frida/SKILL.md`: alpha stub *(done in this proposal's patch)*
+- `docs/frida/QUICKSTART.md` + `SETUP_MACOS.md` + `SETUP_LINUX.md` (lifted, revised)
+- 5 JS templates in `core/dynamic/frida/templates/` (lifted, with author-attribution headers)
+- **No runner yet** - templates discoverable, no execution path.
+
+### PR 2 - Runner + `/frida` command (~1500 LOC)
+
+- `core/dynamic/frida/{cli,runner,platform}.py` + tests
+- `libexec/raptor-frida` with lifecycle integration
+- `bin/raptor frida` route + `raptor.py` mode entry
+- Updates docs/frida/* to v2 shape
+- Includes remote-host (`--host`) support out of the gate
+
+### PR 3 - Pipeline integrations (~1000 LOC, may split further)
+
+- `/validate --runtime` (Stage C2 with frida confirmation)
+- `function-trace-generator-agent` macOS backend
+- `/agentic` optional post-pass for dynamic verification
+
+Autonomous LLM-guided mode (the old `autonomous.py`) is **not** in any of these PRs. If it ships later, it goes through `core/orchestration/` and dispatches like every other LLM pass.
+
+---
+
+## What's already done in this proposal's companion patch
+
+The fork this proposal ships from already has:
+- `core/config/__init__.py` TOOL_DEPS entry for `frida` ✅
+- `.claude/skills/frida/SKILL.md` alpha stub ✅
+
+Both are scoped to land cleanly as PR 1 above. The runner code is **not** written - that's PR 2 and warrants @Splinters-io's design hand because the dispatch model, output schema, and `--unsafe-attach` semantics are decisions worth aligning on first.
+
+---
+
+## Open questions
+
+1. **Templates location**: `packages/frida/templates/` (PR #57's choice, treats Frida as a "package" alongside `packages/codeql/` etc.) vs. `core/dynamic/frida/templates/` (treats it as a runtime substrate alongside `core/sandbox/`). I lean `core/dynamic/` because Frida is dynamic-analysis infrastructure consumed by multiple commands, not a package with one CLI surface.
+2. **`raptor frida` vs `/frida`**: keep both (CLI works without claude, skill works inside claude session, like `agentic`/`scan`), or skill-only? I lean keep-both - `raptor doctor` proved the value of claude-free entry points.
+3. **Remote frida-server lifecycle**: operator-managed (recommended for v1) vs. RAPTOR-managed-via-SSH (later)?
+4. **Schema for `events.jsonl`**: design now or let runner emit raw frida messages and add a schema layer once consumers (`/validate`, `function-trace-generator`) exist?
+5. **eBPF**: separate proposal entirely, Linux-only, targets `/fuzz` and `/crash-analysis` syscall tracing. Don't bundle.
+
+---
+
+## Operational note from the field
+
+While drafting this, I attempted `frida-ps -H 10.10.20.1` from a freshly installed `frida-tools 14.8.2` against a host with frida supposedly running. The host pinged (26ms RTT) but every common `frida-server` port (27042–27045, 1337, 8888) refused connection. Likely `frida-server` was bound to `127.0.0.1` rather than `0.0.0.0` - the default-bind on most server builds.
+
+**Implication for SETUP_*.md:** the remote-frida-server install docs need a prominent "bind to 0.0.0.0 or use SSH-forward" callout. Add it to `SETUP_LINUX.md` and (when written) `SETUP_ANDROID.md` / `SETUP_IOS.md`.
+
+---
+
+## Decision asks for @Splinters-io
+
+1. Confirm you're good with the **template attribution** model above (`// Originally authored by @Splinters-io (PR #57)` headers + commit-body credit).
+2. **PR 1 ready to ship?** It's just the doctor wiring + skill stub + templates with attribution. Low risk, opens the door for PR 2.
+3. **Templates location** - `packages/` vs. `core/dynamic/`? Either's fine; the answer constrains PR 1.
+4. **Are you taking PR 2 yourself**, or would a collaboration shape (you on runner design + Splinters' templates / me on the boring lifecycle wiring + tests) work better?
+5. **Anything in your in-progress rewrite** that should preempt this design? - if you've already moved past it, throw this away.

--- a/docs/frida/QUICKSTART.md
+++ b/docs/frida/QUICKSTART.md
@@ -1,0 +1,84 @@
+# Frida - Quickstart
+
+Dynamic instrumentation via Frida, wired into RAPTOR's run-lifecycle.
+
+## Install (host)
+
+Frida host CLI + Python bindings:
+
+```bash
+pipx install frida-tools         # recommended (PEP 668-safe)
+# or:
+pip install --user frida-tools
+```
+
+Verify:
+
+```bash
+raptor doctor          # confirms `frida` binary is detected
+frida --version        # client version
+```
+
+## Install (target)
+
+Frida-server on the target is the operator's concern. Common shapes:
+
+- **Local macOS / Linux process**: no target install needed - frida attaches via task_for_pid / ptrace.
+- **Android (rooted) / iOS (jailbroken)**: drop the matching `frida-server` build under `/data/local/tmp/` or `/usr/sbin/`, run it, then connect with `--usb`. Target-side setup is device- and OS-version-specific - follow the upstream frida-server instructions for your platform.
+- **Remote Linux**: copy `frida-server` to the host, start with `-l 0.0.0.0:27042` (not the default localhost-only bind), then connect from the host with `--host <ip>`.
+
+`raptor doctor` only checks the host side. Target reachability is your job.
+
+## Run
+
+```bash
+# List bundled templates
+raptor frida --list-templates
+
+# Attach to a local process by PID
+raptor frida --target 1234 --template api-trace --duration 30
+
+# Spawn a binary and trace its first 60 seconds of syscalls
+raptor frida --target ./victim --template api-trace --duration 60
+
+# Bypass SSL pinning on a USB-attached mobile target. Spawn by bundle id (frida resolves bundle ids for spawn); attach-by-name needs the running process's name, not the bundle id, so --spawn is the reliable form.
+raptor frida --target com.example.app --template ssl-unpin --usb --spawn --duration 120
+
+# Remote frida-server on the LAN
+raptor frida --target target-binary --template api-trace --host 10.10.20.1
+```
+
+Operator-supplied scripts:
+
+```bash
+raptor frida --target Safari --script ./my-hook.js --duration 30
+```
+
+## Output
+
+Each run drops into a lifecycle-managed directory:
+
+```
+out/projects/<project>/frida-<timestamp>/      # if a /project is active
+out/frida_<timestamp>/                         # otherwise
+```
+
+Contents:
+
+- `events.jsonl` - one JSON object per `send(...)` from the script.
+- `metadata.json` - target, host info, timings, errors.
+- `script.js` - copy of what executed (template or operator-supplied).
+- `frida-report.md` - short human-readable summary.
+
+## Common failure modes
+
+| Symptom | Likely cause |
+|---------|--------------|
+| `frida: run failed: ptrace denied` (Linux) | `kernel.yama.ptrace_scope` ≥ 1; relax via `sysctl` or attach as the target's owning user. |
+| `frida: run failed: ... task_for_pid` (macOS) | System process or hardened target; needs SIP-disabled or signed binary entitlement. |
+| `Failed to enumerate processes: unable to connect to remote frida-server` | frida-server bound to localhost only - re-launch with `-l 0.0.0.0:27042` or SSH-forward 27042. |
+| Empty `events.jsonl` | Script didn't hook anything that fired during the window; raise `--duration` or check `metadata.json` for an `error`. |
+
+## Status
+
+Alpha. Templates and runner are minimal starters - richer bundle in progress. See `docs/frida-integration-proposal.md` for the v2 design and roadmap.

--- a/docs/frida/SETUP_LINUX.md
+++ b/docs/frida/SETUP_LINUX.md
@@ -1,0 +1,77 @@
+# Frida on Linux
+
+## Host install
+
+```bash
+pipx install frida-tools       # Ubuntu 24.04+ / Debian 12+ (PEP 668)
+# or, in a venv:
+pip install frida-tools
+```
+
+## Ptrace permissions
+
+The kernel `yama.ptrace_scope` sysctl gates who can `ptrace` what:
+
+| Value | Meaning |
+|-------|---------|
+| 0 | Classic - any process can ptrace any other process with the same UID. |
+| 1 | Default - only child / explicit-trace targets allowed (most distros). |
+| 2 | Admin-only. |
+| 3 | Ptrace disabled entirely. |
+
+To attach to a sibling process you own (the common case), drop to 0 temporarily:
+
+```bash
+sudo sysctl -w kernel.yama.ptrace_scope=0
+```
+
+`raptor doctor` reports the current `ptrace_scope` in its host snapshot, and `metadata.json` from each run records it - useful for "why did attach fail" forensics.
+
+## Spawn-and-attach
+
+Spawning a binary you can execute doesn't need ptrace_scope=0:
+
+```bash
+raptor frida --target ./vulnerable --template api-trace --duration 60
+```
+
+## Remote frida-server (the common ARM / embedded case)
+
+On the target (typically an embedded device or VM):
+
+```bash
+# download matching frida-server for the target's arch
+./frida-server -l 0.0.0.0:27042 &
+```
+
+**The `-l 0.0.0.0:27042` is critical.** Default builds bind to `127.0.0.1` only, which is unreachable from another host. (We tripped on this during proposal drafting - host pinged but every frida port refused connection. See `docs/frida-integration-proposal.md` "Operational note from the field.")
+
+From the RAPTOR host:
+
+```bash
+raptor frida --target some-process --host 10.10.20.1 --template api-trace
+```
+
+Treat the network channel as **unauthenticated**. Frida-server has no auth in front of it. Bind to a trusted-only network, or SSH-forward 27042 instead of exposing it.
+
+## Hardening notes
+
+A frida-server bound to `0.0.0.0` is effectively a remote-attach service for any host on the network. For research labs this is fine; on shared networks, prefer:
+
+```bash
+# On the target: bind to localhost only
+./frida-server -l 127.0.0.1:27042 &
+
+# On the host: SSH-forward instead of --host
+ssh -L 27042:127.0.0.1:27042 target-user@10.10.20.1
+raptor frida --target some-process --host 127.0.0.1 --template api-trace
+```
+
+## Common errors
+
+| Symptom | Fix |
+|---------|-----|
+| `ptrace: Operation not permitted` | Lower `ptrace_scope` or spawn-and-attach instead. |
+| `unable to connect to remote frida-server` | frida-server isn't running, or bound to localhost only. Check from the target with `ss -tlnp | grep 27042`. |
+| `failed to enumerate processes: timeout` | Network filter / firewall between host and target. |
+| frida-server killed by SELinux on Android-flavoured Linux | Run `setenforce 0` while researching, or label the binary appropriately. |

--- a/docs/frida/SETUP_MACOS.md
+++ b/docs/frida/SETUP_MACOS.md
@@ -1,0 +1,58 @@
+# Frida on macOS
+
+Host: anything modern (Frida 17.x supports Apple Silicon natively).
+Target: any macOS process you have permission to instrument.
+
+## Host install
+
+```bash
+pipx install frida-tools
+```
+
+System Python on macOS is externally-managed under PEP 668; `pipx` is the cleanest path. Plain `pip install frida-tools` works inside a virtualenv.
+
+## Attaching to your own processes
+
+No SIP changes required. `task_for_pid` works for processes you own when you're the same UID.
+
+```bash
+raptor frida --target Safari --template api-trace --duration 30
+```
+
+If you don't see the process under `frida-ps`, the target's owning UID is probably different (root daemons, helper processes signed by Apple). See below.
+
+## Attaching to system / Apple-signed processes
+
+These are blocked by default by `task_for_pid` checks even as root, because the targets have the `com.apple.private.disable-task_for_pid` entitlement.
+
+To attach: SIP must be partially disabled. Boot into recovery mode and:
+
+```
+csrutil disable --without debug
+```
+
+Then reboot. This permits `task_for_pid` but keeps filesystem and kext protections.
+
+**This significantly reduces system security. Use a dedicated research VM.** RAPTOR's runner does not require SIP to be off; it only matters for the targets you can attach to.
+
+## Spawning a binary you don't own
+
+Frida spawn-and-attach for a binary you can execute works without SIP changes:
+
+```bash
+raptor frida --target ./my-binary --template api-trace --duration 60
+```
+
+Hardened-runtime binaries with `com.apple.security.get-task-allow=false` (most distributed App Store apps) reject the attach. Either:
+- Use a debug build, or
+- Re-sign the binary with `--entitlements` that include `get-task-allow=true`.
+
+`codesign -d --entitlements - <binary>` shows the existing entitlements.
+
+## Remote frida-server (e.g., from a macOS host to a Linux target)
+
+Same as Linux - see `SETUP_LINUX.md`. macOS-side just needs `frida-tools` and a route to the target's port 27042.
+
+## Apple Silicon notes
+
+`frida 17.x` ships arm64 builds. If you see "no provisioning profile" or arch mismatches, you're likely on an old Intel `frida-server` binary. Match host and target architectures.

--- a/libexec/raptor-frida
+++ b/libexec/raptor-frida
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+#
+# raptor-frida - libexec wrapper that runs a Frida session inside a
+# lifecycle-managed output directory.
+#
+# Two consumers:
+#   * .claude/skills/frida/SKILL.md invokes this directly via Bash, so
+#     the /frida slash command lands in a tracked run dir.
+#   * raptor.py mode "frida" (bin/raptor frida) calls this for the
+#     same reason - it's the single source of truth for the lifecycle
+#     plumbing.
+#
+# Usage:
+#   libexec/raptor-frida --target <pid|name|binary> --template <name>
+#                         [--script <path>] [--host HOST[:PORT]]
+#                         [--usb] [--duration N] [--spawn]
+#                         [--unsafe-attach] [--out DIR]
+#
+# If --out is omitted, an output dir is resolved via
+# raptor-run-lifecycle (active project or out/frida_<ts>/).
+
+set -euo pipefail
+
+# ─── trust-marker check (inline by design - do not source from a shared file) ───
+if [ -z "${CLAUDECODE:-}" ] && [ -z "${_RAPTOR_TRUSTED:-}" ]; then
+    echo "$0: internal dispatch script." >&2
+    echo "  Run via 'bin/raptor frida' instead." >&2
+    echo "  Tests / power users: set _RAPTOR_TRUSTED=1 to bypass." >&2
+    exit 2
+fi
+# ─── end trust-marker check ─────────────────────────────────────────
+
+# ─── resolve RAPTOR_DIR through symlinks (matches raptor-agentic) ───
+SCRIPT="$0"
+_symhops=0
+while [ -L "$SCRIPT" ]; do
+    _symhops=$((_symhops + 1))
+    if [ "$_symhops" -gt 32 ]; then
+        echo "raptor-frida: symlink hop limit exceeded resolving $0" >&2
+        exit 1
+    fi
+    DIR="$(cd "$(dirname "$SCRIPT")" && pwd)"
+    SCRIPT="$(readlink "$SCRIPT")"
+    [[ "$SCRIPT" != /* ]] && SCRIPT="$DIR/$SCRIPT"
+done
+unset _symhops
+RAPTOR_DIR="$(cd "$(dirname "$SCRIPT")/.." && pwd)"
+
+if [ ! -f "$RAPTOR_DIR/raptor.py" ]; then
+    echo "raptor-frida: cannot find raptor.py under $RAPTOR_DIR" >&2
+    exit 1
+fi
+
+. "$RAPTOR_DIR/core/security/_dangerous_env_strip.sh"
+
+export RAPTOR_DIR
+# Make `python3 -m core.dynamic.frida.cli` importable regardless of the
+# caller's cwd. Relying on cwd==RAPTOR_DIR (the caller having cd'd in)
+# silently breaks direct `libexec/raptor-frida` invocations and the
+# `raptor frida` route once it stops cd-ing (so operator-relative
+# --target paths resolve against the operator's cwd, not the repo).
+export PYTHONPATH="$RAPTOR_DIR${PYTHONPATH:+:$PYTHONPATH}"
+
+# ─── short-circuit query modes (no target / lifecycle needed) ───────
+# --list-templates and -h/--help just print and exit; running them
+# through the lifecycle would create an empty run dir for nothing.
+for a in "$@"; do
+    case "$a" in
+        --list-templates|-h|--help)
+            exec python3 -m core.dynamic.frida.cli "$@"
+            ;;
+    esac
+done
+
+# ─── extract --target and --out from args for lifecycle setup ───────
+# We can't trust positional order - pull them out of the argv carefully.
+TARGET=""
+OUT=""
+PASS_ARGS=()
+i=0
+ARGS=("$@")
+while [ $i -lt ${#ARGS[@]} ]; do
+    a="${ARGS[$i]}"
+    case "$a" in
+        --target)
+            i=$((i + 1))
+            TARGET="${ARGS[$i]:-}"
+            PASS_ARGS+=("--target" "$TARGET")
+            ;;
+        --target=*)
+            TARGET="${a#--target=}"
+            PASS_ARGS+=("--target=$TARGET")
+            ;;
+        --out)
+            i=$((i + 1))
+            OUT="${ARGS[$i]:-}"
+            ;;
+        --out=*)
+            OUT="${a#--out=}"
+            ;;
+        *)
+            PASS_ARGS+=("$a")
+            ;;
+    esac
+    i=$((i + 1))
+done
+
+if [ -z "$TARGET" ]; then
+    echo "raptor-frida: --target is required" >&2
+    exit 2
+fi
+
+# ─── resolve output dir via run lifecycle if not provided ──────────
+if [ -z "$OUT" ]; then
+    # raptor-run-lifecycle's last line is OUTPUT_DIR=<path>. Capture
+    # all output and pluck it out so any warnings stay visible.
+    LIFECYCLE_OUT=$("$RAPTOR_DIR/libexec/raptor-run-lifecycle" \
+        start frida --target "$TARGET")
+    LIFECYCLE_RC=$?
+    echo "$LIFECYCLE_OUT"
+    if [ $LIFECYCLE_RC -ne 0 ]; then
+        echo "raptor-frida: run lifecycle start failed" >&2
+        exit $LIFECYCLE_RC
+    fi
+    OUT="$(echo "$LIFECYCLE_OUT" | awk -F= '/^OUTPUT_DIR=/ {print $2; exit}')"
+    if [ -z "$OUT" ]; then
+        echo "raptor-frida: could not parse OUTPUT_DIR from lifecycle" >&2
+        exit 1
+    fi
+    LIFECYCLE_OWNED=1
+else
+    LIFECYCLE_OWNED=0
+fi
+
+PASS_ARGS+=("--out" "$OUT")
+
+# ─── run the Python CLI ─────────────────────────────────────────────
+set +e
+python3 -m core.dynamic.frida.cli "${PASS_ARGS[@]}"
+RC=$?
+set -e
+
+# ─── lifecycle close-out (only if we opened it) ─────────────────────
+if [ $LIFECYCLE_OWNED -eq 1 ]; then
+    if [ $RC -eq 0 ]; then
+        "$RAPTOR_DIR/libexec/raptor-run-lifecycle" complete "$OUT" || true
+    else
+        "$RAPTOR_DIR/libexec/raptor-run-lifecycle" fail "$OUT" \
+            "frida cli exited $RC" || true
+    fi
+fi
+
+exit $RC

--- a/raptor.py
+++ b/raptor.py
@@ -19,6 +19,7 @@ Available Modes:
     agentic     - Full autonomous workflow
     codeql      - CodeQL-only analysis
     doctor      - Status report for local setup (no claude needed)
+    frida       - Dynamic instrumentation via Frida (alpha)
     help        - Show detailed help for a specific mode
 
 Examples:
@@ -1044,6 +1045,27 @@ def mode_doctor(args: list) -> int:
     return doctor_main(args)
 
 
+def mode_frida(args: list) -> int:
+    """Run a Frida dynamic-instrumentation session.
+
+    The libexec wrapper owns lifecycle setup (output directory + run
+    state tracking) and dispatches to :mod:`core.dynamic.frida.cli`.
+    Routing through the wrapper rather than calling the cli module
+    directly keeps the lifecycle behaviour identical whether the
+    operator runs ``bin/raptor frida ...`` or invokes the wrapper
+    directly from a /frida skill.
+    """
+    import subprocess
+    script_root = Path(__file__).parent
+    wrapper = script_root / "libexec" / "raptor-frida"
+    if not wrapper.exists():
+        print(f"✗ Frida wrapper not found: {wrapper}")
+        return 1
+    env = os.environ.copy()
+    env.setdefault("_RAPTOR_TRUSTED", "1")
+    return subprocess.call([str(wrapper), *args], env=env)
+
+
 def _mode_help_scripts() -> dict:
     """Map mode name → the script whose argparse renders that mode's help.
 
@@ -1130,6 +1152,7 @@ Available Modes:
   codeql      - CodeQL-only analysis
   analyze     - LLM-powered vulnerability analysis (requires SARIF input)
   doctor      - Status report for local setup (no claude needed)
+  frida       - Dynamic instrumentation via Frida (alpha)
 
 Examples:
   # Full autonomous workflow
@@ -1264,6 +1287,7 @@ def main():
         'analyze': mode_llm_analysis,
         'doctor': mode_doctor,
         'describe': mode_describe,
+        'frida': mode_frida,
     }
     
     if mode not in mode_handlers:

--- a/raptor.py
+++ b/raptor.py
@@ -1061,7 +1061,7 @@ def mode_frida(args: list) -> int:
     if not wrapper.exists():
         print(f"✗ Frida wrapper not found: {wrapper}")
         return 1
-    env = os.environ.copy()
+    env = RaptorConfig.get_safe_env()
     env.setdefault("_RAPTOR_TRUSTED", "1")
     return subprocess.call([str(wrapper), *args], env=env)
 

--- a/raptor.py
+++ b/raptor.py
@@ -1056,6 +1056,7 @@ def mode_frida(args: list) -> int:
     directly from a /frida skill.
     """
     import subprocess
+    from core.config import RaptorConfig
     script_root = Path(__file__).parent
     wrapper = script_root / "libexec" / "raptor-frida"
     if not wrapper.exists():


### PR DESCRIPTION
New /frida command: spawn-only Frida function/argument tracing and Stalker basic-block coverage (drcov), sandboxed and degrading gracefully when the frida binding is absent. 

Documented in `docs/DYNAMIC_INSTRUMENTATION_QUICKSTART.md` + `DEPENDENCIES + README`.

Split off from combined PR https://github.com/gadievron/raptor/pull/815