### PR TITLE
fix(cli): remove redundant _preflight_script_args subprocess check

### DIFF
--- a/raptor.py
+++ b/raptor.py
@@ -247,32 +247,6 @@ def _wants_help(args: list) -> bool:
     return "--help" in args or "-h" in args
 
 
-def _preflight_script_args(script_path: Path, args: list) -> int | None:
-    """Ask subprocess modes to parse args before lifecycle side effects.
-
-    Some wrapped modes resolve projects, create run directories, print
-    OUTPUT_DIR, and start LLM dispatcher plumbing in the parent before the
-    child script's argparse sees malformed flags. For modes that support the
-    ``RAPTOR_ARGPARSE_ONLY`` contract, run that cheap parse-only path first.
-
-    Returns an exit code when preflight failed or timed out. Returns ``None``
-    when the caller should continue into the normal lifecycle.
-    """
-    if script_path.name != "raptor_agentic.py":
-        return None
-    from core.config import RaptorConfig
-    env = RaptorConfig.get_safe_env()
-    env["RAPTOR_ARGPARSE_ONLY"] = "1"
-    cmd = [sys.executable, str(script_path)] + args
-    try:
-        proc = subprocess.run(cmd, env=env, timeout=15)
-    except subprocess.TimeoutExpired:
-        print(f"✗ Argument validation for {script_path.name} timed out",
-              file=sys.stderr)
-        return 1
-    return proc.returncode if proc.returncode != 0 else None
-
-
 def _run_with_lifecycle(command: str, script_path: Path, args: list,
                         label: str) -> int:
     """Run a script with lifecycle start/complete/fail wrapping.
@@ -296,10 +270,6 @@ def _run_with_lifecycle(command: str, script_path: Path, args: list,
     # to recognise the flag. Pre-flight gate fires below, after
     # the catalog estimate is computed.
     max_cost_usd, args = _extract_and_strip_max_cost_usd(args)
-
-    preflight_rc = _preflight_script_args(script_path, args)
-    if preflight_rc is not None:
-        return preflight_rc
 
     # CLAUDE.md DEFAULT TARGET DIRECTORY: back-fill --repo from
     # (1) active project → (2) RAPTOR_CALLER_DIR when args don't carry

--- a/raptor_agentic.py
+++ b/raptor_agentic.py
@@ -1414,9 +1414,6 @@ Examples:
     add_cli_args(parser)
     args = parser.parse_args()
 
-    if os.environ.get("RAPTOR_ARGPARSE_ONLY") == "1":
-        return
-
     apply_cli_args(args, parser=parser)
 
     if args.threat_model_only:


### PR DESCRIPTION
The preflight spawned a second Python process on every /agentic invocation just to validate argparse flags before lifecycle setup. This was added alongside --threat-model (5d967bff) to catch bad flags before creating an output directory.

Now redundant: the --help side-effect-free guard (#757) handles the main case, and the lifecycle fail path properly marks orphan directories as status=failed when argparse rejects flags (exit 2). The 15s timeout was also a latent hazard on slow-start environments.

Also removes the dead RAPTOR_ARGPARSE_ONLY handler from raptor_agentic.py (no remaining callers).