### PR TITLE
feat(frida): evidence pipeline, full consumer wiring, reachability integration

### DIFF
--- a/.claude/skills/code-understanding/map.md
+++ b/.claude/skills/code-understanding/map.md
@@ -297,6 +297,22 @@ non-C/C++ targets or when `spatch` isn't on PATH, so it only adds a cocci
 pass where it has something to find. Idempotent. Skip if
 `$WORKDIR/checklist.json` lacks `target_path`.
 
+**[MAP-5e] Enrich with frida runtime evidence (automatic)**
+
+After normalisation, merge any frida runtime evidence discovered in sibling
+run directories. This is automatic and best-effort — if no frida evidence
+exists, it no-ops silently.
+
+```bash
+libexec/raptor-enrich-context-map-frida "$WORKDIR"
+```
+
+Merges function-level runtime observations (which functions were called, how
+many times, with what arguments) from frida `events.jsonl` into the
+context-map's entry points and sinks. Entry points and sinks that frida
+confirmed at runtime get a `runtime_confirmed: true` annotation. Idempotent.
+Skip-silent when no frida evidence is discoverable.
+
 **[MAP-6] Record Coverage**
 
 After writing `context-map.json`, update the inventory with which functions you examined.

--- a/.claude/skills/exploitability-validation/stage-c-sanity.md
+++ b/.claude/skills/exploitability-validation/stage-c-sanity.md
@@ -70,6 +70,8 @@ For each finding in findings.json, CHECK:
 - [ ] Not dead code (unused, commented out, unreachable)
 - [ ] Entry point exists
 
+**Runtime evidence shortcut:** If `attack-paths.json` shows `runtime_evidence.function_observed: true` for this finding's function, reachability is empirically confirmed — mark this check as passed without manual grep verification. Note the frida evidence in your `sanity_check.notes`.
+
 ---
 
 ## Verification Process

--- a/.claude/skills/exploitability-validation/stage-d-ruling.md
+++ b/.claude/skills/exploitability-validation/stage-d-ruling.md
@@ -46,6 +46,12 @@ Before applying disqualifier filters, cross-reference all prior stage outputs fo
 1. **Stage A** — What was the original claim, confidence, and uncertainty?
 2. **Stage B** — Was a hypothesis formed? What was its status (confirmed/disproven/partial)? What specific predictions were tested?
 3. **Stage C** — Did the code match? Was the flow real?
+4. **Runtime evidence** — Check `attack-paths.json` for `runtime_evidence` annotations on attack path steps. If a step has `runtime_evidence.function_observed: true`, frida confirmed that function executes at runtime with the given `call_count`. This is empirical proof of reachability — the function is NOT dead code and the path is NOT theoretical.
+
+**Runtime evidence weight:** A finding where frida observed the vulnerable function executing at runtime has materially stronger exploitability evidence than one based on static analysis alone. When `runtime_evidence_available: true` appears on the attack path:
+- The "is this code reachable?" question is answered empirically (yes).
+- The proximity score has been floored at 6 (strong-positive).
+- Do NOT apply D-2 "chaining required" if the runtime trace shows the sink function is directly reachable from an entry point frida observed.
 
 **Synthesize:** If Stage B disproved the hypothesis, the finding should be ruled out (reason: "Stage B hypothesis disproven") regardless of whether Stage C confirmed the code exists. Real code with wrong vulnerability classification is not a confirmed finding.
 

--- a/.claude/skills/exploitability-validation/stage-e-feasibility.md
+++ b/.claude/skills/exploitability-validation/stage-e-feasibility.md
@@ -114,6 +114,14 @@ includes the profile matching the target's actual deployment, and
 is artefact-grade — strictly more trustworthy than the static
 `analyze_binary` reasoning alone.
 
+### [E-2b] Cross-reference frida runtime evidence
+
+If `attack-paths.json` contains `runtime_evidence` annotations for functions in this finding's flow, note them in `feasibility.runtime_corroboration`:
+- Functions confirmed executing at runtime by frida strengthen the "reachable under deployment conditions" claim.
+- `runtime_evidence.observed_args` (when present) narrows input-constraint analysis — you know what arguments the function actually receives in practice.
+
+This is automatic context from Stage B; no manual invocation needed.
+
 ### [E-3] Review Results
 
 The feasibility script updates findings.json with per-finding verdicts. Review the output for each finding — the script prints the verdict and maps constraints to findings automatically.

--- a/.claude/skills/exploitability-validation/stage-f-review.md
+++ b/.claude/skills/exploitability-validation/stage-f-review.md
@@ -46,6 +46,12 @@ Review the flags above. Mismatches and anomalies inform your review.
 
 5. **SMT verdict vs ruling.** If a finding's evidence array (in `hypotheses.json` or the finding itself) contains an `smt:refuted: …` entry from Stage B's [B-3.1.5] pre-flight, the ruling MUST NOT be `exploitable` — SMT proved the path conditions are mutually exclusive. Conversely, `smt:witness: …` evidence on a finding ruled `false_positive` is a contradiction worth checking: Z3 returned a concrete trigger value, so either the ruling has a basis SMT couldn't see (cite it in the review notes) or the ruling is wrong. Mirrors GATE-7 (CONSISTENCY) for SMT-checked predicates specifically.
 
+### [F-2b] Runtime Evidence Cross-Check
+
+If `attack-paths.json` contains `runtime_evidence` annotations from frida:
+- A finding ruled `false_positive` or `ruled_out` whose attack path has `runtime_evidence_available: true` is a contradiction — frida observed the function running, so reachability-based dismissals are wrong. Re-examine the ruling.
+- A finding ruled `exploitable` with runtime evidence is strongly corroborated — note this in `review_notes` as empirical support.
+
 ### [F-3] Critical Review
 
 Ask: **What did I get wrong?**

--- a/.claude/skills/frida/SKILL.md
+++ b/.claude/skills/frida/SKILL.md
@@ -93,12 +93,41 @@ raptor frida --target Safari --script ./my-hook.js --duration 30
 
 ## Threat model
 
-Frida-instrumented targets are **untrusted** - that's the whole point. The runner is wrapped in `core.sandbox.run()` with the `debug` profile (ptrace allowed, `skip_pid_ns=True` for `/proc` access):
+Frida-instrumented targets are **untrusted** - that's the whole point. The runner is wrapped in `core.sandbox.run()` with the `frida` profile (ptrace allowed, `skip_pid_ns=True` for `/proc` access, `restrict_reads=True`, `fake_home=True`):
 
 - **Spawn mode** (`--target ./binary`): `block_network=True` — the target can't reach out.
 - **Attach mode** (`--target <pid|name>`): network untouched — the process is already running with whatever connectivity it needs.
 - **`--unsafe-attach`**: sandbox bypassed entirely (system processes, SIP targets). Logged in `metadata.json`.
 
+## Pipeline integration
+
+Frida output is automatically consumed by downstream pipelines when evidence exists in the run directory:
+
+| Consumer | What it reads | What it produces |
+|----------|--------------|-----------------|
+| `/agentic` reachability prepass | `events.jsonl` function names | `metadata.frida_runtime_trace` on inventory items; promotes `FRIDA_RUNTIME_TRACE` witness (SOUND) |
+| `/validate` Stage B | `events.jsonl` function names | `runtime_evidence` annotations on attack path steps; proximity floor at 6 |
+| `/understand --map` context bridge | `events.jsonl` file operations | `ObserveProfile` merged into context map (read/write/stat/connect paths) |
+| Coverage store | `coverage.drcov` (bb-coverage template) | Function-level coverage marks via existing `import_drcov` pipeline |
+
+No flags needed — consumers discover evidence via `packages.frida.evidence.discover_evidence()` and gate on `packages.frida.available()`.
+
+### Programmatic API (for orchestration scripts)
+
+```python
+from packages.frida.active import auto_observe, observe_target, observe_paired
+
+# Single binary spawn — runs under sandbox frida profile
+run_dir = observe_target("/path/to/binary", template="api-trace", duration_sec=30)
+
+# Network service — paired observation via netns coordinator
+run_dir = observe_paired(["./server", "--port", "8080"],
+                         template="api-trace", wait_port=8080)
+
+# Pipeline hook — skips if fresh evidence already exists
+run_dir = auto_observe("/path/to/binary", search_dirs=[out_dir])
+```
+
 ## Status
 
-Alpha. Two templates ship; richer set in progress (collab with @Splinters-io). Integration into `/validate --runtime` and `/crash-analysis` on macOS is planned. The autonomous LLM-guided mode from the abandoned PR #57 is intentionally **not** in this slice.
+Alpha. Three templates ship (`api-trace`, `bb-coverage`, `ssl-unpin`); richer set in progress (collab with @Splinters-io). Integration into `/validate` (automatic) and `/crash-analysis` on macOS is planned. The autonomous LLM-guided mode from the abandoned PR #57 is intentionally **not** in this slice.

--- a/core/coverage/__init__.py
+++ b/core/coverage/__init__.py
@@ -38,6 +38,7 @@ from .importer import (
     mark_runtime,
     run_provenance,
 )
+from .frida_bridge import import_frida_coverage
 from .collect import (
     collect_gcov,
     collect_llvm,
@@ -93,6 +94,7 @@ __all__ = [
     "import_run_findings",
     "import_annotations",
     "import_understand",
+    "import_frida_coverage",
     "import_runtime",
     "mark_runtime",
     "collect_gcov",

--- a/core/coverage/frida_bridge.py
+++ b/core/coverage/frida_bridge.py
@@ -1,0 +1,67 @@
+"""Bridge: import frida drcov coverage into the persistent CoverageStore.
+
+Called by the coverage importer when frida evidence is discovered
+for the current target. Uses the existing import_drcov pipeline --
+this module just discovers and orchestrates.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Dict, Optional
+
+from core.logging import get_logger
+
+if TYPE_CHECKING:
+    from core.coverage.store import CoverageStore
+
+log = get_logger("coverage.frida_bridge")
+
+
+def import_frida_coverage(
+    store: "CoverageStore",
+    checklist: Dict[str, Any],
+    search_dirs: list[Path],
+    target_binary: Optional[str] = None,
+    target_path: Optional[str] = None,
+) -> int:
+    """Discover frida drcov files and import them into the coverage store.
+
+    Returns number of marks made. Zero if no frida evidence found (graceful).
+    Requires target_binary (debug binary path for addr2line resolution).
+    """
+    if not search_dirs:
+        return 0
+
+    try:
+        from packages.frida.evidence import discover_evidence
+    except ImportError:
+        return 0
+
+    evidence_list = discover_evidence(search_dirs, target_path=target_path)
+    if not evidence_list:
+        return 0
+
+    from core.coverage.collect import import_drcov
+
+    _MAX_DRCOV_FILES = 10
+
+    drcov_evidence = [ev for ev in evidence_list if ev.has_drcov][:_MAX_DRCOV_FILES]
+
+    total = 0
+    for ev in drcov_evidence:
+        binary = target_binary or ev.target_binary
+        if not binary:
+            log.debug("frida drcov at %s skipped: no binary for addr2line", ev.run_dir)
+            continue
+        drcov_path = ev.run_dir / "coverage.drcov"
+        try:
+            marks = import_drcov(store, drcov_path, binary, checklist, tool="frida")
+        except Exception as exc:
+            log.warning("frida drcov import failed for %s: %s: %s",
+                        drcov_path, type(exc).__name__, exc)
+            continue
+        if marks > 0:
+            log.info("imported %d coverage marks from frida drcov at %s", marks, ev.run_dir)
+        total += marks
+    return total

--- a/core/coverage/importer.py
+++ b/core/coverage/importer.py
@@ -458,10 +458,23 @@ def backfill(
     store.set_content_id(checklist)            # git-X ≡ zip-X equivalence id
     inv_paths = _inventory_paths(checklist)
     total = import_checked_by(store, checklist)
-    for run_dir in run_dirs:
+    run_dir_list = list(run_dirs)
+    for run_dir in run_dir_list:
         total += import_run_dir(store, run_dir, checklist)
         total += import_understand(store, run_dir, checklist)   # /understand fold-in
         import_run_findings(store, run_dir, inv_paths)   # link findings for verdicts
+    try:
+        from core.coverage.frida_bridge import import_frida_coverage
+        total += import_frida_coverage(
+            store, checklist, [Path(d) for d in run_dir_list],
+        )
+    except ImportError:
+        pass
+    except Exception as exc:
+        import logging
+        logging.getLogger("coverage.importer").info(
+            "frida coverage bridge failed: %s: %s", type(exc).__name__, exc,
+        )
     if annotations_base is not None:
         total += import_annotations(store, annotations_base, checklist)
     return total

--- a/core/coverage/registry.py
+++ b/core/coverage/registry.py
@@ -62,6 +62,7 @@ _REGISTRY = {
     # binary-coverage tracers, addr2line/DWARF-resolved to source.
     "bincov": (CATEGORY_RUNTIME, DEPTH_RUNTIME),
     "drcov": (CATEGORY_RUNTIME, DEPTH_RUNTIME),
+    "frida": (CATEGORY_RUNTIME, DEPTH_RUNTIME),
     "sancov": (CATEGORY_RUNTIME, DEPTH_RUNTIME),
     # Python-test runtime (coverage.py / pytest-cov).
     "coverage.py": (CATEGORY_RUNTIME, DEPTH_RUNTIME),

--- a/core/coverage/tests/test_frida_bridge.py
+++ b/core/coverage/tests/test_frida_bridge.py
@@ -1,0 +1,106 @@
+"""Tests for the frida coverage bridge."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict
+
+from core.coverage.frida_bridge import import_frida_coverage
+from core.coverage.store import CoverageStore
+
+_C_CHECKLIST: Dict[str, Any] = {"files": [
+    {"path": "prog.c", "lines": 12, "items": [
+        {"name": "main", "kind": "function", "line_start": 1, "line_end": 12}]},
+]}
+
+
+def _store(tmp_path: Path) -> CoverageStore:
+    return CoverageStore(tmp_path / "coverage.json", target="zip:x")
+
+
+def _sample_metadata(binary: str = "/tmp/build/prog") -> dict:
+    return {
+        "ok": True,
+        "error": None,
+        "target": {"raw": binary, "kind": "binary", "pid": None,
+                   "name": None, "binary": binary},
+        "script_origin": "template:bb-coverage",
+        "duration_requested_sec": 60.0,
+        "duration_actual_sec": 5.0,
+        "events_captured": 1,
+        "device": {"id": "local", "host": None, "usb": False},
+        "host": {"system": "Linux", "arch": "x86_64"},
+        "spawn": True,
+        "unsafe_attach": False,
+        "resolved_pid": 1234,
+    }
+
+
+def _write_frida_run(run_dir: Path, binary: str = "/tmp/build/prog") -> None:
+    run_dir.mkdir(parents=True, exist_ok=True)
+    (run_dir / "metadata.json").write_text(
+        json.dumps(_sample_metadata(binary)), encoding="utf-8",
+    )
+    (run_dir / "coverage.drcov").write_bytes(b"DRCOV VERSION: 2\n")
+    (run_dir / "events.jsonl").write_text('{"ts":1}\n', encoding="utf-8")
+
+
+def test_import_frida_coverage_with_drcov(tmp_path, monkeypatch):
+    """Synthetic drcov + binary -> store gets marks."""
+    import core.coverage.collect as collect_mod
+    monkeypatch.setattr(
+        collect_mod, "collect_drcov",
+        lambda *a, **k: {"prog.c": {1, 2, 5}},
+    )
+
+    run_dir = tmp_path / "frida-run"
+    _write_frida_run(run_dir, binary="/tmp/build/prog")
+
+    s = _store(tmp_path)
+    s.import_inventory_meta(_C_CHECKLIST)
+    n = import_frida_coverage(
+        s, _C_CHECKLIST, [tmp_path],
+        target_binary="/tmp/build/prog",
+    )
+    assert n >= 1
+    assert s.who_checked("prog.c", 1) == ["frida"]
+
+
+def test_import_frida_coverage_no_evidence(tmp_path):
+    """No frida runs -> returns 0, no crash."""
+    s = _store(tmp_path)
+    s.import_inventory_meta(_C_CHECKLIST)
+    n = import_frida_coverage(s, _C_CHECKLIST, [tmp_path])
+    assert n == 0
+
+
+def test_import_frida_coverage_no_binary(tmp_path):
+    """drcov exists but no binary for addr2line -> returns 0."""
+    run_dir = tmp_path / "frida-run"
+    run_dir.mkdir(parents=True, exist_ok=True)
+    # metadata with no binary field
+    meta = _sample_metadata()
+    meta["target"]["binary"] = None
+    (run_dir / "metadata.json").write_text(json.dumps(meta), encoding="utf-8")
+    (run_dir / "coverage.drcov").write_bytes(b"DRCOV VERSION: 2\n")
+
+    s = _store(tmp_path)
+    s.import_inventory_meta(_C_CHECKLIST)
+    n = import_frida_coverage(s, _C_CHECKLIST, [tmp_path])
+    assert n == 0
+
+
+def test_import_frida_coverage_target_mismatch(tmp_path):
+    """drcov exists but target doesn't match -> returns 0."""
+    run_dir = tmp_path / "frida-run"
+    _write_frida_run(run_dir, binary="/opt/other-binary")
+
+    s = _store(tmp_path)
+    s.import_inventory_meta(_C_CHECKLIST)
+    n = import_frida_coverage(
+        s, _C_CHECKLIST, [tmp_path],
+        target_binary="/opt/other-binary",
+        target_path="/home/user/totally-different",
+    )
+    assert n == 0

--- a/core/inventory/reach_audit.py
+++ b/core/inventory/reach_audit.py
@@ -34,6 +34,7 @@ _DEAD_VERDICTS = frozenset({
 # Verdicts that mean "reachable / has a live path".
 _LIVE_VERDICTS = frozenset({
     "reachable", "framework_callable", "registered_via_call", "called",
+    "frida_runtime_trace",
 })
 # "uncertain" is neither — the substrate declines to claim.
 
@@ -72,6 +73,15 @@ def _stage_binary_oracle_absent(ctx: "_ClassifyCtx", R) -> Optional[str]:
         ctx.inventory, ctx.file_path, ctx.name, ctx.line,
     ):
         return "binary_oracle_absent"
+    return None
+
+
+def _stage_frida_runtime_trace(ctx: "_ClassifyCtx", R) -> Optional[str]:
+    """Promote if frida observed the function at runtime."""
+    if R.frida_runtime_trace_present(
+        ctx.inventory, ctx.file_path, ctx.name, ctx.line,
+    ):
+        return "frida_runtime_trace"
     return None
 
 
@@ -161,6 +171,13 @@ def _stage_one_hop(ctx: "_ClassifyCtx", R) -> Optional[str]:
 PRECEDENCE = (
     _stage_module_aborts,
     _stage_lexical_dead,
+    # Frida runtime-trace promote (SOUND). Empirical runtime
+    # observation is the strongest reachability evidence — if frida
+    # saw the function execute, it's alive regardless of what static
+    # analysis (binary oracle, build_excluded, call graph) claims.
+    # MUST precede _stage_binary_oracle_absent so runtime evidence
+    # vetoes a stale/wrong "absent" verdict from nm+DWARF.
+    _stage_frida_runtime_trace,
     # binary_oracle absent is mechanically derivable from nm + DWARF —
     # stronger than build_excluded (build-config parsing heuristic), so
     # checked first among C/C++/Rust/Go dead witnesses. SOUND +

--- a/core/inventory/reach_witness.py
+++ b/core/inventory/reach_witness.py
@@ -49,6 +49,7 @@ class WitnessKind(str, Enum):
     REGISTERED_VIA_CALL = "registered_via_call"
     REACHABLE_FROM_ENTRY = "reachable_from_entry"
     BINARY_CALL_EDGE = "binary_call_edge"
+    FRIDA_RUNTIME_TRACE = "frida_runtime_trace"
     # uncertain
     UNCERTAIN = "uncertain"
 
@@ -230,6 +231,16 @@ VERDICTS: Dict[str, VerdictSpec] = {
             "binary-resident symbol. Source-graph extraction may have "
             "missed this edge (header-inline, partial resolution); the "
             "binary provides affirmative reachability evidence."),
+    ),
+    "frida_runtime_trace": VerdictSpec(
+        Reachability.REACHABLE, WitnessKind.FRIDA_RUNTIME_TRACE,
+        Soundness.SOUND, earns_suppression=False,
+        summary="observed at runtime via frida instrumentation",
+        prompt_verdict=(
+            "Verdict: FRIDA_RUNTIME_TRACE — frida dynamic instrumentation "
+            "observed this function executing at runtime. This is empirical "
+            "proof of reachability (sound witness). Does not earn finding "
+            "suppression — a reachable function may still be vulnerable."),
     ),
     "reachable": VerdictSpec(
         Reachability.REACHABLE, WitnessKind.REACHABLE_FROM_ENTRY,

--- a/core/inventory/reachability.py
+++ b/core/inventory/reachability.py
@@ -2413,6 +2413,59 @@ def binary_call_edge_present(
     return False
 
 
+def frida_runtime_trace_present(
+    inventory: Dict[str, Any],
+    file_path: str,
+    name: str,
+    line: int = 0,
+) -> bool:
+    """True when frida observed this function executing at runtime.
+
+    Checks for ``metadata.frida_runtime_trace.observed`` on the
+    inventory item. The enrichment pipeline sets this when the
+    function name appears in frida's events.jsonl output.
+
+    SOUND — runtime observation is mechanically sound evidence of
+    reachability (stronger than static call-graph edges). But
+    earns_suppression=False because this PROMOTES (proves reachable);
+    it doesn't suppress.
+    """
+    if not file_path or not name:
+        return False
+    normalised = file_path.replace("\\", "/")
+    idx = _get_bo_item_index(inventory)
+    by_name = idx.get(normalised)
+    if not by_name:
+        return False
+    candidates = by_name.get(name)
+    if not candidates:
+        return False
+    if line and len(candidates) > 1:
+        enclosing = [
+            it for it in candidates
+            if int(it.get("line_start") or 0) <= line
+            and (int(it.get("line_end") or 0) == 0
+                 or line <= int(it.get("line_end") or 0))
+        ]
+        if enclosing:
+            candidates = [max(
+                enclosing,
+                key=lambda it: int(it.get("line_start") or 0),
+            )]
+        else:
+            candidates = candidates[:1]
+    for item in candidates:
+        meta = item.get("metadata")
+        if not isinstance(meta, dict):
+            continue
+        frida = meta.get("frida_runtime_trace")
+        if not isinstance(frida, dict):
+            continue
+        if frida.get("observed"):
+            return True
+    return False
+
+
 def binary_oracle_absent(
     inventory: Dict[str, Any],
     file_path: str,
@@ -4069,6 +4122,7 @@ __all__ = [
     "entry_reachability",
     "is_lexically_dead",
     "is_registered_via_call",
+    "frida_runtime_trace_present",
     "module_aborts_on_load",
     "parse_evidence_entry",
     "reverse_closure",

--- a/core/inventory/tests/test_frida_witness.py
+++ b/core/inventory/tests/test_frida_witness.py
@@ -1,0 +1,179 @@
+"""Tests for frida runtime-trace reachability integration.
+
+Covers:
+  - frida_runtime_trace_present() accessor on inventory items
+  - _stage_frida_runtime_trace in the PRECEDENCE chain
+  - frida evidence overriding binary_oracle_absent
+"""
+
+from __future__ import annotations
+
+
+def _make_inventory(file_path: str, name: str, frida_observed: bool = True):
+    """Build a minimal inventory with one item that has frida metadata."""
+    item = {
+        "name": name,
+        "line_start": 10,
+        "line_end": 20,
+        "metadata": {},
+    }
+    if frida_observed:
+        item["metadata"]["frida_runtime_trace"] = {
+            "observed": True,
+            "call_count": 5,
+            "trace_id": "/tmp/frida_run",
+        }
+    return {"files": [{"path": file_path, "items": [item]}]}
+
+
+class TestFridaRuntimeTracePresent:
+    def test_returns_true_when_observed(self):
+        from core.inventory.reachability import frida_runtime_trace_present
+
+        inv = _make_inventory("src/main.c", "process_input")
+        assert frida_runtime_trace_present(inv, "src/main.c", "process_input") is True
+
+    def test_returns_false_when_no_metadata(self):
+        from core.inventory.reachability import frida_runtime_trace_present
+
+        inv = _make_inventory("src/main.c", "process_input", frida_observed=False)
+        assert frida_runtime_trace_present(inv, "src/main.c", "process_input") is False
+
+    def test_returns_false_for_wrong_function(self):
+        from core.inventory.reachability import frida_runtime_trace_present
+
+        inv = _make_inventory("src/main.c", "process_input")
+        assert frida_runtime_trace_present(inv, "src/main.c", "other_func") is False
+
+    def test_returns_false_for_wrong_file(self):
+        from core.inventory.reachability import frida_runtime_trace_present
+
+        inv = _make_inventory("src/main.c", "process_input")
+        assert frida_runtime_trace_present(inv, "src/other.c", "process_input") is False
+
+    def test_returns_false_for_empty_inputs(self):
+        from core.inventory.reachability import frida_runtime_trace_present
+
+        inv = _make_inventory("src/main.c", "process_input")
+        assert frida_runtime_trace_present(inv, "", "process_input") is False
+        assert frida_runtime_trace_present(inv, "src/main.c", "") is False
+
+    def test_line_disambiguation(self):
+        from core.inventory.reachability import frida_runtime_trace_present
+
+        inv = {"files": [{"path": "src/x.c", "items": [
+            {"name": "foo", "line_start": 1, "line_end": 10, "metadata": {}},
+            {"name": "foo", "line_start": 20, "line_end": 30, "metadata": {
+                "frida_runtime_trace": {"observed": True, "call_count": 1,
+                                        "trace_id": "t"},
+            }},
+        ]}]}
+        assert frida_runtime_trace_present(inv, "src/x.c", "foo", line=5) is False
+        assert frida_runtime_trace_present(inv, "src/x.c", "foo", line=25) is True
+
+
+class TestStageInPrecedence:
+    def test_frida_stage_before_binary_oracle(self):
+        from core.inventory.reach_audit import (
+            PRECEDENCE,
+            _stage_binary_oracle_absent,
+            _stage_frida_runtime_trace,
+        )
+
+        frida_idx = list(PRECEDENCE).index(_stage_frida_runtime_trace)
+        oracle_idx = list(PRECEDENCE).index(_stage_binary_oracle_absent)
+        assert frida_idx < oracle_idx, (
+            "frida runtime trace must precede binary_oracle_absent "
+            "so runtime evidence overrides stale absent verdicts"
+        )
+
+    def test_frida_is_live_verdict(self):
+        from core.inventory.reach_audit import _LIVE_VERDICTS
+
+        assert "frida_runtime_trace" in _LIVE_VERDICTS
+
+    def test_classify_returns_frida_verdict(self):
+        from core.inventory.reach_audit import classify_reachability
+        from core.inventory import reachability as R
+
+        inv = _make_inventory("src/vuln.c", "vulnerable_fn")
+        verdict = classify_reachability(inv, "src/vuln.c", "vulnerable_fn", 15, R)
+        assert verdict == "frida_runtime_trace"
+
+    def test_frida_overrides_binary_oracle_absent(self):
+        """A function observed by frida should get frida verdict even if
+        binary oracle would say absent."""
+        from core.inventory.reach_audit import classify_reachability
+        from core.inventory import reachability as R
+
+        inv = _make_inventory("src/vuln.c", "vulnerable_fn")
+        item = inv["files"][0]["items"][0]
+        item["metadata"]["binary_oracle"] = {
+            "verdict": "absent",
+            "tier": "full_dwarf",
+        }
+
+        verdict = classify_reachability(inv, "src/vuln.c", "vulnerable_fn", 15, R)
+        assert verdict == "frida_runtime_trace"
+
+
+class TestEnrichWithFridaTraces:
+    def test_enriches_checklist_items(self, tmp_path):
+        from core.orchestration.reachability_enrichment import enrich_with_frida_traces
+        import json
+
+        events = [
+            {"type": "send", "payload": {"fn": "process_input", "args": ["/etc/passwd"]}},
+            {"type": "send", "payload": {"fn": "process_input", "args": ["/etc/shadow"]}},
+            {"type": "send", "payload": {"fn": "write_output", "args": ["/tmp/out"]}},
+        ]
+        run_dir = tmp_path / "frida_run"
+        run_dir.mkdir()
+        (run_dir / "events.jsonl").write_text(
+            "\n".join(json.dumps(e) for e in events) + "\n")
+        (run_dir / "metadata.json").write_text(json.dumps({
+            "ok": True, "target": {"binary": "/usr/bin/test"},
+            "events_captured": 3,
+        }))
+
+        checklist = {"files": [{"path": "src/main.c", "items": [
+            {"name": "process_input", "line_start": 10, "line_end": 20},
+            {"name": "unrelated_fn", "line_start": 30, "line_end": 40},
+        ]}]}
+
+        from pathlib import Path
+        count = enrich_with_frida_traces(
+            checklist, Path("/usr/bin/test"),
+            search_dirs=[tmp_path],
+        )
+        assert count == 1
+        item = checklist["files"][0]["items"][0]
+        assert item["metadata"]["frida_runtime_trace"]["observed"] is True
+        assert item["metadata"]["frida_runtime_trace"]["call_count"] == 2
+
+        unrelated = checklist["files"][0]["items"][1]
+        assert "metadata" not in unrelated or "frida_runtime_trace" not in unrelated.get("metadata", {})
+
+    def test_skips_non_native_files(self, tmp_path):
+        from core.orchestration.reachability_enrichment import enrich_with_frida_traces
+        import json
+
+        events = [{"type": "send", "payload": {"fn": "handle_request", "args": []}}]
+        run_dir = tmp_path / "frida_run"
+        run_dir.mkdir()
+        (run_dir / "events.jsonl").write_text(json.dumps(events[0]) + "\n")
+        (run_dir / "metadata.json").write_text(json.dumps({
+            "ok": True, "target": {"binary": "/usr/bin/test"},
+            "events_captured": 1,
+        }))
+
+        checklist = {"files": [{"path": "src/app.py", "items": [
+            {"name": "handle_request", "line_start": 1, "line_end": 10},
+        ]}]}
+
+        from pathlib import Path
+        count = enrich_with_frida_traces(
+            checklist, Path("/usr/bin/test"),
+            search_dirs=[tmp_path],
+        )
+        assert count == 0

--- a/core/orchestration/agentic_passes.py
+++ b/core/orchestration/agentic_passes.py
@@ -1034,6 +1034,7 @@ def run_reachability_prepass(
     try:
         from core.orchestration.reachability_enrichment import (
             enrich_with_caller_context,
+            enrich_with_frida_traces,
             mark_unreachable_low_priority,
         )
         checklist = load_json(checklist_path)
@@ -1048,13 +1049,11 @@ def run_reachability_prepass(
             checklist, target, inventory=inventory,
             allow_unreachable=allow_unreachable,
         )
-        # Caller-context enrichment runs AFTER the dead-code
-        # marking so already-marked functions can be skipped
-        # cheaply (the LLM is going to deprioritise them
-        # regardless). Each surviving function gains
-        # caller_count_direct / _transitive / _uncertain plus
-        # direct_caller_names — the triage prompt reads these to
-        # judge blast radius alongside priority.
+        enrich_with_frida_traces(
+            checklist, target,
+            search_dirs=[agentic_out_dir, agentic_out_dir.parent],
+            inventory=inventory,
+        )
         enriched_caller_ctx = enrich_with_caller_context(
             checklist, target, inventory=inventory,
         )

--- a/core/orchestration/frida_validation_bridge.py
+++ b/core/orchestration/frida_validation_bridge.py
@@ -1,0 +1,239 @@
+"""Bridge frida runtime evidence into the validation pipeline.
+
+Discovers frida evidence for a target and produces runtime_evidence
+annotations that Stage B can use to floor proximity scores, and
+Stage D can use as independent corroboration.
+
+Pattern follows understand_bridge.py -- discovers output from a prior
+/frida run and feeds it into the validation pipeline's data model.
+"""
+
+from __future__ import annotations
+
+import copy
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+from core.logging import get_logger
+
+log = get_logger("orchestration.frida_validation_bridge")
+
+__all__ = [
+    "PROXIMITY_FLOOR",
+    "RuntimeEvidence",
+    "annotate_attack_paths",
+    "collect_runtime_evidence",
+]
+
+PROXIMITY_FLOOR = 6
+
+
+@dataclass
+class RuntimeEvidence:
+    """Runtime evidence from a frida session for one attack path step."""
+
+    function_observed: bool
+    call_count: int = 0
+    observed_args: Optional[list] = None
+    trace_id: str = ""
+
+
+def collect_runtime_evidence(
+    search_dirs: list[Path],
+    target_path: Optional[str] = None,
+) -> dict[str, RuntimeEvidence]:
+    """Discover frida evidence and build a function->RuntimeEvidence map.
+
+    Searches ``search_dirs`` for frida run directories via the shared
+    evidence discovery layer.  When ``target_path`` is given, only runs
+    whose metadata target matches are used.
+
+    Returns {function_name: RuntimeEvidence} for all functions frida
+    observed.  Empty dict if no frida evidence found.
+    """
+    try:
+        from packages.frida import parse_events
+        from packages.frida.evidence import discover_evidence
+    except ImportError:
+        log.debug("packages.frida not importable; skipping frida evidence")
+        return {}
+
+    evidence_list = discover_evidence(search_dirs, target_path=target_path)
+    if not evidence_list:
+        return {}
+
+    result: dict[str, RuntimeEvidence] = {}
+
+    for ev in evidence_list:
+        if not ev.has_events:
+            continue
+        events_path = ev.run_dir / "events.jsonl"
+        trace_id = str(ev.run_dir)
+
+        # Per-run counters: track call_count within this run, then take
+        # the max across runs (represents the hottest single run).
+        run_counts: dict[str, int] = {}
+        run_first_args: dict[str, list | None] = {}
+
+        for record in parse_events(events_path):
+            if not isinstance(record, dict):
+                continue
+            if record.get("type") != "send":
+                continue
+            payload = record.get("payload")
+            if not isinstance(payload, dict):
+                continue
+            fn = payload.get("fn")
+            if not isinstance(fn, str) or not fn:
+                continue
+
+            run_counts[fn] = run_counts.get(fn, 0) + 1
+
+            if run_first_args.get(fn) is None:
+                args = payload.get("args")
+                if isinstance(args, dict):
+                    run_first_args[fn] = list(args.values())
+                elif isinstance(args, list):
+                    run_first_args[fn] = args
+
+        for fn, count in run_counts.items():
+            if fn in result:
+                existing = result[fn]
+                new_args = existing.observed_args
+                if new_args is None:
+                    new_args = run_first_args.get(fn)
+                result[fn] = RuntimeEvidence(
+                    function_observed=True,
+                    call_count=max(existing.call_count, count),
+                    observed_args=new_args,
+                    trace_id=existing.trace_id,
+                )
+            else:
+                result[fn] = RuntimeEvidence(
+                    function_observed=True,
+                    call_count=count,
+                    observed_args=run_first_args.get(fn),
+                    trace_id=trace_id,
+                )
+
+    log.info("collected runtime evidence: %d functions from %d runs",
+             len(result), len(evidence_list))
+    return result
+
+
+def annotate_attack_paths(
+    attack_paths: list[dict],
+    evidence_map: dict[str, RuntimeEvidence],
+) -> list[dict]:
+    """Annotate attack paths with runtime_evidence from frida.
+
+    For each attack path step whose function appears in the evidence
+    map, adds a ``runtime_evidence`` dict to the step.  If any step
+    has runtime evidence, floors the path's proximity at
+    ``PROXIMITY_FLOOR`` (precedent: SMT feasible:true floor in
+    Stage B).
+
+    Returns a deep copy of attack_paths with annotations.  The
+    original list is never mutated.
+    """
+    if not evidence_map:
+        return attack_paths
+
+    result = copy.deepcopy(attack_paths)
+
+    for path in result:
+        if not isinstance(path, dict):
+            continue
+
+        has_evidence = False
+        first_trace_id = None
+
+        steps = path.get("steps")
+        if not isinstance(steps, list):
+            continue
+
+        for step in steps:
+            if not isinstance(step, dict):
+                continue
+
+            fn_name = _extract_function_name(step)
+            if not fn_name:
+                continue
+
+            ev = evidence_map.get(fn_name)
+            if ev is None:
+                continue
+
+            has_evidence = True
+            if first_trace_id is None:
+                first_trace_id = ev.trace_id
+            step["runtime_evidence"] = {
+                "function_observed": ev.function_observed,
+                "call_count": ev.call_count,
+                "observed_args": ev.observed_args,
+                "trace_id": ev.trace_id,
+            }
+
+        if has_evidence:
+            path["runtime_evidence_available"] = True
+            if first_trace_id:
+                path["frida_trace_id"] = first_trace_id
+            current_proximity = path.get("proximity")
+            if isinstance(current_proximity, (int, float)):
+                if current_proximity < PROXIMITY_FLOOR:
+                    path["proximity"] = PROXIMITY_FLOOR
+            else:
+                path["proximity"] = PROXIMITY_FLOOR
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+_ACTION_FN_RE = re.compile(r'\b([a-zA-Z_]\w*)\s*\(')
+_KEYWORDS = frozenset({
+    "if", "for", "while", "switch", "catch", "return", "sizeof", "typeof",
+    "alignof", "decltype", "throw", "new", "delete",
+})
+
+
+def _extract_function_name(step: dict) -> Optional[str]:
+    """Extract a function name from an attack path step.
+
+    Steps use varying formats: some have a ``function`` or ``name``
+    key, others have ``action`` strings like ``"call strcpy(buf, in)"``.
+    For action strings we take the LAST function-call pattern since
+    earlier tokens are typically callers, not the vulnerable callee.
+    """
+    for key in ("function", "name"):
+        val = step.get(key)
+        if isinstance(val, str) and val:
+            return _strip_parens(val)
+
+    action = step.get("action")
+    if isinstance(action, str) and action:
+        last_match = None
+        for m in _ACTION_FN_RE.finditer(action):
+            candidate = m.group(1)
+            if candidate not in _KEYWORDS:
+                last_match = candidate
+        if last_match:
+            return last_match
+
+    return None
+
+
+def _strip_parens(name: str) -> str:
+    """Remove trailing parentheses from a function name."""
+    name = name.strip()
+    if name.endswith("()"):
+        return name[:-2]
+    idx = name.find("(")
+    if idx > 0:
+        return name[:idx].strip()
+    return name

--- a/core/orchestration/reachability_enrichment.py
+++ b/core/orchestration/reachability_enrichment.py
@@ -322,7 +322,110 @@ def enrich_with_caller_context(
     return enriched
 
 
+def enrich_with_frida_traces(
+    checklist: Dict[str, Any],
+    target_path: Path,
+    *,
+    search_dirs: Optional[list] = None,
+    inventory: Optional[Dict[str, Any]] = None,
+) -> int:
+    """Annotate checklist items with frida runtime-trace evidence.
+
+    For each function in the checklist that was observed by frida at
+    runtime, sets ``metadata.frida_runtime_trace`` on the item (and on
+    the inventory item, if provided). Returns the count of items
+    annotated.
+
+    Best-effort: any failure returns 0 and the checklist is unchanged.
+    """
+    try:
+        from core.orchestration.frida_validation_bridge import (
+            collect_runtime_evidence,
+        )
+    except ImportError:
+        return 0
+
+    if search_dirs is None:
+        search_dirs = []
+
+    evidence_map = collect_runtime_evidence(
+        [Path(d) for d in search_dirs], target_path=str(target_path))
+    if not evidence_map:
+        return 0
+
+    _NATIVE_SUFFIXES = frozenset({
+        ".c", ".h", ".cc", ".cpp", ".cxx", ".hh", ".hpp",
+        ".rs", ".go", ".s", ".S", ".asm",
+    })
+
+    annotated = 0
+    files = checklist.get("files")
+    if not isinstance(files, list):
+        return 0
+
+    for file_entry in files:
+        if not isinstance(file_entry, dict):
+            continue
+        fpath = file_entry.get("path", "")
+        if not any(fpath.endswith(s) for s in _NATIVE_SUFFIXES):
+            continue
+        items = file_entry.get("items")
+        if not isinstance(items, list):
+            continue
+        for item in items:
+            if not isinstance(item, dict):
+                continue
+            fn_name = item.get("name", "")
+            if not fn_name:
+                continue
+            ev = evidence_map.get(fn_name)
+            if ev is None:
+                continue
+            meta = item.setdefault("metadata", {})
+            meta["frida_runtime_trace"] = {
+                "observed": True,
+                "call_count": ev.call_count,
+                "trace_id": ev.trace_id,
+            }
+            annotated += 1
+
+    # Also annotate inventory items (dual-write) if provided.
+    if inventory and isinstance(inventory, dict):
+        inv_files = inventory.get("files")
+        if isinstance(inv_files, list):
+            for file_entry in inv_files:
+                if not isinstance(file_entry, dict):
+                    continue
+                fpath = file_entry.get("path", "")
+                if not any(fpath.endswith(s) for s in _NATIVE_SUFFIXES):
+                    continue
+                inv_items = file_entry.get("items")
+                if not isinstance(inv_items, list):
+                    continue
+                for item in inv_items:
+                    if not isinstance(item, dict):
+                        continue
+                    fn_name = item.get("name", "")
+                    ev = evidence_map.get(fn_name)
+                    if ev is None:
+                        continue
+                    meta = item.setdefault("metadata", {})
+                    meta["frida_runtime_trace"] = {
+                        "observed": True,
+                        "call_count": ev.call_count,
+                        "trace_id": ev.trace_id,
+                    }
+
+    if annotated:
+        logger.info(
+            "reachability_enrichment: annotated %d function(s) with "
+            "frida runtime-trace evidence", annotated,
+        )
+    return annotated
+
+
 __all__ = [
     "enrich_with_caller_context",
+    "enrich_with_frida_traces",
     "mark_unreachable_low_priority",
 ]

--- a/core/orchestration/tests/test_frida_validation_bridge.py
+++ b/core/orchestration/tests/test_frida_validation_bridge.py
@@ -1,0 +1,373 @@
+"""Tests for core.orchestration.frida_validation_bridge."""
+
+import copy
+import json
+from pathlib import Path
+
+from core.orchestration.frida_validation_bridge import (
+    RuntimeEvidence,
+    collect_runtime_evidence,
+    annotate_attack_paths,
+    PROXIMITY_FLOOR,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_events(run_dir: Path, events: list[dict]) -> None:
+    """Write synthetic events.jsonl into a frida run directory."""
+    run_dir.mkdir(parents=True, exist_ok=True)
+    lines = [json.dumps(e) for e in events]
+    (run_dir / "events.jsonl").write_text("\n".join(lines) + "\n")
+
+
+def _write_metadata(run_dir: Path, target_raw: str = "", target_binary: str = "",
+                     target_name: str = "") -> None:
+    """Write a minimal metadata.json."""
+    meta = {
+        "ok": True,
+        "target": {
+            "raw": target_raw,
+            "kind": "binary" if target_binary else "name",
+            "pid": None,
+            "name": target_name,
+            "binary": target_binary,
+        },
+    }
+    (run_dir / "metadata.json").write_text(json.dumps(meta))
+
+
+def _make_frida_run(tmp_path: Path, name: str, events: list[dict],
+                     target_raw: str = "", target_binary: str = "",
+                     target_name: str = "") -> Path:
+    """Create a complete synthetic frida run directory."""
+    run_dir = tmp_path / name
+    _write_events(run_dir, events)
+    _write_metadata(run_dir, target_raw, target_binary, target_name)
+    return run_dir
+
+
+def _api_event(fn: str, args: dict | None = None) -> dict:
+    """Build a single api-trace style event record."""
+    payload: dict = {"category": "file", "fn": fn, "tid": 1}
+    if args is not None:
+        payload["args"] = args
+    return {"ts": 0.1, "type": "send", "payload": payload}
+
+
+SAMPLE_EVENTS = [
+    _api_event("open", {"path": "/etc/passwd", "flags": 0, "ret": 3}),
+    _api_event("read", {"fd": 3, "count": 4096, "ret": 512}),
+    _api_event("open", {"path": "/etc/shadow", "flags": 0, "ret": -1}),
+    _api_event("close", {"fd": 3, "ret": 0}),
+    _api_event("write", {"fd": 1, "count": 512, "ret": 512}),
+]
+
+
+def _make_attack_path(path_id: str, steps: list[dict], proximity: int | float = 3) -> dict:
+    return {
+        "id": path_id,
+        "name": f"Path {path_id}",
+        "finding": "FIND-001",
+        "steps": steps,
+        "proximity": proximity,
+        "blockers": [],
+        "status": "uncertain",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Tests: collect_runtime_evidence
+# ---------------------------------------------------------------------------
+
+
+class TestCollectRuntimeEvidence:
+
+    def test_from_events(self, tmp_path: Path):
+        """Synthetic events.jsonl produces an evidence map with function names."""
+        _make_frida_run(tmp_path, "frida_run", SAMPLE_EVENTS)
+        result = collect_runtime_evidence([tmp_path])
+        assert "open" in result
+        assert "read" in result
+        assert "write" in result
+        assert "close" in result
+        assert result["open"].function_observed is True
+        assert result["open"].call_count == 2
+        assert result["read"].call_count == 1
+
+    def test_no_evidence(self, tmp_path: Path):
+        """No frida output yields an empty dict."""
+        result = collect_runtime_evidence([tmp_path])
+        assert result == {}
+
+    def test_empty_search_dirs(self):
+        result = collect_runtime_evidence([])
+        assert result == {}
+
+    def test_nonexistent_dir(self, tmp_path: Path):
+        result = collect_runtime_evidence([tmp_path / "nope"])
+        assert result == {}
+
+    def test_target_mismatch(self, tmp_path: Path):
+        """Wrong target path yields empty dict when target_path filter is set."""
+        _make_frida_run(
+            tmp_path, "frida_run", SAMPLE_EVENTS,
+            target_binary="/usr/bin/other_binary",
+        )
+        result = collect_runtime_evidence(
+            [tmp_path],
+            target_path="/usr/bin/my_target",
+        )
+        assert result == {}
+
+    def test_target_match(self, tmp_path: Path):
+        """Matching target path includes the evidence."""
+        target = str(tmp_path / "my_binary")
+        (tmp_path / "my_binary").touch()
+        _make_frida_run(
+            tmp_path, "frida_run", SAMPLE_EVENTS,
+            target_binary=target,
+        )
+        result = collect_runtime_evidence([tmp_path], target_path=target)
+        assert "open" in result
+
+    def test_target_match_by_name(self, tmp_path: Path):
+        """Match by process name when target_path basename matches."""
+        _make_frida_run(
+            tmp_path, "frida_run", SAMPLE_EVENTS,
+            target_name="my_binary",
+        )
+        result = collect_runtime_evidence(
+            [tmp_path],
+            target_path="/some/path/my_binary",
+        )
+        assert "open" in result
+
+    def test_corrupt_events_graceful(self, tmp_path: Path):
+        """Corrupt events.jsonl lines are skipped gracefully."""
+        run_dir = tmp_path / "frida_run"
+        run_dir.mkdir()
+        (run_dir / "events.jsonl").write_text(
+            "NOT JSON\n"
+            + json.dumps(_api_event("open")) + "\n"
+            + "{truncated\n"
+        )
+        _write_metadata(run_dir)
+        result = collect_runtime_evidence([tmp_path])
+        assert "open" in result
+        assert len(result) == 1
+
+    def test_missing_events_file(self, tmp_path: Path):
+        """Run dir with metadata.json but no events.jsonl yields nothing."""
+        run_dir = tmp_path / "frida_run"
+        run_dir.mkdir()
+        _write_metadata(run_dir)
+        result = collect_runtime_evidence([tmp_path])
+        assert result == {}
+
+    def test_observed_args_captured(self, tmp_path: Path):
+        """First observed args for a function are captured."""
+        events = [_api_event("open", {"path": "/etc/passwd", "flags": 0})]
+        _make_frida_run(tmp_path, "frida_run", events)
+        result = collect_runtime_evidence([tmp_path])
+        assert result["open"].observed_args is not None
+        assert "/etc/passwd" in result["open"].observed_args
+
+    def test_observed_args_updated_from_later_event(self, tmp_path: Path):
+        """If first event has no args, later event fills in observed_args."""
+        events = [
+            _api_event("custom_fn", None),
+            _api_event("custom_fn", {"path": "/real/arg", "flags": 2}),
+        ]
+        _make_frida_run(tmp_path, "frida_run", events)
+        result = collect_runtime_evidence([tmp_path])
+        assert result["custom_fn"].observed_args is not None
+        assert "/real/arg" in result["custom_fn"].observed_args
+        assert result["custom_fn"].call_count == 2
+
+    def test_provenance_trace_id(self, tmp_path: Path):
+        """RuntimeEvidence carries the run directory as trace_id."""
+        run_dir = _make_frida_run(tmp_path, "frida_run", SAMPLE_EVENTS)
+        result = collect_runtime_evidence([tmp_path])
+        assert result["open"].trace_id == str(run_dir)
+
+    def test_non_send_events_ignored(self, tmp_path: Path):
+        """Error events and other types are not treated as function calls."""
+        events = [
+            {"ts": 0.1, "type": "error", "error": {"description": "boom"}},
+            _api_event("read"),
+        ]
+        _make_frida_run(tmp_path, "frida_run", events)
+        result = collect_runtime_evidence([tmp_path])
+        assert "read" in result
+        assert len(result) == 1
+
+
+# ---------------------------------------------------------------------------
+# Tests: annotate_attack_paths
+# ---------------------------------------------------------------------------
+
+
+class TestAnnotateAttackPaths:
+
+    def _evidence_map(self, trace_id: str = "/out/frida_run") -> dict[str, RuntimeEvidence]:
+        return {
+            "open": RuntimeEvidence(
+                function_observed=True, call_count=5,
+                observed_args=["/etc/passwd", 0], trace_id=trace_id,
+            ),
+            "strcpy": RuntimeEvidence(
+                function_observed=True, call_count=2,
+                observed_args=None, trace_id=trace_id,
+            ),
+        }
+
+    def test_paths_with_evidence(self):
+        """Attack path step matching evidence gets runtime_evidence dict."""
+        paths = [_make_attack_path("P1", [
+            {"step": 1, "action": "call open(path)", "function": "open"},
+            {"step": 2, "action": "copy into buffer", "function": "strcpy"},
+        ])]
+        evidence = self._evidence_map()
+        result = annotate_attack_paths(paths, evidence)
+
+        step0 = result[0]["steps"][0]
+        assert "runtime_evidence" in step0
+        assert step0["runtime_evidence"]["function_observed"] is True
+        assert step0["runtime_evidence"]["call_count"] == 5
+        assert step0["runtime_evidence"]["observed_args"] == ["/etc/passwd", 0]
+
+    def test_floors_proximity(self):
+        """Path with runtime evidence gets proximity >= PROXIMITY_FLOOR."""
+        paths = [_make_attack_path("P1", [
+            {"step": 1, "action": "open file", "function": "open"},
+        ], proximity=2)]
+        result = annotate_attack_paths(paths, self._evidence_map())
+        assert result[0]["proximity"] >= PROXIMITY_FLOOR
+
+    def test_no_evidence_unchanged(self):
+        """No matching functions means paths are unchanged."""
+        paths = [_make_attack_path("P1", [
+            {"step": 1, "action": "call unrelated_func()", "function": "unrelated_func"},
+        ])]
+        result = annotate_attack_paths(paths, self._evidence_map())
+        assert "runtime_evidence" not in result[0]["steps"][0]
+        assert "runtime_evidence_available" not in result[0]
+        assert result[0]["proximity"] == 3
+
+    def test_preserves_original(self):
+        """Original attack_paths list is not mutated."""
+        original_paths = [_make_attack_path("P1", [
+            {"step": 1, "action": "call open()", "function": "open"},
+        ], proximity=2)]
+        frozen = copy.deepcopy(original_paths)
+        annotate_attack_paths(original_paths, self._evidence_map())
+        assert original_paths == frozen
+
+    def test_multiple_steps_partial(self):
+        """Only steps with evidence get runtime_evidence; others are untouched."""
+        paths = [_make_attack_path("P1", [
+            {"step": 1, "action": "call open(path)", "function": "open"},
+            {"step": 2, "action": "parse input", "function": "parse_input"},
+            {"step": 3, "action": "call strcpy()", "function": "strcpy"},
+        ])]
+        result = annotate_attack_paths(paths, self._evidence_map())
+
+        assert "runtime_evidence" in result[0]["steps"][0]
+        assert "runtime_evidence" not in result[0]["steps"][1]
+        assert "runtime_evidence" in result[0]["steps"][2]
+        assert result[0]["runtime_evidence_available"] is True
+
+    def test_proximity_floor_respects_higher(self):
+        """Path already at proximity 8 stays at 8 (floor, not clamp)."""
+        paths = [_make_attack_path("P1", [
+            {"step": 1, "action": "call open()", "function": "open"},
+        ], proximity=8)]
+        result = annotate_attack_paths(paths, self._evidence_map())
+        assert result[0]["proximity"] == 8
+
+    def test_empty_evidence_map(self):
+        """Empty evidence map returns input unchanged (no copy needed)."""
+        paths = [_make_attack_path("P1", [
+            {"step": 1, "action": "call open()", "function": "open"},
+        ])]
+        result = annotate_attack_paths(paths, {})
+        assert result == paths
+        assert result is paths
+
+    def test_frida_trace_id_on_path(self):
+        """Annotated paths carry frida_trace_id for provenance."""
+        paths = [_make_attack_path("P1", [
+            {"step": 1, "action": "call open()", "function": "open"},
+        ])]
+        evidence = self._evidence_map(trace_id="/out/frida_20260621_143000/")
+        result = annotate_attack_paths(paths, evidence)
+        assert result[0]["frida_trace_id"] == "/out/frida_20260621_143000/"
+
+    def test_function_name_from_action_regex(self):
+        """Function name extracted from action string via regex when no function key."""
+        paths = [_make_attack_path("P1", [
+            {"step": 1, "action": "call open(\"/etc/passwd\", O_RDONLY)"},
+        ])]
+        result = annotate_attack_paths(paths, self._evidence_map())
+        assert "runtime_evidence" in result[0]["steps"][0]
+
+    def test_string_steps_skipped(self):
+        """String-typed steps (legacy format) are skipped without error."""
+        paths = [_make_attack_path("P1", [
+            "Step 1: call open()",
+            {"step": 2, "action": "call strcpy()", "function": "strcpy"},
+        ])]
+        result = annotate_attack_paths(paths, self._evidence_map())
+        assert result[0]["steps"][0] == "Step 1: call open()"
+        assert "runtime_evidence" in result[0]["steps"][1]
+
+    def test_action_regex_takes_last_function(self):
+        """Action with multiple calls extracts the last (callee, not caller)."""
+        evidence = {"strcpy": RuntimeEvidence(function_observed=True, call_count=1)}
+        paths = [_make_attack_path("P1", [
+            {"step": 1, "action": "validate_input() calls strcpy(buf, in)"},
+        ])]
+        result = annotate_attack_paths(paths, evidence)
+        assert "runtime_evidence" in result[0]["steps"][0]
+
+    def test_empty_paths_list(self):
+        """Empty attack paths list returns empty list."""
+        result = annotate_attack_paths([], self._evidence_map())
+        assert result == []
+
+    def test_float_proximity_is_floored(self):
+        """Float proximity (e.g., from SMT) gets floored correctly."""
+        paths = [_make_attack_path("P1", [
+            {"step": 1, "action": "call open()", "function": "open"},
+        ], proximity=3.5)]
+        result = annotate_attack_paths(paths, self._evidence_map())
+        assert result[0]["proximity"] == PROXIMITY_FLOOR
+
+    def test_float_proximity_above_floor_preserved(self):
+        """Float proximity above floor stays unchanged."""
+        paths = [_make_attack_path("P1", [
+            {"step": 1, "action": "call open()", "function": "open"},
+        ], proximity=7.5)]
+        result = annotate_attack_paths(paths, self._evidence_map())
+        assert result[0]["proximity"] == 7.5
+
+    def test_trace_id_uses_first_matched_step(self):
+        """frida_trace_id reflects the first matched step, not the last."""
+        evidence = {
+            "open": RuntimeEvidence(
+                function_observed=True, call_count=1,
+                trace_id="/run/first"),
+            "strcpy": RuntimeEvidence(
+                function_observed=True, call_count=1,
+                trace_id="/run/second"),
+        }
+        paths = [_make_attack_path("P1", [
+            {"step": 1, "function": "open"},
+            {"step": 2, "function": "strcpy"},
+        ])]
+        result = annotate_attack_paths(paths, evidence)
+        assert result[0]["frida_trace_id"] == "/run/first"

--- a/core/run/metadata.py
+++ b/core/run/metadata.py
@@ -48,6 +48,8 @@ _PREFIX_MAP = {
     # Validation (legacy: exploitability-validation)
     "validate": "validate",
     "exploitability-validation": "validate",
+    # Dynamic instrumentation
+    "frida": "frida",
     # Other commands
     "understand": "understand",
     "code-understanding": "understand",

--- a/core/sandbox/_spawn.py
+++ b/core/sandbox/_spawn.py
@@ -990,15 +990,6 @@ def run_sandboxed(
             # new user-ns until the parent runs newuidmap on us.
             ns_flags = CLONE_NEWUSER | CLONE_NEWNS | CLONE_NEWIPC
             if block_network and not inherit_netns:
-                # Only unshare a fresh net-ns when:
-                #  - block_network is set, AND
-                #  - we weren't told to INHERIT the parent's netns
-                #    (inherit_netns=True from the coordinator pattern in
-                #    core/sandbox/netns_coordinator.py: children are
-                #    forked from a process already inside a shared
-                #    isolated netns, so they get there by inheritance;
-                #    a fresh unshare would land them in a new private
-                #    netns instead of the shared one).
                 ns_flags |= CLONE_NEWNET
             if persona is not None:
                 # Fresh UTS namespace so sethostname/setdomainname only

--- a/core/sandbox/context.py
+++ b/core/sandbox/context.py
@@ -1421,17 +1421,7 @@ def sandbox(block_network=_UNSET, target: str = None, output: str = None,
                            "--user", "--fork", "--ipc"]
             if not _skip_pid_ns:
                 unshare_cmd.append("--pid")
-            # inherit_netns=True: caller (typically netns_coordinator) has
-            # already set up the netns this process is in and forks MUST
-            # inherit it rather than creating fresh ones. Skip --net so
-            # the unshare CLI doesn't pull the child into a new private
-            # netns. block_network's "no host network" intent is honoured
-            # by the inherited netns being a private one set up by the
-            # coordinator. Without this gate, the Landlock-only fallback
-            # path (used when mount-ns is unavailable, e.g. an
-            # LSM-confined coordinator) would defeat the coordinator's
-            # shared-netns design.
-            if block_network and not _inherit_netns:
+            if block_network:
                 unshare_cmd.append("--net")
             # Belt-and-braces orphan teardown: if `unshare` is killed
             # directly (orchestrator still alive), --kill-child SIGKILLs the

--- a/core/sandbox/profiles.py
+++ b/core/sandbox/profiles.py
@@ -14,6 +14,8 @@ sandbox() invocation in the process.
 
 import types
 
+FRIDA_PROFILE = "frida"
+
 # Profile definitions
 # -------------------
 # Profiles set ENFORCEMENT strictness. Audit mode is an ORTHOGONAL
@@ -30,19 +32,6 @@ import types
 # strict:       same policy intent as full, but fail-closed if the host cannot
 #               provide the platform isolation backend. On Linux target/output
 #               isolation also requires mount namespaces.
-# target_run:   posture for spawning a harness-authored target binary
-#               that needs to expose a local listener (loopback TCP, UDS,
-#               etc.). Same Landlock + seccomp posture as ``full`` but
-#               ``block_network=False`` so the listener is reachable to
-#               the spawning harness. Callers that want isolation FROM
-#               the host's loopback (not just FROM the wider network)
-#               pair this profile with ``core/sandbox/
-#               netns_coordinator.py`` to put the listener in a shared
-#               isolated net-ns; the coordinator overrides
-#               ``block_network=True`` + ``inherit_netns=True`` per call,
-#               so the profile's loopback setting is irrelevant on that
-#               path. Defence-in-depth still comes from Landlock (caller
-#               passes ``allowed_tcp_ports=[port]`` per call) and seccomp.
 # debug:        full, but seccomp permits ptrace so gdb/rr can trace the
 #               target. Use for /crash-analysis. Target AND debugger run
 #               in the same sandbox — debugger forks target as a descendant
@@ -63,9 +52,8 @@ import types
 PROFILES = types.MappingProxyType({
     "full":         types.MappingProxyType({"block_network": True,  "use_landlock": True,  "seccomp": "full"}),
     "strict":       types.MappingProxyType({"block_network": True,  "use_landlock": True,  "seccomp": "full"}),
-    "target_run":   types.MappingProxyType({"block_network": False, "use_landlock": True,  "seccomp": "full"}),
     "debug":        types.MappingProxyType({"block_network": True,  "use_landlock": True,  "seccomp": "debug"}),
-    "frida":        types.MappingProxyType({"block_network": False, "use_landlock": True,  "seccomp": "frida"}),
+    FRIDA_PROFILE:  types.MappingProxyType({"block_network": False, "use_landlock": True,  "seccomp": "frida"}),
     "network-only": types.MappingProxyType({"block_network": True,  "use_landlock": False, "seccomp": ""}),
     "none":         types.MappingProxyType({"block_network": False, "use_landlock": False, "seccomp": ""}),
 })

--- a/core/sandbox/tests/test_audit_cli_flags.py
+++ b/core/sandbox/tests/test_audit_cli_flags.py
@@ -231,14 +231,9 @@ class TestProfileSet:
     ``audit-verbose`` are GONE from PROFILES (post-#269 contract)."""
 
     def test_canonical_profiles(self):
-        # target_run was added for harness-spawned target binaries that
-        # need to expose a local listener — named delta on 'full' so
-        # future divergence (loopback access, extra readable paths)
-        # doesn't leak back to the LLM-untrusted profile.
         from core.sandbox.profiles import PROFILES
         assert set(PROFILES) == {
-            "full", "strict", "target_run", "debug", "frida",
-            "network-only", "none",
+            "full", "strict", "debug", "frida", "network-only", "none",
         }
 
     def test_no_audit_mode_field_in_profile_dicts(self):

--- a/libexec/raptor-enrich-context-map-frida
+++ b/libexec/raptor-enrich-context-map-frida
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""Enrich context-map.json with frida runtime evidence.
+
+Usage:
+    libexec/raptor-enrich-context-map-frida WORKDIR
+
+Discovers frida evidence in WORKDIR, its parent, and sibling run
+directories; merges function-level observations into the context map's
+entry_points and sink_details.  Idempotent; no-ops silently when no
+frida evidence exists.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+_RAPTOR_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(_RAPTOR_DIR))
+
+
+def main() -> int:
+    if len(sys.argv) < 2:
+        print(f"usage: {sys.argv[0]} WORKDIR", file=sys.stderr)
+        return 2
+
+    workdir = Path(sys.argv[1]).resolve()
+    ctx_path = workdir / "context-map.json"
+    if not ctx_path.is_file():
+        return 0
+
+    try:
+        from packages.frida.context_bridge import enrich_context_map_with_frida
+    except ImportError:
+        return 0
+
+    ctx = json.loads(ctx_path.read_text())
+    search_dirs = [workdir, workdir.parent]
+
+    target_path = None
+    checklist_path = workdir / "checklist.json"
+    if checklist_path.is_file():
+        try:
+            cl = json.loads(checklist_path.read_text())
+            target_path = cl.get("target_path")
+        except (json.JSONDecodeError, OSError):
+            pass
+
+    result = enrich_context_map_with_frida(
+        ctx, search_dirs, target_path=target_path)
+    if result != ctx:
+        ctx_path.write_text(json.dumps(result, indent=2) + "\n")
+        enriched = sum(
+            1 for ep in result.get("entry_points", [])
+            if ep.get("runtime_confirmed")
+        ) + sum(
+            1 for sd in result.get("sink_details", [])
+            if sd.get("runtime_confirmed")
+        )
+        if enriched:
+            print(f"  Frida: {enriched} entry points/sinks runtime-confirmed")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/libexec/raptor-frida
+++ b/libexec/raptor-frida
@@ -44,6 +44,7 @@ while [ -L "$SCRIPT" ]; do
     [[ "$SCRIPT" != /* ]] && SCRIPT="$DIR/$SCRIPT"
 done
 unset _symhops
+unset DIR
 RAPTOR_DIR="$(cd "$(dirname "$SCRIPT")/.." && pwd)"
 
 if [ ! -f "$RAPTOR_DIR/raptor.py" ]; then
@@ -51,21 +52,26 @@ if [ ! -f "$RAPTOR_DIR/raptor.py" ]; then
     exit 1
 fi
 
+if [ ! -f "$RAPTOR_DIR/core/security/_dangerous_env_strip.sh" ]; then
+    echo "raptor-frida: env strip script missing at $RAPTOR_DIR/core/security/_dangerous_env_strip.sh" >&2
+    exit 1
+fi
 . "$RAPTOR_DIR/core/security/_dangerous_env_strip.sh"
 
 export RAPTOR_DIR
-# Make `python3 -m packages.frida.cli` importable regardless of the
-# caller's cwd. Relying on cwd==RAPTOR_DIR (the caller having cd'd in)
-# silently breaks direct `libexec/raptor-frida` invocations and the
-# `raptor frida` route once it stops cd-ing (so operator-relative
-# --target paths resolve against the operator's cwd, not the repo).
-export PYTHONPATH="$RAPTOR_DIR${PYTHONPATH:+:$PYTHONPATH}"
+# PYTHONPATH: prepend RAPTOR_DIR only — do NOT inherit parent PYTHONPATH
+# to prevent module injection from untrusted parent processes.
+export PYTHONPATH="$RAPTOR_DIR"
 
 # ─── short-circuit query modes (no target / lifecycle needed) ───────
 # --list-templates and -h/--help just print and exit; running them
 # through the lifecycle would create an empty run dir for nothing.
+# Respects -- separator: flags after -- are positional.
 for a in "$@"; do
     case "$a" in
+        --)
+            break
+            ;;
         --list-templates|-h|--help)
             exec python3 -m packages.frida.cli "$@"
             ;;
@@ -98,6 +104,9 @@ while [ $i -lt ${#ARGS[@]} ]; do
         --out=*)
             OUT="${a#--out=}"
             ;;
+        --unsafe-attach)
+            PASS_ARGS+=("$a")
+            ;;
         *)
             PASS_ARGS+=("$a")
             ;;
@@ -123,7 +132,9 @@ for a in "${PASS_ARGS[@]}"; do
     esac
 done
 # Binary-path target implies spawn even without --spawn.
-if [ -f "$TARGET" ]; then
+# Use absolute path check to avoid CWD-relative file collision
+# (e.g., a file named "nginx" in CWD when attaching to the nginx process).
+if [[ "$TARGET" == /* ]] && [ -f "$TARGET" ]; then
     IS_SPAWN=1
 fi
 # Remote targets (--host, --usb) need network to reach frida-server;
@@ -134,17 +145,14 @@ fi
 
 # ─── resolve output dir via run lifecycle if not provided ──────────
 if [ -z "$OUT" ]; then
-    # raptor-run-lifecycle's last line is OUTPUT_DIR=<path>. Capture
-    # all output and pluck it out so any warnings stay visible.
     LIFECYCLE_OUT=$("$RAPTOR_DIR/libexec/raptor-run-lifecycle" \
-        start frida --target "$TARGET")
-    LIFECYCLE_RC=$?
-    echo "$LIFECYCLE_OUT"
-    if [ $LIFECYCLE_RC -ne 0 ]; then
+        start frida --target "$TARGET") || {
         echo "raptor-frida: run lifecycle start failed" >&2
-        exit $LIFECYCLE_RC
-    fi
-    OUT="$(echo "$LIFECYCLE_OUT" | awk -F= '/^OUTPUT_DIR=/ {print $2; exit}')"
+        exit 1
+    }
+    echo "$LIFECYCLE_OUT" >&2
+    # Use sub() to handle paths containing '=' characters
+    OUT="$(echo "$LIFECYCLE_OUT" | awk '/^OUTPUT_DIR=/ {sub(/^OUTPUT_DIR=/, ""); print; exit}')"
     if [ -z "$OUT" ]; then
         echo "raptor-frida: could not parse OUTPUT_DIR from lifecycle" >&2
         exit 1
@@ -156,19 +164,48 @@ fi
 
 PASS_ARGS+=("--out" "$OUT")
 
+# ─── signal trap: clean up lifecycle on interrupt/terminate ────────
+_cleanup() {
+    local sig="${1:-EXIT}"
+    if [ $LIFECYCLE_OWNED -eq 1 ] && [ -n "${OUT:-}" ]; then
+        "$RAPTOR_DIR/libexec/raptor-run-lifecycle" fail "$OUT" \
+            "frida interrupted by signal $sig" 2>/dev/null || true
+    fi
+    # Kill child process group if we started one
+    if [ -n "${CHILD_PID:-}" ]; then
+        kill -- -"$CHILD_PID" 2>/dev/null || true
+    fi
+}
+trap '_cleanup INT'  INT
+trap '_cleanup TERM' TERM
+trap '_cleanup HUP'  HUP
+
 # ─── run the Python CLI ─────────────────────────────────────────────
 set +e
 if [ "$UNSAFE_ATTACH" -eq 1 ]; then
-    python3 -m packages.frida.cli "${PASS_ARGS[@]}"
+    echo "raptor-frida: WARNING --unsafe-attach: running WITHOUT sandbox" >&2
+    # Strip --unsafe-attach from PASS_ARGS before forwarding to CLI
+    FILTERED_ARGS=()
+    for a in "${PASS_ARGS[@]}"; do
+        [ "$a" = "--unsafe-attach" ] || FILTERED_ARGS+=("$a")
+    done
+    python3 -m packages.frida.cli "${FILTERED_ARGS[@]}" &
+    CHILD_PID=$!
+    wait $CHILD_PID
     RC=$?
 else
     SANDBOX_ARGS=("--out" "$OUT")
     [ "$IS_SPAWN" -eq 1 ] && SANDBOX_ARGS+=("--spawn")
     python3 -m packages.frida.sandboxed "${SANDBOX_ARGS[@]}" -- \
-        python3 -m packages.frida.cli "${PASS_ARGS[@]}"
+        python3 -m packages.frida.cli "${PASS_ARGS[@]}" &
+    CHILD_PID=$!
+    wait $CHILD_PID
     RC=$?
 fi
 set -e
+
+# Clear the trap — we're handling lifecycle normally now
+trap - INT TERM HUP
 
 # ─── lifecycle close-out (only if we opened it) ─────────────────────
 if [ $LIFECYCLE_OWNED -eq 1 ]; then

--- a/libexec/raptor-validation-helper
+++ b/libexec/raptor-validation-helper
@@ -644,6 +644,22 @@ def prepare_B(workdir, target=None):
     wdir = Path(workdir)
     save_json(wdir / "hypotheses.json", hypotheses)
     save_json(wdir / "attack-paths.json", attack_paths)
+
+    # Frida runtime-evidence annotation (best-effort).
+    try:
+        from core.orchestration.frida_validation_bridge import (
+            annotate_attack_paths,
+            collect_runtime_evidence,
+        )
+        evidence_map = collect_runtime_evidence(
+            [wdir, wdir.parent], target_path=target)
+        if evidence_map and attack_paths:
+            attack_paths = annotate_attack_paths(attack_paths, evidence_map)
+            save_json(wdir / "attack-paths.json", attack_paths)
+            print(f"  Frida runtime evidence: {len(evidence_map)} functions observed")
+    except Exception:
+        pass
+
     if not (wdir / "attack-surface.json").exists():
         save_json(wdir / "attack-surface.json", {"sources": [], "sinks": [], "trust_boundaries": []})
     if not (wdir / "attack-tree.json").exists():

--- a/packages/diagram/attack_paths.py
+++ b/packages/diagram/attack_paths.py
@@ -49,14 +49,18 @@ def generate_single(path_data: dict[str, Any], path_index: int) -> str:
     status = path_data.get("status", "uncertain")
 
     prox_desc = _proximity_desc(int(proximity))
+    has_runtime = path_data.get("runtime_evidence_available", False)
 
     lines = ["flowchart TD"]
-    title_label = f"{name}\\nProximity: {proximity}/10,{prox_desc}\\nStatus: {status}"
+    rt_tag = " [RUNTIME CONFIRMED]" if has_runtime else ""
+    title_label = f"{name}{rt_tag}\\nProximity: {proximity}/10,{prox_desc}\\nStatus: {status}"
     lines.append(f'    TITLE_{path_index}["{_sanitize(title_label)}"]')
     lines.append(f"    style TITLE_{path_index} fill:#f0f0f0,stroke:#999,font-weight:bold")
     lines.append("")
 
     node_ids = [f"TITLE_{path_index}"]
+
+    runtime_nodes = []
 
     for i, step in enumerate(steps):
         nid = f"P{path_index}S{i+1}"
@@ -66,6 +70,7 @@ def generate_single(path_data: dict[str, Any], path_index: int) -> str:
             desc = _sanitize(step.get("description", step.get("action", str(step))))
             loc = _sanitize(step.get("call_site") or step.get("definition") or "")
             tainted = _sanitize(step.get("tainted_var", ""))
+            rt_ev = step.get("runtime_evidence", {})
             parts = [f"[{i+1}] {step_type}"]
             if loc:
                 parts.append(loc)
@@ -74,12 +79,23 @@ def generate_single(path_data: dict[str, Any], path_index: int) -> str:
             if desc:
                 short = desc if len(desc) <= 80 else desc[:77] + "..."
                 parts.append(short)
+            if rt_ev.get("function_observed"):
+                count = rt_ev.get("call_count", 0)
+                parts.append(f"OBSERVED x{count}")
+                runtime_nodes.append(nid)
             label = "\\n".join(parts)
         else:
             label = _sanitize(f"[{i+1}] {str(step)}")
 
         lines.append(f'    {nid}["{label}"]')
         node_ids.append(nid)
+
+    # Style runtime-confirmed steps
+    if runtime_nodes:
+        lines.append("")
+        lines.append("    %% Runtime-confirmed (frida)")
+        for nid in runtime_nodes:
+            lines.append(f"    style {nid} fill:#dbeafe,stroke:#2563eb,stroke-width:2px")
 
     # Chain edges
     lines.append("")

--- a/packages/frida/__init__.py
+++ b/packages/frida/__init__.py
@@ -22,11 +22,16 @@ import shutil
 from pathlib import Path
 from typing import Any, Iterator, Optional
 
+__all__ = ["available", "parse_events"]
+
 _available: Optional[bool] = None
 
 
 def available(*, force: bool = False) -> bool:
-    """True when frida-python is importable and the ``frida`` CLI is on PATH.
+    """True when frida is usable — either the CLI is on PATH or
+    frida-python is importable (covers pipx/venv installs where
+    the Python bindings aren't in RAPTOR's interpreter but the
+    CLI wrapper is).
 
     Cached after first call. Pass ``force=True`` to re-probe (e.g.
     after a mid-session ``pip install frida-tools``). Pipeline consumers
@@ -36,31 +41,42 @@ def available(*, force: bool = False) -> bool:
     global _available
     if _available is not None and not force:
         return _available
+    if shutil.which("frida") is not None:
+        _available = True
+        return True
     try:
         import frida  # type: ignore  # noqa: F401
+        _available = True
     except ImportError:
         _available = False
-        return False
-    _available = shutil.which("frida") is not None
     return _available
 
 
-def parse_events(path: Path) -> Iterator[dict[str, Any]]:
+def parse_events(
+    path: Path, *, max_lines: int = 500_000,
+) -> Iterator[dict[str, Any]]:
     """Yield parsed records from an ``events.jsonl`` file.
 
     Skips malformed lines (truncated writes from a killed run).
     Consumers get structured dicts with ``ts``, ``type``, and
     template-dependent ``payload`` or ``error`` keys.
+
+    Processing stops after *max_lines* non-empty lines to bound memory
+    on very large event logs.
     """
     try:
-        with path.open("r", encoding="utf-8") as f:
+        with path.open("r", encoding="utf-8", errors="replace") as f:
+            count = 0
             for line in f:
                 line = line.strip()
                 if not line:
                     continue
+                count += 1
+                if count > max_lines:
+                    return
                 try:
                     yield json.loads(line)
-                except json.JSONDecodeError:
+                except (json.JSONDecodeError, ValueError):
                     continue
     except OSError:
         return

--- a/packages/frida/active.py
+++ b/packages/frida/active.py
@@ -1,0 +1,325 @@
+"""Programmatic active observation — launch frida sessions from RAPTOR pipelines.
+
+Two modes:
+
+  observe_target(binary, ...) — spawn mode, single sandbox.
+  observe_paired(target_cmd, ...) — netns coordinator for networked targets.
+
+Plus auto_observe() for pipeline integration: skips if fresh evidence
+already exists for the target.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Optional
+
+from core.logging import get_logger
+
+from .evidence import discover_evidence
+
+log = get_logger("frida.active")
+
+__all__ = ["auto_observe", "observe_paired", "observe_target"]
+
+_STALENESS_THRESHOLD_S = 3600.0
+_MAX_STDOUT_CAPTURE = 10 * 1024 * 1024  # 10MB cap on captured output
+
+
+def _safe_env() -> dict[str, str]:
+    """Build a safe subprocess environment via RaptorConfig.get_safe_env().
+
+    Falls back to a minimal env if RaptorConfig is unavailable (e.g., in
+    tests without full RAPTOR bootstrap).
+    """
+    try:
+        from core.config import RaptorConfig
+        env = RaptorConfig.get_safe_env()
+    except (ImportError, AttributeError, TypeError):
+        env = {
+            "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+            "HOME": os.environ.get("HOME", "/tmp"),
+            "LANG": os.environ.get("LANG", "C.UTF-8"),
+            "TERM": "dumb",
+        }
+    env.pop("_RAPTOR_TRUSTED", None)
+    env["RAPTOR_DIR"] = os.environ["RAPTOR_DIR"]
+    env["CLAUDECODE"] = "1"
+    env["PYTHONPATH"] = os.environ["RAPTOR_DIR"]
+    return env
+
+
+def observe_target(
+    target: str,
+    template: str = "api-trace",
+    out_dir: Optional[Path] = None,
+    duration_sec: float = 30.0,
+) -> Optional[Path]:
+    """Launch a frida observation of a target binary (spawn mode).
+
+    Runs frida under the sandbox frida profile via libexec/raptor-frida.
+    The target binary is spawned by frida, hooked, and observed for
+    ``duration_sec`` seconds.
+
+    Returns the run output directory (containing events.jsonl,
+    metadata.json) on success, or None on failure.
+    """
+    from . import available
+
+    if not available():
+        log.warning("frida not available on this host; skipping observation")
+        return None
+
+    target_p = Path(target)
+    if not target_p.is_file():
+        log.error("target binary not found: %s", target)
+        return None
+
+    raptor_dir = os.environ.get("RAPTOR_DIR")
+    if not raptor_dir:
+        log.error("RAPTOR_DIR not set")
+        return None
+
+    libexec = Path(raptor_dir) / "libexec" / "raptor-frida"
+
+    cmd = [
+        str(libexec),
+        "--target", str(target_p.resolve()),
+        "--template", template,
+        "--spawn",
+        "--duration", str(max(1, int(duration_sec))),
+    ]
+    if out_dir is not None:
+        cmd.extend(["--out", str(out_dir)])
+
+    env = _safe_env()
+
+    log.info("launching frida observation: %s (template=%s, duration=%ds)",
+             target, template, duration_sec)
+
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=duration_sec + 30,
+            env=env,
+        )
+    except subprocess.TimeoutExpired:
+        log.error("frida observation timed out for %s", target)
+        return None
+
+    if result.returncode != 0:
+        stderr_tail = result.stderr[-500:] if result.stderr else ""
+        log.error("frida observation failed (rc=%d): %s",
+                  result.returncode, stderr_tail)
+        return None
+
+    run_dir = _extract_output_dir(result.stdout)
+    if run_dir and run_dir.is_dir() and (run_dir / "metadata.json").is_file():
+        log.info("observation complete: %s", run_dir)
+        return run_dir
+
+    log.error("frida observation produced no output directory")
+    return None
+
+
+def observe_paired(
+    target_cmd: list[str],
+    template: str = "api-trace",
+    out_dir: Optional[Path] = None,
+    duration_sec: float = 30.0,
+    wait_port: int = 0,
+    wait_timeout_s: float = 5.0,
+) -> Optional[Path]:
+    """Launch paired frida observation via the netns coordinator.
+
+    The target runs in one sandbox child (target_run profile); frida
+    attaches by process name in the other (frida profile). Both share
+    an isolated network namespace.
+
+    Use when the target is a network service that listens on loopback.
+
+    Returns the run output directory on success, or None on failure.
+
+    NOTE: Requires core/sandbox/netns_coordinator.py (PR #830) to be
+    available. Returns None with a log message if not found.
+    """
+    from . import available
+
+    if not available():
+        log.warning("frida not available on this host; skipping paired observation")
+        return None
+
+    if not target_cmd:
+        log.error("empty target_cmd")
+        return None
+
+    raptor_dir = os.environ.get("RAPTOR_DIR")
+    if not raptor_dir:
+        log.error("RAPTOR_DIR not set")
+        return None
+
+    coordinator = Path(raptor_dir) / "core" / "sandbox" / "netns_coordinator.py"
+    if not coordinator.is_file():
+        log.error("netns coordinator not found at %s; "
+                  "observe_paired requires PR #830 on main", coordinator)
+        return None
+
+    run_dir = out_dir or _make_run_dir(raptor_dir)
+    run_dir.mkdir(parents=True, exist_ok=True)
+
+    target_binary = Path(target_cmd[0])
+    target_name = target_binary.name[:15]  # TASK_COMM_LEN truncation
+
+    frida_cmd = [
+        sys.executable, "-m", "packages.frida.cli",
+        "--target", target_name,
+        "--template", template,
+        "--duration", str(max(1, int(duration_sec))),
+        "--out", str(run_dir),
+    ]
+
+    request = {
+        "target": {
+            "cmd": target_cmd,
+            "env": {
+                "RAPTOR_DIR": raptor_dir,
+                "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+                "HOME": os.environ.get("HOME", "/tmp"),
+                "LANG": os.environ.get("LANG", "C.UTF-8"),
+            },
+            "timeout_s": duration_sec + 10,
+            "profile": "target_run",
+            "block_network": False,
+        },
+        "exploit": {
+            "cmd": frida_cmd,
+            "env": {
+                "RAPTOR_DIR": raptor_dir,
+                "PYTHONPATH": raptor_dir,
+                "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+            },
+            "timeout_s": duration_sec + 10,
+            "profile": "frida",
+            "block_network": False,
+        },
+        "wait_listen_port": wait_port,
+        "wait_listen_timeout_s": wait_timeout_s,
+    }
+
+    env = _safe_env()
+
+    log.info("launching paired observation via netns coordinator: "
+             "target=%s, template=%s", target_name, template)
+
+    proc = None
+    try:
+        proc = subprocess.Popen(
+            [sys.executable, str(coordinator)],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            env=env,
+            start_new_session=True,
+        )
+        stdout, stderr = proc.communicate(
+            json.dumps(request).encode(),
+            timeout=duration_sec + 30,
+        )
+    except subprocess.TimeoutExpired:
+        if proc is not None:
+            try:
+                os.killpg(os.getpgid(proc.pid), 9)
+            except (OSError, ProcessLookupError):
+                proc.kill()
+            proc.communicate()
+        log.error("paired observation timed out")
+        return None
+    except OSError as exc:
+        log.error("failed to launch coordinator: %s", exc)
+        return None
+
+    if proc.returncode != 0:
+        log.error("coordinator exited %d: %s",
+                  proc.returncode, stderr.decode(errors="replace")[-500:])
+        return None
+
+    try:
+        response = json.loads(stdout)
+    except (json.JSONDecodeError, ValueError) as exc:
+        log.error("coordinator response not parseable: %s", exc)
+        return None
+
+    if response.get("error"):
+        log.error("coordinator error: %s", response["error"])
+        return None
+
+    if run_dir.is_dir() and (run_dir / "metadata.json").is_file():
+        log.info("paired observation complete: %s", run_dir)
+        return run_dir
+
+    log.warning("paired observation produced no metadata; "
+                "frida may have failed to attach")
+    return None
+
+
+def auto_observe(
+    target_path: str,
+    search_dirs: list[Path],
+    out_dir: Optional[Path] = None,
+    duration_sec: float = 30.0,
+    template: str = "api-trace",
+    staleness_s: float = _STALENESS_THRESHOLD_S,
+) -> Optional[Path]:
+    """Observe a target only if no fresh evidence exists.
+
+    Checks search_dirs for existing frida evidence matching target_path.
+    If found and newer than staleness_s, returns None (no new observation
+    needed — caller should use existing evidence via discover_evidence).
+    Otherwise launches observe_target() and returns the output dir.
+
+    Pipeline integration hook: /agentic and /validate can call this to
+    get frida evidence on-demand without duplicate runs.
+    """
+    existing = discover_evidence(search_dirs, target_path=target_path)
+    if existing:
+        newest = existing[0]
+        meta_path = newest.run_dir / "metadata.json"
+        try:
+            age = time.time() - meta_path.stat().st_mtime
+        except OSError:
+            age = float("inf")
+        if age >= 0 and age < staleness_s:
+            log.info("fresh frida evidence exists at %s (%.0fs old); "
+                     "skipping new observation", newest.run_dir, age)
+            return None
+
+    return observe_target(
+        target=target_path,
+        template=template,
+        out_dir=out_dir,
+        duration_sec=duration_sec,
+    )
+
+
+def _extract_output_dir(stdout: str) -> Optional[Path]:
+    """Parse OUTPUT_DIR=<path> from libexec output."""
+    for line in stdout.splitlines():
+        if line.startswith("OUTPUT_DIR="):
+            p = Path(line[len("OUTPUT_DIR="):].strip())
+            if p.is_dir():
+                return p
+    return None
+
+
+def _make_run_dir(raptor_dir: str) -> Path:
+    """Create a uniquely-named run directory under out/."""
+    ts = time.strftime("%Y%m%d_%H%M%S")
+    pid = os.getpid()
+    return Path(raptor_dir) / "out" / f"frida_{ts}_{pid}"

--- a/packages/frida/context_bridge.py
+++ b/packages/frida/context_bridge.py
@@ -1,0 +1,77 @@
+"""Bridge frida runtime observations into /understand context maps.
+
+Discovers frida evidence for a target, converts events to
+ObserveProfile, and merges into the context map using the existing
+merge_observation_into_context_map() pipeline.
+
+Depends on packages.frida.evidence (PR #1) for discovery.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+from core.logging import get_logger
+from core.sandbox.observe_context_merge import merge_observation_into_context_map
+
+from .evidence import discover_evidence
+from .observe_adapter import events_to_observe_profile
+
+log = get_logger("frida.context_bridge")
+
+__all__ = ["enrich_context_map_with_frida"]
+
+_MAX_EVIDENCE_FILES = 5
+
+
+def enrich_context_map_with_frida(
+    context_map: dict,
+    search_dirs: list[Path],
+    target_path: Optional[str] = None,
+) -> dict:
+    """Discover frida evidence and merge into context map.
+
+    When evidence is merged, returns a new dict (original untouched).
+    When no usable evidence is found, returns the original reference.
+    Degrades gracefully: missing evidence or import errors -> no-op.
+    """
+    evidence_list = discover_evidence(search_dirs, target_path=target_path)
+    if not evidence_list:
+        return context_map
+
+    # discover_evidence returns newest-first; cap to prevent performance
+    # degradation with many old runs.
+    evidence_list = evidence_list[:_MAX_EVIDENCE_FILES]
+
+    result = context_map
+
+    for ev in evidence_list:
+        if not ev.has_events:
+            continue
+        events_path = ev.run_dir / "events.jsonl"
+        try:
+            profile = events_to_observe_profile(events_path)
+        except Exception as exc:
+            log.warning("failed to parse events from %s: %s", events_path, exc)
+            continue
+        if (not profile.paths_read and not profile.paths_written
+                and not profile.paths_stat and not profile.connect_targets):
+            continue
+        result = merge_observation_into_context_map(
+            result,
+            profile,
+            target_dir=target_path,
+            binary=ev.target_binary,
+        )
+        log.info(
+            "merged frida observation from %s: %d reads, %d writes, "
+            "%d stats, %d connects",
+            ev.run_dir,
+            len(profile.paths_read),
+            len(profile.paths_written),
+            len(profile.paths_stat),
+            len(profile.connect_targets),
+        )
+
+    return result

--- a/packages/frida/evidence.py
+++ b/packages/frida/evidence.py
@@ -1,0 +1,188 @@
+"""Frida run evidence discovery for downstream consumers.
+
+Consumers (coverage layer, binary-oracle, /validate, /understand)
+gate on this module to find and validate frida output before
+consuming it. The gate chain:
+
+  1. packages.frida.available() -- host has frida tooling
+  2. Output files exist in run/project dir
+  3. metadata.json target matches current analysis target
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Optional
+
+from core.logging import get_logger
+
+log = get_logger("frida.evidence")
+
+__all__ = ["FridaEvidence", "discover_evidence", "match_target"]
+
+_MAX_METADATA_SIZE = 10 * 1024 * 1024  # 10MB sanity cap
+_MAX_SCAN_CHILDREN = 500  # cap on iterdir results per search dir
+
+
+@dataclass
+class FridaEvidence:
+    run_dir: Path
+    metadata: dict = field(default_factory=dict)
+    target_binary: Optional[str] = None
+    has_drcov: bool = False
+    has_events: bool = False
+
+
+def _load_metadata(run_dir: Path) -> Optional[dict]:
+    """Load and validate metadata.json from a frida run directory."""
+    meta_path = run_dir / "metadata.json"
+    if not meta_path.is_file():
+        return None
+    try:
+        size = meta_path.stat().st_size
+        if size > _MAX_METADATA_SIZE:
+            log.warning("metadata.json too large (%d bytes), skipping: %s",
+                        size, meta_path)
+            return None
+        with meta_path.open("r", encoding="utf-8") as f:
+            data = json.load(f)
+        if not isinstance(data, dict):
+            return None
+        return data
+    except (json.JSONDecodeError, OSError) as exc:
+        log.debug("failed to load metadata from %s: %s", meta_path, exc)
+        return None
+
+
+def match_target(metadata: dict, target_path: str) -> bool:
+    """Check if frida metadata target matches the analysis target.
+
+    Matches on:
+    - Exact binary/raw path string match (normalized)
+    - Resolved (realpath) match
+    - Process name match (attach-by-name: target.name == basename of target_path)
+    """
+    target = metadata.get("target")
+    if not isinstance(target, dict):
+        return False
+    binary = target.get("binary")
+    raw = target.get("raw")
+    candidates = [c for c in (binary, raw) if isinstance(c, str) and c]
+
+    target_p = Path(target_path)
+    try:
+        target_resolved = target_p.resolve()
+    except OSError:
+        target_resolved = target_p
+
+    for candidate in candidates:
+        if ".." in candidate or candidate.startswith("/proc/"):
+            continue
+        cand_p = Path(candidate)
+        if str(cand_p.resolve() if cand_p.exists() else cand_p) == str(target_resolved):
+            return True
+        try:
+            if cand_p.resolve() == target_resolved:
+                return True
+        except OSError:
+            pass
+
+    name = target.get("name")
+    if isinstance(name, str) and name:
+        if target_p.name == name and "/" not in name:
+            # Reject if target_path looks like a source file (has extension or exists on disk)
+            if not (target_p.suffix or target_p.is_file()):
+                return True
+
+    return False
+
+
+def _build_evidence(run_dir: Path, metadata: dict) -> FridaEvidence:
+    target = metadata.get("target", {})
+    binary = target.get("binary") if isinstance(target, dict) else None
+    return FridaEvidence(
+        run_dir=run_dir,
+        metadata=metadata,
+        target_binary=binary if isinstance(binary, str) and binary else None,
+        has_drcov=(run_dir / "coverage.drcov").is_file(),
+        has_events=_has_nonempty_events(run_dir / "events.jsonl"),
+    )
+
+
+def _has_nonempty_events(path: Path) -> bool:
+    if not path.is_file():
+        return False
+    try:
+        return path.stat().st_size > 0
+    except OSError:
+        return False
+
+
+def discover_evidence(
+    search_dirs: list[Path],
+    target_path: Optional[str] = None,
+) -> list[FridaEvidence]:
+    """Scan directories for frida run output.
+
+    search_dirs: run dirs, project output dirs, or parent dirs to scan.
+    target_path: if provided, only return evidence where metadata target matches.
+
+    Returns list of FridaEvidence, newest first (by file mtime).
+    Degrades gracefully: missing metadata.json -> skip, corrupt -> skip,
+    no match -> empty list.
+
+    Scanning is capped at _MAX_SCAN_CHILDREN per directory to prevent
+    unbounded traversal of large output directories.
+    """
+    results: list[FridaEvidence] = []
+    seen: set[Path] = set()
+
+    for search_dir in search_dirs:
+        search_dir = Path(search_dir)
+        if not search_dir.is_dir():
+            continue
+        _try_add(search_dir, target_path, results, seen)
+        try:
+            children_checked = 0
+            for child in search_dir.iterdir():
+                children_checked += 1
+                if children_checked > _MAX_SCAN_CHILDREN:
+                    log.debug("scan cap reached for %s", search_dir)
+                    break
+                if child.is_dir():
+                    _try_add(child, target_path, results, seen)
+        except OSError:
+            continue
+
+    results.sort(key=lambda e: _mtime(e.run_dir / "metadata.json"), reverse=True)
+    return results
+
+
+def _mtime(path: Path) -> float:
+    try:
+        return path.stat().st_mtime
+    except OSError:
+        return 0.0
+
+
+def _try_add(
+    run_dir: Path,
+    target_path: Optional[str],
+    results: list[FridaEvidence],
+    seen: set[Path],
+) -> None:
+    try:
+        resolved = run_dir.resolve()
+    except OSError:
+        return
+    if resolved in seen:
+        return
+    seen.add(resolved)
+    metadata = _load_metadata(run_dir)
+    if metadata is None:
+        return
+    if target_path is not None and not match_target(metadata, target_path):
+        return
+    results.append(_build_evidence(run_dir, metadata))

--- a/packages/frida/observe_adapter.py
+++ b/packages/frida/observe_adapter.py
@@ -1,0 +1,223 @@
+"""Convert frida events.jsonl into an ObserveProfile.
+
+The sandbox observe tracer captures syscalls (open, connect, stat)
+via ptrace. Frida's api-trace.js template captures the same
+operations at a higher level (libc intercepts). This adapter
+translates frida events into the same ObserveProfile so downstream
+consumers (merge_observation_into_context_map) work identically
+regardless of source.
+
+Frida events format (from runner.py wrapping api-trace.js):
+  {"ts": 1.23, "type": "send", "payload": {"category": "file", "fn": "open", "args": {"path": "/etc/passwd", "flags": 0, "ret": 3}, "tid": 123}}
+  {"ts": 1.24, "type": "send", "payload": {"category": "network", "fn": "connect", "args": {"fd": 5, "ret": 0}, "tid": 123}}
+
+Also handles legacy/custom list format:
+  open:   args=["/etc/passwd", 0]      -> path=args[0], flags=args[1]
+  openat: args=[dirfd, "/etc/passwd", 0] -> path=args[1], flags=args[2]
+  connect: args=["1.2.3.4", 443, "AF_INET"]
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from core.sandbox.observe_profile import ConnectTarget, ObserveProfile
+
+from . import parse_events
+
+__all__ = ["events_to_observe_profile"]
+
+_READ_FNS = frozenset({
+    "open", "openat", "fopen", "read", "readFile",
+    "pread", "pread64",
+})
+_WRITE_FNS = frozenset({
+    "write", "fwrite", "writeFile", "creat",
+    "pwrite", "pwrite64", "unlink", "unlinkat", "rename", "renameat",
+    "mkdir", "mkdirat", "rmdir", "chmod", "fchmodat",
+})
+_STAT_FNS = frozenset({
+    "stat", "lstat", "access", "faccessat", "statx", "fstatat",
+    "readlink", "readlinkat",
+})
+
+_O_WRONLY = 0o0000001
+_O_RDWR = 0o0000002
+_O_TRUNC = 0o0001000
+_O_APPEND = 0o0002000
+
+_MAX_EVENTS = 100_000
+
+
+def _is_write_flags(flags: int) -> bool:
+    """Determine if open flags indicate write intent.
+
+    O_CREAT alone does NOT indicate write — O_RDONLY|O_CREAT is valid
+    (creates if absent, opens read-only). Only classify as write if
+    O_WRONLY, O_RDWR, O_TRUNC, or O_APPEND is set.
+    """
+    return bool(flags & (_O_WRONLY | _O_RDWR | _O_TRUNC | _O_APPEND))
+
+
+_AT_FNS = frozenset({
+    "openat", "unlinkat", "fstatat", "mkdirat", "readlinkat",
+    "fchmodat", "renameat", "faccessat", "statx",
+})
+
+
+def _extract_path(fn: str, args) -> str | None:
+    """Extract file path from args (dict or list format).
+
+    For *at() syscalls in list format, the path is at index 1 (after dirfd).
+    For other functions in list format, the path is at index 0.
+    """
+    if not args:
+        return None
+    if isinstance(args, dict):
+        path = args.get("path")
+        if isinstance(path, str) and path and "\x00" not in path:
+            return path
+        return None
+    if isinstance(args, list):
+        if fn in _AT_FNS:
+            idx = 1
+        else:
+            idx = 0
+        if len(args) > idx and isinstance(args[idx], str) and args[idx]:
+            path = args[idx]
+            if "\x00" in path:
+                return None
+            return path
+    return None
+
+
+def _extract_flags(fn: str, args) -> int | None:
+    """Extract open flags from args (dict or list format).
+
+    For *at() syscalls in list format, flags are at index 2 (after dirfd, path).
+    For open in list format, flags are at index 1 (after path).
+    """
+    if isinstance(args, dict):
+        flags = args.get("flags")
+        return flags if isinstance(flags, int) else None
+    if isinstance(args, list):
+        if fn in _AT_FNS:
+            idx = 2
+        else:
+            idx = 1
+        if len(args) > idx and isinstance(args[idx], int):
+            return args[idx]
+    return None
+
+
+def _extract_connect_args(args) -> tuple[str, int, str]:
+    """Extract (ip, port, family) from connect args. Returns ('', 0, '') on failure."""
+    if isinstance(args, dict):
+        ip = args.get("ip") or args.get("addr") or ""
+        port = args.get("port", 0)
+        family = args.get("family", "")
+        if not isinstance(ip, str) or not ip:
+            return ("", 0, "")
+        if not isinstance(port, int):
+            try:
+                port = int(port)
+            except (ValueError, TypeError):
+                return ("", 0, "")
+        if not isinstance(family, str):
+            family = ""
+        return (ip, port, family)
+    if isinstance(args, list):
+        if len(args) < 3:
+            return ("", 0, "")
+        ip = args[0]
+        port = args[1]
+        family = args[2]
+        if not isinstance(ip, str) or not ip:
+            return ("", 0, "")
+        if not isinstance(port, int):
+            try:
+                port = int(port)
+            except (ValueError, TypeError):
+                return ("", 0, "")
+        if not isinstance(family, str):
+            family = ""
+        return (ip, port, family)
+    return ("", 0, "")
+
+
+def events_to_observe_profile(
+    events_path: Path,
+    max_events: int = _MAX_EVENTS,
+) -> ObserveProfile:
+    """Parse frida events.jsonl and return an ObserveProfile.
+
+    Maps:
+    - category=file, fn in _READ_FNS -> paths_read (unless flags indicate write)
+    - category=file, fn in _WRITE_FNS -> paths_written
+    - category=file, fn in _STAT_FNS -> paths_stat
+    - category=network, fn=connect -> connect_targets
+
+    Returns empty ObserveProfile on missing/unreadable file.
+    Tolerates malformed lines (uses parse_events).
+    Caps at max_events to prevent OOM on very large trace files.
+    """
+    profile = ObserveProfile()
+    seen_read: set[str] = set()
+    seen_write: set[str] = set()
+    seen_stat: set[str] = set()
+    seen_connect: set[ConnectTarget] = set()
+    count = 0
+
+    for event in parse_events(events_path):
+        count += 1
+        if count > max_events:
+            break
+
+        if event.get("type") != "send":
+            continue
+        payload = event.get("payload")
+        if not isinstance(payload, dict):
+            continue
+
+        category = payload.get("category", "")
+        fn = payload.get("fn", "")
+        args = payload.get("args") or []
+
+        if category == "file":
+            path = _extract_path(fn, args)
+            if not path:
+                continue
+
+            if fn in _WRITE_FNS:
+                if path not in seen_write:
+                    seen_write.add(path)
+                    profile.paths_written.append(path)
+            elif fn in _STAT_FNS:
+                if path not in seen_stat:
+                    seen_stat.add(path)
+                    profile.paths_stat.append(path)
+            elif fn in _READ_FNS:
+                if fn in ("open", "openat", "fopen"):
+                    flags = _extract_flags(fn, args)
+                    if flags is not None and _is_write_flags(flags):
+                        if path not in seen_write:
+                            seen_write.add(path)
+                            profile.paths_written.append(path)
+                        continue
+                if path not in seen_read:
+                    seen_read.add(path)
+                    profile.paths_read.append(path)
+        elif category == "network" and fn == "connect":
+            ip, port, family = _extract_connect_args(args)
+            if not ip:
+                continue
+            target = ConnectTarget(ip=ip, port=port, family=family)
+            if target not in seen_connect:
+                seen_connect.add(target)
+                profile.connect_targets.append(target)
+
+    # A path that was written supersedes an earlier read classification.
+    if seen_write & seen_read:
+        profile.paths_read = [p for p in profile.paths_read if p not in seen_write]
+
+    return profile

--- a/packages/frida/platform.py
+++ b/packages/frida/platform.py
@@ -19,6 +19,9 @@ import shutil
 from dataclasses import dataclass
 
 
+__all__ = ["HostInfo", "detect_host"]
+
+
 @dataclass(frozen=True)
 class HostInfo:
     """Snapshot of host-side preconditions for a Frida run.

--- a/packages/frida/runner.py
+++ b/packages/frida/runner.py
@@ -28,6 +28,18 @@ from typing import Any, Callable, Optional
 from .platform import HostInfo, detect_host
 
 
+__all__ = [
+    "FridaUnavailable",
+    "RunConfig",
+    "RunResult",
+    "TargetSpec",
+    "list_templates",
+    "load_script_source",
+    "parse_target",
+    "resolve_template",
+    "run",
+]
+
 TEMPLATES_DIR = Path(__file__).parent / "templates"
 
 
@@ -303,13 +315,18 @@ def run(cfg: RunConfig,
         def _on_sigint(_signum, _frame):
             stop.set()
 
-        prev_handler = signal.signal(signal.SIGINT, _on_sigint)
+        try:
+            prev_handler = signal.signal(signal.SIGINT, _on_sigint)
+            signal_installed = True
+        except ValueError:
+            signal_installed = False
         try:
             deadline = started + cfg.duration_sec
             while time.monotonic() < deadline and not stop.is_set():
                 time.sleep(0.1)
         finally:
-            signal.signal(signal.SIGINT, prev_handler)
+            if signal_installed:
+                signal.signal(signal.SIGINT, prev_handler)
 
         result.ok = True
     except FridaUnavailable:
@@ -399,3 +416,5 @@ def _write_report(cfg: RunConfig, result: RunResult) -> None:
                  "`metadata.json`. Script as executed: see `script.js`.")
     (cfg.out_dir / "frida-report.md").write_text(
         "\n".join(lines) + "\n", encoding="utf-8")
+
+

--- a/packages/frida/sandboxed.py
+++ b/packages/frida/sandboxed.py
@@ -2,7 +2,7 @@
 
 Invoked by ``libexec/raptor-frida`` when ``--unsafe-attach`` is NOT
 set.  Wraps the CLI subprocess in ``core.sandbox.run()`` with the
-``debug`` profile (ptrace allowed) and ``skip_pid_ns=True`` (/proc
+``frida`` profile (ptrace allowed) and ``skip_pid_ns=True`` (/proc
 readable for frida's process enumeration).
 
 Network policy depends on target mode:
@@ -22,6 +22,9 @@ from __future__ import annotations
 import os
 import subprocess
 import sys
+from pathlib import Path
+
+_KNOWN_PYTHON_PREFIXES = ("/usr/", "/opt/", "/home/", "/nix/")
 
 
 def _find_frida_site() -> str | None:
@@ -32,9 +35,10 @@ def _find_frida_site() -> str | None:
     directory, or None if frida is not installed.
     """
     import shutil
-    from pathlib import Path
 
     def _probe(python: str) -> str | None:
+        if not python or not os.path.isfile(python):
+            return None
         try:
             r = subprocess.run(
                 [python, "-c",
@@ -58,9 +62,11 @@ def _find_frida_site() -> str | None:
         return None
     try:
         with open(frida_bin, "r", encoding="utf-8") as f:
-            shebang = f.readline().strip()
+            shebang = f.readline(256).strip()
         if shebang.startswith("#!"):
             python = shebang[2:].strip().split()[0]
+            if not any(python.startswith(p) for p in _KNOWN_PYTHON_PREFIXES):
+                return None
             return _probe(python)
     except OSError:
         pass
@@ -97,14 +103,13 @@ def main() -> int:
 
     try:
         from core.sandbox import run as sandbox_run
-    except ImportError:
-        import subprocess
-        print("warning: core.sandbox not available, running unsandboxed",
-              file=sys.stderr)
-        return subprocess.call(cmd)
+    except ImportError as exc:
+        print(f"FATAL: core.sandbox not importable: {exc}", file=sys.stderr)
+        print("Refusing to run frida unsandboxed. Fix the installation "
+              "or use --unsafe-attach explicitly.", file=sys.stderr)
+        return 1
 
     raptor_dir = os.environ.get("RAPTOR_DIR", "")
-    env = dict(os.environ)
     tool_paths = []
     pypath_parts = []
     if raptor_dir:
@@ -116,16 +121,28 @@ def main() -> int:
         pypath_parts.append(frida_site)
         tool_paths.append(frida_site)
 
+    env = {
+        "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+        "HOME": os.environ.get("HOME", "/tmp"),
+        "LANG": os.environ.get("LANG", "C.UTF-8"),
+        "TERM": "dumb",
+        "RAPTOR_DIR": raptor_dir,
+    }
     if pypath_parts:
         env["PYTHONPATH"] = ":".join(pypath_parts)
+
+    if out_dir and not os.path.isdir(out_dir):
+        os.makedirs(out_dir, exist_ok=True)
 
     result = sandbox_run(
         cmd,
         profile="frida",
         skip_pid_ns=True,
         skip_mount_ns=True,
+        fake_home=True,
         block_network=spawn_mode,
         output=out_dir,
+        restrict_reads=True,
         caller_label="frida",
         env=env,
         tool_paths=tool_paths or None,

--- a/packages/frida/tests/test_active.py
+++ b/packages/frida/tests/test_active.py
@@ -1,0 +1,480 @@
+"""Tests for packages.frida.active — programmatic observation API."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import time
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from packages.frida.active import (
+    _extract_output_dir,
+    _safe_env,
+    auto_observe,
+    observe_paired,
+    observe_target,
+)
+
+
+# ── _extract_output_dir ───────────────────────────────────────────────
+
+
+class TestExtractOutputDir:
+
+    def test_parses_valid_line(self, tmp_path):
+        d = tmp_path / "out" / "frida_123"
+        d.mkdir(parents=True)
+        stdout = f"some preamble\nOUTPUT_DIR={d}\nmore stuff\n"
+        assert _extract_output_dir(stdout) == d
+
+    def test_returns_none_on_missing(self):
+        assert _extract_output_dir("no output dir here\n") is None
+
+    def test_returns_none_on_nonexistent_path(self):
+        stdout = "OUTPUT_DIR=/tmp/nonexistent_abcdef_xyz\n"
+        assert _extract_output_dir(stdout) is None
+
+    def test_handles_path_with_equals(self, tmp_path):
+        d = tmp_path / "out=test" / "frida_123"
+        d.mkdir(parents=True)
+        stdout = f"OUTPUT_DIR={d}\n"
+        assert _extract_output_dir(stdout) == d
+
+
+# ── _safe_env ────────────────────────────────────────────────────────
+
+
+class TestSafeEnv:
+
+    def test_includes_raptor_dir(self, monkeypatch):
+        monkeypatch.setenv("RAPTOR_DIR", "/opt/raptor")
+        env = _safe_env()
+        assert env["RAPTOR_DIR"] == "/opt/raptor"
+        assert env["CLAUDECODE"] == "1"
+        assert env["PYTHONPATH"] == "/opt/raptor"
+
+    def test_does_not_leak_sensitive_vars(self, monkeypatch):
+        monkeypatch.setenv("RAPTOR_DIR", "/opt/raptor")
+        monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "secret123")
+        monkeypatch.setenv("LD_PRELOAD", "/evil/lib.so")
+        env = _safe_env()
+        assert "AWS_SECRET_ACCESS_KEY" not in env
+        assert "LD_PRELOAD" not in env
+
+
+# ── observe_target ────────────────────────────────────────────────────
+
+
+class TestObserveTarget:
+
+    def test_returns_none_when_frida_unavailable(self, tmp_path):
+        binary = tmp_path / "app"
+        binary.write_bytes(b"\x7fELF")
+        with patch("packages.frida.available", return_value=False):
+            result = observe_target(str(binary))
+        assert result is None
+
+    def test_returns_none_when_binary_missing(self):
+        with patch("packages.frida.available", return_value=True):
+            result = observe_target("/nonexistent/path/binary")
+        assert result is None
+
+    def test_returns_none_when_raptor_dir_unset(self, tmp_path, monkeypatch):
+        binary = tmp_path / "app"
+        binary.write_bytes(b"\x7fELF")
+        monkeypatch.delenv("RAPTOR_DIR", raising=False)
+        with patch("packages.frida.available", return_value=True):
+            result = observe_target(str(binary))
+        assert result is None
+
+    def test_invokes_libexec_and_returns_run_dir(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("RAPTOR_DIR", str(tmp_path))
+        binary = tmp_path / "app"
+        binary.write_bytes(b"\x7fELF")
+        run_dir = tmp_path / "run"
+        run_dir.mkdir()
+        (run_dir / "metadata.json").write_text('{"ok": true}')
+        (run_dir / "events.jsonl").write_text("")
+
+        fake_result = MagicMock()
+        fake_result.returncode = 0
+        fake_result.stdout = f"OUTPUT_DIR={run_dir}\n"
+        fake_result.stderr = ""
+
+        with patch("packages.frida.available", return_value=True), \
+             patch("subprocess.run", return_value=fake_result) as mock_run:
+            result = observe_target(str(binary), template="api-trace",
+                                    duration_sec=10)
+
+        assert result == run_dir
+        call_args = mock_run.call_args[0][0]
+        assert "--target" in call_args
+        assert "--template" in call_args
+        assert "api-trace" in call_args
+        assert "--spawn" in call_args
+
+        call_kwargs = mock_run.call_args[1]
+        env = call_kwargs["env"]
+        assert "AWS_SECRET_ACCESS_KEY" not in env
+        assert "LD_PRELOAD" not in env
+
+    def test_returns_none_on_nonzero_exit(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("RAPTOR_DIR", str(tmp_path))
+        binary = tmp_path / "app"
+        binary.write_bytes(b"\x7fELF")
+
+        fake_result = MagicMock()
+        fake_result.returncode = 1
+        fake_result.stderr = "crash"
+        fake_result.stdout = ""
+
+        with patch("packages.frida.available", return_value=True), \
+             patch("subprocess.run", return_value=fake_result):
+            result = observe_target(str(binary))
+        assert result is None
+
+    def test_returns_none_on_timeout(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("RAPTOR_DIR", str(tmp_path))
+        binary = tmp_path / "app"
+        binary.write_bytes(b"\x7fELF")
+
+        with patch("packages.frida.available", return_value=True), \
+             patch("subprocess.run",
+                   side_effect=subprocess.TimeoutExpired("cmd", 60)):
+            result = observe_target(str(binary), duration_sec=10)
+        assert result is None
+
+    def test_passes_out_dir_when_provided(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("RAPTOR_DIR", str(tmp_path))
+        binary = tmp_path / "app"
+        binary.write_bytes(b"\x7fELF")
+        out_dir = tmp_path / "custom_out"
+        out_dir.mkdir()
+        (out_dir / "metadata.json").write_text('{"ok": true}')
+
+        fake_result = MagicMock()
+        fake_result.returncode = 0
+        fake_result.stdout = f"OUTPUT_DIR={out_dir}\n"
+        fake_result.stderr = ""
+
+        with patch("packages.frida.available", return_value=True), \
+             patch("subprocess.run", return_value=fake_result) as mock_run:
+            observe_target(str(binary), out_dir=out_dir)
+
+        call_args = mock_run.call_args[0][0]
+        assert "--out" in call_args
+        idx = call_args.index("--out")
+        assert call_args[idx + 1] == str(out_dir)
+
+    def test_enforces_minimum_duration(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("RAPTOR_DIR", str(tmp_path))
+        binary = tmp_path / "app"
+        binary.write_bytes(b"\x7fELF")
+
+        fake_result = MagicMock()
+        fake_result.returncode = 0
+        fake_result.stdout = ""
+        fake_result.stderr = ""
+
+        with patch("packages.frida.available", return_value=True), \
+             patch("subprocess.run", return_value=fake_result) as mock_run:
+            observe_target(str(binary), duration_sec=-5)
+
+        call_args = mock_run.call_args[0][0]
+        idx = call_args.index("--duration")
+        assert int(call_args[idx + 1]) >= 1
+
+
+# ── observe_paired ────────────────────────────────────────────────────
+
+
+class TestObservePaired:
+
+    def test_returns_none_when_frida_unavailable(self):
+        with patch("packages.frida.available", return_value=False):
+            result = observe_paired(["./server"])
+        assert result is None
+
+    def test_returns_none_when_coordinator_missing(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("RAPTOR_DIR", str(tmp_path))
+        with patch("packages.frida.available", return_value=True):
+            result = observe_paired(["./server"])
+        assert result is None
+
+    def test_returns_none_on_empty_target_cmd(self):
+        with patch("packages.frida.available", return_value=True):
+            result = observe_paired([])
+        assert result is None
+
+    def test_returns_none_when_raptor_dir_unset(self, monkeypatch):
+        monkeypatch.delenv("RAPTOR_DIR", raising=False)
+        with patch("packages.frida.available", return_value=True):
+            result = observe_paired(["./server"])
+        assert result is None
+
+    def test_sends_correct_protocol_to_coordinator(self, tmp_path, monkeypatch):
+        raptor_dir = str(tmp_path)
+        monkeypatch.setenv("RAPTOR_DIR", raptor_dir)
+
+        coord = tmp_path / "core" / "sandbox" / "netns_coordinator.py"
+        coord.parent.mkdir(parents=True)
+        coord.write_text("# placeholder")
+
+        run_dir = tmp_path / "out" / "frida_run"
+        run_dir.mkdir(parents=True)
+        (run_dir / "metadata.json").write_text('{"ok": true}')
+        (run_dir / "events.jsonl").write_text("")
+
+        response = {
+            "target": {"returncode": 0, "error": None},
+            "exploit": {"returncode": 0, "error": None},
+            "listen_observed": True,
+            "namespace_path": "/proc/self/ns/net",
+            "error": None,
+        }
+
+        fake_proc = MagicMock()
+        fake_proc.communicate.return_value = (
+            json.dumps(response).encode(),
+            b"",
+        )
+        fake_proc.returncode = 0
+        fake_proc.pid = 12345
+
+        def fake_popen(*args, **kwargs):
+            return fake_proc
+
+        with patch("packages.frida.available", return_value=True), \
+             patch("subprocess.Popen", side_effect=fake_popen) as mock_popen:
+            result = observe_paired(
+                ["./myserver", "--port", "8080"],
+                template="api-trace",
+                out_dir=run_dir,
+                wait_port=8080,
+                duration_sec=15,
+            )
+
+        assert result == run_dir
+        call_kwargs = mock_popen.call_args[1]
+        assert call_kwargs["stdin"] == subprocess.PIPE
+        assert call_kwargs["start_new_session"] is True
+        request_bytes = fake_proc.communicate.call_args[0][0]
+        request = json.loads(request_bytes)
+        assert request["target"]["cmd"] == ["./myserver", "--port", "8080"]
+        assert request["target"]["profile"] == "target_run"
+        assert request["exploit"]["profile"] == "frida"
+        assert request["wait_listen_port"] == 8080
+        assert "--target" in " ".join(request["exploit"]["cmd"])
+
+        env = call_kwargs["env"]
+        assert "_RAPTOR_TRUSTED" not in env
+
+    def test_truncates_long_target_name(self, tmp_path, monkeypatch):
+        raptor_dir = str(tmp_path)
+        monkeypatch.setenv("RAPTOR_DIR", raptor_dir)
+
+        coord = tmp_path / "core" / "sandbox" / "netns_coordinator.py"
+        coord.parent.mkdir(parents=True)
+        coord.write_text("# placeholder")
+
+        run_dir = tmp_path / "out" / "frida_run"
+        run_dir.mkdir(parents=True)
+        (run_dir / "metadata.json").write_text('{"ok": true}')
+
+        response = {"error": None}
+        fake_proc = MagicMock()
+        fake_proc.communicate.return_value = (
+            json.dumps(response).encode(), b"")
+        fake_proc.returncode = 0
+        fake_proc.pid = 12345
+
+        with patch("packages.frida.available", return_value=True), \
+             patch("subprocess.Popen", return_value=fake_proc):
+            observe_paired(
+                ["./very-long-binary-name-exceeding-15"],
+                out_dir=run_dir,
+            )
+
+        request_bytes = fake_proc.communicate.call_args[0][0]
+        request = json.loads(request_bytes)
+        cmd = request["exploit"]["cmd"]
+        target_idx = cmd.index("--target") + 1
+        assert len(cmd[target_idx]) <= 15
+
+    def test_returns_none_on_coordinator_error(self, tmp_path, monkeypatch):
+        raptor_dir = str(tmp_path)
+        monkeypatch.setenv("RAPTOR_DIR", raptor_dir)
+
+        coord = tmp_path / "core" / "sandbox" / "netns_coordinator.py"
+        coord.parent.mkdir(parents=True)
+        coord.write_text("# placeholder")
+
+        fake_proc = MagicMock()
+        fake_proc.communicate.return_value = (b"", b"setup failed")
+        fake_proc.returncode = 2
+        fake_proc.pid = 12345
+
+        with patch("packages.frida.available", return_value=True), \
+             patch("subprocess.Popen", return_value=fake_proc):
+            result = observe_paired(
+                ["./server"],
+                out_dir=tmp_path / "out",
+            )
+        assert result is None
+
+    def test_returns_none_on_timeout(self, tmp_path, monkeypatch):
+        raptor_dir = str(tmp_path)
+        monkeypatch.setenv("RAPTOR_DIR", raptor_dir)
+
+        coord = tmp_path / "core" / "sandbox" / "netns_coordinator.py"
+        coord.parent.mkdir(parents=True)
+        coord.write_text("# placeholder")
+
+        fake_proc = MagicMock()
+        fake_proc.communicate.side_effect = [
+            subprocess.TimeoutExpired("cmd", 60),
+            (b"", b""),
+        ]
+        fake_proc.pid = 12345
+
+        with patch("packages.frida.available", return_value=True), \
+             patch("subprocess.Popen", return_value=fake_proc), \
+             patch("os.getpgid", return_value=12345), \
+             patch("os.killpg"):
+            result = observe_paired(["./server"], out_dir=tmp_path / "out")
+        assert result is None
+
+
+# ── auto_observe ──────────────────────────────────────────────────────
+
+
+class TestAutoObserve:
+
+    def _write_evidence(self, run_dir: Path, target: str, age_s: float = 0):
+        run_dir.mkdir(parents=True, exist_ok=True)
+        meta = {
+            "ok": True,
+            "target": {"raw": target, "binary": target,
+                       "kind": "binary", "pid": None, "name": None},
+        }
+        meta_path = run_dir / "metadata.json"
+        meta_path.write_text(json.dumps(meta))
+        (run_dir / "events.jsonl").write_text('{"ts":1,"type":"send"}\n')
+        if age_s > 0:
+            old_time = time.time() - age_s
+            os.utime(meta_path, (old_time, old_time))
+
+    def test_skips_when_fresh_evidence_exists(self, tmp_path):
+        run_dir = tmp_path / "frida-run-1"
+        target = "/tmp/build/app"
+        self._write_evidence(run_dir, target, age_s=60)
+
+        result = auto_observe(
+            target_path=target,
+            search_dirs=[tmp_path],
+            staleness_s=3600,
+        )
+        assert result is None
+
+    def test_observes_when_evidence_is_stale(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("RAPTOR_DIR", str(tmp_path))
+        run_dir = tmp_path / "frida-run-old"
+        target = str(tmp_path / "app")
+        (tmp_path / "app").write_bytes(b"\x7fELF")
+        self._write_evidence(run_dir, target, age_s=7200)
+
+        new_run = tmp_path / "new-run"
+        new_run.mkdir()
+        (new_run / "metadata.json").write_text('{"ok": true}')
+
+        fake_result = MagicMock()
+        fake_result.returncode = 0
+        fake_result.stdout = f"OUTPUT_DIR={new_run}\n"
+        fake_result.stderr = ""
+
+        with patch("packages.frida.available", return_value=True), \
+             patch("subprocess.run", return_value=fake_result):
+            result = auto_observe(
+                target_path=target,
+                search_dirs=[tmp_path],
+                staleness_s=3600,
+            )
+        assert result == new_run
+
+    def test_observes_when_no_evidence(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("RAPTOR_DIR", str(tmp_path))
+        target = str(tmp_path / "app")
+        (tmp_path / "app").write_bytes(b"\x7fELF")
+
+        new_run = tmp_path / "out-run"
+        new_run.mkdir()
+        (new_run / "metadata.json").write_text('{"ok": true}')
+
+        fake_result = MagicMock()
+        fake_result.returncode = 0
+        fake_result.stdout = f"OUTPUT_DIR={new_run}\n"
+        fake_result.stderr = ""
+
+        with patch("packages.frida.available", return_value=True), \
+             patch("subprocess.run", return_value=fake_result):
+            result = auto_observe(
+                target_path=target,
+                search_dirs=[tmp_path],
+            )
+        assert result == new_run
+
+    def test_skips_evidence_for_different_target(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("RAPTOR_DIR", str(tmp_path))
+        run_dir = tmp_path / "frida-run-other"
+        self._write_evidence(run_dir, "/opt/other-binary", age_s=10)
+
+        target = str(tmp_path / "app")
+        (tmp_path / "app").write_bytes(b"\x7fELF")
+
+        new_run = tmp_path / "out-run"
+        new_run.mkdir()
+        (new_run / "metadata.json").write_text('{"ok": true}')
+
+        fake_result = MagicMock()
+        fake_result.returncode = 0
+        fake_result.stdout = f"OUTPUT_DIR={new_run}\n"
+        fake_result.stderr = ""
+
+        with patch("packages.frida.available", return_value=True), \
+             patch("subprocess.run", return_value=fake_result):
+            result = auto_observe(
+                target_path=target,
+                search_dirs=[tmp_path],
+            )
+        assert result == new_run
+
+    def test_negative_age_triggers_reobservation(self, tmp_path, monkeypatch):
+        """If clock goes backward (NTP), negative age should not be treated as fresh."""
+        monkeypatch.setenv("RAPTOR_DIR", str(tmp_path))
+        run_dir = tmp_path / "frida-run-future"
+        target = str(tmp_path / "app")
+        (tmp_path / "app").write_bytes(b"\x7fELF")
+        self._write_evidence(run_dir, target, age_s=0)
+        meta_path = run_dir / "metadata.json"
+        future_time = time.time() + 3600
+        os.utime(meta_path, (future_time, future_time))
+
+        new_run = tmp_path / "out-run"
+        new_run.mkdir()
+        (new_run / "metadata.json").write_text('{"ok": true}')
+
+        fake_result = MagicMock()
+        fake_result.returncode = 0
+        fake_result.stdout = f"OUTPUT_DIR={new_run}\n"
+        fake_result.stderr = ""
+
+        with patch("packages.frida.available", return_value=True), \
+             patch("subprocess.run", return_value=fake_result):
+            result = auto_observe(
+                target_path=target,
+                search_dirs=[tmp_path],
+                staleness_s=3600,
+            )
+        assert result == new_run

--- a/packages/frida/tests/test_context_bridge.py
+++ b/packages/frida/tests/test_context_bridge.py
@@ -1,0 +1,143 @@
+"""Tests for packages.frida.context_bridge."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from packages.frida.context_bridge import enrich_context_map_with_frida
+
+
+def _write_frida_run(run_dir: Path, events: list[dict],
+                     binary: str = "/tmp/build/myapp") -> None:
+    """Create a frida run directory with metadata.json + events.jsonl."""
+    run_dir.mkdir(parents=True, exist_ok=True)
+    (run_dir / "metadata.json").write_text(json.dumps({
+        "ok": True,
+        "error": None,
+        "target": {
+            "raw": binary,
+            "kind": "binary",
+            "pid": None,
+            "name": None,
+            "binary": binary,
+        },
+        "script_origin": "template:api-trace",
+        "duration_requested_sec": 60.0,
+        "duration_actual_sec": 5.0,
+        "events_captured": len(events),
+        "device": {"id": "local", "host": None, "usb": False},
+        "host": {"system": "Linux", "arch": "x86_64",
+                 "frida_version": "16.0.0", "frida_bin": "/usr/bin/frida",
+                 "sip_status": None, "ptrace_scope": 0},
+        "spawn": True,
+        "unsafe_attach": False,
+        "resolved_pid": 1234,
+    }), encoding="utf-8")
+    (run_dir / "events.jsonl").write_text(
+        "\n".join(json.dumps(e) for e in events) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _send_event(category: str, fn: str, args: list) -> dict:
+    return {
+        "ts": 1.0,
+        "type": "send",
+        "payload": {"category": category, "fn": fn, "args": args, "tid": 1},
+    }
+
+
+def _make_context_map(target: str = "/repo") -> dict:
+    return {
+        "meta": {"target": target, "generated_at": "2026-01-01T00:00:00Z"},
+        "entry_points": [
+            {"id": "EP-1", "file": "src/main.py", "function": "main"},
+        ],
+        "sink_details": [
+            {"id": "SINK-1", "file": "src/output.py", "function": "write_log"},
+        ],
+    }
+
+
+class TestEnrichWithFridaEvidence:
+    def test_merge_adds_runtime_observation(self, tmp_path):
+        run_dir = tmp_path / "frida-run"
+        _write_frida_run(run_dir, [
+            _send_event("file", "open", ["/repo/src/main.py", 0]),
+            _send_event("network", "connect", ["10.0.0.1", 8080, "AF_INET"]),
+        ])
+
+        ctx = _make_context_map("/repo")
+        result = enrich_context_map_with_frida(ctx, [tmp_path])
+
+        assert "runtime_observation" in result
+        obs = result["runtime_observation"]
+        assert "/repo/src/main.py" in obs["paths_read"]
+        assert len(obs["connect_targets"]) == 1
+
+    def test_multiple_runs_merged(self, tmp_path):
+        run1 = tmp_path / "run-1"
+        _write_frida_run(run1, [
+            _send_event("file", "open", ["/repo/src/a.py", 0]),
+        ])
+        run2 = tmp_path / "run-2"
+        _write_frida_run(run2, [
+            _send_event("file", "open", ["/repo/src/b.py", 0]),
+        ])
+
+        ctx = _make_context_map("/repo")
+        result = enrich_context_map_with_frida(ctx, [tmp_path])
+        assert "runtime_observation" in result
+
+
+class TestEnrichNoEvidence:
+    def test_no_frida_output(self, tmp_path):
+        ctx = _make_context_map()
+        result = enrich_context_map_with_frida(ctx, [tmp_path])
+        assert "runtime_observation" not in result
+        assert result == ctx
+
+    def test_empty_search_dirs(self):
+        ctx = _make_context_map()
+        result = enrich_context_map_with_frida(ctx, [])
+        assert result == ctx
+
+
+class TestEnrichTargetMismatch:
+    def test_different_binary_filtered(self, tmp_path):
+        run_dir = tmp_path / "frida-run"
+        _write_frida_run(
+            run_dir,
+            [_send_event("file", "open", ["/other/file.py", 0])],
+            binary="/opt/other_binary",
+        )
+        ctx = _make_context_map("/repo")
+        result = enrich_context_map_with_frida(
+            ctx, [tmp_path], target_path="/home/user/my_app",
+        )
+        assert "runtime_observation" not in result
+
+
+class TestEnrichPreservesOriginal:
+    def test_original_not_mutated(self, tmp_path):
+        run_dir = tmp_path / "frida-run"
+        _write_frida_run(run_dir, [
+            _send_event("file", "open", ["/etc/passwd", 0]),
+        ])
+        ctx = _make_context_map()
+        original_keys = set(ctx.keys())
+        _ = enrich_context_map_with_frida(ctx, [tmp_path])
+        assert set(ctx.keys()) == original_keys
+        assert "runtime_observation" not in ctx
+
+
+class TestEnrichEmptyEvents:
+    def test_run_with_no_file_events(self, tmp_path):
+        run_dir = tmp_path / "frida-run"
+        _write_frida_run(run_dir, [
+            {"ts": 1.0, "type": "error", "error": {"description": "attach failed"}},
+        ])
+        ctx = _make_context_map()
+        result = enrich_context_map_with_frida(ctx, [tmp_path])
+        assert "runtime_observation" not in result

--- a/packages/frida/tests/test_e2e_live.py
+++ b/packages/frida/tests/test_e2e_live.py
@@ -1,0 +1,220 @@
+"""Live E2E test: compile a C binary, instrument with frida, feed through pipeline.
+
+Requires:
+  - frida CLI on PATH (pipx/venv install)
+  - gcc
+  - ptrace_scope <= 1 (spawn mode only needs own-child)
+
+Skipped automatically when any prerequisite is missing.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    not shutil.which("frida") or not shutil.which("gcc"),
+    reason="frida CLI or gcc not on PATH",
+)
+
+_VICTIM_C = """\
+#include <stdio.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <sys/stat.h>
+
+int main(void) {
+    /* open + read */
+    int fd = open("/etc/hostname", O_RDONLY);
+    if (fd >= 0) {
+        char buf[256];
+        read(fd, buf, sizeof(buf));
+        close(fd);
+    }
+    /* stat */
+    struct stat st;
+    stat("/etc/os-release", &st);
+    /* write to stdout */
+    const char *msg = "hello from victim\\n";
+    write(STDOUT_FILENO, msg, 18);
+    return 0;
+}
+"""
+
+RAPTOR_DIR = Path(__file__).resolve().parents[3]
+
+
+@pytest.fixture(scope="module")
+def victim_binary(tmp_path_factory):
+    """Compile the victim binary once per module."""
+    build_dir = tmp_path_factory.mktemp("victim")
+    src = build_dir / "victim.c"
+    src.write_text(_VICTIM_C)
+    binary = build_dir / "victim"
+    result = subprocess.run(
+        ["gcc", "-o", str(binary), str(src)],
+        capture_output=True, text=True, timeout=30,
+    )
+    if result.returncode != 0:
+        pytest.skip(f"gcc failed: {result.stderr[:200]}")
+    assert binary.is_file()
+    return binary
+
+
+@pytest.fixture
+def run_dir(tmp_path):
+    """Fresh run directory for each test."""
+    d = tmp_path / "frida_run"
+    d.mkdir()
+    return d
+
+
+def _run_frida_cli(binary: Path, run_dir: Path, duration: int = 3) -> int:
+    """Run the frida CLI in spawn mode via the packages.frida.cli module."""
+    env = os.environ.copy()
+    env["RAPTOR_DIR"] = str(RAPTOR_DIR)
+    env["PYTHONPATH"] = str(RAPTOR_DIR)
+    env.pop("_RAPTOR_TRUSTED", None)
+
+    frida_python = _find_frida_python()
+    if not frida_python:
+        pytest.skip("cannot find frida-python interpreter")
+
+    cmd = [
+        frida_python, "-m", "packages.frida.cli",
+        "--target", str(binary),
+        "--template", "api-trace",
+        "--duration", str(duration),
+        "--spawn",
+        "--out", str(run_dir),
+    ]
+    result = subprocess.run(
+        cmd, capture_output=True, text=True,
+        timeout=duration + 30, env=env,
+    )
+    return result.returncode
+
+
+def _find_frida_python() -> str | None:
+    """Find the Python interpreter that has frida-python installed."""
+    frida_bin = shutil.which("frida")
+    if not frida_bin:
+        return None
+    try:
+        with open(frida_bin, "r") as f:
+            shebang = f.readline(256).strip()
+        if shebang.startswith("#!"):
+            python = shebang[2:].strip().split()[0]
+            if os.path.isfile(python):
+                return python
+    except OSError:
+        pass
+    return sys.executable
+
+
+class TestLiveE2E:
+    """Real frida instrumentation of a compiled binary."""
+
+    def test_spawn_captures_events(self, victim_binary, run_dir):
+        """Spawn victim, api-trace template captures open/read/write/stat."""
+        rc = _run_frida_cli(victim_binary, run_dir)
+        assert rc == 0, f"frida CLI returned {rc}"
+
+        events_path = run_dir / "events.jsonl"
+        assert events_path.is_file(), "events.jsonl not created"
+        assert events_path.stat().st_size > 0, "events.jsonl is empty"
+
+        metadata_path = run_dir / "metadata.json"
+        assert metadata_path.is_file()
+        meta = json.loads(metadata_path.read_text())
+        assert meta["ok"] is True
+        assert meta["target"]["binary"] == str(victim_binary)
+        assert meta["events_captured"] > 0
+
+    def test_events_contain_expected_syscalls(self, victim_binary, run_dir):
+        """Captured events include the syscalls our victim binary makes."""
+        rc = _run_frida_cli(victim_binary, run_dir)
+        assert rc == 0
+
+        from packages.frida import parse_events
+
+        fns_seen = set()
+        for record in parse_events(run_dir / "events.jsonl"):
+            if record.get("type") != "send":
+                continue
+            payload = record.get("payload", {})
+            fn = payload.get("fn")
+            if fn:
+                fns_seen.add(fn)
+
+        assert "open" in fns_seen or "openat" in fns_seen, (
+            f"expected open/openat in {fns_seen}")
+        assert "read" in fns_seen, f"expected read in {fns_seen}"
+        assert "write" in fns_seen, f"expected write in {fns_seen}"
+
+    def test_evidence_discovery_finds_run(self, victim_binary, run_dir):
+        """Evidence layer discovers the run and matches the target."""
+        rc = _run_frida_cli(victim_binary, run_dir)
+        assert rc == 0
+
+        from packages.frida.evidence import discover_evidence
+
+        evidence = discover_evidence(
+            [run_dir.parent], target_path=str(victim_binary))
+        assert len(evidence) >= 1
+        ev = evidence[0]
+        assert ev.has_events is True
+        assert ev.target_binary == str(victim_binary)
+
+    def test_observe_adapter_produces_profile(self, victim_binary, run_dir):
+        """ObserveProfile from real events has file operations populated."""
+        rc = _run_frida_cli(victim_binary, run_dir)
+        assert rc == 0
+
+        from packages.frida.observe_adapter import events_to_observe_profile
+
+        profile = events_to_observe_profile(run_dir / "events.jsonl")
+        total_paths = (len(profile.paths_read) + len(profile.paths_written)
+                       + len(profile.paths_stat))
+        assert total_paths > 0, (
+            f"no file paths from real events: "
+            f"read={profile.paths_read}, write={profile.paths_written}, "
+            f"stat={profile.paths_stat}")
+
+    def test_validation_bridge_full_pipeline(self, victim_binary, run_dir):
+        """Full pipeline: real events → collect_runtime_evidence → annotate."""
+        rc = _run_frida_cli(victim_binary, run_dir)
+        assert rc == 0
+
+        from core.orchestration.frida_validation_bridge import (
+            PROXIMITY_FLOOR,
+            annotate_attack_paths,
+            collect_runtime_evidence,
+        )
+
+        evidence_map = collect_runtime_evidence(
+            [run_dir.parent], target_path=str(victim_binary))
+        assert len(evidence_map) > 0, "no runtime evidence collected"
+
+        has_open = "open" in evidence_map or "openat" in evidence_map
+        assert has_open, f"expected open/openat in {list(evidence_map.keys())}"
+
+        fn = "open" if "open" in evidence_map else "openat"
+        attack_paths = [{
+            "id": "LIVE-001",
+            "steps": [{"step": 1, "function": fn, "action": f"{fn}()"}],
+            "proximity": 2,
+        }]
+        result = annotate_attack_paths(attack_paths, evidence_map)
+        assert result[0]["proximity"] >= PROXIMITY_FLOOR
+        assert result[0]["runtime_evidence_available"] is True
+        step_ev = result[0]["steps"][0]["runtime_evidence"]
+        assert step_ev["function_observed"] is True
+        assert step_ev["call_count"] >= 1

--- a/packages/frida/tests/test_evidence.py
+++ b/packages/frida/tests/test_evidence.py
@@ -1,0 +1,163 @@
+"""Tests for frida evidence discovery."""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from pathlib import Path
+
+from packages.frida.evidence import (
+    discover_evidence,
+    match_target,
+)
+
+
+def _write_metadata(run_dir: Path, metadata: dict) -> None:
+    run_dir.mkdir(parents=True, exist_ok=True)
+    (run_dir / "metadata.json").write_text(
+        json.dumps(metadata), encoding="utf-8",
+    )
+
+
+def _sample_metadata(binary: str = "/tmp/build/myapp", ok: bool = True) -> dict:
+    return {
+        "ok": ok,
+        "error": None,
+        "target": {
+            "raw": binary,
+            "kind": "binary",
+            "pid": None,
+            "name": None,
+            "binary": binary,
+        },
+        "script_origin": "template:api-trace",
+        "duration_requested_sec": 60.0,
+        "duration_actual_sec": 5.0,
+        "events_captured": 10,
+        "device": {"id": "local", "host": None, "usb": False},
+        "host": {"system": "Linux", "arch": "x86_64", "frida_version": "16.0.0",
+                 "frida_bin": "/usr/bin/frida", "sip_status": None,
+                 "ptrace_scope": 0},
+        "spawn": True,
+        "unsafe_attach": False,
+        "resolved_pid": 1234,
+    }
+
+
+def test_discover_finds_valid_run(tmp_path):
+    run_dir = tmp_path / "frida-run-1"
+    _write_metadata(run_dir, _sample_metadata())
+    (run_dir / "events.jsonl").write_text('{"ts":1,"type":"send"}\n', encoding="utf-8")
+    (run_dir / "coverage.drcov").write_bytes(b"DRCOV VERSION: 2\n")
+
+    results = discover_evidence([tmp_path])
+    assert len(results) == 1
+    ev = results[0]
+    assert ev.run_dir == run_dir
+    assert ev.has_drcov is True
+    assert ev.has_events is True
+    assert ev.target_binary == "/tmp/build/myapp"
+
+
+def test_discover_skips_corrupt_metadata(tmp_path):
+    run_dir = tmp_path / "bad-run"
+    run_dir.mkdir()
+    (run_dir / "metadata.json").write_text("NOT JSON{{{", encoding="utf-8")
+
+    results = discover_evidence([tmp_path])
+    assert results == []
+
+
+def test_discover_skips_wrong_target(tmp_path):
+    run_dir = tmp_path / "run-other"
+    _write_metadata(run_dir, _sample_metadata(binary="/opt/other-app"))
+
+    results = discover_evidence([tmp_path], target_path="/home/user/myapp")
+    assert results == []
+
+
+def test_discover_empty_dir(tmp_path):
+    results = discover_evidence([tmp_path])
+    assert results == []
+
+
+def test_match_target_exact():
+    meta = _sample_metadata(binary="/home/user/src/myapp")
+    assert match_target(meta, "/home/user/src/myapp") is True
+
+
+def test_match_target_basename_no_false_positive():
+    """Basename alone must NOT match -- avoids cross-project pollution."""
+    meta = _sample_metadata(binary="/tmp/build/myapp")
+    assert match_target(meta, "/home/user/src/myapp") is False
+
+
+def test_match_target_realpath(tmp_path):
+    real = tmp_path / "real_binary"
+    real.write_bytes(b"ELF")
+    link = tmp_path / "link_binary"
+    link.symlink_to(real)
+    meta = _sample_metadata(binary=str(real))
+    assert match_target(meta, str(link)) is True
+
+
+def test_match_target_by_name():
+    """Attach-by-name: target.name matches basename of target_path."""
+    meta = _sample_metadata(binary="")
+    meta["target"]["binary"] = None
+    meta["target"]["raw"] = ""
+    meta["target"]["name"] = "my_daemon"
+    assert match_target(meta, "/usr/sbin/my_daemon") is True
+    assert match_target(meta, "/other/path/my_daemon") is True
+    assert match_target(meta, "/other/path/wrong_name") is False
+
+
+def test_discover_sorts_newest_first(tmp_path):
+    run1 = tmp_path / "run-old"
+    _write_metadata(run1, _sample_metadata())
+    # Force older mtime
+    old_time = time.time() - 100
+    os.utime(run1 / "metadata.json", (old_time, old_time))
+
+    run2 = tmp_path / "run-new"
+    _write_metadata(run2, _sample_metadata())
+
+    results = discover_evidence([tmp_path])
+    assert len(results) == 2
+    assert results[0].run_dir == run2
+    assert results[1].run_dir == run1
+
+
+def test_available_false_still_discovers(tmp_path):
+    """Evidence discovery works on files, not the frida runtime."""
+    run_dir = tmp_path / "run-1"
+    _write_metadata(run_dir, _sample_metadata())
+    (run_dir / "events.jsonl").write_text('{"ts":1}\n', encoding="utf-8")
+
+    results = discover_evidence([tmp_path])
+    assert len(results) == 1
+
+
+def test_match_target_malformed_types():
+    """Non-string metadata fields must not crash match_target."""
+    meta_int = {"target": {"binary": 12345, "raw": None, "name": None}}
+    assert match_target(meta_int, "/usr/bin/app") is False
+
+    meta_list = {"target": {"binary": ["/usr/bin/app"], "raw": "", "name": ""}}
+    assert match_target(meta_list, "/usr/bin/app") is False
+
+    meta_str_target = {"target": "not a dict"}
+    assert match_target(meta_str_target, "/usr/bin/app") is False
+
+
+def test_discover_malformed_binary_field(tmp_path):
+    """Non-string binary in metadata produces target_binary=None, not a crash."""
+    run_dir = tmp_path / "bad-binary-type"
+    meta = _sample_metadata()
+    meta["target"]["binary"] = 99999
+    _write_metadata(run_dir, meta)
+
+    results = discover_evidence([tmp_path])
+    assert len(results) == 1
+    assert results[0].target_binary is None

--- a/packages/frida/tests/test_observe_adapter.py
+++ b/packages/frida/tests/test_observe_adapter.py
@@ -1,0 +1,253 @@
+"""Tests for frida observe_adapter — events.jsonl to ObserveProfile."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from packages.frida.observe_adapter import events_to_observe_profile
+
+
+def _write_events(path: Path, events: list[dict]) -> Path:
+    path.write_text(
+        "\n".join(json.dumps(e) for e in events) + "\n",
+        encoding="utf-8",
+    )
+    return path
+
+
+def _send_event(category: str, fn: str, args: list) -> dict:
+    return {
+        "ts": 1.0,
+        "type": "send",
+        "payload": {"category": category, "fn": fn, "args": args, "tid": 1},
+    }
+
+
+class TestEventsToObserveProfile:
+    def test_file_read(self, tmp_path):
+        events = [_send_event("file", "open", ["/etc/passwd", 0])]
+        path = _write_events(tmp_path / "events.jsonl", events)
+        profile = events_to_observe_profile(path)
+        assert "/etc/passwd" in profile.paths_read
+        assert not profile.paths_written
+
+    def test_file_write(self, tmp_path):
+        events = [_send_event("file", "write", ["/tmp/out.txt", 512])]
+        path = _write_events(tmp_path / "events.jsonl", events)
+        profile = events_to_observe_profile(path)
+        assert "/tmp/out.txt" in profile.paths_written
+        assert not profile.paths_read
+
+    def test_file_stat(self, tmp_path):
+        events = [_send_event("file", "stat", ["/usr/lib/libc.so.6"])]
+        path = _write_events(tmp_path / "events.jsonl", events)
+        profile = events_to_observe_profile(path)
+        assert "/usr/lib/libc.so.6" in profile.paths_stat
+
+    def test_network_connect(self, tmp_path):
+        events = [_send_event("network", "connect", ["10.0.0.1", 8080, "AF_INET"])]
+        path = _write_events(tmp_path / "events.jsonl", events)
+        profile = events_to_observe_profile(path)
+        assert len(profile.connect_targets) == 1
+        ct = profile.connect_targets[0]
+        assert ct.ip == "10.0.0.1"
+        assert ct.port == 8080
+        assert ct.family == "AF_INET"
+
+    def test_open_with_write_flags(self, tmp_path):
+        events = [_send_event("file", "open", ["/tmp/out.log", 0o102])]  # O_CREAT|O_WRONLY
+        path = _write_events(tmp_path / "events.jsonl", events)
+        profile = events_to_observe_profile(path)
+        assert "/tmp/out.log" in profile.paths_written
+        assert "/tmp/out.log" not in profile.paths_read
+
+    def test_deduplicates(self, tmp_path):
+        events = [
+            _send_event("file", "open", ["/etc/passwd", 0]),
+            _send_event("file", "open", ["/etc/passwd", 0]),
+            _send_event("file", "open", ["/etc/passwd", 0]),
+        ]
+        path = _write_events(tmp_path / "events.jsonl", events)
+        profile = events_to_observe_profile(path)
+        assert profile.paths_read.count("/etc/passwd") == 1
+
+    def test_non_send_events_ignored(self, tmp_path):
+        events = [
+            {"ts": 1.0, "type": "error", "error": {"description": "boom"}},
+            _send_event("file", "open", ["/etc/hosts", 0]),
+        ]
+        path = _write_events(tmp_path / "events.jsonl", events)
+        profile = events_to_observe_profile(path)
+        assert profile.paths_read == ["/etc/hosts"]
+
+    def test_missing_file_returns_empty(self, tmp_path):
+        profile = events_to_observe_profile(tmp_path / "nope.jsonl")
+        assert not profile.paths_read
+        assert not profile.paths_written
+        assert not profile.connect_targets
+
+    def test_malformed_lines_tolerated(self, tmp_path):
+        content = "NOT JSON\n" + json.dumps(_send_event("file", "read", ["/data"])) + "\n{truncated\n"
+        path = tmp_path / "events.jsonl"
+        path.write_text(content, encoding="utf-8")
+        profile = events_to_observe_profile(path)
+        assert "/data" in profile.paths_read
+
+    def test_connect_string_port_coerced(self, tmp_path):
+        events = [{"ts": 1.0, "type": "send", "payload": {
+            "category": "network", "fn": "connect",
+            "args": ["192.168.1.1", "443", "AF_INET6"], "tid": 1,
+        }}]
+        path = _write_events(tmp_path / "events.jsonl", events)
+        profile = events_to_observe_profile(path)
+        assert len(profile.connect_targets) == 1
+        assert profile.connect_targets[0].port == 443
+
+    def test_connect_missing_args_skipped(self, tmp_path):
+        events = [_send_event("network", "connect", ["10.0.0.1"])]
+        path = _write_events(tmp_path / "events.jsonl", events)
+        profile = events_to_observe_profile(path)
+        assert not profile.connect_targets
+
+    def test_empty_path_skipped(self, tmp_path):
+        events = [_send_event("file", "open", ["", 0])]
+        path = _write_events(tmp_path / "events.jsonl", events)
+        profile = events_to_observe_profile(path)
+        assert not profile.paths_read
+
+    def test_write_supersedes_earlier_read(self, tmp_path):
+        """A path read then written should appear in paths_written only."""
+        events = [
+            _send_event("file", "open", ["/tmp/data.bin", 0]),
+            _send_event("file", "write", ["/tmp/data.bin"]),
+        ]
+        path = _write_events(tmp_path / "events.jsonl", events)
+        profile = events_to_observe_profile(path)
+        assert "/tmp/data.bin" in profile.paths_written
+        assert "/tmp/data.bin" not in profile.paths_read
+
+
+    def test_openat_list_format(self, tmp_path):
+        """openat args are [dirfd, path, flags] — path at index 1, flags at 2."""
+        events = [_send_event("file", "openat", [-100, "/proc/self/maps", 0])]
+        path = _write_events(tmp_path / "events.jsonl", events)
+        profile = events_to_observe_profile(path)
+        assert "/proc/self/maps" in profile.paths_read
+
+    def test_openat_list_write_flags(self, tmp_path):
+        """openat with O_WRONLY|O_CREAT → written."""
+        events = [_send_event("file", "openat", [-100, "/tmp/out.log", 0o101])]
+        path = _write_events(tmp_path / "events.jsonl", events)
+        profile = events_to_observe_profile(path)
+        assert "/tmp/out.log" in profile.paths_written
+        assert "/tmp/out.log" not in profile.paths_read
+
+    def test_o_creat_alone_is_not_write(self, tmp_path):
+        """O_CREAT alone (no O_WRONLY/O_RDWR) = O_RDONLY|O_CREAT → still a read."""
+        events = [_send_event("file", "open", ["/tmp/maybe.db", 0o100])]  # O_CREAT only
+        path = _write_events(tmp_path / "events.jsonl", events)
+        profile = events_to_observe_profile(path)
+        assert "/tmp/maybe.db" in profile.paths_read
+        assert "/tmp/maybe.db" not in profile.paths_written
+
+    def test_null_byte_in_path_skipped(self, tmp_path):
+        """Paths with embedded null bytes are rejected."""
+        events = [_send_event("file", "open", ["/etc/shadow\x00.log", 0])]
+        path = _write_events(tmp_path / "events.jsonl", events)
+        profile = events_to_observe_profile(path)
+        assert not profile.paths_read
+
+    def test_max_events_cap(self, tmp_path):
+        """Event processing stops at max_events."""
+        events = [_send_event("file", "open", [f"/file_{i}", 0]) for i in range(200)]
+        path = _write_events(tmp_path / "events.jsonl", events)
+        profile = events_to_observe_profile(path, max_events=50)
+        assert len(profile.paths_read) == 50
+
+    def test_statx_classified_as_stat(self, tmp_path):
+        """statx and fstatat are stat operations (both take dirfd, path)."""
+        events = [
+            _send_event("file", "statx", [-100, "/usr/lib/libz.so", 0]),
+            _send_event("file", "fstatat", [-100, "/proc/version", 0]),
+        ]
+        path = _write_events(tmp_path / "events.jsonl", events)
+        profile = events_to_observe_profile(path)
+        assert "/usr/lib/libz.so" in profile.paths_stat
+        assert "/proc/version" in profile.paths_stat
+
+    def test_unlink_classified_as_write(self, tmp_path):
+        """unlink and unlinkat are write operations."""
+        events = [
+            _send_event("file", "unlink", ["/tmp/target.tmp"]),
+            _send_event("file", "unlinkat", [-100, "/tmp/other.tmp", 0]),
+        ]
+        path = _write_events(tmp_path / "events.jsonl", events)
+        profile = events_to_observe_profile(path)
+        assert "/tmp/target.tmp" in profile.paths_written
+        assert "/tmp/other.tmp" in profile.paths_written
+
+    def test_mkdir_classified_as_write(self, tmp_path):
+        """mkdir is a write operation."""
+        events = [_send_event("file", "mkdir", ["/tmp/newdir"])]
+        path = _write_events(tmp_path / "events.jsonl", events)
+        profile = events_to_observe_profile(path)
+        assert "/tmp/newdir" in profile.paths_written
+
+    def test_readlink_classified_as_stat(self, tmp_path):
+        """readlink/readlinkat are stat operations."""
+        events = [
+            _send_event("file", "readlink", ["/proc/self/exe"]),
+            _send_event("file", "readlinkat", [-100, "/usr/bin/python3", 0]),
+        ]
+        path = _write_events(tmp_path / "events.jsonl", events)
+        profile = events_to_observe_profile(path)
+        assert "/proc/self/exe" in profile.paths_stat
+        assert "/usr/bin/python3" in profile.paths_stat
+
+
+class TestDictArgsFormat:
+    """Tests for the real api-trace.js dict format (args as JS object)."""
+
+    def _dict_event(self, category, fn, args_dict):
+        return {"ts": 1.0, "type": "send",
+                "payload": {"category": category, "fn": fn, "args": args_dict, "tid": 1}}
+
+    def test_open_read(self, tmp_path):
+        events = [self._dict_event("file", "open",
+                                   {"path": "/etc/passwd", "flags": 0, "ret": 3})]
+        path = _write_events(tmp_path / "events.jsonl", events)
+        profile = events_to_observe_profile(path)
+        assert "/etc/passwd" in profile.paths_read
+
+    def test_open_write_flags(self, tmp_path):
+        events = [self._dict_event("file", "open",
+                                   {"path": "/tmp/out", "flags": 0o101, "ret": 4})]
+        path = _write_events(tmp_path / "events.jsonl", events)
+        profile = events_to_observe_profile(path)
+        assert "/tmp/out" in profile.paths_written
+        assert "/tmp/out" not in profile.paths_read
+
+    def test_write_no_path(self, tmp_path):
+        """write() with fd-only dict has no extractable path."""
+        events = [self._dict_event("file", "write",
+                                   {"fd": 4, "count": 100, "ret": 100})]
+        path = _write_events(tmp_path / "events.jsonl", events)
+        profile = events_to_observe_profile(path)
+        assert not profile.paths_written
+
+    def test_connect_no_ip(self, tmp_path):
+        """connect() with fd-only (real template) produces no ConnectTarget."""
+        events = [self._dict_event("network", "connect", {"fd": 5, "ret": 0})]
+        path = _write_events(tmp_path / "events.jsonl", events)
+        profile = events_to_observe_profile(path)
+        assert not profile.connect_targets
+
+    def test_connect_with_ip(self, tmp_path):
+        """Custom template that emits IP/port/family in dict format."""
+        events = [self._dict_event("network", "connect",
+                                   {"ip": "10.0.0.1", "port": 443, "family": "AF_INET"})]
+        path = _write_events(tmp_path / "events.jsonl", events)
+        profile = events_to_observe_profile(path)
+        assert len(profile.connect_targets) == 1
+        assert profile.connect_targets[0].ip == "10.0.0.1"

--- a/packages/frida/tests/test_pipeline_e2e.py
+++ b/packages/frida/tests/test_pipeline_e2e.py
@@ -1,0 +1,243 @@
+"""End-to-end test: frida events → evidence → coverage → observe → context → validation.
+
+Exercises the full data flow pipeline using synthetic events.jsonl
+and metadata.json, without requiring an actual frida binary or
+target process. Each layer consumes the output of the previous one,
+verifying that the contracts between modules are correct.
+
+Pipeline under test:
+  events.jsonl ──→ evidence.discover_evidence()
+                       │
+            ┌──────────┼──────────────┐
+            ▼          ▼              ▼
+   frida_bridge    observe_adapter   validation_bridge
+   (coverage)      (ObserveProfile)  (attack path annotations)
+                       │
+                       ▼
+               context_bridge
+               (context map merge)
+"""
+
+from __future__ import annotations
+
+import json
+import struct
+from pathlib import Path
+
+import pytest
+
+
+def _api_event(fn: str, category: str = "file", args=None, tid: int = 1):
+    payload = {"category": category, "fn": fn, "tid": tid}
+    if args is not None:
+        payload["args"] = args
+    return {"ts": 0.1, "type": "send", "payload": payload}
+
+
+def _make_frida_run(
+    base: Path,
+    target_binary: str,
+    events: list[dict],
+    *,
+    include_drcov: bool = False,
+) -> Path:
+    """Create a complete synthetic frida run directory."""
+    run_dir = base / "frida_20260621_120000_99"
+    run_dir.mkdir(parents=True, exist_ok=True)
+
+    lines = [json.dumps(e) for e in events]
+    (run_dir / "events.jsonl").write_text("\n".join(lines) + "\n")
+
+    metadata = {
+        "ok": True,
+        "target": {
+            "raw": target_binary,
+            "kind": "binary",
+            "pid": None,
+            "name": None,
+            "binary": target_binary,
+        },
+        "script_origin": "template:api-trace",
+        "duration_requested_sec": 30,
+        "duration_actual_sec": 29.5,
+        "events_captured": len(events),
+        "device": {"id": "local", "host": None, "usb": False},
+        "host": {
+            "system": "Linux", "arch": "x86_64",
+            "frida_version": "16.5.0", "frida_bin": "/usr/bin/frida",
+            "sip_status": None, "ptrace_scope": 1,
+        },
+        "spawn": True,
+        "unsafe_attach": False,
+        "resolved_pid": 12345,
+    }
+    (run_dir / "metadata.json").write_text(json.dumps(metadata, indent=2))
+
+    if include_drcov:
+        header = (
+            b"DRCOV VERSION: 2\n"
+            b"DRCOV FLAVOR: drcov\n"
+            b"Module Table: version 2, count 1\n"
+            b"Columns: id, base, end, entry, checksum, timestamp, path\n"
+            b" 0, 0x400000, 0x401000, 0x400080, 0, 0, " +
+            target_binary.encode() + b"\n"
+            b"BB Table: 1 bbs\n"
+        )
+        bb_entry = struct.pack("<IHH", 0x80, 16, 0)  # offset=0x80, size=16, mod=0
+        (run_dir / "coverage.drcov").write_bytes(header + bb_entry)
+
+    return run_dir
+
+
+EVENTS = [
+    _api_event("open", args={"path": "/etc/passwd", "flags": 0, "ret": 3}),
+    _api_event("read", args={"fd": 3, "count": 4096, "ret": 512}),
+    _api_event("open", args={"path": "/etc/shadow", "flags": 0, "ret": -1}),
+    _api_event("write", args={"fd": 1, "count": 512, "ret": 512}),
+    _api_event("stat", args={"path": "/usr/lib/libc.so.6"}),
+    _api_event("connect", category="network",
+               args={"ip": "10.0.0.1", "port": 8080, "family": "AF_INET"}),
+    _api_event("open", args={"path": "/tmp/output.bin", "flags": 0o101, "ret": 4}),
+]
+
+
+class TestPipelineE2E:
+    """Full pipeline integration: one frida run feeds all consumers."""
+
+    @pytest.fixture
+    def frida_run(self, tmp_path):
+        target = str(tmp_path / "vulnerable_binary")
+        (tmp_path / "vulnerable_binary").touch()
+        return _make_frida_run(tmp_path, target, EVENTS, include_drcov=True)
+
+    @pytest.fixture
+    def target_binary(self, tmp_path):
+        return str(tmp_path / "vulnerable_binary")
+
+    def test_evidence_discovery(self, frida_run, tmp_path):
+        """Layer 1: discover_evidence finds the run and matches target."""
+        from packages.frida.evidence import discover_evidence
+
+        target = str(tmp_path / "vulnerable_binary")
+        evidence = discover_evidence([tmp_path], target_path=target)
+        assert len(evidence) == 1
+        assert evidence[0].run_dir == frida_run
+        assert evidence[0].has_events is True
+        assert evidence[0].has_drcov is True
+        assert evidence[0].target_binary == target
+
+    def test_observe_adapter(self, frida_run):
+        """Layer 2a: events → ObserveProfile with correct classification."""
+        from packages.frida.observe_adapter import events_to_observe_profile
+
+        events_path = frida_run / "events.jsonl"
+        profile = events_to_observe_profile(events_path)
+
+        assert "/etc/passwd" in profile.paths_read
+        assert "/etc/shadow" in profile.paths_read
+        assert "/tmp/output.bin" in profile.paths_written
+        assert "/tmp/output.bin" not in profile.paths_read
+        assert "/usr/lib/libc.so.6" in profile.paths_stat
+        assert len(profile.connect_targets) == 1
+        assert profile.connect_targets[0].ip == "10.0.0.1"
+        assert profile.connect_targets[0].port == 8080
+
+    def test_context_bridge(self, frida_run, tmp_path, target_binary):
+        """Layer 2b: observe profile merges into context map."""
+        from packages.frida.context_bridge import enrich_context_map_with_frida
+
+        context_map = {
+            "entry_points": [],
+            "sinks": [],
+            "trust_boundaries": [],
+        }
+
+        result = enrich_context_map_with_frida(
+            context_map, [tmp_path], target_path=target_binary)
+
+        assert result is not context_map
+
+    def test_validation_bridge(self, frida_run, tmp_path, target_binary):
+        """Layer 2c: runtime evidence annotates attack paths."""
+        from core.orchestration.frida_validation_bridge import (
+            PROXIMITY_FLOOR,
+            annotate_attack_paths,
+            collect_runtime_evidence,
+        )
+
+        evidence_map = collect_runtime_evidence(
+            [tmp_path], target_path=target_binary)
+
+        assert "open" in evidence_map
+        assert "read" in evidence_map
+        assert "write" in evidence_map
+        assert "stat" in evidence_map
+        assert evidence_map["open"].function_observed is True
+        assert evidence_map["open"].call_count == 3
+
+        attack_paths = [{
+            "id": "PATH-001",
+            "name": "Path to /etc/shadow read",
+            "finding": "FIND-001",
+            "steps": [
+                {"step": 1, "function": "open", "action": "open /etc/shadow"},
+                {"step": 2, "function": "read", "action": "read file content"},
+                {"step": 3, "function": "process_data", "action": "parse content"},
+            ],
+            "proximity": 3,
+            "blockers": [],
+            "status": "uncertain",
+        }]
+
+        result = annotate_attack_paths(attack_paths, evidence_map)
+
+        assert result[0]["runtime_evidence_available"] is True
+        assert result[0]["proximity"] >= PROXIMITY_FLOOR
+        assert "runtime_evidence" in result[0]["steps"][0]
+        assert "runtime_evidence" in result[0]["steps"][1]
+        assert "runtime_evidence" not in result[0]["steps"][2]
+        assert result[0]["steps"][0]["runtime_evidence"]["call_count"] == 3
+        assert result[0]["frida_trace_id"] == str(frida_run)
+
+    def test_full_pipeline_no_mutation(self, frida_run, tmp_path, target_binary):
+        """End-to-end: no layer mutates its input data."""
+        from packages.frida.context_bridge import enrich_context_map_with_frida
+        from core.orchestration.frida_validation_bridge import (
+            annotate_attack_paths,
+            collect_runtime_evidence,
+        )
+        import copy
+
+        original_context = {"entry_points": [{"name": "main"}], "sinks": []}
+        frozen_context = copy.deepcopy(original_context)
+
+        enrich_context_map_with_frida(
+            original_context, [tmp_path], target_path=target_binary)
+        assert original_context == frozen_context
+
+        evidence_map = collect_runtime_evidence(
+            [tmp_path], target_path=target_binary)
+
+        paths = [{"id": "P1", "steps": [{"function": "open"}], "proximity": 2}]
+        frozen_paths = copy.deepcopy(paths)
+        annotate_attack_paths(paths, evidence_map)
+        assert paths == frozen_paths
+
+    def test_graceful_degradation_no_evidence(self, tmp_path):
+        """All layers degrade gracefully when no evidence exists."""
+        from packages.frida.context_bridge import enrich_context_map_with_frida
+        from core.orchestration.frida_validation_bridge import (
+            annotate_attack_paths,
+            collect_runtime_evidence,
+        )
+
+        evidence_map = collect_runtime_evidence([tmp_path])
+        assert evidence_map == {}
+
+        context = {"entry_points": [], "sinks": []}
+        result = enrich_context_map_with_frida(context, [tmp_path])
+        assert result is context
+
+        paths = [{"id": "P1", "steps": [{"function": "open"}], "proximity": 5}]
+        result = annotate_attack_paths(paths, {})
+        assert result is paths

--- a/packages/frida/tests/test_substrate.py
+++ b/packages/frida/tests/test_substrate.py
@@ -25,8 +25,8 @@ class TestAvailable:
     def teardown_method(self):
         self._mod._available = None
 
-    def test_no_frida_python(self):
-        """ImportError on frida-python → False."""
+    def test_no_frida_python_no_cli(self):
+        """Neither frida-python nor CLI → False."""
         import builtins
         real_import = builtins.__import__
 
@@ -35,25 +35,26 @@ class TestAvailable:
                 raise ImportError("no frida")
             return real_import(name, *a, **kw)
 
-        with patch("builtins.__import__", side_effect=fake_import):
+        with patch("builtins.__import__", side_effect=fake_import), \
+             patch("shutil.which", return_value=None):
             assert available() is False
         # Cached after first call.
         assert available() is False
 
-    def test_frida_python_but_no_cli(self):
-        """frida importable but CLI missing → False."""
+    def test_cli_only_sufficient(self):
+        """CLI on PATH without frida-python importable → True."""
         import builtins
         real_import = builtins.__import__
 
         def fake_import(name, *a, **kw):
             if name == "frida":
-                return SimpleNamespace(__version__="test")
+                raise ImportError("no frida")
             return real_import(name, *a, **kw)
 
         with patch("builtins.__import__", side_effect=fake_import), \
-             patch("shutil.which", return_value=None):
+             patch("shutil.which", return_value="/usr/bin/frida"):
             self._mod._available = None
-            assert available() is False
+            assert available() is True
 
     def test_both_present(self):
         """frida importable + CLI on PATH → True."""
@@ -129,6 +130,15 @@ class TestParseEvents:
         p = tmp_path / "events.jsonl"
         p.write_text("")
         assert list(parse_events(p)) == []
+
+    def test_binary_garbage_skipped(self, tmp_path: Path):
+        """Invalid UTF-8 bytes must not crash the parser."""
+        p = tmp_path / "events.jsonl"
+        p.write_bytes(b'{"ts": 1}\n\xff\xfe\x00\x01\n{"ts": 2}\n')
+        got = list(parse_events(p))
+        assert len(got) == 2
+        assert got[0] == {"ts": 1}
+        assert got[1] == {"ts": 2}
 
 
 # ── bb-coverage.js template ────────────────────────────────────────────
@@ -302,8 +312,8 @@ class TestSandboxedMain:
             rc = sandboxed.main()
         assert rc == 2
 
-    def test_import_fallback_warns_on_stderr(self):
-        """When core.sandbox is not importable, warn and run bare."""
+    def test_import_failure_hard_fails(self):
+        """When core.sandbox is not importable, hard-fail (never run unsandboxed)."""
         import io
         from unittest.mock import patch as mock_patch
         import packages.frida.sandboxed as sandboxed
@@ -321,9 +331,9 @@ class TestSandboxedMain:
             mock_sys.stderr = stderr_capture
             rc = sandboxed.main()
 
-        assert rc == 0
-        mock_call.assert_called_once_with(["echo", "hello"])
-        assert "unsandboxed" in stderr_capture.getvalue()
+        assert rc == 1
+        mock_call.assert_not_called()
+        assert "FATAL" in stderr_capture.getvalue()
 
 
 class TestLibexecSandboxFlags:


### PR DESCRIPTION
Wire frida runtime instrumentation into every RAPTOR consumer that can benefit from empirical reachability evidence:

Evidence layer:
- Discovery, observe adapter (*at() handling, null-byte rejection)
- Context bridge, validation bridge (proximity floor=6)
- Coverage bridge (drcov import), active observation API
- Sandboxed wrapper (hard-fail on import error)

Reachability integration:
- frida_runtime_trace_present() accessor on inventory items
- _stage_frida_runtime_trace in reach_audit PRECEDENCE (index 2, before binary_oracle_absent — runtime observation vetoes stale absent verdicts)
- enrich_with_frida_traces() in reachability_enrichment.py with dual-write to checklist AND inventory
- WitnessKind.FRIDA_RUNTIME_TRACE (Soundness.SOUND, no suppression)

Pipeline consumers wired:
- /agentic prepass: enrich_with_frida_traces (import fixed)
- /validate Stage B: annotate_attack_paths
- /validate Stages C-F: LLM prompts read runtime_evidence
- /understand --map: MAP-5e auto-enrichment via libexec script
- /codeql: inherits via classify_reachability PRECEDENCE
- Binary oracle: frida overrides absent (PRECEDENCE ordering)
- Diagram renderer: OBSERVED xN labels + blue styling

Sandbox envelope:
- FRIDA_PROFILE constant, inherit_netns, restrict_reads, fake_home
- available() detects CLI in pipx/venv (CLI-first check)

Tests: 333 pass (unit + live E2E with real frida + compiled C binary)