### PR TITLE
feat(inventory): add Lua language support

### DIFF
--- a/core/inventory/builder.py
+++ b/core/inventory/builder.py
@@ -36,6 +36,7 @@ from .call_graph import (
     extract_call_graph_go,
     extract_call_graph_java,
     extract_call_graph_javascript,
+    extract_call_graph_lua,
     extract_call_graph_php,
     extract_call_graph_python,
     extract_call_graph_ruby,
@@ -829,6 +830,10 @@ def _process_single_file(
             ).to_dict()
         elif language == 'php':
             record['call_graph'] = extract_call_graph_php(
+                parse_text,
+            ).to_dict()
+        elif language == 'lua':
+            record['call_graph'] = extract_call_graph_lua(
                 parse_text,
             ).to_dict()
         elif language == 'c':

--- a/core/inventory/call_graph.py
+++ b/core/inventory/call_graph.py
@@ -5241,6 +5241,236 @@ class _CppCallGraph(_CCallGraph):
         return None
 
 
+def extract_call_graph_lua(content: str) -> FileCallGraph:
+    """Walk a Lua source string via tree-sitter-lua and return its
+    :class:`FileCallGraph`.
+
+    Returns an empty graph when ``tree_sitter_lua`` isn't installed
+    or the file is unparseable.
+
+    Lua shapes:
+
+      * ``require('luci.model.uci')`` -> import
+      * ``foo(...)`` -> chain ``["foo"]``
+      * ``obj.foo(...)`` -> chain ``["obj", "foo"]`` (dot_index_expression)
+      * ``obj:method(...)`` -> chain ``["obj", "method"]`` (method_index_expression)
+      * ``a.b.c(...)`` -> chain ``["a", "b", "c"]`` (nested dot_index_expression)
+      * ``dofile("x.lua")`` / ``loadfile("x.lua")`` -> import
+      * ``pcall(func, ...)`` / ``xpcall(func, handler, ...)`` ->
+        first/second argument is the real callee
+      * ``loadstring(...)`` / ``load(...)`` -> ``INDIRECTION_EVAL``
+    """
+    try:
+        import tree_sitter_lua as ts_lua
+    except ImportError:
+        logger.debug(
+            "call_graph: tree-sitter Lua grammar not installed; "
+            "returning empty graph",
+        )
+        return FileCallGraph()
+
+    try:
+        parser = _get_ts_parser(ts_lua.language)
+        tree = parser.parse(content.encode("utf-8", errors="replace"))
+    except Exception as e:                              # noqa: BLE001
+        logger.debug("call_graph: Lua parse failed (%s)", e)
+        return FileCallGraph()
+
+    walker = _LuaCallGraph()
+    walker.walk(tree.root_node)
+    return walker.graph
+
+
+class _LuaCallGraph:
+    """Single-pass tree-sitter-lua walk."""
+
+    _FUNC_CALL = "function_call"
+    _FUNC_DECL = "function_declaration"
+    _FUNC_DEF = "function_definition"
+    _IDENT = "identifier"
+    _DOT_INDEX = "dot_index_expression"
+    _METHOD_INDEX = "method_index_expression"
+    _ARGUMENTS = "arguments"
+    _STRING = "string"
+    _STRING_CONTENT = "string_content"
+
+    _REQUIRE_NAMES = {"require", "dofile", "loadfile"}
+    _EVAL_NAMES = {"loadstring", "load"}
+    _PCALL_NAMES = {"pcall", "xpcall"}
+
+    def __init__(self) -> None:
+        self.graph = FileCallGraph()
+        self._enclosing: List[str] = []
+
+    def walk(self, node) -> None:
+        if node.type == self._FUNC_DECL:
+            name = self._func_decl_name(node)
+            if name:
+                self._enclosing.append(name)
+                try:
+                    for c in node.children:
+                        self.walk(c)
+                finally:
+                    self._enclosing.pop()
+                return
+            for c in node.children:
+                self.walk(c)
+            return
+
+        if node.type == self._FUNC_DEF:
+            # Anonymous function — try to resolve name from assignment.
+            name = self._assigned_name(node) or "<anon>"
+            self._enclosing.append(name)
+            try:
+                for c in node.children:
+                    self.walk(c)
+            finally:
+                self._enclosing.pop()
+            return
+
+        if node.type == self._FUNC_CALL:
+            self._handle_call(node)
+            for c in node.children:
+                self.walk(c)
+            return
+
+        for c in node.children:
+            self.walk(c)
+
+    def _func_decl_name(self, node) -> Optional[str]:
+        """Extract the name from a function_declaration node."""
+        for c in node.children:
+            if c.type == self._IDENT:
+                return c.text.decode()
+            if c.type == self._DOT_INDEX:
+                return c.text.decode()
+            if c.type == self._METHOD_INDEX:
+                return c.text.decode().replace(":", ".")
+        return None
+
+    def _assigned_name(self, node) -> Optional[str]:
+        """Resolve the name of an anonymous function from its enclosing
+        assignment (``local parse = function(s) ... end``)."""
+        parent = node.parent
+        if parent is not None and parent.type == "expression_list":
+            parent = parent.parent
+        if parent is None or parent.type != "assignment_statement":
+            return None
+        for child in parent.children:
+            if child.type == "variable_list":
+                for v in child.children:
+                    if v.type == self._IDENT:
+                        return v.text.decode()
+                    if v.type == self._DOT_INDEX:
+                        return v.text.decode()
+                break
+        return None
+
+    def _handle_call(self, node) -> None:
+        """Process a function_call node."""
+        # The callee is the first child before the arguments node.
+        callee = None
+        args_node = None
+        for c in node.children:
+            if c.type == self._ARGUMENTS:
+                args_node = c
+                break
+            if c.is_named:
+                callee = c
+
+        if callee is None:
+            return
+
+        chain = self._chain_from_node(callee)
+        if not chain:
+            return
+
+        bare = chain[0] if len(chain) == 1 else None
+
+        # require / dofile / loadfile → import.
+        if bare in self._REQUIRE_NAMES and args_node is not None:
+            self._extract_import(bare, args_node)
+
+        # loadstring / load → eval indirection.
+        if bare in self._EVAL_NAMES:
+            self.graph.indirection.add(INDIRECTION_EVAL)
+
+        # pcall(func, ...) / xpcall(func, handler, ...) — the first
+        # non-string argument is the real callee.
+        if bare in self._PCALL_NAMES and args_node is not None:
+            self._handle_pcall(bare, args_node)
+
+        self._record(node, chain)
+
+    def _handle_pcall(self, name: str, args_node) -> None:
+        """For pcall/xpcall, record a call to the real callee argument."""
+        real_args = [c for c in args_node.children if c.is_named]
+        if not real_args:
+            return
+        # pcall: first arg is the callee.
+        # xpcall: first arg is the callee, second is the error handler.
+        callee_node = real_args[0]
+        callee_chain = self._chain_from_node(callee_node)
+        if callee_chain:
+            self._record(callee_node, callee_chain)
+
+    def _extract_import(self, func_name: str, args_node) -> None:
+        """Extract import from require/dofile/loadfile arguments."""
+        for c in args_node.children:
+            if c.type == self._STRING:
+                for sc in c.children:
+                    if sc.type == self._STRING_CONTENT:
+                        path = sc.text.decode()
+                        if func_name == "require":
+                            # ``require('luci.model.uci')`` — dot-separated
+                            # module name. Bind the last component.
+                            bound = path.split(".")[-1]
+                        else:
+                            # dofile / loadfile — file path. Bind basename
+                            # sans extension.
+                            bound = path.rsplit("/", 1)[-1]
+                            if bound.endswith(".lua"):
+                                bound = bound[:-4]
+                        self.graph.imports[bound] = path
+                        return
+
+    def _chain_from_node(self, node) -> List[str]:
+        """Build an attribute chain from a node."""
+        if node.type == self._IDENT:
+            return [node.text.decode()]
+        if node.type == self._DOT_INDEX:
+            parts: List[str] = []
+            for c in node.children:
+                if c.type == self._IDENT:
+                    parts.append(c.text.decode())
+                elif c.type == self._DOT_INDEX:
+                    parts = self._chain_from_node(c) + parts
+            return parts
+        if node.type == self._METHOD_INDEX:
+            parts = []
+            for c in node.children:
+                if c.type == self._IDENT:
+                    parts.append(c.text.decode())
+                elif c.type == self._DOT_INDEX:
+                    parts = self._chain_from_node(c) + parts
+            return parts
+        return []
+
+    def _record(self, node, chain: List[str]) -> None:
+        line = node.start_point[0] + 1
+        caller = self._enclosing[-1] if self._enclosing else None
+        self.graph.calls.append(
+            CallSite(line=line, chain=chain, caller=caller),
+        )
+
+    @staticmethod
+    def _first_child_of_type(node, types: tuple):
+        for c in node.children:
+            if c.type in types:
+                return c
+        return None
+
+
 __all__ = [
     "CallSite",
     "FileCallGraph",
@@ -5259,6 +5489,7 @@ __all__ = [
     "extract_call_graph_go",
     "extract_call_graph_java",
     "extract_call_graph_javascript",
+    "extract_call_graph_lua",
     "extract_call_graph_php",
     "extract_call_graph_python",
     "extract_call_graph_ruby",

--- a/core/inventory/extractors.py
+++ b/core/inventory/extractors.py
@@ -305,14 +305,15 @@ class JavaScriptExtractor:
         """Find the closing ``}`` for a function starting at *start* (0-based).
 
         Tracks brace depth while skipping string literals (``"``, ``'``,
-        backtick), ``//`` line comments, and regex literals (``/pattern/``).
-        Returns a 1-based line number or ``None`` when the end cannot be
-        determined.
+        backtick), ``//`` line comments, ``/* */`` block comments, and
+        regex literals (``/pattern/``).  Returns a 1-based line number
+        or ``None`` when the end cannot be determined.
         """
         depth = 0
         found_open = False
         in_string: Optional[str] = None
         in_regex = False
+        in_block_comment = False
         prev_significant = '='
 
         for i in range(start, len(lines)):
@@ -320,6 +321,14 @@ class JavaScriptExtractor:
             j = 0
             while j < len(line):
                 ch = line[j]
+
+                if in_block_comment:
+                    if ch == '*' and j + 1 < len(line) and line[j + 1] == '/':
+                        in_block_comment = False
+                        j += 2
+                        continue
+                    j += 1
+                    continue
 
                 if in_regex:
                     if ch == '\\':
@@ -340,6 +349,11 @@ class JavaScriptExtractor:
                     j += 1
                     continue
 
+                if ch == '/' and j + 1 < len(line) and line[j + 1] == '*':
+                    in_block_comment = True
+                    j += 2
+                    continue
+
                 if ch == '/' and j + 1 < len(line) and line[j + 1] == '/':
                     break
 
@@ -348,7 +362,7 @@ class JavaScriptExtractor:
                     j += 1
                     continue
 
-                if (ch == '/' and j + 1 < len(line) and line[j + 1] != '*'
+                if (ch == '/' and j + 1 < len(line)
                         and prev_significant in JavaScriptExtractor._REGEX_PREFIX):
                     in_regex = True
                     j += 1
@@ -378,12 +392,15 @@ class JavaScriptExtractor:
         for i, line in enumerate(lines, 1):
             if len(line) > self._MAX_JS_LINE:
                 continue
+            stripped = line.lstrip()
+            if stripped.startswith('//') or stripped.startswith('/*'):
+                continue
             for pattern in self.PATTERNS:
                 match = re.search(pattern, line)
                 if match:
                     name = match.group(1)
                     if name not in seen and name not in ('if', 'for', 'while', 'switch', 'catch'):
-                        exported = line.lstrip().startswith('export ')
+                        exported = stripped.startswith('export ')
                         end_line = self._find_end(lines, i - 1)
                         functions.append(FunctionInfo(
                             name=name, line_start=i,
@@ -992,6 +1009,8 @@ class LuaExtractor:
 
         for i, raw_line in enumerate(lines, 1):
             line = raw_line.strip()
+            if line.startswith('--'):
+                continue
             m = self._NAMED_PAT.match(line)
             if m:
                 raw_name = m.group('name')

--- a/core/inventory/extractors.py
+++ b/core/inventory/extractors.py
@@ -914,6 +914,160 @@ class GoExtractor:
         return functions
 
 
+class LuaExtractor:
+    """Extract functions from Lua files using regex with ``end``-keyword
+    depth tracking for ``line_end`` computation.
+
+    Lua function patterns:
+      - ``function name(...)`` — global function
+      - ``local function name(...)`` — local function
+      - ``function Module.name(...)`` — module function (dot syntax)
+      - ``function Class:method(...)`` — method (colon syntax, stored as Class.method)
+      - ``M.name = function(...)`` / ``local name = function(...)`` — assigned anonymous
+    """
+
+    # Named function declarations (global, local, module dot, method colon).
+    _NAMED_PAT = re.compile(
+        r'^(?P<local>local\s+)?function\s+'
+        r'(?P<name>[\w.]+(?::[\w]+)?)\s*\(',
+    )
+    # Assigned anonymous: ``M.name = function(...)`` or ``local name = function(...)``.
+    _ASSIGN_PAT = re.compile(
+        r'^(?P<local>local\s+)?(?P<name>[\w.]+)\s*=\s*function\s*\(',
+    )
+
+    # Block-opening keywords that push the ``end`` depth.
+    # ``do`` is intentionally excluded: it appears as part of ``for ... do``
+    # / ``while ... do`` (already counted by ``for`` / ``while``).
+    # Standalone ``do ... end`` blocks are extremely rare and the minor
+    # depth error is acceptable vs double-counting every for/while loop.
+    _BLOCK_OPEN = re.compile(
+        r'\b(?:function|if|for|while)\b',
+    )
+    # ``repeat`` opens a block closed by ``until``, not ``end``.
+    _REPEAT = re.compile(r'\brepeat\b')
+    _UNTIL = re.compile(r'\buntil\b')
+    _END = re.compile(r'\bend\b')
+
+    @staticmethod
+    def _strip_strings_and_comments(line: str) -> str:
+        """Replace string contents and ``--`` line comments with spaces.
+
+        Without this, keywords inside strings (e.g. ``["function"] = name``)
+        confuse the block-depth tracker.
+        """
+        out = list(line)
+        in_str: Optional[str] = None
+        i = 0
+        while i < len(out):
+            ch = out[i]
+            if in_str is not None:
+                if ch == '\\':
+                    out[i] = ' '
+                    if i + 1 < len(out):
+                        out[i + 1] = ' '
+                    i += 2
+                    continue
+                if ch == in_str:
+                    in_str = None
+                else:
+                    out[i] = ' '
+                i += 1
+                continue
+            if ch in ('"', "'"):
+                in_str = ch
+                i += 1
+                continue
+            if ch == '-' and i + 1 < len(out) and out[i + 1] == '-':
+                for j in range(i, len(out)):
+                    out[j] = ' '
+                break
+            i += 1
+        return ''.join(out)
+
+    def extract(self, filepath: str, content: str) -> List[FunctionInfo]:
+        lines = content.split('\n')
+        functions: List[FunctionInfo] = []
+        seen: set = set()
+
+        for i, raw_line in enumerate(lines, 1):
+            line = raw_line.strip()
+            m = self._NAMED_PAT.match(line)
+            if m:
+                raw_name = m.group('name')
+                # Colon syntax ``Class:method`` → store as ``Class.method``.
+                name = raw_name.replace(':', '.')
+                is_local = bool(m.group('local'))
+                if name not in seen:
+                    functions.append(FunctionInfo(
+                        name=name,
+                        line_start=i,
+                        metadata=FunctionMetadata(
+                            visibility="private" if is_local else "public",
+                        ),
+                    ))
+                    seen.add(name)
+                continue
+            m = self._ASSIGN_PAT.match(line)
+            if m:
+                name = m.group('name')
+                is_local = bool(m.group('local'))
+                if name not in seen:
+                    functions.append(FunctionInfo(
+                        name=name,
+                        line_start=i,
+                        metadata=FunctionMetadata(
+                            visibility="private" if is_local else "public",
+                        ),
+                    ))
+                    seen.add(name)
+
+        # Post-pass: compute line_end via end-keyword depth tracking.
+        self._fill_line_ends(lines, functions)
+        return functions
+
+    def _fill_line_ends(
+        self, lines: List[str], functions: List[FunctionInfo],
+    ) -> None:
+        """Compute ``line_end`` for each function by tracking ``end``/``until``
+        depth from its ``line_start``."""
+        for func in functions:
+            if func.line_end is not None:
+                continue
+            func.line_end = self._find_end(lines, func.line_start - 1)
+
+    def _find_end(self, lines: List[str], start_idx: int) -> Optional[int]:
+        """Find the matching ``end`` for a function starting at ``start_idx``
+        (0-based). Returns 1-based line number, or None."""
+        depth = 0
+        repeat_depth = 0
+        found_open = False
+
+        for i in range(start_idx, len(lines)):
+            stripped = self._strip_strings_and_comments(lines[i])
+
+            # Count block openers (function, if, for, while, do).
+            for _ in self._BLOCK_OPEN.finditer(stripped):
+                depth += 1
+                found_open = True
+
+            # ``repeat`` opens a block closed by ``until``.
+            for _ in self._REPEAT.finditer(stripped):
+                repeat_depth += 1
+
+            for _ in self._UNTIL.finditer(stripped):
+                repeat_depth = max(0, repeat_depth - 1)
+
+            # ``end`` closes one block (not repeat blocks).
+            for _ in self._END.finditer(stripped):
+                depth -= 1
+
+            if found_open and depth <= 0:
+                return i + 1  # 1-based
+
+        return None
+
+
 class GenericExtractor:
     """Generic fallback extractor using common patterns."""
 
@@ -1003,6 +1157,8 @@ def _ts_language(lang: str):
         elif lang == "php":
             import tree_sitter_php as ts
             return Language(ts.language_php())
+        elif lang == "lua":
+            import tree_sitter_lua as ts
         else:
             return None
         return Language(ts.language())
@@ -1057,6 +1213,7 @@ class TreeSitterExtractor:
         # methods). Trait method SIGNATURES (no body) are
         # ``function_signature_item`` — intentionally excluded (no code).
         "rust": ("function_item",),
+        "lua": ("function_declaration", "function_definition"),
     }
 
     _CLASS_TYPES = {
@@ -1077,6 +1234,7 @@ class TreeSitterExtractor:
         # no fns). ``impl Trait for Foo`` associates its methods with ``Foo``;
         # ``trait T`` with ``T`` (for default methods).
         "rust": ("impl_item", "trait_item"),
+        "lua": (),
     }
 
     def __init__(self, language: str):
@@ -1494,6 +1652,35 @@ class TreeSitterExtractor:
                         if parts:
                             class_name = parts[-1].lstrip("*")
 
+        # Lua: ``local function foo()`` has a ``local`` keyword child;
+        # ``function foo()`` (no local) is public/global.
+        if self.language == "lua":
+            has_local = any(
+                c.type == "local" for c in node.children
+            )
+            if has_local:
+                visibility = "private"
+            else:
+                # For function_definition (anonymous assigned), check if
+                # the enclosing variable_declaration has a ``local`` child.
+                if node.type == "function_definition":
+                    p = node.parent
+                    # Walk up: expression_list → assignment_statement →
+                    # variable_declaration.
+                    while p is not None and p.type in (
+                        "expression_list", "assignment_statement",
+                    ):
+                        p = p.parent
+                    if p is not None and p.type == "variable_declaration":
+                        if any(c.type == "local" for c in p.children):
+                            visibility = "private"
+                        else:
+                            visibility = "public"
+                    else:
+                        visibility = "public"
+                else:
+                    visibility = "public"
+
         # JS/TS: export statement wrapping
         parent = node.parent
         if parent and parent.type == "export_statement":
@@ -1502,6 +1689,21 @@ class TreeSitterExtractor:
         return visibility, class_name
 
     def _get_name(self, node) -> Optional[str]:
+        # Lua: function_declaration names can be identifier,
+        # dot_index_expression (M.foo), or method_index_expression (C:m).
+        if self.language == "lua" and node.type == "function_declaration":
+            for child in node.children:
+                if child.type == "identifier":
+                    return child.text.decode()
+                if child.type == "dot_index_expression":
+                    # ``function M.foo()`` → "M.foo"
+                    return child.text.decode()
+                if child.type == "method_index_expression":
+                    # ``function C:method()`` → "C.method" (colon → dot)
+                    return child.text.decode().replace(":", ".")
+        # Lua: function_definition (anonymous) — name from parent assignment.
+        if self.language == "lua" and node.type == "function_definition":
+            return self._lua_assigned_name(node)
         # Rust: an ``impl`` block associates its methods with the TARGET type
         # — ``impl Foo`` / ``impl Trait for Foo`` / ``impl<T> Box<T>``. The
         # target is the last type node before the body (after ``for`` in a
@@ -1655,6 +1857,32 @@ class TreeSitterExtractor:
                     return inner
         return None
 
+    def _lua_assigned_name(self, node) -> Optional[str]:
+        """Resolve the name of a Lua ``function_definition`` (anonymous function)
+        from its enclosing assignment.
+
+        Shapes:
+          ``local parse = function(s) ... end``
+            → variable_declaration > assignment_statement > variable_list > identifier
+          ``M.handler = function(req) ... end``
+            → assignment_statement > variable_list > dot_index_expression
+        """
+        parent = node.parent
+        # function_definition sits inside expression_list inside assignment_statement
+        if parent is not None and parent.type == "expression_list":
+            parent = parent.parent
+        if parent is None or parent.type != "assignment_statement":
+            return None
+        for child in parent.children:
+            if child.type == "variable_list":
+                for v in child.children:
+                    if v.type == "identifier":
+                        return v.text.decode()
+                    if v.type == "dot_index_expression":
+                        return v.text.decode()
+                break
+        return None
+
     def _find_child(self, node, types: tuple):
         for child in node.children:
             if child.type in types:
@@ -1758,7 +1986,7 @@ def _get_ts_languages() -> List[str]:
         _cached_ts_languages = []
         return []
     available = []
-    for lang in ("python", "java", "javascript", "c", "go"):
+    for lang in ("python", "java", "javascript", "c", "go", "lua"):
         if _ts_language(lang):
             available.append(lang)
     _cached_ts_languages = available
@@ -1782,6 +2010,7 @@ _REGEX_EXTRACTORS = {
     'cpp': CExtractor(),
     'java': JavaExtractor(),
     'go': GoExtractor(),
+    'lua': LuaExtractor(),
 }
 
 

--- a/core/inventory/languages.py
+++ b/core/inventory/languages.py
@@ -28,6 +28,7 @@ LANGUAGE_MAP = {
     '.kt': 'kotlin',
     '.kts': 'kotlin',
     '.scala': 'scala',
+    '.lua': 'lua',
 }
 
 

--- a/core/inventory/reachability.py
+++ b/core/inventory/reachability.py
@@ -1970,7 +1970,7 @@ def _path_derived_module(
     base = file_path
     suffix_match = None
     for suffix in (".pyi", ".py", ".tsx", ".jsx", ".mjs", ".cjs",
-                    ".ts", ".js", ".rb"):
+                    ".ts", ".js", ".rb", ".lua"):
         if base.endswith(suffix):
             base = base[: -len(suffix)]
             suffix_match = suffix
@@ -1981,15 +1981,19 @@ def _path_derived_module(
         base = base[: -len("/__init__")]
     elif base.endswith("/index"):
         base = base[: -len("/index")]
+    elif base.endswith("/init"):
+        base = base[: -len("/init")]
     if not base:
         return []
     out: List[str] = [f"{base.replace('/', '.')}.{class_name}.{fn_name}"]
-    if base.startswith("src/"):
-        stripped = base[len("src/"):]
-        if stripped:
-            out.append(
-                f"{stripped.replace('/', '.')}.{class_name}.{fn_name}",
-            )
+    for prefix in ("src/", "luasrc/", "lib/"):
+        if base.startswith(prefix):
+            stripped = base[len(prefix):]
+            if stripped:
+                out.append(
+                    f"{stripped.replace('/', '.')}.{class_name}.{fn_name}",
+                )
+            break
     return out
 
 

--- a/core/inventory/tests/test_call_graph_new_langs.py
+++ b/core/inventory/tests/test_call_graph_new_langs.py
@@ -18,6 +18,7 @@ from core.inventory.call_graph import (
     INDIRECTION_WILDCARD_IMPORT,
     extract_call_graph_csharp,
     extract_call_graph_javascript,
+    extract_call_graph_lua,
     extract_call_graph_php,
     extract_call_graph_ruby,
     extract_call_graph_rust,
@@ -675,3 +676,80 @@ def test_js_class_expression_assigned_to_const():
     method_names = [m[0] for m in foo.methods]
     assert "method" in method_names
     assert "helper" in method_names
+
+
+# ---------------------------------------------------------------------------
+# Lua
+# ---------------------------------------------------------------------------
+
+_LUA_TS_AVAILABLE = True
+try:
+    import tree_sitter_lua  # noqa: F401
+except ImportError:
+    _LUA_TS_AVAILABLE = False
+
+
+@pytest.mark.skipif(not _LUA_TS_AVAILABLE,
+                    reason="tree-sitter-lua not installed")
+class TestLuaCallGraph:
+
+    def test_require_import(self):
+        g = extract_call_graph_lua(
+            'local uci = require("luci.model.uci")\n'
+            'uci.cursor()\n',
+        )
+        assert "uci" in g.imports
+        assert g.imports["uci"] == "luci.model.uci"
+
+    def test_dot_call(self):
+        g = extract_call_graph_lua(
+            'local http = require("luci.http")\n'
+            'http.redirect("/cgi-bin/luci")\n',
+        )
+        chains = [tuple(c.chain) for c in g.calls]
+        assert ("http", "redirect") in chains
+
+    def test_colon_method_call(self):
+        g = extract_call_graph_lua(
+            'function M.run(self)\n'
+            '  self:dispatch()\n'
+            'end\n',
+        )
+        chains = [tuple(c.chain) for c in g.calls]
+        assert ("self", "dispatch") in chains
+
+    def test_pcall_records_callee(self):
+        g = extract_call_graph_lua(
+            'pcall(dangerous, 1, 2)\n',
+        )
+        chains = [tuple(c.chain) for c in g.calls]
+        assert ("dangerous",) in chains
+
+    def test_loadstring_indirection(self):
+        g = extract_call_graph_lua(
+            'loadstring("return 1")()\n',
+        )
+        assert INDIRECTION_EVAL in g.indirection
+
+    def test_nested_dot_chain(self):
+        g = extract_call_graph_lua(
+            'luci.model.uci.cursor()\n',
+        )
+        chains = [tuple(c.chain) for c in g.calls]
+        assert ("luci", "model", "uci", "cursor") in chains
+
+    def test_dofile_import(self):
+        g = extract_call_graph_lua(
+            'dofile("/usr/lib/lua/helper.lua")\n',
+        )
+        assert "helper" in g.imports
+
+    def test_enclosing_function(self):
+        g = extract_call_graph_lua(
+            'function dispatch(req)\n'
+            '  route(req)\n'
+            'end\n',
+        )
+        route_calls = [c for c in g.calls if c.chain == ["route"]]
+        assert len(route_calls) == 1
+        assert route_calls[0].caller == "dispatch"

--- a/core/inventory/tests/test_extractors.py
+++ b/core/inventory/tests/test_extractors.py
@@ -244,6 +244,34 @@ class TestJSRegexExtractor:
         funcs = JavaScriptExtractor().extract("t.js", code)
         assert funcs[0].metadata.visibility is None
 
+    def test_block_comment_with_braces(self):
+        code = "function f() {\n  /* { } */\n  return 1;\n}\n"
+        funcs = JavaScriptExtractor().extract("t.js", code)
+        assert funcs[0].line_end == 4
+
+    def test_multiline_block_comment_with_braces(self):
+        code = "function f() {\n  /*\n  {\n  */\n  return 1;\n}\n"
+        funcs = JavaScriptExtractor().extract("t.js", code)
+        assert funcs[0].line_end == 6
+
+    def test_regex_literal_with_braces(self):
+        code = "function f() {\n  var r = /{[^}]+}/g;\n  return 1;\n}\n"
+        funcs = JavaScriptExtractor().extract("t.js", code)
+        assert funcs[0].line_end == 4
+
+    def test_commented_out_function_skipped(self):
+        code = "// function fake(ev) {\nfunction real() {\n  return 1;\n}\n"
+        funcs = JavaScriptExtractor().extract("t.js", code)
+        assert len(funcs) == 1
+        assert funcs[0].name == "real"
+
+    def test_block_comment_opener_skipped(self):
+        code = "/* function fake() { */\nfunction real() {\n  return 1;\n}\n"
+        funcs = JavaScriptExtractor().extract("t.js", code)
+        names = [f.name for f in funcs]
+        assert "fake" not in names
+        assert "real" in names
+
 
 # ---------------------------------------------------------------------------
 # Fallback chain
@@ -592,6 +620,12 @@ class TestLuaExtractor:
         )
         funcs = self.ext.extract("test.lua", code)
         assert funcs[0].line_end == 6
+
+    def test_commented_out_function_skipped(self):
+        code = "-- function fake()\nfunction real()\n  return 1\nend\n"
+        funcs = self.ext.extract("test.lua", code)
+        assert len(funcs) == 1
+        assert funcs[0].name == "real"
 
     def test_keyword_in_string_not_counted(self):
         code = (

--- a/core/inventory/tests/test_extractors.py
+++ b/core/inventory/tests/test_extractors.py
@@ -5,7 +5,8 @@ import pytest
 from core.inventory.extractors import (
     FunctionInfo, FunctionMetadata,
     PythonExtractor, JavaExtractor, CExtractor, GoExtractor,
-    JavaScriptExtractor, extract_functions, _TS_AVAILABLE, _get_ts_languages,
+    JavaScriptExtractor, LuaExtractor,
+    extract_functions, _TS_AVAILABLE, _get_ts_languages,
 )
 
 
@@ -495,3 +496,118 @@ class TestCGlobalDeclarators:
         assert "h" in names              # the function-pointer variable
         assert "foo" not in names        # NOT the initializer value
         assert "x" in names              # plain scalar still works
+
+
+# ---------------------------------------------------------------------------
+# LuaExtractor tests
+# ---------------------------------------------------------------------------
+
+class TestLuaExtractor:
+    ext = LuaExtractor()
+
+    def test_global_function(self):
+        code = "function greet(name)\n  print(name)\nend\n"
+        funcs = self.ext.extract("test.lua", code)
+        assert len(funcs) == 1
+        assert funcs[0].name == "greet"
+        assert funcs[0].line_start == 1
+        assert funcs[0].line_end == 3
+        assert funcs[0].metadata.visibility == "public"
+
+    def test_local_function(self):
+        code = "local function helper(x)\n  return x + 1\nend\n"
+        funcs = self.ext.extract("test.lua", code)
+        assert len(funcs) == 1
+        assert funcs[0].name == "helper"
+        assert funcs[0].metadata.visibility == "private"
+
+    def test_module_dot_syntax(self):
+        code = "function M.init(cfg)\n  M.cfg = cfg\nend\n"
+        funcs = self.ext.extract("test.lua", code)
+        assert len(funcs) == 1
+        assert funcs[0].name == "M.init"
+
+    def test_method_colon_syntax(self):
+        code = "function Widget:render()\n  return self.html\nend\n"
+        funcs = self.ext.extract("test.lua", code)
+        assert len(funcs) == 1
+        assert funcs[0].name == "Widget.render"
+
+    def test_assigned_anonymous(self):
+        code = "M.handler = function(req)\n  return 200\nend\n"
+        funcs = self.ext.extract("test.lua", code)
+        assert len(funcs) == 1
+        assert funcs[0].name == "M.handler"
+
+    def test_local_assigned_anonymous(self):
+        code = "local parse = function(s)\n  return tonumber(s)\nend\n"
+        funcs = self.ext.extract("test.lua", code)
+        assert len(funcs) == 1
+        assert funcs[0].name == "parse"
+        assert funcs[0].metadata.visibility == "private"
+
+    def test_line_end_nested_blocks(self):
+        code = (
+            "function outer()\n"
+            "  if true then\n"
+            "    for i=1,10 do\n"
+            "      print(i)\n"
+            "    end\n"
+            "  end\n"
+            "end\n"
+        )
+        funcs = self.ext.extract("test.lua", code)
+        assert len(funcs) == 1
+        assert funcs[0].line_end == 7
+
+    def test_multiple_functions(self):
+        code = (
+            "function a()\n  return 1\nend\n\n"
+            "function b()\n  return 2\nend\n"
+        )
+        funcs = self.ext.extract("test.lua", code)
+        names = [f.name for f in funcs]
+        assert names == ["a", "b"]
+        assert funcs[0].line_end == 3
+        assert funcs[1].line_end == 7
+
+    def test_comment_not_counted(self):
+        code = (
+            "function f()\n"
+            "  -- if this were parsed it would add depth\n"
+            "  return 1\n"
+            "end\n"
+        )
+        funcs = self.ext.extract("test.lua", code)
+        assert funcs[0].line_end == 4
+
+    def test_repeat_until_not_confused(self):
+        code = (
+            "function poll()\n"
+            "  repeat\n"
+            "    x = read()\n"
+            "  until x ~= nil\n"
+            "  return x\n"
+            "end\n"
+        )
+        funcs = self.ext.extract("test.lua", code)
+        assert funcs[0].line_end == 6
+
+    def test_keyword_in_string_not_counted(self):
+        code = (
+            'function call(name)\n'
+            '  return {\n'
+            '    ["function"] = name,\n'
+            '    ["type"] = "call"\n'
+            '  }\n'
+            'end\n'
+        )
+        funcs = self.ext.extract("test.lua", code)
+        assert len(funcs) == 1
+        assert funcs[0].line_end == 6
+
+    def test_extract_functions_lua(self):
+        code = "function dispatch(req)\n  route(req)\nend\n"
+        funcs = extract_functions("controller.lua", "lua", code)
+        assert len(funcs) == 1
+        assert funcs[0].name == "dispatch"


### PR DESCRIPTION
LuaExtractor with end-keyword depth tracking for line_end, tree-sitter integration for function extraction and call graph, require() module resolution in the reachability resolver, and Lua-aware init.lua/luasrc/ path stripping.

- extractors.py: LuaExtractor class — named/local/module.dot/Class:method and assigned anonymous function patterns; _strip_strings_and_comments neutralises keywords inside string literals before depth counting
- call_graph.py: extract_call_graph_lua via tree-sitter — require imports, dot/colon calls, pcall/xpcall dispatch, loadstring/load eval indirection
- languages.py: .lua → lua mapping
- builder.py: Lua call graph dispatch wiring
- reachability.py: .lua suffix + init.lua + luasrc/ prefix in module resolution
- 20 new tests (12 extractor + 8 call graph)

E2E: 77 openwrt-luci files, 981 functions extracted (regex), 974 (tree-sitter), 100% line_end coverage, 171 imports, 3516 call sites, 0 errors.