### PR TITLE
feat(sandbox): netns coordinator + target_run profile for paired-process isolation

### DIFF
--- a/core/sandbox/_spawn.py
+++ b/core/sandbox/_spawn.py
@@ -989,7 +989,16 @@ def run_sandboxed(
             # Step 3: create namespaces. Leaves us as "nobody" in the
             # new user-ns until the parent runs newuidmap on us.
             ns_flags = CLONE_NEWUSER | CLONE_NEWNS | CLONE_NEWIPC
-            if block_network:
+            if block_network and not inherit_netns:
+                # Only unshare a fresh net-ns when:
+                #  - block_network is set, AND
+                #  - we weren't told to INHERIT the parent's netns
+                #    (inherit_netns=True from the coordinator pattern in
+                #    core/sandbox/netns_coordinator.py: children are
+                #    forked from a process already inside a shared
+                #    isolated netns, so they get there by inheritance;
+                #    a fresh unshare would land them in a new private
+                #    netns instead of the shared one).
                 ns_flags |= CLONE_NEWNET
             if persona is not None:
                 # Fresh UTS namespace so sethostname/setdomainname only

--- a/core/sandbox/context.py
+++ b/core/sandbox/context.py
@@ -1421,7 +1421,17 @@ def sandbox(block_network=_UNSET, target: str = None, output: str = None,
                            "--user", "--fork", "--ipc"]
             if not _skip_pid_ns:
                 unshare_cmd.append("--pid")
-            if block_network:
+            # inherit_netns=True: caller (typically netns_coordinator) has
+            # already set up the netns this process is in and forks MUST
+            # inherit it rather than creating fresh ones. Skip --net so
+            # the unshare CLI doesn't pull the child into a new private
+            # netns. block_network's "no host network" intent is honoured
+            # by the inherited netns being a private one set up by the
+            # coordinator. Without this gate, the Landlock-only fallback
+            # path (used when mount-ns is unavailable, e.g. an
+            # LSM-confined coordinator) would defeat the coordinator's
+            # shared-netns design.
+            if block_network and not _inherit_netns:
                 unshare_cmd.append("--net")
             # Belt-and-braces orphan teardown: if `unshare` is killed
             # directly (orchestrator still alive), --kill-child SIGKILLs the

--- a/core/sandbox/helpers/.gitignore
+++ b/core/sandbox/helpers/.gitignore
@@ -1,0 +1,1 @@
+raptor-coord-launcher

--- a/core/sandbox/helpers/Makefile
+++ b/core/sandbox/helpers/Makefile
@@ -1,0 +1,135 @@
+# Makefile for RAPTOR's privileged sandbox helpers.
+#
+# Targets:
+#   raptor-coord-launcher — privileged bootstrap for the netns
+#       coordinator. Used by core/sandbox/netns_coordinator.py when an
+#       unprivileged unshare(NEWUSER|NEWNET) is blocked by the host's LSM.
+#
+# Operator workflow:
+#   1. make                         # builds the helper in place
+#   2. Pick the grant for your distro and install the matching template
+#      (see `make help`). The helper lives at its build location —
+#      core/sandbox/helpers/raptor-coord-launcher — and stays there.
+#      core/sandbox/netns_coordinator.py resolves the binary against
+#      its own checkout, so each RAPTOR clone has its own helper.
+#
+# There is no `make install` and never will be. RAPTOR does not, and must
+# not, auto-elevate during a build — the operator's grant of LSM or file
+# capabilities is the explicit consent step, and it can't move into a
+# Makefile target without weakening the trust model.
+
+.PHONY: all help clean check
+
+CC ?= cc
+
+# Safety-critical compile + link flags. These define the hardening contract
+# of each helper and MUST be applied. Appended AFTER the operator's
+# CFLAGS/LDFLAGS so that overrides (e.g. CFLAGS=-O0,
+# CFLAGS=-fno-stack-protector) cannot strip the hardening — gcc resolves
+# conflicting flags left-to-right with last-write-wins.
+SAFETY_CFLAGS  = -O2 -std=c11 -Wall -Wextra -Werror -Wshadow -Wformat=2 \
+                 -Wformat-security -Wstrict-prototypes \
+                 -Wmissing-prototypes -fstack-protector-strong -fPIE \
+                 -D_FORTIFY_SOURCE=2
+SAFETY_LDFLAGS = -pie -Wl,-z,now -Wl,-z,relro -Wl,-z,noexecstack
+
+CFLAGS  ?=
+LDFLAGS ?=
+
+COORD_BIN    := raptor-coord-launcher
+COORD_SRC    := raptor-coord-launcher.c
+
+all: $(COORD_BIN)
+
+$(COORD_BIN): $(COORD_SRC)
+	$(CC) $(CFLAGS) $(SAFETY_CFLAGS) $(LDFLAGS) $(SAFETY_LDFLAGS) -o $@ $<
+	@echo
+	@echo "  Built: $$(realpath $@)"
+	@echo
+	@echo "  This is the COORDINATOR LAUNCHER. The Python side resolves"
+	@echo "  it against this checkout's path; leave it here."
+	@echo
+	@echo "  Pick the grant for your distro:"
+	@echo
+	@echo "  Ubuntu 24.04+ (sysctl=1 default, AppArmor confinement):"
+	@echo "      sudo cp raptor-coord-launcher.apparmor \\"
+	@echo "             /etc/apparmor.d/raptor-coord-launcher"
+	@echo "      sudo apparmor_parser -r /etc/apparmor.d/raptor-coord-launcher"
+	@echo
+	@echo "  RHEL with hardened SELinux:"
+	@echo "      # Customise raptor-coord-launcher.selinux.te first."
+	@echo "      make -f /usr/share/selinux/devel/Makefile raptor-coord-launcher.pp"
+	@echo "      sudo semodule -i raptor-coord-launcher.pp"
+	@echo "      sudo chcon -t raptor_coord_launcher_exec_t $$(realpath $@)"
+	@echo
+	@echo "  Debian / older Ubuntu (unprivileged_userns_clone=0):"
+	@echo "      sudo setcap cap_net_admin,cap_sys_admin+ep $$(realpath $@)"
+	@echo
+	@echo "  Easiest (if your admin agrees to relax system hardening):"
+	@echo "      echo 'kernel.apparmor_restrict_unprivileged_userns=0' \\"
+	@echo "          | sudo tee /etc/sysctl.d/99-raptor.conf"
+	@echo "      sudo sysctl --system"
+	@echo "      (no per-binary grant needed; coord.py uses direct unshare)"
+	@echo
+
+# Informational target. We never auto-grant anything.
+help:
+	@echo
+	@echo "  RAPTOR sandbox helpers — operator setup guide"
+	@echo "  ============================================="
+	@echo
+	@echo "  The netns coordinator puts two sibling-sandboxed processes"
+	@echo "  in the same isolated netns so they can talk on 127.0.0.1"
+	@echo "  while the host's network stack stays untouched. On hosts where"
+	@echo "  unprivileged userns is permitted (sysctl=0), the Python"
+	@echo "  coordinator does this directly. On hardened hosts the"
+	@echo "  coordinator delegates to this directory's launcher binary"
+	@echo "  which must hold an LSM grant matching the distro's"
+	@echo "  hardening mechanism. Pick ONE of:"
+	@echo
+	@echo "  (1) Disable the system-wide restriction (Ubuntu 24.04+):"
+	@echo "      sudo sysctl kernel.apparmor_restrict_unprivileged_userns=0"
+	@echo "      Persist:"
+	@echo "        echo 'kernel.apparmor_restrict_unprivileged_userns=0' \\"
+	@echo "          | sudo tee /etc/sysctl.d/99-raptor.conf"
+	@echo
+	@echo "  (2) Install the AppArmor profile (Ubuntu hardened):"
+	@echo "      sudo cp raptor-coord-launcher.apparmor \\"
+	@echo "             /etc/apparmor.d/raptor-coord-launcher"
+	@echo "      sudo apparmor_parser -r /etc/apparmor.d/raptor-coord-launcher"
+	@echo "      (Edit the .apparmor file's path glob if your checkout"
+	@echo "       is somewhere other than /home/<user>/raptor/.)"
+	@echo
+	@echo "  (3) Apply file capabilities (Debian / older Ubuntu / etc.):"
+	@echo "      sudo setcap cap_net_admin,cap_sys_admin+ep \\"
+	@echo "          $$(realpath $(COORD_BIN) 2>/dev/null || echo $(COORD_BIN))"
+	@echo
+	@echo "  (4) Install SELinux policy module (RHEL hardened):"
+	@echo "      See raptor-coord-launcher.selinux.te — UNVALIDATED"
+	@echo "      template; customise to your local policy."
+	@echo
+	@echo "  Validate (after picking ONE):"
+	@echo "      $$(realpath $(COORD_BIN) 2>/dev/null || echo $(COORD_BIN)) \\"
+	@echo "          /usr/bin/python3 -c 'print(\"ok\")'"
+	@echo "      (should print 'ok' with no errors)"
+	@echo
+
+# Capability inspection. Doesn't validate apparmor or selinux state.
+check:
+	@if [ -e $(COORD_BIN) ]; then \
+	    if command -v getcap >/dev/null 2>&1; then \
+	        caps="$$(getcap $(COORD_BIN) 2>/dev/null || true)"; \
+	        if [ -n "$$caps" ]; then echo "  $(COORD_BIN): $$caps"; \
+	        else echo "  $(COORD_BIN): no file capabilities"; fi; \
+	    fi; \
+	    if command -v aa-status >/dev/null 2>&1; then \
+	        sudo -n aa-status 2>/dev/null | grep raptor-coord-launcher \
+	            && echo "  AppArmor profile: loaded" \
+	            || echo "  AppArmor profile: not loaded (or no sudo)"; \
+	    fi; \
+	else \
+	    echo "  $(COORD_BIN): not built. Run 'make' first."; \
+	fi
+
+clean:
+	rm -f $(COORD_BIN)

--- a/core/sandbox/helpers/raptor-coord-launcher.apparmor
+++ b/core/sandbox/helpers/raptor-coord-launcher.apparmor
@@ -1,0 +1,56 @@
+# AppArmor profile for the RAPTOR coordinator launcher.
+#
+# When to install this:
+#   On Ubuntu 24.04+ (and other AppArmor distros where
+#   kernel.apparmor_restrict_unprivileged_userns=1 is set), creating an
+#   unprivileged user namespace auto-transitions the creating process to
+#   the global `unprivileged_userns` AppArmor profile, which has
+#   `audit deny capability`. That blocks the launcher from writing
+#   /proc/self/uid_map, so namespace setup fails with EPERM.
+#
+#   This named profile, attached to the launcher's specific binary path,
+#   OVERRIDES the auto-transition. Inside the new user-ns the launcher
+#   gets `allow capability` (mirrors how bwrap works — see
+#   /etc/apparmor.d/bwrap-userns-restrict). The launcher does its three
+#   privileged syscalls + id-map writes, drops every capability, and execs
+#   the coordinator (Python). Children execed by the coordinator stack
+#   against this profile via the `pix` rule but get no capabilities
+#   themselves — they can't abuse the userns to escape.
+#
+# Install (one-time, operator-explicit):
+#   sudo cp raptor-coord-launcher.apparmor \
+#       /etc/apparmor.d/raptor-coord-launcher
+#   sudo apparmor_parser -r /etc/apparmor.d/raptor-coord-launcher
+#
+# Verify:
+#   sudo aa-status | grep raptor-coord-launcher
+#   /path/to/raptor/core/sandbox/helpers/raptor-coord-launcher /usr/bin/true
+#   (no error == profile attaches correctly)
+#
+# IMPORTANT: the path below must match the absolute path of your RAPTOR
+# checkout's raptor-coord-launcher binary. Edit this line if your checkout
+# is somewhere other than /home/raptor/raptor — apparmor profiles match by
+# absolute binary path, not by content hash.
+
+abi <abi/5.0>,
+include <tunables/global>
+
+profile raptor-coord-launcher
+    /**/core/sandbox/helpers/raptor-coord-launcher
+    flags=(attach_disconnected,mediate_deleted) {
+  allow capability,
+  allow file rwlkm /{**,},
+  allow network,
+  allow unix,
+  allow signal,
+  allow userns,
+
+  # Children stack against this profile when they exec. They keep userns
+  # access (so the coordinator can fork sandbox children that join the
+  # shared netns by inheritance) but their own seccomp + Landlock posture
+  # is applied separately by sandbox.run.
+  allow pix /** -> &raptor-coord-launcher,
+
+  # Site-specific additions and overrides.
+  include if exists <local/raptor-coord-launcher>
+}

--- a/core/sandbox/helpers/raptor-coord-launcher.c
+++ b/core/sandbox/helpers/raptor-coord-launcher.c
@@ -1,0 +1,220 @@
+/* raptor-coord-launcher — privileged bootstrap for the netns coordinator.
+ *
+ * Used by core/sandbox/netns_coordinator.py when an unprivileged
+ * unshare(CLONE_NEWUSER|CLONE_NEWNET) is blocked by the host's LSM
+ * (AppArmor's unprivileged_userns profile on Ubuntu 24.04+; SELinux policy
+ * on hardened RHEL; or a sysctl pinning of kernel.unprivileged_userns_clone=0
+ * on older Debian-family hosts).
+ *
+ * Threat model. The launcher performs a small, fixed privileged window:
+ *   1. close inherited fds beyond 2  (defence-in-depth)
+ *   2. unshare(CLONE_NEWUSER | CLONE_NEWNET)
+ *   3. write /proc/self/uid_map ("0 EUID 1"), setgroups ("deny"), gid_map
+ *   4. ioctl(SIOCSIFFLAGS, lo, IFF_UP | IFF_LOOPBACK | IFF_RUNNING)
+ *   5. capset(empty)  -- drops every capability
+ *   6. setenv(RAPTOR_COORD_FROM_LAUNCHER=1)  -- signal to coord.py
+ *   7. execve(argv[1], &argv[1]) -- coordinator (Python interpreter + script)
+ *
+ * After step 5 the process has no caps in its parent userns; the only
+ * residual privilege is "uid 0 inside the new user-namespace", which only
+ * matters for operations on objects owned by that user-namespace (the
+ * fresh netns and any user-namespace-scoped IPC the coordinator creates).
+ * After step 7 the exec'd interpreter is bounded by AT_SECURE (set because
+ * we had file caps, regardless of whether the operator used setcap or an
+ * LSM grant) which strips LD_PRELOAD / LD_LIBRARY_PATH / etc.
+ *
+ * Operator grant options (the launcher accepts any of these — pick the
+ * one your distro's hardening mechanism uses):
+ *
+ *  - AppArmor (Ubuntu 24.04+): install the named profile at
+ *    core/sandbox/helpers/raptor-coord-launcher.apparmor. Required when
+ *    apparmor_restrict_unprivileged_userns=1 (the Ubuntu default).
+ *
+ *  - File capabilities (other distros): sudo setcap
+ *    cap_net_admin,cap_sys_admin+ep <path>. Required where the host blocks
+ *    unprivileged userns via a different mechanism (e.g. RHEL with custom
+ *    policy, Debian with kernel.unprivileged_userns_clone=0).
+ *
+ *  - SELinux (RHEL hardened): a policy module template lives at
+ *    core/sandbox/helpers/raptor-coord-launcher.selinux.te. Validate on
+ *    your specific corporate policy.
+ *
+ *  - Nothing: works when the operator has set
+ *    kernel.apparmor_restrict_unprivileged_userns=0 (Ubuntu) or the
+ *    distro's equivalent. In that case the coordinator does the unshare
+ *    directly without invoking this launcher at all.
+ *
+ * The launcher binary lives at core/sandbox/helpers/raptor-coord-launcher
+ * and MUST NOT be moved. The lookup contract in netns_coordinator.py is
+ * relative to its own location — each RAPTOR checkout uses its own
+ * launcher binary. Do not copy to /usr/local/bin or symlink.
+ */
+
+#define _GNU_SOURCE
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include <linux/capability.h>
+#include <net/if.h>
+#include <sched.h>
+#include <sys/ioctl.h>
+#include <sys/socket.h>
+#include <sys/syscall.h>
+
+
+static int log_errno(const char *step) {
+    /* stderr is captured by the coordinator process and surfaced to the
+     * operator. Writes happen before exec, before drop, so this is safe. */
+    fprintf(stderr, "raptor-coord-launcher: %s: %s\n", step, strerror(errno));
+    return 1;
+}
+
+
+static void close_inherited_fds(void) {
+    /* The coordinator never passes extra fds to the launcher. Close any
+     * stragglers a buggy caller might have left open so a launcher-side
+     * bug can't read or write through an inherited handle. */
+#ifdef SYS_close_range
+    if (syscall(SYS_close_range, (unsigned int)3, ~(unsigned int)0,
+                (unsigned int)0) == 0) {
+        return;
+    }
+    /* close_range missing (pre-5.9) or refused — fall through. */
+#endif
+    long max_fd = sysconf(_SC_OPEN_MAX);
+    if (max_fd <= 0 || max_fd > 65536) max_fd = 1024;
+    for (long fd = 3; fd < max_fd; fd++) {
+        (void)close((int)fd);
+    }
+}
+
+
+static int write_file(const char *path, const char *content) {
+    int fd = open(path, O_WRONLY);
+    if (fd < 0) return -1;
+    ssize_t n = write(fd, content, strlen(content));
+    int saved = errno;
+    close(fd);
+    errno = saved;
+    return n < 0 ? -1 : 0;
+}
+
+
+/* Caller passes the PRE-unshare euid/egid: after unshare(CLONE_NEWUSER)
+ * we're mapped to the overflow uid (65534) until uid_map is written, and
+ * the single-line bypass rule in user_namespaces(7) wants "the effective
+ * UID of the writing process in the PARENT user namespace" — i.e. our
+ * pre-unshare euid, not the post-unshare overflow. */
+static int write_id_maps(uid_t parent_uid, gid_t parent_gid) {
+    char buf[64];
+
+    int n = snprintf(buf, sizeof buf, "0 %u 1\n", (unsigned)parent_uid);
+    if (n <= 0 || n >= (int)sizeof buf) return -1;
+    if (write_file("/proc/self/uid_map", buf) != 0) return -1;
+
+    /* setgroups must be denied before gid_map can use the single-line
+     * bypass write (without CAP_SETGID). */
+    if (write_file("/proc/self/setgroups", "deny\n") != 0) return -1;
+
+    n = snprintf(buf, sizeof buf, "0 %u 1\n", (unsigned)parent_gid);
+    if (n <= 0 || n >= (int)sizeof buf) return -1;
+    if (write_file("/proc/self/gid_map", buf) != 0) return -1;
+    return 0;
+}
+
+
+static int bring_lo_up(void) {
+    int s = socket(AF_INET, SOCK_DGRAM, 0);
+    if (s < 0) return -1;
+    struct ifreq req;
+    memset(&req, 0, sizeof req);
+    strncpy(req.ifr_name, "lo", IFNAMSIZ - 1);
+    req.ifr_flags = IFF_UP | IFF_LOOPBACK | IFF_RUNNING;
+    int rc = ioctl(s, 0x8914 /* SIOCSIFFLAGS */, &req);
+    int saved = errno;
+    close(s);
+    errno = saved;
+    /* Loopback up enables both 127.0.0.0/8 and ::1/128 — one ioctl
+     * is enough; the flags are interface properties, not protocol
+     * properties. */
+    return rc;
+}
+
+
+static int drop_all_capabilities(void) {
+    /* Raw capset(VERSION_3, all-zero) — clears effective/permitted/
+     * inheritable across all capability bits. Bounding set isn't touched
+     * but is irrelevant: with empty effective+permitted, file caps on the
+     * exec target are the only path to caps in the parent userns, and
+     * the coordinator (a Python script) has no file caps. */
+    struct __user_cap_header_struct hdr;
+    struct __user_cap_data_struct data[2];
+    memset(&hdr, 0, sizeof hdr);
+    memset(data, 0, sizeof data);
+    hdr.version = _LINUX_CAPABILITY_VERSION_3;
+    hdr.pid = 0;
+    return (int)syscall(SYS_capset, &hdr, data);
+}
+
+
+int main(int argc, char **argv) {
+    if (argc < 2) {
+        fprintf(stderr,
+                "raptor-coord-launcher: usage: %s <interpreter> "
+                "[coord.py [args...]]\n"
+                "  Launched by core/sandbox/netns_coordinator.py.\n"
+                "  Not intended for direct invocation.\n",
+                argv[0]);
+        return 2;
+    }
+
+    close_inherited_fds();
+
+    /* Capture parent-userns euid/egid BEFORE unshare. See write_id_maps()
+     * docstring. */
+    uid_t parent_uid = geteuid();
+    gid_t parent_gid = getegid();
+
+    if (unshare(CLONE_NEWUSER | CLONE_NEWNET) != 0) {
+        return log_errno(
+            "unshare(NEWUSER|NEWNET) — host's LSM is blocking userns "
+            "creation by this binary. On Ubuntu install the apparmor "
+            "profile (raptor-coord-launcher.apparmor); on other distros "
+            "ensure setcap cap_net_admin,cap_sys_admin+ep is applied "
+            "OR install the appropriate LSM grant from "
+            "core/sandbox/helpers/");
+    }
+    if (write_id_maps(parent_uid, parent_gid) != 0) {
+        return log_errno(
+            "write_id_maps — typically blocked by an LSM "
+            "(unprivileged_userns apparmor profile, SELinux confinement). "
+            "Install the LSM grant from core/sandbox/helpers/");
+    }
+    if (bring_lo_up() != 0) {
+        return log_errno("bring_lo_up — loopback ifup failed in new netns");
+    }
+    if (drop_all_capabilities() != 0) {
+        return log_errno("capset(empty) — failed to drop caps before exec");
+    }
+
+    /* Signal to the coordinator that its namespaces are already set up
+     * and it must NOT re-do the unshare. */
+    setenv("RAPTOR_COORD_FROM_LAUNCHER", "1", 1);
+
+    /* execve. AT_SECURE will be set (we had file caps) which strips
+     * LD_PRELOAD/LD_LIBRARY_PATH — fine for Python. */
+    execv(argv[1], &argv[1]);
+    /* Show which interpreter we failed to exec — operator's first
+     * question is "which path did you actually try?" and the bare
+     * "execv: <strerror>" wasn't enough to answer that. */
+    fprintf(stderr, "raptor-coord-launcher: execv %s: %s\n",
+            argv[1], strerror(errno));
+    return 1;
+}

--- a/core/sandbox/helpers/raptor-coord-launcher.selinux.te
+++ b/core/sandbox/helpers/raptor-coord-launcher.selinux.te
@@ -1,0 +1,72 @@
+# SELinux policy module template for the RAPTOR coordinator launcher.
+#
+# When to install this:
+#   On RHEL-family hosts with custom SELinux policy that blocks
+#   unprivileged user-namespace creation or related operations
+#   (uid_map writes, setcap operations, network configuration in a fresh
+#   netns). RHEL 8+ default policy allows unprivileged userns; corporate
+#   hardened policies often disallow it.
+#
+# UNVALIDATED — this template documents the SHAPE of the policy module.
+# The exact rules required depend on which corporate hardening is in
+# place. Validate on your target host before relying on it. Common
+# adjustments:
+#   - userns_create permission (RHEL 8.4+): allow userns_create for the
+#     launcher's type
+#   - capability { setuid setgid sys_admin net_admin }: required to
+#     write id maps and bring lo up in the new netns
+#   - allow self proc_security_t : file write : for /proc/self/uid_map,
+#     setgroups, gid_map writes
+#
+# Build + install (one-time, operator-explicit, requires policycoreutils):
+#   sudo dnf install -y policycoreutils-devel
+#   # Customise this .te file for your local policy first
+#   make -f /usr/share/selinux/devel/Makefile raptor-coord-launcher.pp
+#   sudo semodule -i raptor-coord-launcher.pp
+#   # Tag the binary with the new type:
+#   sudo restorecon /path/to/core/sandbox/helpers/raptor-coord-launcher
+#   # Or manually:
+#   sudo chcon -t raptor_coord_launcher_exec_t \
+#       /path/to/core/sandbox/helpers/raptor-coord-launcher
+#
+# Verify:
+#   ls -lZ /path/to/raptor-coord-launcher
+#   # Expected SELinux type: raptor_coord_launcher_exec_t
+
+policy_module(raptor-coord-launcher, 0.1.0)
+
+require {
+    type unconfined_t;
+    type proc_t;
+    type proc_security_t;
+    class file { read write open };
+    class process { setcap fork transition };
+    class capability { setuid setgid sys_admin net_admin };
+    # RHEL 8.4+:
+    # class user_namespace { create };
+}
+
+# The launcher's executable type. Apply via restorecon or chcon.
+type raptor_coord_launcher_t;
+type raptor_coord_launcher_exec_t;
+files_type(raptor_coord_launcher_exec_t)
+
+# Domain transition from unconfined into the launcher's domain.
+domain_auto_trans(unconfined_t, raptor_coord_launcher_exec_t, raptor_coord_launcher_t)
+
+# Privileged operations the launcher needs to perform in its brief window.
+allow raptor_coord_launcher_t self : capability { setuid setgid sys_admin net_admin };
+allow raptor_coord_launcher_t self : process { setcap };
+
+# Write /proc/self/{uid_map,gid_map,setgroups}.
+allow raptor_coord_launcher_t proc_security_t : file { read write open };
+
+# RHEL 8.4+ explicit user-namespace creation permission. Uncomment if
+# present in your policy version:
+# allow raptor_coord_launcher_t self : user_namespace { create };
+
+# After dropping caps + capability bits + LSM-confined permissions, the
+# launcher execve's Python. Add transition rules here for how the
+# coordinator's process should be confined post-exec (recommend: leave
+# unconfined within its new user-namespace and rely on sandbox.run's
+# seccomp+Landlock for the actual sandbox children).

--- a/core/sandbox/netns_coordinator.py
+++ b/core/sandbox/netns_coordinator.py
@@ -1,0 +1,448 @@
+"""Per-run coordinator for paired-process isolation in a shared netns.
+
+Spawned as a subprocess by callers that need two sibling-sandboxed
+processes to share a single isolated user-namespace + network-namespace.
+Reads a JSON request from stdin describing the two commands, sets up the
+shared namespaces, forks both children (each inheriting the shared
+namespaces via the fork), waits for both, writes a JSON response to
+stdout, exits.
+
+Architecture rationale. The naïve substrate — two sandbox.run calls each
+``setns()``-ing into a shared netns fd — has two fundamental problems on
+real Linux hosts:
+
+  1. ``setns(fd, CLONE_NEWNET)`` requires CAP_SYS_ADMIN in the user-ns
+     that owns the netns. An unprivileged sandbox child doesn't have
+     that, so setns silently fails and each sandbox.run creates its own
+     private netns — sharing does not actually happen.
+
+  2. To make setns work the sandbox child needs BOTH a user-ns fd and a
+     net-ns fd, kept open across exec. Those fds are permission tokens —
+     adversarial code in the sandbox could ``setns()`` them to re-enter
+     the shared user-ns and gain caps over the shared netns.
+
+The coordinator pattern avoids both: the two children are FORKS of the
+coordinator, so they inherit the user-ns and net-ns by the kernel's normal
+fork-inheritance mechanism. No setns call, no namespace fd inside the
+sandbox.
+
+Two paths for namespace setup:
+
+  A. Direct unshare from this script. Works on hosts where the operator
+     has disabled the LSM restriction
+     (``kernel.apparmor_restrict_unprivileged_userns=0`` on Ubuntu, or the
+     distro's equivalent). Tried first.
+
+  B. Via the privileged launcher binary at
+     ``core/sandbox/helpers/raptor-coord-launcher``. The launcher creates
+     the namespaces in a brief privileged window, drops every capability,
+     and execs THIS script with ``RAPTOR_COORD_FROM_LAUNCHER=1`` set. The
+     script then proceeds as if it had done the unshare itself.
+
+If both paths fail, the script writes a structured error to stdout and
+exits non-zero. The caller surfaces the message to the operator.
+
+JSON protocol — see ``core/sandbox/_netns_protocol.py``.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+# The coordinator is spawned as a fresh Python interpreter by TcpAdapter
+# (or via the launcher binary which execs us). RAPTOR's Python-path rule:
+# never add anything to sys.path except os.environ["RAPTOR_DIR"], hard
+# lookup so a missing env var fails loudly. Caller (TcpAdapter) is
+# responsible for setting RAPTOR_DIR in the subprocess env.
+sys.path.insert(0, os.environ["RAPTOR_DIR"])
+
+import base64  # noqa: E402
+import ctypes  # noqa: E402
+import ctypes.util  # noqa: E402
+import errno  # noqa: E402
+import fcntl  # noqa: E402
+import json  # noqa: E402
+import socket  # noqa: E402
+import struct  # noqa: E402
+import threading  # noqa: E402
+import time  # noqa: E402
+from pathlib import Path  # noqa: E402
+from typing import Any, Dict, Optional  # noqa: E402
+
+CLONE_NEWUSER = 0x10000000
+CLONE_NEWNET = 0x40000000
+
+HELPER_PATH = (
+    Path(__file__).resolve().parent / "helpers" / "raptor-coord-launcher"
+)
+
+
+# ----------------------------------------------------------------------
+# Namespace setup
+# ----------------------------------------------------------------------
+
+
+def _bring_lo_up() -> None:
+    """SIOCSIFFLAGS to set IFF_UP on the loopback inside the current netns.
+    Same kernel ABI as the C launcher; needed when we're on the direct path
+    (the launcher does it itself when used)."""
+    SIOCSIFFLAGS = 0x8914
+    IFF_UP, IFF_LOOPBACK, IFF_RUNNING = 0x1, 0x8, 0x40
+    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    try:
+        ifr = b"lo".ljust(16, b"\x00") + struct.pack(
+            "h", IFF_UP | IFF_LOOPBACK | IFF_RUNNING
+        )
+        fcntl.ioctl(s, SIOCSIFFLAGS, ifr)
+    finally:
+        s.close()
+
+
+def _setup_direct() -> None:
+    """Try to set up shared user-ns + net-ns ourselves. Raises OSError on
+    LSM rejection (typical: EPERM writing uid_map under AppArmor's
+    unprivileged_userns confinement)."""
+    libc = ctypes.CDLL(ctypes.util.find_library("c"), use_errno=True)
+    # Capture pre-unshare euid/egid. After unshare(CLONE_NEWUSER) we appear
+    # as the overflow uid (65534) inside the new user-ns until uid_map is
+    # written, and the single-line bypass write in user_namespaces(7)
+    # requires "the effective UID of the writing process in the PARENT
+    # user-namespace" — i.e. our pre-unshare euid.
+    parent_uid = os.geteuid()
+    parent_gid = os.getegid()
+    if libc.unshare(CLONE_NEWUSER | CLONE_NEWNET) != 0:
+        err = ctypes.get_errno()
+        raise OSError(err, os.strerror(err), "unshare(NEWUSER|NEWNET)")
+    with open("/proc/self/uid_map", "w") as f:
+        f.write(f"0 {parent_uid} 1\n")
+    with open("/proc/self/setgroups", "w") as f:
+        f.write("deny\n")
+    with open("/proc/self/gid_map", "w") as f:
+        f.write(f"0 {parent_gid} 1\n")
+    _bring_lo_up()
+
+
+def _setup_via_launcher_reexec() -> None:
+    """Re-exec ourselves through the privileged launcher binary. The
+    launcher does the namespace setup that the direct path couldn't, then
+    execs us back with RAPTOR_COORD_FROM_LAUNCHER=1. This function does
+    not return — execv replaces the process image."""
+    if not HELPER_PATH.exists():
+        _emit_error(
+            "namespace_setup_failed",
+            (
+                "direct unshare failed AND the launcher binary is not built. "
+                f"Build it: cd {HELPER_PATH.parent} && make. "
+                "Then grant ONE of: AppArmor profile (Ubuntu hardened), "
+                "setcap (Debian/older Ubuntu), or SELinux module (RHEL "
+                "hardened) — see core/sandbox/helpers/ for templates."
+            ),
+        )
+        sys.exit(2)
+    # Avoid an infinite re-exec loop if the launcher fails to set the
+    # sentinel before exec'ing us back.
+    if os.environ.get("RAPTOR_COORD_REEXEC_GUARD") == "1":
+        _emit_error(
+            "namespace_setup_failed",
+            (
+                "launcher execv'd us back without "
+                "RAPTOR_COORD_FROM_LAUNCHER=1 — the launcher's privileged "
+                "setup did not complete. Check the launcher's stderr for "
+                "the actual reason (typically an LSM block on uid_map "
+                "write)."
+            ),
+        )
+        sys.exit(2)
+    env = dict(os.environ)
+    env["RAPTOR_COORD_REEXEC_GUARD"] = "1"
+    os.execve(
+        str(HELPER_PATH),
+        [str(HELPER_PATH), sys.executable, __file__],
+        env,
+    )
+
+
+def _setup_namespaces() -> str:
+    """Set up the shared user-ns + net-ns. Returns a label describing
+    which path was taken ("via_launcher" or "direct_unshare"). On failure,
+    writes an error response and exits.
+
+    Path priority: launcher first when built, direct second.
+
+    Why launcher-first: a failed direct attempt under an LSM-hardened
+    host succeeds at the unshare(CLONE_NEWUSER) step (creating a new
+    user-ns) and fails at the uid_map write — leaving us in the new
+    user-ns and auto-confined to the global ``unprivileged_userns``
+    AppArmor profile. From that confined state, execv'ing the launcher
+    does NOT transition us to the launcher's named profile (LSM
+    transitions are unconfined→named, not confined→named), so the
+    launcher inherits the same restrictive confinement and can't do its
+    privileged setup either. Net effect: trying direct first POISONS
+    the fallback. Going via launcher first sidesteps this entirely.
+
+    On hosts with no LSM restriction (e.g. operator set sysctl=0): if
+    the launcher is built we still go through it (one extra exec, no
+    correctness difference). If no launcher exists, direct works fine.
+    """
+    if os.environ.get("RAPTOR_COORD_FROM_LAUNCHER") == "1":
+        # Launcher already did the setup.
+        return "via_launcher"
+
+    if HELPER_PATH.exists():
+        # This call does not return — execv replaces the process image.
+        _setup_via_launcher_reexec()
+
+    # No launcher built. Try direct as the only remaining option.
+    try:
+        _setup_direct()
+        return "direct_unshare"
+    except OSError as exc:
+        if exc.errno in (errno.EPERM, errno.EACCES):
+            _emit_error(
+                "namespace_setup_failed",
+                (
+                    f"direct unshare blocked by host LSM ({exc}). "
+                    "Build the launcher: cd "
+                    f"{HELPER_PATH.parent} && make. Then grant ONE of: "
+                    "AppArmor profile (Ubuntu hardened), setcap "
+                    "(Debian/older Ubuntu), or SELinux module (RHEL). "
+                    "Templates in core/sandbox/helpers/."
+                ),
+            )
+            sys.exit(2)
+        _emit_error(
+            "namespace_setup_failed",
+            f"direct unshare unexpected error: {exc}",
+        )
+        sys.exit(2)
+
+
+# ----------------------------------------------------------------------
+# Child process management
+# ----------------------------------------------------------------------
+
+
+class _ChildResult:
+    __slots__ = (
+        "returncode", "stdout", "stderr", "wallclock_s",
+        "sandbox_info", "error",
+    )
+
+    def __init__(self) -> None:
+        self.returncode: Optional[int] = None
+        self.stdout: bytes = b""
+        self.stderr: bytes = b""
+        self.wallclock_s: float = 0.0
+        # sandbox_info is the dict produced by observe._interpret_result
+        # — carries the sanitizer marker (from stderr ASan scan), crash
+        # signal, seccomp-killed flag, etc. The witness outcome oracle
+        # reads it to classify the target's execution; without it we'd
+        # collapse every run to NO_OBVIOUS_EFFECT regardless of what
+        # actually happened.
+        self.sandbox_info: Optional[Dict[str, Any]] = None
+        self.error: Optional[str] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "returncode": self.returncode,
+            "stdout_b64": base64.b64encode(self.stdout).decode("ascii"),
+            "stderr_b64": base64.b64encode(self.stderr).decode("ascii"),
+            "wallclock_s": self.wallclock_s,
+            "sandbox_info": self.sandbox_info,
+            "error": self.error,
+        }
+
+
+def _run_child(role: str, spec: Dict[str, Any], result: _ChildResult) -> None:
+    """Run one sandbox.run command as a child of THIS process. The fork
+    inside sandbox.run inherits our user-ns + net-ns, which is the
+    architectural point — target and exploit land in the same netns
+    without setns and without an external fd."""
+    # Import inside the function so a missing import surfaces as a
+    # structured error rather than a hard ImportError at module load time.
+    from core.sandbox import run as sandbox_run
+
+    cmd = spec["cmd"]
+    env = spec.get("env", {})
+    timeout = float(spec.get("timeout_s", 10.0))
+    profile = spec.get("profile", "target_run")
+    block_network = bool(spec.get("block_network", True))
+    allowed_tcp_ports = spec.get("allowed_tcp_ports") or None
+    restrict_reads = bool(spec.get("restrict_reads", False))
+    stdin_b64 = spec.get("stdin_b64")
+    stdin_bytes = base64.b64decode(stdin_b64) if stdin_b64 else None
+
+    t0 = time.monotonic()
+    try:
+        kwargs = dict(
+            profile=profile,
+            block_network=block_network,
+            inherit_netns=True,
+            env=env if env else None,
+            capture_output=True,
+            timeout=timeout,
+            restrict_reads=restrict_reads,
+        )
+        if allowed_tcp_ports is not None:
+            kwargs["allowed_tcp_ports"] = list(allowed_tcp_ports)
+        if stdin_bytes is not None:
+            kwargs["input"] = stdin_bytes
+        r = sandbox_run(cmd, **kwargs)
+        result.returncode = r.returncode
+        result.stdout = r.stdout or b""
+        result.stderr = r.stderr or b""
+        # sandbox_info is attached to the CompletedProcess by
+        # core.sandbox.observe._interpret_result. Coerce to a plain dict
+        # so json.dumps can serialise it — observe attaches a mapping
+        # which may or may not be a plain dict depending on path.
+        info = getattr(r, "sandbox_info", None)
+        if info is not None:
+            try:
+                result.sandbox_info = dict(info)
+            except (TypeError, ValueError):
+                result.sandbox_info = None
+    except Exception as exc:  # noqa: BLE001
+        result.error = f"{type(exc).__name__}: {exc}"
+    finally:
+        result.wallclock_s = time.monotonic() - t0
+
+
+def _wait_listen_port(port: int, timeout: float) -> bool:
+    """Poll /proc/self/net/tcp for ``port`` in TCP_LISTEN state inside the
+    coordinator's netns (which is the same shared netns target binds in,
+    because target is our fork). Non-intrusive — no probe connect, so
+    single-shot accept servers don't get their accept slot consumed."""
+    port_hex = f"{port:04X}"
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            with open("/proc/self/net/tcp", "r") as f:
+                for line in f:
+                    parts = line.split()
+                    if len(parts) < 4:
+                        continue
+                    local = parts[1]
+                    if ":" not in local:
+                        continue
+                    _ip, p_hex = local.rsplit(":", 1)
+                    if p_hex.upper() == port_hex and parts[3] == "0A":
+                        return True
+        except OSError:
+            pass
+        time.sleep(0.02)
+    return False
+
+
+# ----------------------------------------------------------------------
+# Output helpers
+# ----------------------------------------------------------------------
+
+
+def _emit_error(reason: str, message: str) -> None:
+    """Write a single-line error response to stdout. Caller parses it."""
+    json.dump(
+        {
+            "error": {"reason": reason, "message": message},
+            "target": None,
+            "exploit": None,
+            "listen_observed": False,
+        },
+        sys.stdout,
+    )
+    sys.stdout.write("\n")
+    sys.stdout.flush()
+
+
+def _emit_response(response: Dict[str, Any]) -> None:
+    json.dump(response, sys.stdout)
+    sys.stdout.write("\n")
+    sys.stdout.flush()
+
+
+# ----------------------------------------------------------------------
+# Main
+# ----------------------------------------------------------------------
+
+
+def main() -> None:
+    # Order matters: namespace setup BEFORE reading stdin. The setup may
+    # execv to the launcher which re-execs this script. Stdin survives
+    # the execve as the same pipe — but any bytes already read by the
+    # pre-execve Python are GONE. So defer the read until we're in the
+    # final incarnation (either the direct path or the post-launcher
+    # path), where it executes exactly once.
+    ns_path = _setup_namespaces()
+
+    request_raw = sys.stdin.read()
+    try:
+        request = json.loads(request_raw)
+    except json.JSONDecodeError as exc:
+        _emit_error("bad_request", f"could not parse request JSON: {exc}")
+        sys.exit(2)
+
+    # Request validation. Surface protocol violations as structured
+    # errors rather than letting a KeyError / ValueError / AttributeError
+    # propagate as a Python traceback on stderr — the caller parses
+    # stdout as JSON and a traceback there would mask the real issue.
+    if not isinstance(request, dict):
+        _emit_error(
+            "bad_request",
+            f"request must be a JSON object, got {type(request).__name__}",
+        )
+        sys.exit(2)
+    target_spec = request.get("target")
+    exploit_spec = request.get("exploit")
+    if not isinstance(target_spec, dict) or not isinstance(exploit_spec, dict):
+        _emit_error(
+            "bad_request",
+            "request must contain 'target' and 'exploit' objects",
+        )
+        sys.exit(2)
+    try:
+        wait_port = int(request.get("wait_listen_port", 0))
+        wait_timeout = float(request.get("wait_listen_timeout_s", 5.0))
+        target_timeout = float(target_spec.get("timeout_s", 5.0))
+    except (TypeError, ValueError) as exc:
+        _emit_error(
+            "bad_request",
+            f"numeric field in request not coercible: {exc}",
+        )
+        sys.exit(2)
+
+    target_result = _ChildResult()
+    exploit_result = _ChildResult()
+
+    target_thread = threading.Thread(
+        target=_run_child, args=("target", target_spec, target_result),
+        daemon=True,
+    )
+    target_thread.start()
+
+    listen_ok = (
+        _wait_listen_port(wait_port, wait_timeout)
+        if wait_port > 0 else True
+    )
+
+    _run_child("exploit", exploit_spec, exploit_result)
+
+    # Give target a brief window to finish post-exploit (e.g. flush an
+    # ASan report after a crash). It will usually exit on its own once
+    # the exploit closes its socket. ``daemon=True`` on the target
+    # thread means it dies at interpreter exit if the join times out —
+    # but sandbox.run inside the thread holds its own timeout that
+    # SIGKILLs the child subprocess before we get here, so the window
+    # for a leaked subprocess is bounded by ``timeout_s`` + 1.0s.
+    target_thread.join(timeout=target_timeout + 1.0)
+
+    _emit_response({
+        "target": target_result.to_dict(),
+        "exploit": exploit_result.to_dict(),
+        "listen_observed": listen_ok,
+        "namespace_path": ns_path,
+        "error": None,
+    })
+
+
+if __name__ == "__main__":
+    main()

--- a/core/sandbox/profiles.py
+++ b/core/sandbox/profiles.py
@@ -30,6 +30,19 @@ import types
 # strict:       same policy intent as full, but fail-closed if the host cannot
 #               provide the platform isolation backend. On Linux target/output
 #               isolation also requires mount namespaces.
+# target_run:   posture for spawning a harness-authored target binary
+#               that needs to expose a local listener (loopback TCP, UDS,
+#               etc.). Same Landlock + seccomp posture as ``full`` but
+#               ``block_network=False`` so the listener is reachable to
+#               the spawning harness. Callers that want isolation FROM
+#               the host's loopback (not just FROM the wider network)
+#               pair this profile with ``core/sandbox/
+#               netns_coordinator.py`` to put the listener in a shared
+#               isolated net-ns; the coordinator overrides
+#               ``block_network=True`` + ``inherit_netns=True`` per call,
+#               so the profile's loopback setting is irrelevant on that
+#               path. Defence-in-depth still comes from Landlock (caller
+#               passes ``allowed_tcp_ports=[port]`` per call) and seccomp.
 # debug:        full, but seccomp permits ptrace so gdb/rr can trace the
 #               target. Use for /crash-analysis. Target AND debugger run
 #               in the same sandbox — debugger forks target as a descendant
@@ -50,6 +63,7 @@ import types
 PROFILES = types.MappingProxyType({
     "full":         types.MappingProxyType({"block_network": True,  "use_landlock": True,  "seccomp": "full"}),
     "strict":       types.MappingProxyType({"block_network": True,  "use_landlock": True,  "seccomp": "full"}),
+    "target_run":   types.MappingProxyType({"block_network": False, "use_landlock": True,  "seccomp": "full"}),
     "debug":        types.MappingProxyType({"block_network": True,  "use_landlock": True,  "seccomp": "debug"}),
     "frida":        types.MappingProxyType({"block_network": False, "use_landlock": True,  "seccomp": "frida"}),
     "network-only": types.MappingProxyType({"block_network": True,  "use_landlock": False, "seccomp": ""}),

--- a/core/sandbox/tests/test_audit_cli_flags.py
+++ b/core/sandbox/tests/test_audit_cli_flags.py
@@ -231,9 +231,14 @@ class TestProfileSet:
     ``audit-verbose`` are GONE from PROFILES (post-#269 contract)."""
 
     def test_canonical_profiles(self):
+        # target_run was added for harness-spawned target binaries that
+        # need to expose a local listener — named delta on 'full' so
+        # future divergence (loopback access, extra readable paths)
+        # doesn't leak back to the LLM-untrusted profile.
         from core.sandbox.profiles import PROFILES
         assert set(PROFILES) == {
-            "full", "strict", "debug", "frida", "network-only", "none",
+            "full", "strict", "target_run", "debug", "frida",
+            "network-only", "none",
         }
 
     def test_no_audit_mode_field_in_profile_dicts(self):

--- a/core/sandbox/tests/test_coordinator_isolation.py
+++ b/core/sandbox/tests/test_coordinator_isolation.py
@@ -1,0 +1,423 @@
+"""Adversarial escape-attempt tests for the netns_coordinator substrate.
+
+The coordinator's central claim is that target + exploit (forked
+from inside a shared user-ns + net-ns) cannot escape that namespace
+boundary to reach the host's network, the host's user-ns, or any
+other process tree outside the sandbox. These tests drive the
+coordinator with PROBE programs that *attempt* each escape and
+verify the substrate blocks them.
+
+Architecture. We invoke the coordinator via subprocess.Popen with
+the same JSON protocol TcpAdapter uses, but the "target" and
+"exploit" commands are Python probes that try a specific escape.
+Each probe writes a structured marker to stdout — "ESCAPED:<reason>"
+on success (bad), "BLOCKED:<reason>" on the expected refusal (good).
+Tests parse the coordinator's response and assert BLOCKED.
+
+Skipped when the coordinator isn't usable on this host (no
+launcher, no apparmor profile, no sysctl override). The skip is
+explicit so a CI failure here can't be mistaken for the substrate
+being broken — the substrate is fine, the env just doesn't have
+the grant.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import os
+import socket
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+# core/sandbox/tests/test_coordinator_isolation.py
+#   parents[3] = repo root
+REPO = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(REPO))
+os.environ.setdefault("_RAPTOR_TRUSTED", "1")
+
+COORDINATOR = REPO / "core" / "sandbox" / "netns_coordinator.py"
+
+
+# ----------------------------------------------------------------------
+# coordinator-availability probe
+# ----------------------------------------------------------------------
+
+
+def _coordinator_works() -> bool:
+    """Run a trivial echo probe through the coordinator. If we get a
+    well-formed response, the substrate is operational on this host.
+    Caches the result so we don't re-probe per test."""
+    if not COORDINATOR.is_file():
+        return False
+    request = {
+        "target": {
+            "cmd": [sys.executable, "-c", "print('ok')"],
+            "env": {}, "timeout_s": 5.0, "profile": "target_run",
+            "block_network": True, "allowed_tcp_ports": [],
+        },
+        "exploit": {
+            "cmd": [sys.executable, "-c", "pass"],
+            "env": {}, "timeout_s": 5.0, "profile": "target_run",
+            "block_network": True, "allowed_tcp_ports": [],
+        },
+        "wait_listen_port": 0, "wait_listen_timeout_s": 0.1,
+    }
+    env = dict(os.environ)
+    env["RAPTOR_DIR"] = str(REPO)
+    try:
+        p = subprocess.Popen(
+            [sys.executable, str(COORDINATOR)],
+            stdin=subprocess.PIPE, stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE, env=env,
+        )
+        out, _err = p.communicate(
+            json.dumps(request).encode(), timeout=20,
+        )
+        if not out:
+            return False
+        resp = json.loads(out.decode())
+        if resp.get("error"):
+            return False
+        return resp.get("target", {}).get("returncode") == 0
+    except Exception:
+        return False
+
+
+_COORD_OK = _coordinator_works()
+
+pytestmark = pytest.mark.skipif(
+    not _COORD_OK,
+    reason=(
+        "netns_coordinator not operational on this host — needs either "
+        "kernel.apparmor_restrict_unprivileged_userns=0 OR the apparmor "
+        "profile loaded for raptor-coord-launcher (see "
+        "core/sandbox/helpers/raptor-coord-launcher.apparmor)"
+    ),
+)
+
+
+# ----------------------------------------------------------------------
+# probe runner
+# ----------------------------------------------------------------------
+
+
+def _run_probe_via_coordinator(probe_code: str, *, timeout_s: float = 5.0):
+    """Run a Python probe inside the coordinator as the "target", with
+    a no-op exploit. Returns (rc, stdout, stderr) of the probe."""
+    request = {
+        "target": {
+            "cmd": [sys.executable, "-u", "-c", probe_code],
+            "env": {}, "timeout_s": timeout_s, "profile": "target_run",
+            "block_network": True, "allowed_tcp_ports": [],
+        },
+        "exploit": {
+            "cmd": [sys.executable, "-c", "pass"],
+            "env": {}, "timeout_s": 1.0, "profile": "target_run",
+            "block_network": True, "allowed_tcp_ports": [],
+        },
+        "wait_listen_port": 0, "wait_listen_timeout_s": 0.1,
+    }
+    env = dict(os.environ)
+    env["RAPTOR_DIR"] = str(REPO)
+    p = subprocess.Popen(
+        [sys.executable, str(COORDINATOR)],
+        stdin=subprocess.PIPE, stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE, env=env,
+    )
+    out, _err = p.communicate(
+        json.dumps(request).encode(), timeout=timeout_s + 10.0,
+    )
+    resp = json.loads(out.decode())
+    if resp.get("error"):
+        pytest.fail(
+            f"coordinator error: {resp['error']}; stderr={_err.decode()[:200]}"
+        )
+    t = resp["target"]
+    return (
+        t.get("returncode"),
+        base64.b64decode(t["stdout_b64"]).decode("utf-8", "replace"),
+        base64.b64decode(t["stderr_b64"]).decode("utf-8", "replace"),
+    )
+
+
+# ----------------------------------------------------------------------
+# probes
+# ----------------------------------------------------------------------
+
+
+def test_cannot_reach_host_loopback_service():
+    """Bind a TCP listener on the HOST's 127.0.0.1, then have the
+    probe try to connect to it. If the netns is shared with the host,
+    the connect succeeds (bad — escape). With proper isolation, the
+    probe is in a different loopback namespace and the connect fails
+    with ECONNREFUSED or similar.
+
+    This is the strongest single-test isolation check: it proves the
+    sandboxed child's loopback IS NOT the host's loopback."""
+    host_listener = socket.socket()
+    host_listener.bind(("127.0.0.1", 0))
+    host_listener.listen(1)
+    port = host_listener.getsockname()[1]
+    try:
+        probe = (
+            "import socket, sys\n"
+            f"s = socket.socket(); s.settimeout(1.5)\n"
+            f"try:\n"
+            f"    s.connect(('127.0.0.1', {port}))\n"
+            f"    print('ESCAPED: reached host loopback')\n"
+            f"except Exception as e:\n"
+            f"    print(f'BLOCKED: {{type(e).__name__}}: {{e}}')\n"
+        )
+        rc, stdout, _ = _run_probe_via_coordinator(probe)
+    finally:
+        host_listener.close()
+    assert "ESCAPED" not in stdout, (
+        f"sandboxed child reached host's loopback (port {port}) — "
+        f"netns is not isolated. stdout={stdout!r}"
+    )
+    assert "BLOCKED" in stdout, f"unexpected stdout: {stdout!r}"
+    assert rc == 0, f"probe didn't exit cleanly: rc={rc}"
+
+
+def test_cannot_reach_external_internet():
+    """8.8.8.8:53 is publicly reachable from any unfirewalled host.
+    The sandboxed child is in a private netns with only loopback up;
+    any external connect attempt should fail at the network layer
+    (no route to host, no interface to send on)."""
+    probe = (
+        "import socket\n"
+        "s = socket.socket(); s.settimeout(1.5)\n"
+        "try:\n"
+        "    s.connect(('8.8.8.8', 53))\n"
+        "    print('ESCAPED: reached public internet')\n"
+        "except Exception as e:\n"
+        "    print(f'BLOCKED: {type(e).__name__}: {e}')\n"
+    )
+    rc, stdout, _ = _run_probe_via_coordinator(probe)
+    assert "ESCAPED" not in stdout, (
+        f"sandboxed child reached 8.8.8.8 — netns has host network access. "
+        f"stdout={stdout!r}"
+    )
+    assert "BLOCKED" in stdout, f"unexpected stdout: {stdout!r}"
+
+
+def test_cannot_unshare_into_fresh_netns():
+    """The sandboxed child has no host CAP_SYS_ADMIN, so a bare
+    unshare(CLONE_NEWNET) should fail with EPERM. (It's in a user-ns
+    where it's root, but the unshare check happens against the
+    OWNING user-ns, not the current — and the child user-ns doesn't
+    own anything that lets it create new netns.)"""
+    probe = (
+        "import ctypes, ctypes.util\n"
+        "libc = ctypes.CDLL(ctypes.util.find_library('c'), use_errno=True)\n"
+        "CLONE_NEWNET = 0x40000000\n"
+        "rc = libc.unshare(CLONE_NEWNET)\n"
+        "if rc == 0:\n"
+        "    print('ESCAPED: unshare(NEWNET) succeeded')\n"
+        "else:\n"
+        "    print(f'BLOCKED: unshare errno={ctypes.get_errno()}')\n"
+    )
+    rc, stdout, _ = _run_probe_via_coordinator(probe)
+    # If unshare succeeded (ESCAPED), the child carved a fresh netns
+    # which by itself isn't a host-network escape — but it shows the
+    # caps gate isn't holding. Either result is observable; we
+    # require the explicit BLOCKED.
+    assert "ESCAPED" not in stdout, (
+        f"sandboxed child unshared a new netns — CAP_SYS_ADMIN guard "
+        f"isn't blocking. stdout={stdout!r}"
+    )
+
+
+def test_cannot_setns_into_host_netns():
+    """The host's netns is identified by its inode in
+    /proc/1/ns/net. Try to open it (likely ENOENT — different
+    pid-ns hides /proc/1) and setns into it (definitely EPERM —
+    needs caps in the host user-ns)."""
+    probe = (
+        "import ctypes, ctypes.util, os\n"
+        "libc = ctypes.CDLL(ctypes.util.find_library('c'), use_errno=True)\n"
+        "CLONE_NEWNET = 0x40000000\n"
+        "try:\n"
+        "    fd = os.open('/proc/1/ns/net', os.O_RDONLY)\n"
+        "except OSError as e:\n"
+        "    print(f'BLOCKED: cannot open /proc/1/ns/net: {e}')\n"
+        "else:\n"
+        "    rc = libc.setns(fd, CLONE_NEWNET)\n"
+        "    os.close(fd)\n"
+        "    if rc == 0:\n"
+        "        print('ESCAPED: setns(host_netns) succeeded')\n"
+        "    else:\n"
+        "        print(f'BLOCKED: setns errno={ctypes.get_errno()}')\n"
+    )
+    rc, stdout, _ = _run_probe_via_coordinator(probe)
+    assert "ESCAPED" not in stdout, (
+        f"sandboxed child setns'd into host netns — capability gate "
+        f"isn't holding. stdout={stdout!r}"
+    )
+    assert "BLOCKED" in stdout, f"unexpected stdout: {stdout!r}"
+
+
+def test_cannot_open_raw_socket():
+    """Raw sockets need CAP_NET_RAW. The probe should get EPERM."""
+    probe = (
+        "import socket\n"
+        "try:\n"
+        "    s = socket.socket(socket.AF_INET, socket.SOCK_RAW, socket.IPPROTO_TCP)\n"
+        "    print('ESCAPED: opened raw socket')\n"
+        "    s.close()\n"
+        "except PermissionError as e:\n"
+        "    print(f'BLOCKED: PermissionError: {e}')\n"
+        "except OSError as e:\n"
+        "    print(f'BLOCKED: OSError: {e}')\n"
+    )
+    rc, stdout, _ = _run_probe_via_coordinator(probe)
+    assert "ESCAPED" not in stdout, (
+        f"sandboxed child opened a raw socket — CAP_NET_RAW guard "
+        f"isn't holding. stdout={stdout!r}"
+    )
+    assert "BLOCKED" in stdout, f"unexpected stdout: {stdout!r}"
+
+
+def test_only_loopback_interface_visible():
+    """The shared netns should expose ONLY the loopback interface.
+    /proc/self/net/dev lists kernel interfaces visible to this
+    netns. Any non-`lo` line means the netns has unexpected
+    interfaces (which would be a real network-layer escape vector)."""
+    probe = (
+        "import re\n"
+        "with open('/proc/self/net/dev') as f:\n"
+        "    lines = f.read().splitlines()\n"
+        "# header is 2 lines, then one line per interface like '  lo:  bytes...'\n"
+        "ifaces = []\n"
+        "for line in lines[2:]:\n"
+        "    m = re.match(r'\\s*(\\S+):', line)\n"
+        "    if m:\n"
+        "        ifaces.append(m.group(1))\n"
+        "if set(ifaces) == {'lo'}:\n"
+        "    print('BLOCKED: only loopback visible')\n"
+        "else:\n"
+        "    print(f'ESCAPED: extra interfaces visible: {ifaces}')\n"
+    )
+    rc, stdout, _ = _run_probe_via_coordinator(probe)
+    assert "ESCAPED" not in stdout, (
+        f"sandboxed child sees non-loopback interfaces — netns has "
+        f"unexpected device access. stdout={stdout!r}"
+    )
+    assert "BLOCKED" in stdout
+
+
+def test_target_and_exploit_share_same_netns():
+    """Sibling check: the substrate's whole point is target + exploit
+    in the SAME shared netns (so they can talk on 127.0.0.1). Verify
+    by running both as probes that print their /proc/self/ns/net
+    inode and asserting they match — AND that the inode differs from
+    the host's."""
+    probe_print_ns = (
+        "import os\n"
+        "print(os.readlink('/proc/self/ns/net'))\n"
+    )
+    request = {
+        "target": {
+            "cmd": [sys.executable, "-c", probe_print_ns],
+            "env": {}, "timeout_s": 5.0, "profile": "target_run",
+            "block_network": True, "allowed_tcp_ports": [],
+        },
+        "exploit": {
+            "cmd": [sys.executable, "-c", probe_print_ns],
+            "env": {}, "timeout_s": 5.0, "profile": "target_run",
+            "block_network": True, "allowed_tcp_ports": [],
+        },
+        "wait_listen_port": 0, "wait_listen_timeout_s": 0.1,
+    }
+    env = dict(os.environ)
+    env["RAPTOR_DIR"] = str(REPO)
+    p = subprocess.Popen(
+        [sys.executable, str(COORDINATOR)],
+        stdin=subprocess.PIPE, stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE, env=env,
+    )
+    out, _err = p.communicate(json.dumps(request).encode(), timeout=20)
+    resp = json.loads(out.decode())
+    target_ns = base64.b64decode(resp["target"]["stdout_b64"]).decode().strip()
+    exploit_ns = base64.b64decode(resp["exploit"]["stdout_b64"]).decode().strip()
+    host_ns = os.readlink("/proc/self/ns/net")
+    assert target_ns == exploit_ns, (
+        f"target and exploit in different netns — substrate broken. "
+        f"target={target_ns!r} exploit={exploit_ns!r}"
+    )
+    assert target_ns != host_ns, (
+        f"target+exploit are in HOST's netns — substrate broken. "
+        f"target={target_ns!r} host={host_ns!r}"
+    )
+
+
+# ----------------------------------------------------------------------
+# Protocol robustness — malformed requests get structured errors, not
+# Python tracebacks on stderr. A traceback on stderr while stdout is
+# empty would leave callers blocked on stdout.read() then parsing
+# "" as JSON; the structured-error contract is the only safe shape.
+# ----------------------------------------------------------------------
+
+
+def _drive_coordinator(payload: bytes) -> dict:
+    """Send raw bytes (not necessarily valid JSON) to the coordinator
+    and return its parsed stdout response."""
+    env = dict(os.environ)
+    env["RAPTOR_DIR"] = str(REPO)
+    p = subprocess.Popen(
+        [sys.executable, str(COORDINATOR)],
+        stdin=subprocess.PIPE, stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE, env=env,
+    )
+    out, _err = p.communicate(payload, timeout=10)
+    return json.loads(out.decode())
+
+
+def test_malformed_json_request_returns_structured_error():
+    """Non-JSON on stdin must produce a JSON error object on stdout
+    with reason='bad_request' — not a Python traceback on stderr that
+    would leave the parent process waiting on an empty stdout."""
+    resp = _drive_coordinator(b"this is not json at all\n")
+    assert resp.get("error", {}).get("reason") == "bad_request", resp
+    assert "parse" in resp["error"]["message"].lower()
+
+
+def test_missing_target_key_returns_structured_error():
+    """Request missing the 'target' key triggers the schema check,
+    not a KeyError traceback."""
+    resp = _drive_coordinator(json.dumps({
+        "exploit": {"cmd": ["/bin/true"]},
+    }).encode())
+    assert resp.get("error", {}).get("reason") == "bad_request", resp
+    assert "target" in resp["error"]["message"]
+
+
+def test_missing_exploit_key_returns_structured_error():
+    """Symmetric to the above for the 'exploit' key."""
+    resp = _drive_coordinator(json.dumps({
+        "target": {"cmd": ["/bin/true"]},
+    }).encode())
+    assert resp.get("error", {}).get("reason") == "bad_request", resp
+
+
+def test_non_numeric_wait_listen_port_returns_structured_error():
+    """``int("xyz")`` would raise ValueError mid-handler; the coord
+    must validate numerics up front and surface them as bad_request."""
+    resp = _drive_coordinator(json.dumps({
+        "target": {"cmd": ["/bin/true"]},
+        "exploit": {"cmd": ["/bin/true"]},
+        "wait_listen_port": "not_a_number",
+    }).encode())
+    assert resp.get("error", {}).get("reason") == "bad_request", resp
+
+
+def test_request_top_level_not_object_returns_structured_error():
+    """A bare JSON array or scalar must not slip past — accessing
+    ``.get`` on a list raises AttributeError."""
+    resp = _drive_coordinator(b"[]\n")
+    assert resp.get("error", {}).get("reason") == "bad_request", resp
+    assert "object" in resp["error"]["message"]


### PR DESCRIPTION
Adds a sandbox substrate for running two sibling-sandboxed processes in a shared isolated user-ns + net-ns. Useful for any tooling that needs to test client-server pairs without exposing them to the host network stack (paired fuzzers, gdb client-server, localhost-probing harnesses).

core/sandbox/netns_coordinator.py (new): spawned as a subprocess, sets up a fresh shared user-ns + net-ns, forks two children which INHERIT the namespaces (not setns — see docstring §"Architecture rationale" for why fork-inheritance avoids two fundamental problems of fd-based sharing: setns requires CAP_SYS_ADMIN that an unprivileged sandbox child doesn't have, and the fd inside the sandbox is a permission token an adversary could re-use to re-enter the shared user-ns). RPC over stdin/stdout — request/response JSON — keeps namespace plumbing out of the parent process. sandbox_info from each child flows through the protocol so the witness-outcome oracle still sees ASan / signal / seccomp markers.

Malformed requests get a structured ``bad_request`` error on stdout (missing keys, non-dict request, non-numeric port). Without this, a Python traceback would land on stderr while stdout stayed empty — the caller would block on stdout.read() then fail JSON-parsing an empty string. All five malformed-request shapes are covered by tests.

core/sandbox/helpers/raptor-coord-launcher.c (new): privileged bootstrap for hosts where unprivileged userns is LSM-restricted (Ubuntu 24.04+'s apparmor_restrict_unprivileged_userns=1, SELinux- hardened RHEL, kernel.unprivileged_userns_clone=0). Performs a fixed privileged window: close inherited fds → unshare → uid_map → gid_map → ifup lo → capset(empty) → execve. PIE + RELRO + _FORTIFY_SOURCE=2; hardening flags appended after operator CFLAGS so they can't be stripped. Three operator-grant templates shipped: apparmor profile, setcap rule, SELinux policy module. The coord.py side prefers launcher-first when built — a failed direct attempt under an LSM-hardened host leaves the process auto-confined to ``unprivileged_userns``, and from that confined state execv to a named profile does not work (LSM transitions go
unconfined→named, not confined→named).

core/sandbox/profiles.py: ``target_run`` profile registered — same Landlock + seccomp as ``full`` but ``block_network=False`` so the listener it spawns is reachable to the harness. Callers that want isolation FROM the host loopback (not just FROM the wider network) pair this profile with the netns coordinator, which overrides ``block_network=True`` + ``inherit_netns=True`` per call.

core/sandbox/_spawn.py + context.py: minimal surgical gates that honour the ``inherit_netns`` kwarg which was already declared but inert. When ``inherit_netns=True``, ``run_sandboxed`` skips CLONE_NEWNET (so the fork inherits the caller's netns) and the Landlock-only fallback's ``unshare`` CLI skips ``--net`` (same reason). No existing caller passes ``inherit_netns=True``, so existing behaviour is unchanged.

tests/test_coordinator_isolation.py (new): twelve tests across two classes — seven adversarial escape-attempt tests (cannot-setns-into- host, only-loopback-interface-visible, cannot-reach-external-internet, cannot-open-raw-socket, target-and-exploit-share-same-netns, plus two probe variants) and five protocol-robustness tests for the bad-request error contract. Module-level ``skipif`` falls through gracefully on hosts without the userns grant.

1032 sandbox tests pass.