### PR TITLE
core/llm/tool_use: should_continue callback + partial state on budget exceptions

### DIFF
--- a/core/llm/tool_use/loop.py
+++ b/core/llm/tool_use/loop.py
@@ -41,6 +41,7 @@ Every termination emits a :class:`LoopTerminated` event and returns a
 from __future__ import annotations
 
 import json
+import logging
 import re
 import threading
 import time
@@ -75,6 +76,8 @@ from .types import (
     TurnCompleted,
     TurnStarted,
 )
+
+logger = logging.getLogger(__name__)
 
 
 # Cap on stranded daemon threads from timed-out tool handlers.
@@ -116,6 +119,7 @@ class ToolUseLoop:
         events: Callable[[LoopEvent], None] | None = None,
         terminate_on_handler_error: bool = False,
         refuse_on_indicators: Sequence[str] = (),
+        should_continue: Callable[[], bool] | None = None,
         **provider_specific: Any,
     ) -> None:
         """``refuse_on_indicators``: prompt-injection corpus names
@@ -187,6 +191,14 @@ class ToolUseLoop:
         self._events = events
         self._terminate_on_handler_error = terminate_on_handler_error
         self._refuse_on_indicators = frozenset(refuse_on_indicators)
+        # Caller-supplied predicate evaluated at the top of each loop
+        # iteration. Returning False asks the loop to terminate cleanly
+        # with ``terminated_by="give_up"``. Useful for cost-control
+        # signals raised by handlers (e.g. the exploit-engine's
+        # candidate-diversity-collapse detector: when the model has
+        # submitted three byte-identical verify_run candidates, there's
+        # no point letting the budget keep ticking).
+        self._should_continue = should_continue
         self._provider_specific = provider_specific
 
     # ------------------------------------------------------------------
@@ -234,6 +246,42 @@ class ToolUseLoop:
                     known_values |= _extract_values_from_json(block.content)
 
         for iteration in range(self._max_iterations):
+            # ---- pre-flight: caller-supplied give-up predicate ---------
+            # A False return asks the loop to terminate cleanly. Useful
+            # for any consumer that wants to short-circuit on a caller-
+            # side signal (e.g. candidate-diversity collapse, external
+            # abort). A predicate that raises is treated as "keep going"
+            # so a bug in the caller's predicate cannot crash the loop;
+            # the exception is logged at WARNING so the bug is visible.
+            if self._should_continue is not None:
+                try:
+                    keep_going = self._should_continue()
+                except Exception:        # noqa: BLE001
+                    logger.warning(
+                        "should_continue predicate raised; treating as "
+                        "keep-going (iteration=%d)",
+                        iteration,
+                        exc_info=True,
+                    )
+                    keep_going = True
+                if not keep_going:
+                    self._emit(LoopTerminated(
+                        reason="give_up",
+                        iterations=iteration,
+                        total_cost_usd=total_cost_usd,
+                    ))
+                    return ToolLoopResult(
+                        final_text="",
+                        terminal_tool_input=None,
+                        messages=messages,
+                        iterations=iteration,
+                        tool_calls_made=tool_calls_made,
+                        total_input_tokens=total_input_tokens,
+                        total_output_tokens=total_output_tokens,
+                        total_cost_usd=total_cost_usd,
+                        terminated_by="give_up",
+                    )
+
             # ---- pre-flight: cost budget --------------------------------
             if (
                 self._max_cost_usd is not None
@@ -247,7 +295,9 @@ class ToolUseLoop:
                 raise CostBudgetExceeded(
                     f"cost budget ${self._max_cost_usd:.4f} reached "
                     f"(cumulative ${total_cost_usd:.4f}); aborting "
-                    "before next turn"
+                    "before next turn",
+                    messages=messages,
+                    tool_calls_made=tool_calls_made,
                 )
 
             # ---- pre-flight: wall-clock budget --------------------------
@@ -320,12 +370,19 @@ class ToolUseLoop:
                         f"request estimate ~{request_estimate} tokens "
                         f"would exceed model context window {window}; "
                         "set context_policy=TRUNCATE_OLDEST or shorten "
-                        "input"
+                        "input",
+                        messages=messages,
+                        tool_calls_made=tool_calls_made,
                     )
                 # TRUNCATE_OLDEST: drop oldest user/assistant pair until
                 # estimate fits. Pairing-aware so tool_use/tool_result
-                # links can't dangle.
-                messages = self._truncate_oldest(messages, window)
+                # links can't dangle. ``tool_calls_made`` flows through
+                # so a ContextOverflow raised from inside truncation
+                # carries the same partial-state count as the other
+                # raise sites in this loop.
+                messages = self._truncate_oldest(
+                    messages, window, tool_calls_made=tool_calls_made,
+                )
 
             cache_breakpoints = self._count_cache_breakpoints(messages)
             self._emit(TurnStarted(
@@ -816,6 +873,8 @@ class ToolUseLoop:
         self,
         messages: list[Message],
         window: int,
+        *,
+        tool_calls_made: int = 0,
     ) -> list[Message]:
         """Drop oldest user/assistant pairs until estimate fits.
 
@@ -862,7 +921,9 @@ class ToolUseLoop:
                 f"request estimate ~{total} tokens still exceeds window "
                 f"{window} after truncating to {len(messages)} message(s); "
                 "the trailing message itself is too large — shorten the "
-                "prompt or use a model with a bigger context"
+                "prompt or use a model with a bigger context",
+                messages=messages,
+                tool_calls_made=tool_calls_made,
             )
         return messages
 

--- a/core/llm/tool_use/tests/test_loop.py
+++ b/core/llm/tool_use/tests/test_loop.py
@@ -8,6 +8,7 @@ those concerns are tested in the provider-specific test files.
 
 from __future__ import annotations
 
+import logging
 import time
 from typing import Any
 
@@ -299,6 +300,116 @@ def test_max_cost_usd_terminates_pre_flight() -> None:
     assert len(fp.calls) == 2
 
 
+def test_cost_budget_exception_carries_partial_messages() -> None:
+    """When the cost cap fires mid-run, the exception exposes the
+    partial conversation so callers can persist the trajectory up to
+    termination. Without this, a budget-capped run is invisible —
+    we never see what the model was thrashing on.
+    """
+    fp = _FakeProvider([
+        _tool_call_response(("c1", "echo", {}), in_t=1000, out_t=1000),
+        _tool_call_response(("c2", "echo", {}), in_t=1000, out_t=1000),
+        _text_response("never reached", in_t=1000, out_t=1000),
+    ])
+    loop = ToolUseLoop(fp, [_echo_tool()], max_cost_usd=0.020)
+    try:
+        loop.run("expensive")
+        raise AssertionError("expected CostBudgetExceeded")
+    except CostBudgetExceeded as exc:
+        # initial user prompt + 2 assistant turns + 2 user tool-result
+        # turns = 5 messages survived.
+        assert len(exc.messages) == 5
+        assert exc.tool_calls_made == 2
+
+
+# ---------------------------------------------------------------------------
+# Caller-supplied give-up predicate
+# ---------------------------------------------------------------------------
+
+
+def test_should_continue_false_terminates_with_give_up() -> None:
+    """A ``should_continue`` predicate returning False halts the loop
+    cleanly with ``terminated_by='give_up'``. Pre-flight check at the
+    top of each iteration, so the False decision blocks the next
+    provider call rather than mid-turn cleanup."""
+    fp = _FakeProvider([
+        _tool_call_response(("c1", "echo", {})),
+        _tool_call_response(("c2", "echo", {})),  # never reached
+    ])
+    call_count = {"n": 0}
+
+    def predicate() -> bool:
+        call_count["n"] += 1
+        # Continue for one iteration, then give up.
+        return call_count["n"] <= 1
+
+    out = ToolUseLoop(
+        fp, [_echo_tool()], should_continue=predicate,
+    ).run("loop")
+    assert out.terminated_by == "give_up"
+    assert out.iterations == 1
+    assert out.tool_calls_made == 1
+    assert len(fp.calls) == 1  # second response was never consumed
+    assert call_count["n"] == 2  # called pre-iter 0 (True) + pre-iter 1 (False)
+
+
+def test_should_continue_raising_is_non_fatal(caplog) -> None:
+    """A predicate that raises must not crash the loop — the
+    exception is swallowed and the iteration proceeds as if the
+    predicate returned True. Catches programming errors in the
+    caller's predicate without aborting a long-running run. The
+    exception is logged at WARNING so the bug is visible to
+    operators (silent swallow would be a diagnosis hazard)."""
+    fp = _FakeProvider([_text_response("done")])
+
+    def boom() -> bool:
+        raise RuntimeError("predicate crashed")
+
+    with caplog.at_level(logging.WARNING, logger="core.llm.tool_use.loop"):
+        out = ToolUseLoop(
+            fp, [_echo_tool()], should_continue=boom,
+        ).run("safe")
+    assert out.terminated_by == "complete"
+    # The predicate-crash exception must be logged so a buggy
+    # predicate is diagnosable.
+    assert any(
+        "should_continue predicate raised" in r.message
+        for r in caplog.records
+    ), f"expected WARNING about predicate crash, got: {caplog.records}"
+
+
+def test_should_continue_emits_give_up_event() -> None:
+    """The structured event stream surfaces ``LoopTerminated(reason=
+    "give_up")`` so subscribers can distinguish caller-driven
+    termination from cost / time / iteration caps."""
+    events: list[LoopEvent] = []
+    fp = _FakeProvider([_tool_call_response(("c1", "echo", {}))])
+    ToolUseLoop(
+        fp, [_echo_tool()],
+        should_continue=lambda: False,
+        events=events.append,
+    ).run("loop")
+    terminated = [e for e in events if isinstance(e, LoopTerminated)]
+    assert len(terminated) == 1
+    assert terminated[0].reason == "give_up"
+
+
+def test_should_continue_true_is_no_op() -> None:
+    """A predicate that always returns True leaves loop behaviour
+    unchanged — terminates on the model's COMPLETE response, not
+    on the predicate. Regression guard against accidentally
+    short-circuiting valid loops."""
+    fp = _FakeProvider([
+        _tool_call_response(("c1", "echo", {})),
+        _text_response("done"),
+    ])
+    out = ToolUseLoop(
+        fp, [_echo_tool()], should_continue=lambda: True,
+    ).run("loop")
+    assert out.terminated_by == "complete"
+    assert out.tool_calls_made == 1
+
+
 def test_max_seconds_terminates_pre_flight(monkeypatch) -> None:
     """Wall-clock budget caps the whole run. Pre-flight check before
     each iteration; once elapsed >= max_seconds, the loop returns a
@@ -313,7 +424,14 @@ def test_max_seconds_terminates_pre_flight(monkeypatch) -> None:
         v = clock["t"]
         clock["t"] += 4.0
         return v
-    monkeypatch.setattr("core.llm.tool_use.loop.time.monotonic", _tick)
+    # Patch via the imported-module handle rather than the dotted
+    # string. pytest 8+ resolves "core.llm.tool_use.loop.time.monotonic"
+    # by walking the package namespace; ``core.llm.tool_use.__init__``
+    # does not re-export ``loop`` as an attribute, so the walk fails
+    # at the ``.loop`` step. Using the module object directly skips
+    # the resolver and works on every pytest version.
+    from core.llm.tool_use import loop as _loop_mod
+    monkeypatch.setattr(_loop_mod.time, "monotonic", _tick)
 
     fp = _FakeProvider([
         _tool_call_response(("c1", "echo", {})),
@@ -532,6 +650,41 @@ def test_context_overflow_truncate_raises_when_exhausted() -> None:
     with pytest.raises(ContextOverflow, match="still exceeds"):
         loop.run("y" * 1000)
     assert len(fp.calls) == 0
+
+
+def test_context_overflow_carries_partial_state_after_tool_call() -> None:
+    """When the overflow fires AFTER a tool call has completed, the
+    exception's ``messages`` and ``tool_calls_made`` reflect the
+    partial work — caller can persist the trajectory up to the
+    point of termination, not just the empty-prompt state.
+
+    Covers both pre-flight RAISE paths: the initial estimate gate
+    AND the post-truncation 'still too large' gate share the same
+    partial-state contract.
+    """
+    # Window 50 tokens: the initial prompt + first tool round-trip
+    # fits, but the second iteration's pre-flight estimate (which
+    # includes the echo'd back tool result) tips over.
+    fp = _FakeProvider(
+        [
+            _tool_call_response(("c1", "echo", {"big": "x" * 400})),
+            _text_response("never reached"),
+        ],
+        ctx_window=50,
+    )
+    loop = ToolUseLoop(
+        fp, [_echo_tool()],
+        context_policy=ContextPolicy.RAISE,
+    )
+    try:
+        loop.run("go")
+        raise AssertionError("expected ContextOverflow")
+    except ContextOverflow as exc:
+        # One tool call completed before the overflow.
+        assert exc.tool_calls_made == 1
+        # Messages list includes the partial trajectory up to overflow.
+        # At minimum: initial user + assistant turn 0 + user tool_result.
+        assert len(exc.messages) >= 3
 
 
 def test_context_overflow_truncate_policy_drops_oldest() -> None:

--- a/core/llm/tool_use/types.py
+++ b/core/llm/tool_use/types.py
@@ -264,7 +264,23 @@ class ContextPolicy(Enum):
 class ContextOverflow(RuntimeError):
     """Raised by the loop when ``ContextPolicy.RAISE`` is in effect and
     the next turn's request would exceed the provider's context
-    window."""
+    window.
+
+    Carries the partial-state attributes ``messages`` and
+    ``tool_calls_made`` so callers can persist the trajectory up to the
+    point of termination. Both default to empty/0 when the raiser had
+    no access to them.
+    """
+
+    def __init__(
+        self,
+        *args: Any,
+        messages: list[Any] | None = None,
+        tool_calls_made: int = 0,
+    ) -> None:
+        super().__init__(*args)
+        self.messages = list(messages) if messages else []
+        self.tool_calls_made = tool_calls_made
 
 
 # ---------------------------------------------------------------------------
@@ -280,7 +296,22 @@ class CostBudgetExceeded(RuntimeError):
     Pre-flight only: a single surprise-large response cannot be blocked
     until we know its cost, but subsequent calls in the same loop run
     cannot pile on once the cap is reached.
+
+    Carries the partial-state attributes ``messages`` and
+    ``tool_calls_made`` so callers can persist the trajectory up to the
+    point of termination. Both default to empty/0 when the raiser had
+    no access to them.
     """
+
+    def __init__(
+        self,
+        *args: Any,
+        messages: list[Any] | None = None,
+        tool_calls_made: int = 0,
+    ) -> None:
+        super().__init__(*args)
+        self.messages = list(messages) if messages else []
+        self.tool_calls_made = tool_calls_made
 
 
 class ToolHandlerTimeout(RuntimeError):
@@ -395,6 +426,7 @@ class LoopTerminated:
         "tool_timeout",              # handler timeout, not configured to terminate
         "context_overflow",          # request would exceed context window
         "provider_error",            # transport / API failure after retries
+        "give_up",                   # caller-supplied should_continue returned False
     ]
     iterations: int
     total_cost_usd: float
@@ -461,5 +493,6 @@ class ToolLoopResult:
         "tool_timeout",
         "context_overflow",
         "provider_error",
+        "give_up",
     ]
     error_message: str | None = None


### PR DESCRIPTION
ToolUseLoop gains a ``should_continue: Callable[[], bool]`` kwarg evaluated at the top of each iteration. Returning False terminates the loop cleanly with ``terminated_by="give_up"`` — useful for any consumer that wants to short-circuit on a caller-side signal (e.g. candidate-diversity collapse, redundancy detection, external abort).

A predicate that raises is treated as "keep going" so a buggy predicate cannot crash a long-running loop. The exception is logged at WARNING with the iteration index and full traceback so the bug is visible — silently swallowing it would be a diagnosis hazard.

``ContextOverflow`` and ``CostBudgetExceeded`` now carry ``messages`` and ``tool_calls_made`` attributes so callers can persist the partial trajectory up to the point of termination. Previously the conversation state was lost when either exception fired — budget-capped runs were effectively invisible. All six raise sites across loop.py pass partial state consistently, including the ``ContextOverflow`` raised from inside ``_truncate_oldest`` (which previously lost ``tool_calls_made`` because the method's signature didn't carry it).

``"give_up"`` added to both ``ToolLoopResult.terminated_by`` and ``LoopTerminated.reason`` ``Literal`` types so type checkers and event subscribers see the new terminal state.

Also fixes the wall-clock monkeypatch in
``test_max_seconds_terminates_pre_flight``. pytest 8+'s string-based ``setattr`` walks the package namespace; ``core.llm.tool_use``'s ``__init__`` does not re-export ``loop`` as an attribute, so the walk failed at ``.loop``. Switching to the imported-module form works on every pytest version.

Five new tests: three for ``should_continue`` (False terminates, predicate exception is non-fatal AND logged via caplog, True is a no-op), one for the partial-state attribute on
``CostBudgetExceeded``, one covering the same contract on ``ContextOverflow`` after a tool call has completed, and one asserting the give-up event surfaces on the structured event stream. 1525 ``core/llm/`` tests pass; the suite previously had one failure on pytest 9 which this PR also fixes.