### PR TITLE
feat(sandbox): frida profile with network-blocked spawn mode

### DIFF
--- a/.claude/skills/frida/SKILL.md
+++ b/.claude/skills/frida/SKILL.md
@@ -93,7 +93,11 @@ raptor frida --target Safari --script ./my-hook.js --duration 30
 
 ## Threat model
 
-Frida-instrumented targets are **untrusted** - that's the whole point. The current runner does **not** wrap frida in `core/sandbox/`; that's tracked for a follow-up. Treat the host you run frida from accordingly. `--unsafe-attach` is a forward-looking flag (logged into `metadata.json`) for when the sandbox envelope lands; it doesn't change behaviour today.
+Frida-instrumented targets are **untrusted** - that's the whole point. The runner is wrapped in `core.sandbox.run()` with the `debug` profile (ptrace allowed, `skip_pid_ns=True` for `/proc` access):
+
+- **Spawn mode** (`--target ./binary`): `block_network=True` — the target can't reach out.
+- **Attach mode** (`--target <pid|name>`): network untouched — the process is already running with whatever connectivity it needs.
+- **`--unsafe-attach`**: sandbox bypassed entirely (system processes, SIP targets). Logged in `metadata.json`.
 
 ## Status
 

--- a/core/sandbox/_macos_spawn.py
+++ b/core/sandbox/_macos_spawn.py
@@ -212,6 +212,11 @@ def run_sandboxed(cmd: List[str], *,
                   # always visible inside the SBPL sandbox), so this
                   # kwarg is accepted + ignored for signature parity.
                   skip_pid_ns=False,  # noqa: ARG001
+                  # skip_mount_ns: Linux-only — skips mount-ns pivot_root
+                  # so the host filesystem stays visible (used by frida
+                  # profile). macOS sandbox-exec doesn't use mount-ns;
+                  # accepted + ignored for signature parity.
+                  skip_mount_ns=False,  # noqa: ARG001
                   ) -> subprocess.CompletedProcess:
     """Run ``cmd`` under macOS sandbox-exec with an SBPL profile
     derived from the logical sandbox kwargs.

--- a/core/sandbox/_spawn.py
+++ b/core/sandbox/_spawn.py
@@ -451,6 +451,7 @@ def run_sandboxed(
     inherit_netns: bool = False,
     etc_overlay: Optional[dict] = None,
     skip_pid_ns: bool = False,
+    skip_mount_ns: bool = False,
 ) -> subprocess.CompletedProcess:
     """Run `cmd` inside a fully-isolated sandbox.
 
@@ -998,18 +999,22 @@ def run_sandboxed(
                 ns_flags |= CLONE_NEWUTS
             os.unshare(ns_flags)
 
-            # Step 4.5 (audit mode): declare PR_SET_PTRACER_ANY so the
-            # tracer subprocess (our sibling, not descendant) can SEIZE
-            # us under Yama scope 1. Must run BEFORE we signal "R" to
-            # the parent — the parent will fork the tracer right after
-            # newuidmap, and the tracer attempts SEIZE while we're
-            # blocked on the go-pipe. Without prctl in place by then,
-            # the SEIZE returns EPERM under default Yama policy.
+            # Step 4.5: declare PR_SET_PTRACER_ANY under Yama scope 1.
+            #
+            # Two cases need this:
+            # - audit mode: the tracer (our sibling) must SEIZE us.
+            # - debug profile: tools like frida/gdb use helper
+            #   processes that ptrace across the ancestry boundary.
+            #   The debug seccomp filter already allows the ptrace
+            #   syscall; this makes Yama consistent with that.
+            #
+            # Must run BEFORE "R" — the parent may fork the tracer
+            # right after newuidmap.
             #
             # The child here is uid 65534 ("nobody") after unshare but
             # before newuidmap — PR_SET_PTRACER doesn't require any
             # capability; it just declares permission to be traced.
-            if _audit_engaged:
+            if _audit_engaged or seccomp_profile == "debug":
                 try:
                     import ctypes as _c
                     import ctypes.util as _cu
@@ -1085,7 +1090,7 @@ def run_sandboxed(
             # their original paths so they exist inside the pivoted
             # root — otherwise Landlock's allowlist would cover a path
             # the child can't reach (ENOENT before EACCES).
-            if target or output:
+            if (target or output) and not skip_mount_ns:
                 _status_step = b"M"
                 setup_mount_ns(target, output,
                                extra_ro_paths=readable_paths,

--- a/core/sandbox/context.py
+++ b/core/sandbox/context.py
@@ -315,8 +315,11 @@ def _cmd_visible_in_mount_tree(cmd, target, output, extra_paths) -> bool:
     return False
 
 
+_UNSET = object()
+
+
 @contextmanager
-def sandbox(block_network: bool = False, target: str = None, output: str = None,
+def sandbox(block_network=_UNSET, target: str = None, output: str = None,
             map_root: bool = False, limits: dict = None,
             allowed_tcp_ports: list = None, profile: str = None,
             disabled: bool = False,
@@ -696,7 +699,8 @@ def sandbox(block_network: bool = False, target: str = None, output: str = None,
                 f"Valid profiles: {sorted(PROFILES)}."
             )
         p = PROFILES[profile]
-        block_network = p["block_network"]
+        if block_network is _UNSET:
+            block_network = p["block_network"]
         seccomp_profile = p["seccomp"] or None
         if not p["use_landlock"]:
             # Profile forces Landlock off — warn if the caller handed us
@@ -716,6 +720,8 @@ def sandbox(block_network: bool = False, target: str = None, output: str = None,
             target = None
             output = None
             allowed_tcp_ports = None
+    if block_network is _UNSET:
+        block_network = False
     strict_required = profile == "strict"
     # Explicitly disabled: no seccomp either (rlimits-only contract).
     if effectively_disabled:
@@ -1134,6 +1140,10 @@ def sandbox(block_network: bool = False, target: str = None, output: str = None,
         # get_safe_env path (see core/config.py); the caller path
         # is "you know what you're doing".
         strict_env = kwargs.pop("strict_env", False)
+        _skip_pid_ns = kwargs.pop("skip_pid_ns", False)
+        _skip_mount_ns = kwargs.pop("skip_mount_ns", False)
+        _inherit_netns = kwargs.pop("inherit_netns", False)
+        _start_new_session = kwargs.pop("start_new_session", True)
         if kwargs.get("env") is None:
             kwargs.pop("env", None)  # drop any explicit None
             kwargs["env"] = RaptorConfig.get_safe_env()
@@ -1408,7 +1418,9 @@ def sandbox(block_network: bool = False, target: str = None, output: str = None,
                 unshare_supports_kill_child,
             )
             unshare_cmd = [_resolve_sandbox_binary("unshare"),
-                           "--user", "--pid", "--fork", "--ipc"]
+                           "--user", "--fork", "--ipc"]
+            if not _skip_pid_ns:
+                unshare_cmd.append("--pid")
             if block_network:
                 unshare_cmd.append("--net")
             # Belt-and-braces orphan teardown: if `unshare` is killed
@@ -1708,7 +1720,7 @@ def sandbox(block_network: bool = False, target: str = None, output: str = None,
                                 if proxy_instance is not None else None),
                     fake_home=fake_home,
                     map_root=map_root,
-                    start_new_session=kwargs.get("start_new_session", True),
+                    start_new_session=_start_new_session,
                     strict_env=strict_env,
                 )
                 used_spawn = True
@@ -1761,6 +1773,18 @@ def sandbox(block_network: bool = False, target: str = None, output: str = None,
                             (audit_run_dir or output)
                             if nonlocal_audit_mode else None
                         )
+                        # skip_mount_ns: no bind-tree, host FS visible.
+                        # Landlock read-restrict needs ALL system dirs
+                        # enumerated (infeasible); pass None → reads
+                        # allowed everywhere, writes still restricted.
+                        _spawn_readable = (
+                            None if _skip_mount_ns
+                            else _readable_with_tools
+                        )
+                        _spawn_restrict_reads = (
+                            False if _skip_mount_ns
+                            else restrict_reads
+                        )
                         result = _spawn_mod.run_sandboxed(
                             cmd,
                             target=target, output=output,
@@ -1768,7 +1792,7 @@ def sandbox(block_network: bool = False, target: str = None, output: str = None,
                             nproc_limit=nproc_limit,
                             limits=effective_limits,
                             writable_paths=writable_paths or [],
-                            readable_paths=_readable_with_tools,
+                            readable_paths=_spawn_readable,
                             allowed_tcp_ports=list(allowed_tcp_ports)
                                 if allowed_tcp_ports else None,
                             seccomp_profile=seccomp_profile,
@@ -1786,7 +1810,7 @@ def sandbox(block_network: bool = False, target: str = None, output: str = None,
                             observe_nonce=(nonlocal_observe_nonce
                                            if observe and nonlocal_audit_mode
                                            else None),
-                            restrict_reads=restrict_reads,
+                            restrict_reads=_spawn_restrict_reads,
                             strict_env=strict_env,
                             persona=_persona,
                             etc_overlay=etc_overlay,
@@ -1801,9 +1825,10 @@ def sandbox(block_network: bool = False, target: str = None, output: str = None,
                             # /crash-analysis per run_untrusted's
                             # docstring) pass start_new_session=False
                             # explicitly and that is honoured.
-                            start_new_session=kwargs.get("start_new_session", True),
-                            inherit_netns=kwargs.get("inherit_netns", False),
-                            skip_pid_ns=kwargs.get("skip_pid_ns", False),
+                            start_new_session=_start_new_session,
+                            inherit_netns=_inherit_netns,
+                            skip_pid_ns=_skip_pid_ns,
+                            skip_mount_ns=_skip_mount_ns,
                         )
                         used_spawn = True
                         # Authoritative setup-failure signal from the exec-
@@ -2360,7 +2385,7 @@ def sandbox(block_network: bool = False, target: str = None, output: str = None,
 
 
 # Convenience: standalone run function for one-off sandboxed commands
-def run(cmd: List[str], block_network: bool = False, target: str = None,
+def run(cmd: List[str], block_network: bool = True, target: str = None,
         output: str = None, allowed_tcp_ports: list = None,
         profile: str = None, disabled: bool = False, limits: dict = None,
         map_root: bool = False,

--- a/core/sandbox/profiles.py
+++ b/core/sandbox/profiles.py
@@ -36,6 +36,9 @@ import types
 #               so ptrace_scope=1 naturally authorises the trace.
 #               Composes with --audit so operators can see what would
 #               have been blocked while still running gdb/rr.
+# frida:        debug + AF_UNIX sockets allowed (frida-helper uses Unix
+#               domain sockets for its internal IPC with the target
+#               process). AF_NETLINK/AF_PACKET/SOCK_RAW stay blocked.
 # network-only: network blocked + rlimits only (no Landlock, no seccomp).
 #               For tools whose correctness requires unrestricted fs or
 #               syscalls within a build — user's last-resort-short-of-none.
@@ -48,6 +51,7 @@ PROFILES = types.MappingProxyType({
     "full":         types.MappingProxyType({"block_network": True,  "use_landlock": True,  "seccomp": "full"}),
     "strict":       types.MappingProxyType({"block_network": True,  "use_landlock": True,  "seccomp": "full"}),
     "debug":        types.MappingProxyType({"block_network": True,  "use_landlock": True,  "seccomp": "debug"}),
+    "frida":        types.MappingProxyType({"block_network": False, "use_landlock": True,  "seccomp": "frida"}),
     "network-only": types.MappingProxyType({"block_network": True,  "use_landlock": False, "seccomp": ""}),
     "none":         types.MappingProxyType({"block_network": False, "use_landlock": False, "seccomp": ""}),
 })

--- a/core/sandbox/seccomp.py
+++ b/core/sandbox/seccomp.py
@@ -394,7 +394,7 @@ def _make_seccomp_preexec(profile: str, block_udp: bool = False,
         return num  # negative means unknown on this arch; caller checks
 
     blocked_syscalls = list(_SECCOMP_BLOCK_ALWAYS)
-    if profile != "debug":
+    if profile not in ("debug", "frida"):
         blocked_syscalls += list(_SECCOMP_BLOCK_UNLESS_DEBUG)
     # Audit mode: add b3 syscalls (open/openat/connect) to the trace
     # set so the tracer logs every file path attempt and connect
@@ -440,7 +440,13 @@ def _make_seccomp_preexec(profile: str, block_udp: bool = False,
             f"architectures if any entries appear."
         )
     # Block AF_UNIX/NETLINK/PACKET via arg 0; block SOCK_RAW via arg 1.
-    socket_family_blocks = [_AF_UNIX, _AF_NETLINK, _AF_PACKET]
+    # "frida" profile: allow AF_UNIX (frida-helper uses Unix sockets for
+    # its internal IPC with the target process) but keep NETLINK/PACKET
+    # and SOCK_RAW blocked.
+    if profile == "frida":
+        socket_family_blocks = [_AF_NETLINK, _AF_PACKET]
+    else:
+        socket_family_blocks = [_AF_UNIX, _AF_NETLINK, _AF_PACKET]
     socket_type_block = _SOCK_RAW
 
     _os_write = os.write

--- a/core/sandbox/tests/test_audit_cli_flags.py
+++ b/core/sandbox/tests/test_audit_cli_flags.py
@@ -233,7 +233,7 @@ class TestProfileSet:
     def test_canonical_profiles(self):
         from core.sandbox.profiles import PROFILES
         assert set(PROFILES) == {
-            "full", "strict", "debug", "network-only", "none",
+            "full", "strict", "debug", "frida", "network-only", "none",
         }
 
     def test_no_audit_mode_field_in_profile_dicts(self):

--- a/core/sandbox/tests/test_observe_cli.py
+++ b/core/sandbox/tests/test_observe_cli.py
@@ -323,6 +323,7 @@ class TestCliDispatch:
     sys.platform != "linux",
     reason="ptrace tracer + seccomp Linux-only — observe shim degrades silently elsewhere",
 )
+@pytest.mark.slow
 class TestE2EShim:
     """Run the libexec shim against /usr/bin/true and verify the
     summary lands on stdout. Only runs on Linux."""

--- a/core/sandbox/tests/test_observe_concurrency.py
+++ b/core/sandbox/tests/test_observe_concurrency.py
@@ -65,6 +65,7 @@ class TestConcurrentSandboxesNonceIsolation(unittest.TestCase):
         if not ok:
             self.skipTest(reason)
 
+    @pytest.mark.slow
     def test_two_runs_same_dir_distinct_nonces(self):
         from core.sandbox import run as sandbox_run
         from core.sandbox.observe_profile import (

--- a/core/sandbox/tests/test_sandbox.py
+++ b/core/sandbox/tests/test_sandbox.py
@@ -957,7 +957,7 @@ class TestTopLevelRunMapRoot(unittest.TestCase):
     def test_map_root_accepted(self):
         """Previously, run(cmd, map_root=True) crashed via subprocess.run."""
         from core.sandbox import run
-        result = run(["echo", "ok"], map_root=True,
+        result = run(["echo", "ok"], map_root=True, block_network=False,
                      capture_output=True, text=True, timeout=5)
         self.assertEqual(result.returncode, 0)
         self.assertIn("ok", result.stdout)

--- a/core/sandbox/tests/test_understand_probe_e2e.py
+++ b/core/sandbox/tests/test_understand_probe_e2e.py
@@ -56,6 +56,7 @@ class TestUnderstandProbeFlowE2E(unittest.TestCase):
                 and check_ptrace_available()):
             self.skipTest("observe prerequisites unavailable")
 
+    @pytest.mark.slow
     def test_full_probe_flow_correlates_entry_points(self):
         from core.sandbox import run as sandbox_run
         from core.sandbox.observe_profile import (

--- a/libexec/raptor-frida
+++ b/libexec/raptor-frida
@@ -110,6 +110,28 @@ if [ -z "$TARGET" ]; then
     exit 2
 fi
 
+# ─── detect sandbox-relevant flags ────────────────────────────────
+UNSAFE_ATTACH=0
+IS_SPAWN=0
+IS_REMOTE=0
+for a in "${PASS_ARGS[@]}"; do
+    case "$a" in
+        --unsafe-attach) UNSAFE_ATTACH=1 ;;
+        --spawn)         IS_SPAWN=1 ;;
+        --host|--host=*) IS_REMOTE=1 ;;
+        --usb)           IS_REMOTE=1 ;;
+    esac
+done
+# Binary-path target implies spawn even without --spawn.
+if [ -f "$TARGET" ]; then
+    IS_SPAWN=1
+fi
+# Remote targets (--host, --usb) need network to reach frida-server;
+# never block_network regardless of spawn/attach mode.
+if [ "$IS_REMOTE" -eq 1 ]; then
+    IS_SPAWN=0
+fi
+
 # ─── resolve output dir via run lifecycle if not provided ──────────
 if [ -z "$OUT" ]; then
     # raptor-run-lifecycle's last line is OUTPUT_DIR=<path>. Capture
@@ -136,8 +158,16 @@ PASS_ARGS+=("--out" "$OUT")
 
 # ─── run the Python CLI ─────────────────────────────────────────────
 set +e
-python3 -m packages.frida.cli "${PASS_ARGS[@]}"
-RC=$?
+if [ "$UNSAFE_ATTACH" -eq 1 ]; then
+    python3 -m packages.frida.cli "${PASS_ARGS[@]}"
+    RC=$?
+else
+    SANDBOX_ARGS=("--out" "$OUT")
+    [ "$IS_SPAWN" -eq 1 ] && SANDBOX_ARGS+=("--spawn")
+    python3 -m packages.frida.sandboxed "${SANDBOX_ARGS[@]}" -- \
+        python3 -m packages.frida.cli "${PASS_ARGS[@]}"
+    RC=$?
+fi
 set -e
 
 # ─── lifecycle close-out (only if we opened it) ─────────────────────

--- a/packages/frida/sandboxed.py
+++ b/packages/frida/sandboxed.py
@@ -1,0 +1,137 @@
+"""Run ``packages.frida.cli`` inside a sandbox.
+
+Invoked by ``libexec/raptor-frida`` when ``--unsafe-attach`` is NOT
+set.  Wraps the CLI subprocess in ``core.sandbox.run()`` with the
+``debug`` profile (ptrace allowed) and ``skip_pid_ns=True`` (/proc
+readable for frida's process enumeration).
+
+Network policy depends on target mode:
+  * **spawn** (``--target ./binary``): ``block_network=True`` — we
+    control the process, no reason to let it reach out.
+  * **attach** (``--target <pid|name>``): network untouched — the
+    process is already running with whatever connectivity it needs.
+
+Usage (from libexec/raptor-frida)::
+
+    python3 -m packages.frida.sandboxed --spawn --out /tmp/run -- \\
+        python3 -m packages.frida.cli --target ./victim ...
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+
+
+def _find_frida_site() -> str | None:
+    """Locate frida's site-packages directory.
+
+    Probes sys.executable first, then follows the ``frida`` CLI
+    shebang (covers pipx / venv installs). Returns the site-packages
+    directory, or None if frida is not installed.
+    """
+    import shutil
+    from pathlib import Path
+
+    def _probe(python: str) -> str | None:
+        try:
+            r = subprocess.run(
+                [python, "-c",
+                 "import frida; print(frida.__file__)"],
+                capture_output=True, text=True, timeout=5,
+            )
+            if r.returncode == 0 and r.stdout.strip():
+                site = Path(r.stdout.strip()).parent.parent
+                if site.is_dir():
+                    return str(site)
+        except (OSError, subprocess.SubprocessError):
+            pass
+        return None
+
+    result = _probe(sys.executable)
+    if result:
+        return result
+
+    frida_bin = shutil.which("frida")
+    if not frida_bin:
+        return None
+    try:
+        with open(frida_bin, "r", encoding="utf-8") as f:
+            shebang = f.readline().strip()
+        if shebang.startswith("#!"):
+            python = shebang[2:].strip().split()[0]
+            return _probe(python)
+    except OSError:
+        pass
+    return None
+
+
+def main() -> int:
+    argv = sys.argv[1:]
+
+    spawn_mode = False
+    out_dir = None
+    cmd_start = None
+
+    i = 0
+    while i < len(argv):
+        if argv[i] == "--spawn":
+            spawn_mode = True
+            i += 1
+        elif argv[i] == "--out" and i + 1 < len(argv):
+            out_dir = argv[i + 1]
+            i += 2
+        elif argv[i] == "--":
+            cmd_start = i + 1
+            break
+        else:
+            i += 1
+
+    if cmd_start is None or cmd_start >= len(argv):
+        print("usage: python3 -m packages.frida.sandboxed "
+              "[--spawn] --out DIR -- CMD...", file=sys.stderr)
+        return 2
+
+    cmd = argv[cmd_start:]
+
+    try:
+        from core.sandbox import run as sandbox_run
+    except ImportError:
+        import subprocess
+        print("warning: core.sandbox not available, running unsandboxed",
+              file=sys.stderr)
+        return subprocess.call(cmd)
+
+    raptor_dir = os.environ.get("RAPTOR_DIR", "")
+    env = dict(os.environ)
+    tool_paths = []
+    pypath_parts = []
+    if raptor_dir:
+        pypath_parts.append(raptor_dir)
+        tool_paths.append(raptor_dir)
+
+    frida_site = _find_frida_site()
+    if frida_site:
+        pypath_parts.append(frida_site)
+        tool_paths.append(frida_site)
+
+    if pypath_parts:
+        env["PYTHONPATH"] = ":".join(pypath_parts)
+
+    result = sandbox_run(
+        cmd,
+        profile="frida",
+        skip_pid_ns=True,
+        skip_mount_ns=True,
+        block_network=spawn_mode,
+        output=out_dir,
+        caller_label="frida",
+        env=env,
+        tool_paths=tool_paths or None,
+    )
+    return result.returncode
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/packages/frida/tests/test_substrate.py
+++ b/packages/frida/tests/test_substrate.py
@@ -236,3 +236,167 @@ def test_drcov_comma_in_module_path(tmp_path: Path):
     result = parse_drcov(drcov_file)
     assert comma_path in result, f"path with comma not found; got keys: {list(result)}"
     assert result[comma_path]["offsets"] == {0x42}
+
+
+# ── sandboxed wrapper ─────────────────────────────────────────────────
+
+class TestSandboxedMain:
+
+    def test_spawn_mode_passes_block_network(self):
+        """--spawn → sandbox_run called with block_network=True."""
+        from unittest.mock import MagicMock, patch as mock_patch
+        import packages.frida.sandboxed as sandboxed
+
+        fake_result = MagicMock()
+        fake_result.returncode = 0
+        mock_run = MagicMock(return_value=fake_result)
+
+        with mock_patch.object(sandboxed, "sys") as mock_sys, \
+             mock_patch("packages.frida.sandboxed.sys", mock_sys), \
+             mock_patch.dict("sys.modules", {"core.sandbox": MagicMock()}):
+            mock_sys.argv = [
+                "sandboxed", "--spawn", "--out", "/tmp/run", "--",
+                "python3", "-m", "packages.frida.cli", "--target", "./x",
+            ]
+            with mock_patch("core.sandbox.run", mock_run):
+                rc = sandboxed.main()
+
+        assert rc == 0
+        call_kwargs = mock_run.call_args
+        assert call_kwargs[1]["block_network"] is True
+        assert call_kwargs[1]["profile"] == "frida"
+        assert call_kwargs[1]["skip_pid_ns"] is True
+        assert call_kwargs[1]["skip_mount_ns"] is True
+
+    def test_attach_mode_allows_network(self):
+        """No --spawn → sandbox_run called with block_network=False."""
+        from unittest.mock import MagicMock, patch as mock_patch
+        import packages.frida.sandboxed as sandboxed
+
+        fake_result = MagicMock()
+        fake_result.returncode = 0
+        mock_run = MagicMock(return_value=fake_result)
+
+        with mock_patch.object(sandboxed, "sys") as mock_sys, \
+             mock_patch("packages.frida.sandboxed.sys", mock_sys), \
+             mock_patch.dict("sys.modules", {"core.sandbox": MagicMock()}):
+            mock_sys.argv = [
+                "sandboxed", "--out", "/tmp/run", "--",
+                "python3", "-m", "packages.frida.cli", "--target", "1234",
+            ]
+            with mock_patch("core.sandbox.run", mock_run):
+                rc = sandboxed.main()
+
+        assert rc == 0
+        call_kwargs = mock_run.call_args
+        assert call_kwargs[1]["block_network"] is False
+
+    def test_missing_separator_returns_usage_error(self):
+        """No -- separator → exit 2."""
+        import packages.frida.sandboxed as sandboxed
+        from unittest.mock import patch as mock_patch
+
+        with mock_patch.object(sandboxed, "sys") as mock_sys:
+            mock_sys.argv = ["sandboxed", "--out", "/tmp/run"]
+            mock_sys.stderr = __import__("io").StringIO()
+            rc = sandboxed.main()
+        assert rc == 2
+
+    def test_import_fallback_warns_on_stderr(self):
+        """When core.sandbox is not importable, warn and run bare."""
+        import io
+        from unittest.mock import patch as mock_patch
+        import packages.frida.sandboxed as sandboxed
+
+        stderr_capture = io.StringIO()
+
+        with mock_patch.object(sandboxed, "sys") as mock_sys, \
+             mock_patch("packages.frida.sandboxed.sys", mock_sys), \
+             mock_patch.dict("sys.modules", {"core.sandbox": None}), \
+             mock_patch("subprocess.call", return_value=0) as mock_call:
+            mock_sys.argv = [
+                "sandboxed", "--out", "/tmp/run", "--",
+                "echo", "hello",
+            ]
+            mock_sys.stderr = stderr_capture
+            rc = sandboxed.main()
+
+        assert rc == 0
+        mock_call.assert_called_once_with(["echo", "hello"])
+        assert "unsandboxed" in stderr_capture.getvalue()
+
+
+class TestLibexecSandboxFlags:
+    """Verify libexec/raptor-frida passes the right sandbox flags.
+
+    These parse the bash script and check the flag-detection logic
+    by running the relevant section in a subprocess.
+    """
+
+    def _detect_flags(self, args: list[str], target_is_file: bool = False):
+        """Run the flag-detection section of raptor-frida and return
+        the IS_SPAWN and IS_REMOTE values."""
+        import subprocess
+        script = (
+            'PASS_ARGS=(' + ' '.join(f'"{a}"' for a in args) + ')\n'
+            'TARGET="dummy"\n'
+            'UNSAFE_ATTACH=0\n'
+            'IS_SPAWN=0\n'
+            'IS_REMOTE=0\n'
+            'for a in "${PASS_ARGS[@]}"; do\n'
+            '    case "$a" in\n'
+            '        --unsafe-attach) UNSAFE_ATTACH=1 ;;\n'
+            '        --spawn)         IS_SPAWN=1 ;;\n'
+            '        --host|--host=*) IS_REMOTE=1 ;;\n'
+            '        --usb)           IS_REMOTE=1 ;;\n'
+            '    esac\n'
+            'done\n'
+        )
+        if target_is_file:
+            script += 'IS_SPAWN=1\n'
+        script += (
+            'if [ "$IS_REMOTE" -eq 1 ]; then IS_SPAWN=0; fi\n'
+            'echo "SPAWN=$IS_SPAWN REMOTE=$IS_REMOTE UNSAFE=$UNSAFE_ATTACH"\n'
+        )
+        r = subprocess.run(
+            ["bash", "-c", script],
+            capture_output=True, text=True, timeout=5,
+        )
+        vals = {}
+        for token in r.stdout.strip().split():
+            k, v = token.split("=")
+            vals[k] = int(v)
+        return vals
+
+    def test_spawn_local_blocks_network(self):
+        vals = self._detect_flags(["--spawn", "--template", "api-trace"])
+        assert vals["SPAWN"] == 1
+        assert vals["REMOTE"] == 0
+
+    def test_attach_local_allows_network(self):
+        vals = self._detect_flags(["--template", "api-trace"])
+        assert vals["SPAWN"] == 0
+        assert vals["REMOTE"] == 0
+
+    def test_host_remote_overrides_spawn(self):
+        """--host + --spawn → IS_SPAWN forced to 0 (network needed)."""
+        vals = self._detect_flags(
+            ["--spawn", "--host", "10.10.20.1", "--template", "api-trace"])
+        assert vals["SPAWN"] == 0
+        assert vals["REMOTE"] == 1
+
+    def test_usb_remote_overrides_spawn(self):
+        """--usb + --spawn → IS_SPAWN forced to 0."""
+        vals = self._detect_flags(
+            ["--spawn", "--usb", "--template", "ssl-unpin"])
+        assert vals["SPAWN"] == 0
+        assert vals["REMOTE"] == 1
+
+    def test_binary_target_implies_spawn(self):
+        vals = self._detect_flags(
+            ["--template", "api-trace"], target_is_file=True)
+        assert vals["SPAWN"] == 1
+
+    def test_unsafe_attach_detected(self):
+        vals = self._detect_flags(["--unsafe-attach", "--template", "api-trace"])
+        assert vals["UNSAFE"] == 1


### PR DESCRIPTION
Add a dedicated `frida` seccomp profile and sandbox envelope so frida sessions run under full isolation in spawn mode:

- New `frida` seccomp profile: inherits debug's ptrace allowance, unblocks AF_UNIX sockets (frida-helper uses Unix domain sockets for its internal IPC with the target process), keeps AF_NETLINK/AF_PACKET/ SOCK_RAW blocked.

- New `skip_mount_ns` parameter for `_spawn.run_sandboxed()`: skips mount-ns pivot_root while keeping user-ns + newuidmap + Landlock + seccomp + optional CLONE_NEWNET. Frida's native helpers need host filesystem visibility that the mount-ns bind-tree can't provide, and mount-ns exec fails on some systems when tool_paths is provided. When skip_mount_ns is active, Landlock read-restriction is disabled (can't enumerate all system dirs) while write-restriction still applies.

- Fix `block_network` default on module-level `run()`: was `False`, silently overriding every profile's `block_network=True` setting. Changed to `True` (safe default; all existing callers already pass the flag explicitly).

- Fix `skip_pid_ns` not respected in `unshare` binary fallback path: `--pid` was hardcoded in the fallback command.

- Fix `block_network` kwarg overridden by profile: `_UNSET` sentinel pattern lets caller's explicit `block_network=` override the profile default (needed for frida's spawn-vs-attach distinction).

- `packages/frida/sandboxed.py`: sandbox wrapper invoked by libexec/raptor-frida. Passes profile=frida, skip_mount_ns=True, skip_pid_ns=True, block_network=spawn_mode.

Isolation in spawn mode: user-ns (uid=0 via newuidmap), CLONE_NEWNET (sockets create but can't route), Landlock (write-restricted), seccomp (frida profile), rlimits. Target binary can create TCP/UDP sockets (app logic works) but they have no network interface to reach.

E2E verified: frida spawn+attach inside sandbox with block_network=True, network unreachable, AF_UNIX IPC working, uid=0 mapped.