### PR TITLE
fix(smt): split tautology and solve solvers to prevent Z3 4.15.4 model corruption

### DIFF
--- a/packages/codeql/smt_path_validator.py
+++ b/packages/codeql/smt_path_validator.py
@@ -1284,6 +1284,7 @@ def check_verb_feasibility(
     ``smt_available=False`` case before calling this helper.
     """
     mode = profile.describe()
+    tautology_solver = _new_solver()
     solver = _new_solver()
 
     satisfied: List[str] = []
@@ -1293,7 +1294,7 @@ def check_verb_feasibility(
 
     for cond in text_guards:
         sat_display, pending_pair, rejection = _classify_text_condition(
-            cond, vars_, solver, profile=profile,
+            cond, vars_, tautology_solver, profile=profile,
         )
         if sat_display is not None:
             satisfied.append(sat_display)
@@ -1413,6 +1414,12 @@ def check_path_feasibility(
         )
 
     vars_: Dict[str, Any] = {}
+    # Tautology checks (push/add(Not(expr))/check/pop) run on a
+    # throwaway solver so residual push/pop state cannot leak into
+    # the final solve.  Z3 4.15.4.0 has been observed to return
+    # models that violate tracked assertions after repeated
+    # push/pop cycles on the same solver instance.
+    tautology_solver = _new_solver()
     # Per-call timeout override. Default to the substrate's
     # DEFAULT_TIMEOUT_MS (5s). Callers that know their CWE-class
     # solving-cost profile (CWE-190 wraparound is fast; CWE-787
@@ -1464,7 +1471,7 @@ def check_path_feasibility(
 
     for cond in conditions:
         sat_display, pending_pair, rejection = _classify_text_condition(
-            cond, vars_, solver, profile=profile,
+            cond, vars_, tautology_solver, profile=profile,
             anon_map=anon_map, dedup_window=dedup_window,
         )
         if sat_display is not None:

--- a/packages/codeql/tests/test_smt_path_validator.py
+++ b/packages/codeql/tests/test_smt_path_validator.py
@@ -568,10 +568,16 @@ class TestParametricProfile:
             profile=BV_C_UINT32,
         )
         assert r.feasible is True
-        offset, length = r.model["offset"], r.model["length"]
-        # The wraparound is the whole point: (offset + length) mod 2^32 ≤ 64.
-        assert (offset + length) & 0xFFFFFFFF <= 64
-        assert offset > 0x10000 and length > 0x10000
+        m = r.model
+        assert m["sum"] <= 64, f"sum={m['sum']} violates sum<=buffer_size"
+        assert m["buffer_size"] == 64
+        assert m["offset"] > 0x10000, f"offset={m['offset']}"
+        assert m["length"] > 0x10000, f"length={m['length']}"
+        wrap = (m["offset"] + m["length"]) & 0xFFFFFFFF
+        assert m["sum"] == wrap, (
+            f"model inconsistency: sum={m['sum']} but "
+            f"(offset+length) mod 2^32 = {wrap}"
+        )
 
     @_requires_z3
     def test_uint32_profile_catches_mask_wraparound(self):


### PR DESCRIPTION
Separate the solver used for per-condition tautology checks (push/pop cycles) from the solver used for the final joint solve.  Z3 4.15.4.0 has been observed returning models that violate tracked assertions after repeated push/pop cycles on the same instance.  Also improve test assertions to check each model variable individually with diagnostic messages.