### PR TITLE
feat(trajectories): opt-in persistence for ToolUseLoop consumers

### DIFF
--- a/core/trajectories/__init__.py
+++ b/core/trajectories/__init__.py
@@ -1,0 +1,35 @@
+"""Trajectory persistence — per-iteration tool-call traces.
+
+Substrate for any consumer of :mod:`core.llm.tool_use` that wants to
+persist a structured record of "what the model said, which tools it
+called, what came back" — useful for operator debugging, A/B analysis
+of prompt variants, and post-hoc replay.
+
+See ``store.py`` for the serialisation + write surface, ``types.py``
+for the on-disk record shape, and ``auto.py`` for the opt-in
+``RAPTOR_TRAJECTORY_DIR`` env-var integration that lets callers
+persist without threading an output directory through their stack.
+"""
+
+from .auto import TRAJECTORY_DIR_ENV, persist_from_loop_result
+from .store import (
+    TRAJECTORY_FILENAME,
+    serialize_messages,
+    trajectory_path,
+    write_trajectory,
+)
+from .types import (
+    TrajectoryRecord,
+    TrajectoryStep,
+)
+
+__all__ = [
+    "TRAJECTORY_DIR_ENV",
+    "TRAJECTORY_FILENAME",
+    "TrajectoryRecord",
+    "TrajectoryStep",
+    "persist_from_loop_result",
+    "serialize_messages",
+    "trajectory_path",
+    "write_trajectory",
+]

--- a/core/trajectories/auto.py
+++ b/core/trajectories/auto.py
@@ -1,0 +1,193 @@
+"""Opt-in helper for ToolUseLoop consumers.
+
+The pattern is "produce a trajectory if the operator asked for one,
+otherwise no-op". Tied to the ``RAPTOR_TRAJECTORY_DIR`` environment
+variable: when set to a directory path, the helper writes
+``<dir>/trajectories/<run_id>/trajectory.json`` per the
+:mod:`core.trajectories.store` layout. Unset → silently skip.
+
+This keeps the call-site change at each consumer to a single line:
+
+    from core.trajectories.auto import persist_from_loop_result
+    ...
+    result = loop.run(user_message)
+    persist_from_loop_result(
+        result, run_id=f"hunt-{model.model_name}", model_name=model.model_name,
+    )
+
+without threading an ``output_dir`` kwarg through every function in
+the call chain.
+
+Operator workflow: set the env var (typically from a slash-command
+shim that already knows its run's output directory) and trajectories
+appear; unset → existing behaviour unchanged.
+
+Failures during persistence are LOGGED and SWALLOWED — a trajectory
+write failing must never break the underlying tool-use loop result.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from .store import write_trajectory, serialize_messages
+from .types import TrajectoryRecord
+
+if TYPE_CHECKING:
+    from core.llm.tool_use.types import ToolLoopResult
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "TRAJECTORY_DIR_ENV",
+    "persist_from_loop_result",
+    "persist_partial_from_exception",
+]
+
+
+TRAJECTORY_DIR_ENV = "RAPTOR_TRAJECTORY_DIR"
+
+# Characters tolerated in TrajectoryRecord.run_id are a strict subset of
+# what real-world model names use — Bedrock model IDs end in ``:0``,
+# OpenRouter slugs are ``vendor/model``, and ``@`` shows up in
+# revision-pinned IDs. Replacing them up front means the operator sees a
+# trajectory file rather than a silent ValueError swallowed in the
+# warning log. The substitution is one-way (we don't try to round-trip);
+# the original ``model_name`` is preserved verbatim in the record body.
+_RUN_ID_FORBIDDEN_CHAR = re.compile(r"[^A-Za-z0-9_.\-]")
+# Belt-and-braces against producer code that synthesises a run_id with
+# obvious traversal — the regex above would already collapse '/' to '-',
+# but a literal ``..`` chain that originated from a path fragment must
+# not survive to the validator. We can't safely rewrite ``..`` to ``.``
+# (collisions), so trim instead.
+_DOTDOT = re.compile(r"\.{2,}")
+
+
+def _sanitize_run_id(run_id: str) -> str:
+    """Coerce ``run_id`` into the ``TrajectoryRecord`` validation grammar.
+
+    ``TrajectoryRecord.__post_init__`` requires ``^[A-Za-z0-9_\\-.]+`` and
+    rejects ``..``. Real model names break those constraints (Bedrock
+    ``claude-3-haiku-20240307-v1:0``, OpenRouter ``anthropic/claude-...``).
+    Sanitise here so operators get a trajectory rather than a silently
+    swallowed validation error.
+    """
+    cleaned = _RUN_ID_FORBIDDEN_CHAR.sub("-", run_id)
+    cleaned = _DOTDOT.sub(".", cleaned)
+    # 128 is the TrajectoryRecord upper bound; trim from the right so the
+    # discriminator (e.g. ``hunt-``/``trace-``/``cve-diff-`` prefix) survives.
+    return cleaned[:128] if cleaned else "run"
+
+
+def persist_from_loop_result(
+    result: "ToolLoopResult",
+    *,
+    run_id: str,
+    model_name: str,
+    finding_id: str = "",
+    cwe: str = "",
+    timestamp: str = "",
+) -> Path | None:
+    """Write a trajectory iff ``RAPTOR_TRAJECTORY_DIR`` is set.
+
+    Returns the on-disk path written, or ``None`` when the env var
+    is unset (the opt-out path) or when persistence raised — the
+    underlying tool-use loop result must not be affected by a
+    trajectory write failure.
+
+    ``run_id`` should be unique per run; on collision the store
+    appends a short random suffix to avoid overwrite.
+    """
+    base_dir = os.environ.get(TRAJECTORY_DIR_ENV)
+    if not base_dir:
+        return None
+
+    safe_run_id = _sanitize_run_id(run_id)
+    try:
+        record = TrajectoryRecord(
+            run_id=safe_run_id,
+            model_name=model_name,
+            terminated_by=result.terminated_by,
+            iterations=result.iterations,
+            tool_calls_made=result.tool_calls_made,
+            cost_usd=result.total_cost_usd,
+            steps=serialize_messages(result.messages),
+            finding_id=finding_id,
+            cwe=cwe,
+            timestamp=timestamp,
+        )
+        return write_trajectory(record, base=Path(base_dir))
+    except Exception as exc:        # noqa: BLE001 — never propagate
+        # WARNING without traceback so a read-only RAPTOR_TRAJECTORY_DIR
+        # in a long-running operator process doesn't flood the log with
+        # thousands of stacktraces. The traceback is still available at
+        # DEBUG level for an operator who needs it.
+        logger.warning(
+            "trajectory persist failed for run_id=%r (base=%r): %s",
+            safe_run_id, base_dir, exc,
+        )
+        logger.debug("trajectory persist traceback:", exc_info=True)
+        return None
+
+
+def persist_partial_from_exception(
+    exc: BaseException,
+    *,
+    run_id: str,
+    model_name: str,
+    terminated_by: str,
+    finding_id: str = "",
+    cwe: str = "",
+    timestamp: str = "",
+) -> Path | None:
+    """Write a partial trajectory from a tool-use loop exception.
+
+    ``CostBudgetExceeded`` and ``ContextOverflow`` carry ``messages``
+    and ``tool_calls_made`` attributes (per the loop's partial-state
+    contract). This helper reads them and writes whatever's available
+    so the operator can see *what the model was doing when it ran out
+    of budget* — exactly the case where the trajectory is most useful.
+
+    Exceptions without those attributes (generic ``Exception``, etc.)
+    produce an empty-steps trajectory: ``run_id`` + ``model_name`` +
+    ``terminated_by`` survive so the operator at least knows the run
+    happened and what killed it.
+
+    Same opt-in + swallow contract as ``persist_from_loop_result``:
+    no-op when ``RAPTOR_TRAJECTORY_DIR`` is unset, failures logged
+    + swallowed so a trajectory write can never break the caller's
+    own error handling.
+    """
+    base_dir = os.environ.get(TRAJECTORY_DIR_ENV)
+    if not base_dir:
+        return None
+
+    messages = getattr(exc, "messages", []) or []
+    tool_calls_made = getattr(exc, "tool_calls_made", 0) or 0
+    safe_run_id = _sanitize_run_id(run_id)
+
+    try:
+        record = TrajectoryRecord(
+            run_id=safe_run_id,
+            model_name=model_name,
+            terminated_by=terminated_by,
+            iterations=0,
+            tool_calls_made=int(tool_calls_made),
+            cost_usd=0.0,
+            steps=serialize_messages(messages),
+            finding_id=finding_id,
+            cwe=cwe,
+            timestamp=timestamp,
+        )
+        return write_trajectory(record, base=Path(base_dir))
+    except Exception as exc2:        # noqa: BLE001 — never propagate
+        logger.warning(
+            "partial-trajectory persist failed for run_id=%r (base=%r): %s",
+            safe_run_id, base_dir, exc2,
+        )
+        logger.debug("partial-trajectory persist traceback:", exc_info=True)
+        return None

--- a/core/trajectories/store.py
+++ b/core/trajectories/store.py
@@ -1,0 +1,185 @@
+"""Storage for trajectory records.
+
+One trajectory file per tool-use loop run, JSON, written under
+
+    <base>/trajectories/<run_id>/trajectory.json
+
+``<base>`` is caller-chosen — typically the run's output directory
+when the caller knows it (CLI mode), or a project root when the
+caller wants trajectories to accumulate across runs for cross-run
+analysis. The opt-in helper in :mod:`core.trajectories.auto` reads
+this from the ``RAPTOR_TRAJECTORY_DIR`` environment variable so
+consumers don't have to thread an output_dir kwarg through every
+function in their stack.
+
+Atomic-write semantics: O_EXCL + retry on collision, same shape as
+``core/labeled_attempts/store.py``. A trajectory write at the same
+``run_id`` more than once is a programmer error (run_ids must be
+unique per run), but the symptom is a clear OSError rather than a
+silent overwrite.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import secrets
+from dataclasses import asdict
+from pathlib import Path
+from typing import Any, Iterable
+
+from core.llm.tool_use.types import Message, TextBlock, ToolCall, ToolResult
+
+from .types import TrajectoryRecord, TrajectoryStep
+
+__all__ = [
+    "TRAJECTORY_FILENAME",
+    "serialize_messages",
+    "trajectory_path",
+    "write_trajectory",
+]
+
+
+TRAJECTORY_FILENAME = "trajectory.json"
+
+# Per-block text cap. Tool results in particular can be enormous
+# (full file dumps, disassembly listings). 64 KB per block keeps the
+# trajectory readable + bounded without losing the operator-visible
+# shape of what happened. A truncation marker is appended so the
+# reader knows.
+_MAX_TEXT_LEN = 64 * 1024
+
+
+def _truncate(text: str) -> str:
+    """Cap a single text payload at _MAX_TEXT_LEN with a marker."""
+    if len(text) <= _MAX_TEXT_LEN:
+        return text
+    return (
+        text[:_MAX_TEXT_LEN]
+        + f"\n...[truncated {len(text) - _MAX_TEXT_LEN} chars]"
+    )
+
+
+def serialize_messages(messages: Iterable[Message]) -> list[TrajectoryStep]:
+    """Turn a ToolLoopResult.messages list into TrajectoryStep dicts.
+
+    Each Message becomes one step; iteration index counts assistant
+    turns since user turns are interleaved replies to those.
+
+    Tool result content is truncated at :data:`_MAX_TEXT_LEN` per
+    block so a runaway tool (e.g. a `read_file` on a 100 MB file)
+    can't blow up the trajectory size unbounded.
+    """
+    steps: list[TrajectoryStep] = []
+    iteration = 0
+    for msg in messages:
+        text_blocks: list[str] = []
+        tool_calls: list[dict[str, Any]] = []
+        tool_results: list[dict[str, Any]] = []
+        for block in msg.content:
+            if isinstance(block, TextBlock):
+                text_blocks.append(_truncate(block.text))
+            elif isinstance(block, ToolCall):
+                tool_calls.append({
+                    "id": block.id,
+                    "name": block.name,
+                    "input": block.input,
+                })
+            elif isinstance(block, ToolResult):
+                tool_results.append({
+                    "tool_use_id": block.tool_use_id,
+                    "content": _truncate(block.content),
+                    "is_error": block.is_error,
+                })
+        steps.append(TrajectoryStep(
+            iteration=iteration,
+            role=msg.role,
+            text_blocks=text_blocks,
+            tool_calls=tool_calls,
+            tool_results=tool_results,
+        ))
+        # Count iterations on assistant turns — that's "model turn N".
+        if msg.role == "assistant":
+            iteration += 1
+    return steps
+
+
+def trajectory_path(base: Path, run_id: str) -> Path:
+    """Where the trajectory file for ``run_id`` lives under ``base``.
+
+    Returns the canonical path; doesn't create directories or check
+    existence. Useful for callers that want to advertise the path
+    before writing.
+    """
+    return Path(base) / "trajectories" / run_id / TRAJECTORY_FILENAME
+
+
+def _record_to_json(record: TrajectoryRecord) -> str:
+    return json.dumps(asdict(record), indent=2)
+
+
+def _write_atomic(path: Path, payload: str) -> Path:
+    """O_NOFOLLOW + O_EXCL + O_CREAT atomic write. Same shape as
+    labeled_attempts/store._write_atomic but without the random-suffix
+    retry loop: a trajectory collision means duplicate run_id, which
+    is a programmer error worth surfacing.
+
+    If the path-deterministic write loses (e.g. someone planted a
+    symlink), we retry once with a random suffix on the filename so
+    the run's trajectory still lands somewhere — but report the path
+    we ended up using.
+    """
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW
+    try:
+        fd = os.open(path, flags, 0o644)
+    except FileExistsError:
+        # Already exists — for trajectories this is "this run_id was
+        # written before" or a planted-symlink attack. Retry with a
+        # random suffix so the run isn't lost.
+        suffix = secrets.token_hex(3)
+        path = path.with_name(f"{path.stem}-{suffix}{path.suffix}")
+        fd = os.open(path, flags, 0o644)
+    try:
+        os.write(fd, payload.encode("utf-8"))
+    finally:
+        os.close(fd)
+    return path
+
+
+def write_trajectory(
+    record: TrajectoryRecord, *, base: Path,
+) -> Path:
+    """Persist ``record`` under ``<base>/trajectories/<run_id>/``.
+
+    Returns the on-disk path actually written. Raises:
+      * ValueError — record itself is invalid (caught at construction
+        anyway; surfaced here for defensive callers). Also raised when
+        the resolved write path escapes ``base`` — e.g. an attacker
+        planted ``<base>/trajectories`` as a symlink before the run.
+      * OSError — filesystem error.
+    """
+    out = trajectory_path(base, record.run_id)
+    out.parent.mkdir(parents=True, exist_ok=True)
+
+    # Defence-in-depth against a planted symlink at <base>/trajectories
+    # (or any parent component above the trajectory file). _write_atomic
+    # below uses O_NOFOLLOW on the FINAL component only — that catches
+    # someone planting <base>/trajectories/<run>/trajectory.json as a
+    # symlink, but not someone planting <base>/trajectories as a symlink
+    # to /etc/. realpath() walks every component, so post-mkdir we can
+    # verify the resolved write target is still inside the operator's
+    # chosen base.
+    base_real = os.path.realpath(base)
+    out_real = os.path.realpath(out)
+    if not (
+        out_real == os.path.join(base_real, "trajectories", record.run_id,
+                                 TRAJECTORY_FILENAME)
+        or out_real.startswith(base_real + os.sep)
+    ):
+        raise ValueError(
+            f"refusing to write trajectory outside base: "
+            f"base={base_real!r} out={out_real!r}"
+        )
+
+    payload = _record_to_json(record)
+    return _write_atomic(out, payload)

--- a/core/trajectories/test_auto.py
+++ b/core/trajectories/test_auto.py
@@ -1,0 +1,236 @@
+"""Tests for ``core.trajectories.auto`` — env-var opt-in helper."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from core.llm.tool_use.types import (
+    CostBudgetExceeded,
+    Message,
+    TextBlock,
+    ToolCall,
+    ToolResult,
+)
+from core.trajectories.auto import (
+    TRAJECTORY_DIR_ENV,
+    persist_from_loop_result,
+    persist_partial_from_exception,
+)
+
+
+def _fake_result(messages=None, terminated_by="complete"):
+    """Build a minimal ToolLoopResult stand-in. We don't depend on
+    the real dataclass because the helper only reads a small subset
+    of attributes — using a MagicMock keeps the test cheap and
+    insensitive to upstream schema changes."""
+    r = MagicMock()
+    r.messages = messages or [
+        Message(role="user", content=[TextBlock(text="hi")]),
+        Message(role="assistant", content=[
+            TextBlock(text="ok"),
+            ToolCall(id="c1", name="echo", input={}),
+        ]),
+        Message(role="user", content=[
+            ToolResult(tool_use_id="c1", content="result", is_error=False),
+        ]),
+    ]
+    r.terminated_by = terminated_by
+    r.iterations = 2
+    r.tool_calls_made = 1
+    r.total_cost_usd = 0.01
+    return r
+
+
+def test_unset_env_var_is_noop(monkeypatch):
+    """No ``RAPTOR_TRAJECTORY_DIR`` → helper returns None, writes
+    nothing. This is the default path on hosts that haven't opted in."""
+    monkeypatch.delenv(TRAJECTORY_DIR_ENV, raising=False)
+    result = _fake_result()
+    out = persist_from_loop_result(
+        result, run_id="run1", model_name="claude",
+    )
+    assert out is None
+
+
+def test_set_env_var_persists(monkeypatch, tmp_path):
+    """With the env var set, the helper writes a trajectory.json under
+    ``<dir>/trajectories/<run_id>/`` and returns the path."""
+    monkeypatch.setenv(TRAJECTORY_DIR_ENV, str(tmp_path))
+    result = _fake_result()
+    out = persist_from_loop_result(
+        result, run_id="run-a", model_name="claude-haiku-4-5",
+    )
+    assert out is not None
+    assert out.exists()
+    payload = json.loads(out.read_text())
+    assert payload["run_id"] == "run-a"
+    assert payload["model_name"] == "claude-haiku-4-5"
+    assert payload["terminated_by"] == "complete"
+    assert payload["iterations"] == 2
+    assert payload["tool_calls_made"] == 1
+    assert payload["cost_usd"] == pytest.approx(0.01)
+    # finding_id / cwe default to empty for non-finding-driven runs
+    assert payload["finding_id"] == ""
+    assert payload["cwe"] == ""
+    # Three messages → three steps
+    assert len(payload["steps"]) == 3
+
+
+def test_optional_fields_propagate(monkeypatch, tmp_path):
+    """finding_id and cwe land in the record when passed."""
+    monkeypatch.setenv(TRAJECTORY_DIR_ENV, str(tmp_path))
+    out = persist_from_loop_result(
+        _fake_result(), run_id="rid", model_name="m",
+        finding_id="F-001", cwe="CWE-787",
+    )
+    assert out is not None
+    payload = json.loads(out.read_text())
+    assert payload["finding_id"] == "F-001"
+    assert payload["cwe"] == "CWE-787"
+
+
+def test_persist_failure_swallowed(monkeypatch, caplog):
+    """A trajectory write failure must not propagate — the caller's
+    tool-use loop result is the load-bearing artefact, the trajectory
+    is best-effort observability. Failures land in the log so the
+    operator can see them."""
+    # Point the env var at a path that can't be created (file, not dir).
+    bad_target = Path("/dev/null")  # exists, not a directory
+    monkeypatch.setenv(TRAJECTORY_DIR_ENV, str(bad_target))
+    out = persist_from_loop_result(
+        _fake_result(), run_id="rid", model_name="m",
+    )
+    assert out is None
+    # The failure should have been logged at WARNING.
+    assert any(
+        "trajectory persist failed" in r.message
+        for r in caplog.records
+    ), f"expected warning about persist failure, got: {caplog.records}"
+
+
+def test_traversal_run_id_sanitized_not_rejected(monkeypatch, tmp_path):
+    """A traversal-looking run_id gets sanitised (``/`` → ``-``,
+    ``..`` collapsed to ``.``) and lands successfully — operators
+    don't lose a trajectory because the producer passed a run_id with
+    forbidden characters. The on-disk path stays inside the base dir
+    (verified by write_trajectory's realpath check)."""
+    monkeypatch.setenv(TRAJECTORY_DIR_ENV, str(tmp_path))
+    out = persist_from_loop_result(
+        _fake_result(), run_id="../escape", model_name="m",
+    )
+    assert out is not None
+    assert out.exists()
+    # The on-disk path must stay under tmp_path — the realpath check
+    # in store.write_trajectory blocks any escape.
+    assert str(out).startswith(str(tmp_path))
+    # ``../`` is sanitised: '/' → '-' then '..' → '.' so 'escape' is
+    # preserved and the dirname does NOT contain traversal syntax.
+    assert ".." not in str(out)
+
+
+def test_real_world_bedrock_model_name_persists(monkeypatch, tmp_path):
+    """Bedrock model IDs end in ``:0`` which the validator rejects.
+    Sanitisation must turn this into a valid run_id so operators get
+    a trajectory file rather than a silently-swallowed warning."""
+    monkeypatch.setenv(TRAJECTORY_DIR_ENV, str(tmp_path))
+    out = persist_from_loop_result(
+        _fake_result(),
+        run_id="hunt-claude-3-haiku-20240307-v1:0",
+        model_name="claude-3-haiku-20240307-v1:0",
+    )
+    assert out is not None
+    assert out.exists()
+    payload = json.loads(out.read_text())
+    # Model name in the body is preserved verbatim.
+    assert payload["model_name"] == "claude-3-haiku-20240307-v1:0"
+    # run_id in the body is the sanitised form.
+    assert ":" not in payload["run_id"]
+
+
+# ---------------------------------------------------------------------------
+# persist_partial_from_exception — exception-path trajectory.
+# ---------------------------------------------------------------------------
+
+
+def test_partial_from_cost_budget_exception_carries_messages(
+    monkeypatch, tmp_path,
+):
+    """CostBudgetExceeded carries ``messages`` + ``tool_calls_made``
+    (PR #828 contract). The partial-trajectory helper reads them and
+    writes whatever survived to the point of termination."""
+    monkeypatch.setenv(TRAJECTORY_DIR_ENV, str(tmp_path))
+    partial_messages = [
+        Message(role="user", content=[TextBlock(text="hunt")]),
+        Message(role="assistant", content=[
+            TextBlock(text="grep first"),
+            ToolCall(id="c1", name="grep", input={"pattern": "x"}),
+        ]),
+        Message(role="user", content=[
+            ToolResult(tool_use_id="c1", content="result", is_error=False),
+        ]),
+    ]
+    exc = CostBudgetExceeded(
+        "budget", messages=partial_messages, tool_calls_made=1,
+    )
+    out = persist_partial_from_exception(
+        exc, run_id="hunt-x", model_name="claude",
+        terminated_by="max_cost_usd",
+    )
+    assert out is not None
+    payload = json.loads(out.read_text())
+    assert payload["run_id"] == "hunt-x"
+    assert payload["terminated_by"] == "max_cost_usd"
+    assert payload["tool_calls_made"] == 1
+    # Three messages → three steps.
+    assert len(payload["steps"]) == 3
+
+
+def test_partial_from_bare_exception_writes_skeleton(
+    monkeypatch, tmp_path,
+):
+    """A generic Exception has no ``messages`` / ``tool_calls_made``.
+    The helper still writes a skeleton trajectory so the operator can
+    see the run happened and what killed it."""
+    monkeypatch.setenv(TRAJECTORY_DIR_ENV, str(tmp_path))
+    out = persist_partial_from_exception(
+        RuntimeError("something broke"),
+        run_id="hunt-x", model_name="claude",
+        terminated_by="exception:RuntimeError",
+    )
+    assert out is not None
+    payload = json.loads(out.read_text())
+    assert payload["run_id"] == "hunt-x"
+    assert payload["terminated_by"] == "exception:RuntimeError"
+    assert payload["tool_calls_made"] == 0
+    assert payload["steps"] == []
+
+
+def test_partial_unset_env_var_is_noop(monkeypatch):
+    """Same opt-in contract as the success path: no env var → no-op."""
+    monkeypatch.delenv(TRAJECTORY_DIR_ENV, raising=False)
+    out = persist_partial_from_exception(
+        RuntimeError("x"),
+        run_id="hunt-x", model_name="claude",
+        terminated_by="exception:RuntimeError",
+    )
+    assert out is None
+
+
+def test_partial_persist_failure_swallowed(monkeypatch, caplog):
+    """Write failure must not propagate — caller's own error handling
+    is the load-bearing thing, the trajectory is best-effort."""
+    monkeypatch.setenv(TRAJECTORY_DIR_ENV, "/dev/null")
+    out = persist_partial_from_exception(
+        RuntimeError("x"),
+        run_id="hunt-x", model_name="claude",
+        terminated_by="exception:RuntimeError",
+    )
+    assert out is None
+    assert any(
+        "partial-trajectory persist failed" in r.message
+        for r in caplog.records
+    )

--- a/core/trajectories/test_store.py
+++ b/core/trajectories/test_store.py
@@ -1,0 +1,328 @@
+"""Tests for trajectory storage."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO))
+
+from core.llm.tool_use.types import (  # noqa: E402
+    Message,
+    TextBlock,
+    ToolCall,
+    ToolResult,
+)
+from core.trajectories import (  # noqa: E402
+    TRAJECTORY_FILENAME,
+    TrajectoryRecord,
+    serialize_messages,
+    trajectory_path,
+    write_trajectory,
+)
+
+
+# --------------------------------------------------------------------------
+# Helpers
+# --------------------------------------------------------------------------
+
+
+def _msg_assistant_text(text: str) -> Message:
+    return Message(role="assistant", content=[TextBlock(text=text)])
+
+
+def _msg_assistant_tool_call(tool_name: str, **input_) -> Message:
+    return Message(
+        role="assistant",
+        content=[ToolCall(
+            id=f"call-{tool_name}", name=tool_name, input=input_,
+        )],
+    )
+
+
+def _msg_user_tool_result(tool_use_id: str, content: str,
+                          is_error: bool = False) -> Message:
+    return Message(
+        role="user",
+        content=[ToolResult(
+            tool_use_id=tool_use_id, content=content, is_error=is_error,
+        )],
+    )
+
+
+def _record(run_id: str = "run-0001", **overrides) -> TrajectoryRecord:
+    base = dict(
+        run_id=run_id,
+        finding_id="FND-77",
+        model_name="claude-haiku-4-5",
+        cwe="CWE-787",
+        terminated_by="terminal_tool",
+        iterations=3,
+        tool_calls_made=4,
+        cost_usd=0.12,
+        steps=[],
+        timestamp="2026-06-03T14:05:32+00:00",
+    )
+    base.update(overrides)
+    return TrajectoryRecord(**base)
+
+
+# --------------------------------------------------------------------------
+# serialize_messages
+# --------------------------------------------------------------------------
+
+
+def test_serialize_empty_returns_empty():
+    assert serialize_messages([]) == []
+
+
+def test_serialize_text_only_assistant_turn():
+    msgs = [_msg_assistant_text("I will call find_symbol next.")]
+    [step] = serialize_messages(msgs)
+    assert step.role == "assistant"
+    assert step.text_blocks == ["I will call find_symbol next."]
+    assert step.tool_calls == []
+    assert step.tool_results == []
+    assert step.iteration == 0
+
+
+def test_serialize_assistant_tool_call():
+    msgs = [_msg_assistant_tool_call("find_symbol", symbol="parse_header")]
+    [step] = serialize_messages(msgs)
+    assert step.tool_calls == [{
+        "id": "call-find_symbol",
+        "name": "find_symbol",
+        "input": {"symbol": "parse_header"},
+    }]
+
+
+def test_serialize_user_tool_result():
+    msgs = [_msg_user_tool_result("call-1", "found at 0x1234")]
+    [step] = serialize_messages(msgs)
+    assert step.role == "user"
+    assert step.tool_results == [{
+        "tool_use_id": "call-1",
+        "content": "found at 0x1234",
+        "is_error": False,
+    }]
+
+
+def test_serialize_iteration_counter_advances_on_assistant():
+    """User turns share the iteration index of the preceding assistant
+    turn — the counter advances on each assistant turn."""
+    msgs = [
+        _msg_assistant_text("step 0"),               # iteration 0
+        _msg_user_tool_result("c0", "r0"),            # still 1 (next slot)
+        _msg_assistant_text("step 1"),               # iteration 1
+        _msg_user_tool_result("c1", "r1"),
+        _msg_assistant_text("step 2"),               # iteration 2
+    ]
+    steps = serialize_messages(msgs)
+    assert [s.iteration for s in steps] == [0, 1, 1, 2, 2]
+
+
+def test_serialize_truncates_long_text():
+    big = "x" * (200 * 1024)                     # 200 KB > 64 KB cap
+    msgs = [_msg_assistant_text(big)]
+    [step] = serialize_messages(msgs)
+    assert len(step.text_blocks[0]) < len(big)
+    assert "truncated" in step.text_blocks[0]
+
+
+def test_serialize_truncates_long_tool_result():
+    big = "y" * (200 * 1024)
+    msgs = [_msg_user_tool_result("c0", big)]
+    [step] = serialize_messages(msgs)
+    assert "truncated" in step.tool_results[0]["content"]
+
+
+def test_serialize_preserves_mixed_assistant_content():
+    """Assistant turn with text + tool call in the same message."""
+    msg = Message(role="assistant", content=[
+        TextBlock(text="Calling find_symbol."),
+        ToolCall(id="c0", name="find_symbol", input={"name": "x"}),
+    ])
+    [step] = serialize_messages([msg])
+    assert step.text_blocks == ["Calling find_symbol."]
+    assert len(step.tool_calls) == 1
+
+
+def test_serialize_preserves_is_error_flag():
+    msgs = [_msg_user_tool_result("c0", "tool crashed", is_error=True)]
+    [step] = serialize_messages(msgs)
+    assert step.tool_results[0]["is_error"] is True
+
+
+# --------------------------------------------------------------------------
+# write_trajectory / trajectory_path
+# --------------------------------------------------------------------------
+
+
+def test_trajectory_path_under_base(tmp_path):
+    p = trajectory_path(tmp_path, "run-x")
+    assert p == tmp_path / "trajectories" / "run-x" / TRAJECTORY_FILENAME
+
+
+def test_write_creates_run_dir_and_file(tmp_path):
+    rec = _record()
+    written = write_trajectory(rec, base=tmp_path)
+    assert written.exists()
+    assert written.parent.name == "run-0001"
+    assert written.parent.parent.name == "trajectories"
+
+
+def test_write_round_trips_through_json(tmp_path):
+    msg = _msg_assistant_tool_call("find_symbol", symbol="parse_header")
+    rec = _record(steps=serialize_messages([msg]))
+    written = write_trajectory(rec, base=tmp_path)
+    data = json.loads(written.read_text())
+    assert data["run_id"] == "run-0001"
+    assert data["finding_id"] == "FND-77"
+    assert len(data["steps"]) == 1
+    assert data["steps"][0]["tool_calls"][0]["name"] == "find_symbol"
+
+
+def test_write_collision_retries_with_random_suffix(tmp_path):
+    """If the trajectory path already exists (or is planted as a
+    symlink), the write should still land — at a name-suffixed path."""
+    rec = _record(run_id="dup")
+    first = write_trajectory(rec, base=tmp_path)
+    # Second write at same run_id collides and retries.
+    second = write_trajectory(rec, base=tmp_path)
+    assert second.exists()
+    assert second != first
+    assert second.parent == first.parent  # same run dir
+
+
+def test_write_refuses_to_follow_symlink(tmp_path):
+    """A symlink planted at the trajectory path must not get its
+    target overwritten."""
+    rec = _record(run_id="link-x")
+    out = trajectory_path(tmp_path, rec.run_id)
+    out.parent.mkdir(parents=True)
+
+    victim = tmp_path / "victim.txt"
+    victim.write_text("UNTOUCHED")
+    os.symlink(victim, out)
+
+    written = write_trajectory(rec, base=tmp_path)
+    # Did NOT overwrite the symlink target.
+    assert victim.read_text() == "UNTOUCHED"
+    # Landed at a different filename.
+    assert written != out
+
+
+# --------------------------------------------------------------------------
+# TrajectoryRecord validation
+# --------------------------------------------------------------------------
+
+
+def test_record_rejects_invalid_run_id():
+    bad = [
+        "",
+        "../../etc",        # path traversal
+        "a/b",              # slash
+        "a" * 200,          # too long
+        "spaces in name",
+        "name\x00null",
+    ]
+    for run_id in bad:
+        with pytest.raises(ValueError, match="run_id"):
+            _record(run_id=run_id)
+
+
+def test_record_accepts_typical_run_ids():
+    for run_id in [
+        "run-0001",
+        "exploit_2026-06-03",
+        "FND-77.v1",
+        "abc",
+        "A" * 128,                # max length
+    ]:
+        rec = _record(run_id=run_id)
+        assert rec.run_id == run_id
+
+
+def test_record_finding_id_optional():
+    """finding_id defaults to empty so non-finding-driven consumers
+    (e.g. open-ended ToolUseLoop runs from /understand or /cve-diff)
+    can persist trajectories without inventing identifiers."""
+    rec = _record(finding_id="")
+    assert rec.finding_id == ""
+
+
+def test_record_cwe_optional():
+    """cwe defaults to empty for the same reason — non-security-finding
+    consumers shouldn't need to fabricate a CWE."""
+    rec = _record(cwe="")
+    assert rec.cwe == ""
+
+
+# --------------------------------------------------------------------------
+# E2E: full trace + write + read
+# --------------------------------------------------------------------------
+
+
+def test_e2e_engine_run_trajectory(tmp_path):
+    """Simulate a 3-turn engine run end-to-end: messages → serialize →
+    write → read back."""
+    msgs = [
+        # Initial user prompt
+        Message(role="user", content=[
+            TextBlock(text="Exploit the buffer overflow in parse_header."),
+        ]),
+        # Assistant calls find_symbol
+        Message(role="assistant", content=[
+            TextBlock(text="Looking up parse_header."),
+            ToolCall(id="c1", name="find_symbol",
+                     input={"name": "parse_header"}),
+        ]),
+        # Tool result
+        Message(role="user", content=[
+            ToolResult(tool_use_id="c1",
+                       content="parse_header @ src/parser.c:42"),
+        ]),
+        # Assistant submits exploit
+        Message(role="assistant", content=[
+            TextBlock(text="Submitting exploit."),
+            ToolCall(id="c2", name="submit_exploit",
+                     input={"exploit_code": "int main(){abort();}"}),
+        ]),
+    ]
+    rec = TrajectoryRecord(
+        run_id="e2e-run",
+        finding_id="FND-E2E",
+        model_name="claude-haiku-4-5",
+        cwe="CWE-787",
+        terminated_by="terminal_tool",
+        iterations=2,
+        tool_calls_made=2,
+        cost_usd=0.05,
+        steps=serialize_messages(msgs),
+        timestamp="2026-06-03T15:00:00+00:00",
+    )
+    written = write_trajectory(rec, base=tmp_path)
+    data = json.loads(written.read_text())
+
+    assert data["finding_id"] == "FND-E2E"
+    assert data["model_name"] == "claude-haiku-4-5"
+    assert len(data["steps"]) == 4
+
+    # Step 0: initial user prompt
+    assert data["steps"][0]["role"] == "user"
+    assert "buffer overflow" in data["steps"][0]["text_blocks"][0]
+
+    # Step 1: assistant's find_symbol call
+    assert data["steps"][1]["role"] == "assistant"
+    assert data["steps"][1]["tool_calls"][0]["name"] == "find_symbol"
+
+    # Step 2: tool result
+    assert data["steps"][2]["tool_results"][0]["tool_use_id"] == "c1"
+
+    # Step 3: terminal submission
+    assert data["steps"][3]["tool_calls"][0]["name"] == "submit_exploit"

--- a/core/trajectories/types.py
+++ b/core/trajectories/types.py
@@ -1,0 +1,98 @@
+"""Trajectory record schema.
+
+A trajectory is the per-turn record of an LLM tool-use loop: what the
+model said, which tools it called with what arguments, and what came
+back. One :class:`TrajectoryStep` per turn; one
+:class:`TrajectoryRecord` per loop run.
+
+Used for operator-facing debugging ("which tool calls led here?"),
+A/B analysis of prompt variants, and any downstream retrieval that
+wants to rank past runs by tools_used / cost / outcome.
+
+Schema discipline: this is a **persisted** format. Adding fields is
+fine (consumers tolerate unknown keys), removing or renaming is not.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import Any
+
+__all__ = [
+    "TrajectoryRecord",
+    "TrajectoryStep",
+]
+
+# run_id must be safe as a directory name on disk. Same shape as
+# LabeledAttempt's finding_signature: alphanumeric + dash/underscore,
+# bounded length.
+_VALID_RUN_ID = re.compile(r"^[A-Za-z0-9_\-.]{1,128}$")
+
+
+@dataclass(frozen=True)
+class TrajectoryStep:
+    """One turn of conversation history, JSON-serialisable.
+
+    Mirrors :class:`core.llm.tool_use.types.Message` but as plain
+    dicts so the on-disk record doesn't break when the upstream
+    Message dataclass evolves.
+
+    ``text_blocks`` is the concatenated text from any TextBlock content
+    items. ``tool_calls`` is a list of ``{id, name, input}`` dicts for
+    assistant turns. ``tool_results`` is a list of
+    ``{tool_use_id, content, is_error}`` dicts for user turns.
+
+    Text and tool-result content are truncated at :data:`_MAX_TEXT_LEN`
+    in :func:`store.serialize_messages` to keep individual trajectories
+    bounded. Truncation is indicated with a ``...[truncated N chars]``
+    suffix.
+    """
+
+    iteration: int
+    role: str                                 # "user" | "assistant"
+    text_blocks: list[str] = field(default_factory=list)
+    tool_calls: list[dict[str, Any]] = field(default_factory=list)
+    tool_results: list[dict[str, Any]] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class TrajectoryRecord:
+    """One LLM tool-use loop run's trajectory.
+
+    Spine: ``run_id`` + ``model_name`` (always present) + optional
+    ``finding_id`` / ``cwe`` for security-finding-driven runs.
+    ``run_id`` is the operator-chosen / auto-minted identifier that
+    names the on-disk directory (``<base>/trajectories/<run_id>/``).
+
+    ``finding_id`` and ``cwe`` default to ``""`` so consumers that
+    aren't driven by a Finding (e.g. open-ended ``/agentic`` runs,
+    interactive ``/understand`` queries) can persist trajectories
+    without inventing identifiers. Producers that DO have a finding
+    context pass the values for downstream filtering and ranking.
+    """
+
+    run_id: str
+    model_name: str
+    terminated_by: str
+    iterations: int
+    tool_calls_made: int
+    cost_usd: float
+    steps: list[TrajectoryStep]
+    finding_id: str = ""
+    cwe: str = ""
+    timestamp: str = ""
+
+    def __post_init__(self) -> None:
+        if not _VALID_RUN_ID.match(self.run_id):
+            raise ValueError(
+                f"run_id must be alphanumeric/dash/underscore/dot, "
+                f"1-128 chars; got {self.run_id!r}"
+            )
+        if ".." in self.run_id:
+            # Even though `.` is allowed (version suffixes etc.),
+            # `..` is the path-traversal vector. Block it here as
+            # defense in depth; the disk layer rejects it too.
+            raise ValueError(
+                f"run_id must not contain '..'; got {self.run_id!r}"
+            )

--- a/libexec/raptor-cve-diff
+++ b/libexec/raptor-cve-diff
@@ -172,6 +172,12 @@ def cmd_run(argv: list[str]) -> int:
 
     output_dir = _resolve_output_dir(opts["output_dir"])
 
+    # Opt the cve-diff agent into trajectory persistence — writes
+    # <output_dir>/trajectories/cve-diff-<CVE-ID>/trajectory.json so
+    # operators can replay tool calls after the run. The agent reads
+    # this env var via core.trajectories.auto; unset → no-op.
+    os.environ["RAPTOR_TRAJECTORY_DIR"] = str(output_dir)
+
     from cve_diff.analysis.analyzer import AnalysisError
     from cve_diff.core.exceptions import (
         AcquisitionError,

--- a/libexec/raptor-understand
+++ b/libexec/raptor-understand
@@ -546,6 +546,12 @@ def main() -> int:
         # operator-supplied path. Keep inside try so all errors get
         # the clean-exit treatment.
         out_dir = Path(args.out).resolve()
+        # Opt the hunt/trace dispatch into trajectory persistence —
+        # writes <out>/trajectories/<run_id>/trajectory.json so
+        # operators can see per-turn tool calls after the run. The
+        # dispatch reads this env var via core.trajectories.auto;
+        # unset → no-op.
+        os.environ["RAPTOR_TRAJECTORY_DIR"] = str(out_dir)
         if args.hunt is not None:
             payload = _do_hunt(args)
         else:

--- a/packages/code_understanding/dispatch/hunt_dispatch.py
+++ b/packages/code_understanding/dispatch/hunt_dispatch.py
@@ -112,22 +112,45 @@ def default_hunt_dispatch(
         events=events,
     )
 
+    # Trajectory persistence runs on EVERY exit path. Success → full
+    # record; budget / context / generic exception → partial record
+    # built from whatever ``CostBudgetExceeded`` / ``ContextOverflow``
+    # carry on the exception (PR #828 contract). The exception case
+    # is precisely when the trajectory is most useful: "why did this
+    # model burn through its budget without producing variants?"
+    from core.trajectories.auto import (
+        persist_from_loop_result, persist_partial_from_exception,
+    )
+    traj_run_id = f"hunt-{model.model_name}"
+
     try:
         result = loop.run(user_message)
     except CostBudgetExceeded as e:
         logger.warning(f"hunt: model {model.model_name} hit cost cap: {e}")
         if cost_collector is not None:
             cost_collector(max_cost_usd)  # we hit the cap
+        persist_partial_from_exception(
+            e, run_id=traj_run_id, model_name=model.model_name,
+            terminated_by="max_cost_usd",
+        )
         return [{"error": f"cost budget exceeded: {e}"}]
     except Exception as e:  # noqa: BLE001 - dispatch boundary
         logger.warning(
             f"hunt: model {model.model_name} loop failed: {e}",
             exc_info=True,
         )
+        persist_partial_from_exception(
+            e, run_id=traj_run_id, model_name=model.model_name,
+            terminated_by=f"exception:{type(e).__name__}",
+        )
         return [{"error": f"{type(e).__name__}: {e}"}]
 
     if cost_collector is not None:
         cost_collector(float(result.total_cost_usd or 0.0))
+
+    persist_from_loop_result(
+        result, run_id=traj_run_id, model_name=model.model_name,
+    )
 
     if result.terminated_by != "terminal_tool":
         # Loop ended without the model submitting variants.

--- a/packages/code_understanding/dispatch/trace_dispatch.py
+++ b/packages/code_understanding/dispatch/trace_dispatch.py
@@ -115,22 +115,42 @@ def default_trace_dispatch(
         events=events,
     )
 
+    # Trajectory persistence on EVERY exit path — same pattern as
+    # hunt_dispatch.py. Exception case carries partial state from PR
+    # #828's CostBudgetExceeded / ContextOverflow contract.
+    from core.trajectories.auto import (
+        persist_from_loop_result, persist_partial_from_exception,
+    )
+    traj_run_id = f"trace-{model.model_name}"
+
     try:
         result = loop.run(user_message)
     except CostBudgetExceeded as e:
         logger.warning(f"trace: model {model.model_name} hit cost cap: {e}")
         if cost_collector is not None:
             cost_collector(max_cost_usd)
+        persist_partial_from_exception(
+            e, run_id=traj_run_id, model_name=model.model_name,
+            terminated_by="max_cost_usd",
+        )
         return [{"error": f"cost budget exceeded: {e}"}]
     except Exception as e:  # noqa: BLE001 - dispatch boundary
         logger.warning(
             f"trace: model {model.model_name} loop failed: {e}",
             exc_info=True,
         )
+        persist_partial_from_exception(
+            e, run_id=traj_run_id, model_name=model.model_name,
+            terminated_by=f"exception:{type(e).__name__}",
+        )
         return [{"error": f"{type(e).__name__}: {e}"}]
 
     if cost_collector is not None:
         cost_collector(float(result.total_cost_usd or 0.0))
+
+    persist_from_loop_result(
+        result, run_id=traj_run_id, model_name=model.model_name,
+    )
 
     if result.terminated_by != "terminal_tool":
         return [{

--- a/packages/code_understanding/tests/dispatch/test_hunt_dispatch.py
+++ b/packages/code_understanding/tests/dispatch/test_hunt_dispatch.py
@@ -158,6 +158,128 @@ class TestHappyPath:
             )
         assert result == variants_payload
 
+
+class TestTrajectoryWiring:
+    """Hunt dispatch persists a trajectory under
+    ``$RAPTOR_TRAJECTORY_DIR/trajectories/hunt-<model>/`` when the
+    env var is set, no-op otherwise."""
+
+    def test_trajectory_written_when_env_var_set(
+        self, repo, fake_model_config, tmp_path, monkeypatch,
+    ):
+        from packages.code_understanding.dispatch.hunt_dispatch import (
+            default_hunt_dispatch,
+        )
+        from core.trajectories.auto import TRAJECTORY_DIR_ENV
+
+        monkeypatch.setenv(TRAJECTORY_DIR_ENV, str(tmp_path))
+        turns = [
+            FakeTurn(tool_calls=[("submit_variants", {"variants": []})]),
+        ]
+        with _patch_provider(turns):
+            default_hunt_dispatch(
+                fake_model_config, "strcpy", str(repo),
+            )
+
+        # Trajectory should land at the deterministic path the
+        # dispatch derives from the model name.
+        traj_path = (
+            tmp_path / "trajectories"
+            / f"hunt-{fake_model_config.model_name}"
+            / "trajectory.json"
+        )
+        assert traj_path.exists(), (
+            f"trajectory not at {traj_path}; "
+            f"tree was: {list(tmp_path.rglob('*'))}"
+        )
+        payload = json.loads(traj_path.read_text())
+        assert payload["run_id"] == f"hunt-{fake_model_config.model_name}"
+        assert payload["model_name"] == fake_model_config.model_name
+        # finding_id/cwe are empty because hunt isn't finding-driven.
+        assert payload["finding_id"] == ""
+        assert payload["cwe"] == ""
+
+    def test_unset_env_var_is_noop(
+        self, repo, fake_model_config, tmp_path, monkeypatch,
+    ):
+        """No env var → no trajectory directory created."""
+        from packages.code_understanding.dispatch.hunt_dispatch import (
+            default_hunt_dispatch,
+        )
+        from core.trajectories.auto import TRAJECTORY_DIR_ENV
+
+        monkeypatch.delenv(TRAJECTORY_DIR_ENV, raising=False)
+        turns = [
+            FakeTurn(tool_calls=[("submit_variants", {"variants": []})]),
+        ]
+        # Run from tmp_path so any accidental write would land there.
+        monkeypatch.chdir(tmp_path)
+        with _patch_provider(turns):
+            default_hunt_dispatch(
+                fake_model_config, "strcpy", str(repo),
+            )
+        assert not (tmp_path / "trajectories").exists()
+
+    def test_partial_trajectory_persisted_on_cost_cap(
+        self, repo, fake_model_config, tmp_path, monkeypatch,
+    ):
+        """When the loop raises CostBudgetExceeded, the partial-
+        trajectory helper writes whatever turns survived. This is
+        precisely when the trajectory is most useful for operator
+        debugging ("why did this model burn through its budget?").
+
+        Patches ToolUseLoop.run directly with a side_effect that
+        raises CostBudgetExceeded carrying partial state (PR #828
+        contract). Side-steps the natural-trigger path so the test
+        doesn't depend on cost-arithmetic edge cases of the fake
+        provider."""
+        from unittest.mock import patch as _patch
+        from packages.code_understanding.dispatch.hunt_dispatch import (
+            default_hunt_dispatch,
+        )
+        from core.trajectories.auto import TRAJECTORY_DIR_ENV
+        from core.llm.tool_use.types import (
+            CostBudgetExceeded, Message, TextBlock,
+        )
+
+        monkeypatch.setenv(TRAJECTORY_DIR_ENV, str(tmp_path))
+
+        partial_messages = [
+            Message(role="user", content=[TextBlock(text="hunt")]),
+            Message(role="assistant", content=[
+                TextBlock(text="exploring before budget hit"),
+            ]),
+        ]
+        exc = CostBudgetExceeded(
+            "budget", messages=partial_messages, tool_calls_made=0,
+        )
+
+        with _patch_provider([FakeTurn(text="never reached")]):
+            with _patch(
+                "core.llm.tool_use.loop.ToolUseLoop.run",
+                side_effect=exc,
+            ):
+                result = default_hunt_dispatch(
+                    fake_model_config, "x", str(repo),
+                )
+
+        assert isinstance(result, list) and result and "error" in result[0]
+        assert "cost budget exceeded" in result[0]["error"]
+
+        traj_path = (
+            tmp_path / "trajectories"
+            / f"hunt-{fake_model_config.model_name}"
+            / "trajectory.json"
+        )
+        assert traj_path.exists(), (
+            f"partial trajectory should land on cost-cap; "
+            f"not at {traj_path}\ntree: {list(tmp_path.rglob('*'))}"
+        )
+        payload = json.loads(traj_path.read_text())
+        assert payload["terminated_by"] == "max_cost_usd"
+        # Partial messages survived from the exception.
+        assert len(payload["steps"]) == len(partial_messages)
+
     def test_model_uses_grep_then_submits(self, repo, fake_model_config):
         """Multi-turn: model greps first, then submits."""
         from packages.code_understanding.dispatch.hunt_dispatch import (

--- a/packages/code_understanding/tests/dispatch/test_trace_dispatch.py
+++ b/packages/code_understanding/tests/dispatch/test_trace_dispatch.py
@@ -144,6 +144,64 @@ class TestHappyPath:
             )
         assert result == verdicts
 
+
+class TestTrajectoryWiring:
+    """Trace dispatch persists a trajectory under
+    ``$RAPTOR_TRAJECTORY_DIR/trajectories/trace-<model>/`` when the
+    env var is set — same opt-in shape as hunt_dispatch."""
+
+    def test_trajectory_written_when_env_var_set(
+        self, repo, fake_model_config, tmp_path, monkeypatch,
+    ):
+        from packages.code_understanding.dispatch.trace_dispatch import (
+            default_trace_dispatch,
+        )
+        from core.trajectories.auto import TRAJECTORY_DIR_ENV
+
+        monkeypatch.setenv(TRAJECTORY_DIR_ENV, str(tmp_path))
+        turns = [
+            FakeTurn(tool_calls=[("submit_verdicts", {"verdicts": []})]),
+        ]
+        with _patch_provider(turns):
+            default_trace_dispatch(
+                fake_model_config, _sample_traces(), str(repo),
+            )
+
+        traj_path = (
+            tmp_path / "trajectories"
+            / f"trace-{fake_model_config.model_name}"
+            / "trajectory.json"
+        )
+        assert traj_path.exists(), (
+            f"trajectory not at {traj_path}; "
+            f"tree was: {list(tmp_path.rglob('*'))}"
+        )
+        payload = json.loads(traj_path.read_text())
+        assert payload["run_id"] == f"trace-{fake_model_config.model_name}"
+        assert payload["model_name"] == fake_model_config.model_name
+        # finding_id / cwe are empty — trace isn't finding-driven.
+        assert payload["finding_id"] == ""
+        assert payload["cwe"] == ""
+
+    def test_unset_env_var_is_noop(
+        self, repo, fake_model_config, tmp_path, monkeypatch,
+    ):
+        from packages.code_understanding.dispatch.trace_dispatch import (
+            default_trace_dispatch,
+        )
+        from core.trajectories.auto import TRAJECTORY_DIR_ENV
+
+        monkeypatch.delenv(TRAJECTORY_DIR_ENV, raising=False)
+        monkeypatch.chdir(tmp_path)
+        turns = [
+            FakeTurn(tool_calls=[("submit_verdicts", {"verdicts": []})]),
+        ]
+        with _patch_provider(turns):
+            default_trace_dispatch(
+                fake_model_config, _sample_traces(), str(repo),
+            )
+        assert not (tmp_path / "trajectories").exists()
+
     def test_multi_turn_dispatch(self, repo, fake_model_config):
         """Model reads files first, then submits."""
         from packages.code_understanding.dispatch.trace_dispatch import (

--- a/packages/code_understanding/tests/test_libexec_trajectory_e2e.py
+++ b/packages/code_understanding/tests/test_libexec_trajectory_e2e.py
@@ -1,0 +1,211 @@
+"""End-to-end test for trajectory persistence through the
+``libexec/raptor-understand`` shim.
+
+These tests load the shim as a module (via the same ``_load_module``
+pattern test_libexec_understand.py uses for its in-process NUL test)
+and drive ``main()`` with patched LLM internals. The goal is to prove
+that:
+
+  1. The shim sets ``RAPTOR_TRAJECTORY_DIR`` to the resolved output
+     directory before dispatch runs.
+  2. The dispatch reads that env var (via ``core.trajectories.auto``)
+     and writes a ``trajectory.json`` file at the documented path.
+
+Without these tests, a future refactor could rename the env var or
+move the assignment to a code path the dispatch doesn't reach, and
+the dispatch-unit tests would still pass — operators just wouldn't
+get trajectories.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+LIBEXEC = REPO_ROOT / "libexec" / "raptor-understand"
+
+
+def _load_shim():
+    """Import libexec/raptor-understand as a module. The session-wide
+    ``_RAPTOR_TRUSTED=1`` env var (set by the root conftest) lets the
+    script's trust-marker check pass during module load."""
+    loader = SourceFileLoader("raptor_understand_e2e", str(LIBEXEC))
+    spec = importlib.util.spec_from_loader(loader.name, loader)
+    mod = importlib.util.module_from_spec(spec)
+    loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture
+def repo(tmp_path):
+    """Minimal source tree the dispatch can point at."""
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "x.c").write_text("void f(char *p) { strcpy(buf, p); }\n")
+    return tmp_path
+
+
+def _fake_provider_responding_with_empty_variants():
+    """Build a fake LLMProvider whose single turn submits empty variants
+    so the hunt loop terminates cleanly without needing tool dispatch."""
+    from dataclasses import dataclass
+    from typing import Iterator
+
+    from core.llm.tool_use.types import (
+        StopReason,
+        ToolCall,
+        TurnResponse,
+    )
+
+    @dataclass
+    class _FakeTurn:
+        tool_calls: list
+
+    class _FakeProvider:
+        def __init__(self):
+            self._iter: Iterator[_FakeTurn] = iter([
+                _FakeTurn(tool_calls=[("submit_variants", {"variants": []})]),
+            ])
+
+        def turn(self, *_a, **_kw):
+            try:
+                t = next(self._iter)
+            except StopIteration:
+                raise AssertionError("fake provider exhausted")
+            content = [
+                ToolCall(id=f"c{i}", name=name, input=inp)
+                for i, (name, inp) in enumerate(t.tool_calls)
+            ]
+            return TurnResponse(
+                content=content,
+                stop_reason=StopReason.NEEDS_TOOL_CALL,
+                input_tokens=10, output_tokens=5,
+            )
+
+        def supports_tool_use(self): return True
+        def supports_prompt_caching(self): return True
+        def supports_parallel_tools(self): return True
+        def context_window(self): return 200_000
+        def estimate_tokens(self, text): return max(len(text) // 4, 1)
+        def price_per_million(self): return (3.0, 15.0)
+
+        def compute_cost(self, response):
+            return ((response.input_tokens * 3.0
+                     + response.output_tokens * 15.0) / 1_000_000)
+
+    return _FakeProvider()
+
+
+def _patch_shim_for_fake_model(mod, monkeypatch, model_name):
+    """Replace _resolve_models so the fake model name passes the
+    API-key gate without configuring a real key — and create_provider
+    so no real LLM call happens."""
+    from core.llm.config import ModelConfig
+
+    fake_cfg = ModelConfig(
+        provider="anthropic",
+        model_name=model_name,
+        api_key="fake-key-for-test",
+    )
+    monkeypatch.setattr(
+        mod, "_resolve_models", lambda _names: ([fake_cfg], []),
+    )
+    monkeypatch.setattr(
+        "packages.code_understanding.dispatch.hunt_dispatch.create_provider",
+        lambda _cfg: _fake_provider_responding_with_empty_variants(),
+    )
+
+
+def test_understand_hunt_writes_trajectory_at_resolved_out_dir(
+    repo, tmp_path, monkeypatch,
+):
+    """Drive libexec/raptor-understand's main() through the hunt path
+    with a fake provider. Assert that
+    ``<out_dir>/trajectories/hunt-<model>/trajectory.json`` lands.
+
+    This exercises the chain that no unit test could:
+      shim.main() → sets RAPTOR_TRAJECTORY_DIR → calls hunt() →
+      calls default_hunt_dispatch() → ToolUseLoop runs → calls
+      persist_from_loop_result() → reads env var → writes JSON.
+
+    If ANY link in that chain is broken (env var renamed, env var set
+    AFTER dispatch, dispatch not calling the auto helper, etc.) this
+    test fails.
+    """
+    out_dir = tmp_path / "out"
+    # Defensive: the shim sets RAPTOR_TRAJECTORY_DIR via os.environ
+    # which persists across the test session unless monkeypatch knows
+    # about it. Stage it as "absent" so monkeypatch restores it after
+    # the test instead of letting the shim's mutation leak into other
+    # tests in the same pytest session.
+    monkeypatch.delenv("RAPTOR_TRAJECTORY_DIR", raising=False)
+
+    mod = _load_shim()
+    _patch_shim_for_fake_model(mod, monkeypatch, "fake-haiku-x")
+
+    argv = [
+        "raptor-understand",
+        "--hunt", "strcpy misuse",
+        "--hunt-tool", "llm",
+        "--target", str(repo),
+        "--model", "fake-haiku-x",
+        "--out", str(out_dir),
+    ]
+    monkeypatch.setattr(sys, "argv", argv)
+    rc = mod.main()
+    assert rc == 0, f"shim main() returned {rc}"
+
+    expected = (
+        out_dir / "trajectories" / "hunt-fake-haiku-x" / "trajectory.json"
+    )
+    assert expected.exists(), (
+        f"trajectory not at {expected}\n"
+        f"out tree: {sorted(out_dir.rglob('*'))}"
+    )
+    payload = json.loads(expected.read_text())
+    assert payload["model_name"] == "fake-haiku-x"
+    assert payload["run_id"] == "hunt-fake-haiku-x"
+    assert payload["terminated_by"] == "terminal_tool"
+
+
+def test_understand_does_not_clobber_existing_trajectory_env_var(
+    repo, tmp_path, monkeypatch,
+):
+    """If the operator already set RAPTOR_TRAJECTORY_DIR in their
+    environment, the shim overrides it to the resolved --out so the
+    trajectory ends up co-located with the run's other artefacts.
+
+    Pin this behaviour so a future refactor doesn't accidentally
+    "respect" the inherited env var and scatter trajectories outside
+    the run dir.
+    """
+    out_dir = tmp_path / "out"
+    foreign = tmp_path / "foreign"
+    foreign.mkdir()
+    monkeypatch.setenv("RAPTOR_TRAJECTORY_DIR", str(foreign))
+
+    mod = _load_shim()
+    _patch_shim_for_fake_model(mod, monkeypatch, "fake-haiku-x")
+
+    argv = [
+        "raptor-understand",
+        "--hunt", "x",
+        "--hunt-tool", "llm",
+        "--target", str(repo),
+        "--model", "fake-haiku-x",
+        "--out", str(out_dir),
+    ]
+    monkeypatch.setattr(sys, "argv", argv)
+    rc = mod.main()
+    assert rc == 0, f"shim main() returned {rc}"
+
+    # Trajectory lands under --out, not the foreign pre-set dir.
+    assert (out_dir / "trajectories" / "hunt-fake-haiku-x"
+            / "trajectory.json").exists()
+    assert not (foreign / "trajectories").exists()

--- a/packages/cve_diff/cve_diff/agent/loop.py
+++ b/packages/cve_diff/cve_diff/agent/loop.py
@@ -377,8 +377,39 @@ class AgentLoop:
             **provider_kw,
         )
 
+        # Trajectory persistence on every exit path — success, cost
+        # cap, and arbitrary exception — so a budget-exceeded run
+        # (where the partial trajectory is MOST useful for operator
+        # debugging) still gets persisted with whatever survived to
+        # the point of termination. No-op unless RAPTOR_TRAJECTORY_DIR
+        # is set.
+        from core.trajectories.auto import (
+            persist_from_loop_result, persist_partial_from_exception,
+        )
+        _traj_run_id = f"cve-diff-{ctx.cve_id}"
         try:
-            loop_result = loop.run(config.user_message)
+            try:
+                loop_result = loop.run(config.user_message)
+            except CostBudgetExceeded as _e:
+                persist_partial_from_exception(
+                    _e, run_id=_traj_run_id, model_name=config.model_id,
+                    finding_id=ctx.cve_id,
+                    terminated_by="max_cost_usd",
+                )
+                raise
+            except Exception as _e:
+                persist_partial_from_exception(
+                    _e, run_id=_traj_run_id, model_name=config.model_id,
+                    finding_id=ctx.cve_id,
+                    terminated_by=f"exception:{type(_e).__name__}",
+                )
+                raise
+            else:
+                persist_from_loop_result(
+                    loop_result,
+                    run_id=_traj_run_id, model_name=config.model_id,
+                    finding_id=ctx.cve_id,
+                )
         except CostBudgetExceeded:
             return self._finalize(
                 AgentSurrender(

--- a/packages/cve_diff/tests/unit/agent/test_loop.py
+++ b/packages/cve_diff/tests/unit/agent/test_loop.py
@@ -179,6 +179,85 @@ def test_immediate_submit_rescued(monkeypatch: pytest.MonkeyPatch) -> None:
     assert fake.calls
 
 
+def test_trajectory_persisted_when_env_var_set(
+    monkeypatch: pytest.MonkeyPatch, tmp_path,
+) -> None:
+    """When RAPTOR_TRAJECTORY_DIR is set, the cve-diff agent writes a
+    trajectory file keyed off the CVE ID. The libexec shim sets this
+    automatically from --output-dir for operator runs."""
+    import json
+    from core.trajectories.auto import TRAJECTORY_DIR_ENV
+
+    monkeypatch.setenv(TRAJECTORY_DIR_ENV, str(tmp_path))
+    _patch_provider(monkeypatch, [_tc_response(_submit_call())])
+    result = AgentLoop().run(_cfg(), AgentContext(cve_id="CVE-2024-12345"))
+    assert isinstance(result, AgentOutput)
+
+    traj = (
+        tmp_path / "trajectories" / "cve-diff-CVE-2024-12345"
+        / "trajectory.json"
+    )
+    assert traj.exists(), (
+        f"trajectory not at {traj}; tree was: {list(tmp_path.rglob('*'))}"
+    )
+    payload = json.loads(traj.read_text())
+    assert payload["run_id"] == "cve-diff-CVE-2024-12345"
+    assert payload["finding_id"] == "CVE-2024-12345"
+    # cve_id flows into finding_id; cwe stays empty for this consumer
+    assert payload["cwe"] == ""
+    assert payload["terminated_by"] == "terminal_tool"
+
+
+def test_partial_trajectory_persisted_on_cost_cap(
+    monkeypatch: pytest.MonkeyPatch, tmp_path,
+) -> None:
+    """On the CostBudgetExceeded path the agent loop must persist
+    whatever messages survived to the point of termination — this is
+    the case where the trajectory is MOST useful for operator
+    debugging. Earlier wiring used a finally-block that only fired on
+    the success path; this test pins the symmetric exception-path
+    contract."""
+    import json
+    from core.llm.tool_use.types import (
+        CostBudgetExceeded, Message, TextBlock,
+    )
+    from core.trajectories.auto import TRAJECTORY_DIR_ENV
+
+    monkeypatch.setenv(TRAJECTORY_DIR_ENV, str(tmp_path))
+
+    partial_msgs = [
+        Message(role="user", content=[TextBlock(text="diff this")]),
+        Message(role="assistant", content=[TextBlock(text="thinking…")]),
+    ]
+    exc = CostBudgetExceeded(
+        "budget", messages=partial_msgs, tool_calls_made=0,
+    )
+    from unittest.mock import patch
+    _patch_provider(monkeypatch, [_tc_response(_submit_call())])
+    with patch(
+        "core.llm.tool_use.loop.ToolUseLoop.run",
+        side_effect=exc,
+    ):
+        result = AgentLoop().run(_cfg(), AgentContext(cve_id="CVE-2024-99999"))
+    # Surrender output expected — that's the cost-cap exit code path.
+    assert isinstance(result, AgentSurrender)
+    assert result.reason == "budget_cost_usd"
+
+    traj = (
+        tmp_path / "trajectories" / "cve-diff-CVE-2024-99999"
+        / "trajectory.json"
+    )
+    assert traj.exists(), (
+        f"partial trajectory not at {traj}; "
+        f"tree: {list(tmp_path.rglob('*'))}"
+    )
+    payload = json.loads(traj.read_text())
+    assert payload["terminated_by"] == "max_cost_usd"
+    assert payload["finding_id"] == "CVE-2024-99999"
+    # Two partial messages survived to disk.
+    assert len(payload["steps"]) == 2
+
+
 def test_tool_dispatched_then_submit(monkeypatch: pytest.MonkeyPatch) -> None:
     calls: list[dict] = []
 

--- a/packages/cve_diff/tests/unit/cli/test_libexec_trajectory_e2e.py
+++ b/packages/cve_diff/tests/unit/cli/test_libexec_trajectory_e2e.py
@@ -1,0 +1,135 @@
+"""End-to-end test for trajectory env-var wiring through the
+``libexec/raptor-cve-diff`` shim.
+
+Loads the shim as a module and drives ``main()`` with the Pipeline
+mocked. Asserts that by the time the Pipeline is invoked,
+``RAPTOR_TRAJECTORY_DIR`` is set to the resolved output directory —
+which is the contract the agent loop relies on for trajectory
+persistence (see ``core.trajectories.auto.persist_from_loop_result``).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+from unittest.mock import patch
+
+
+REPO_ROOT = Path(__file__).resolve().parents[5]
+LIBEXEC = REPO_ROOT / "libexec" / "raptor-cve-diff"
+
+
+def _load_shim():
+    """Import libexec/raptor-cve-diff as a module. The session-wide
+    ``_RAPTOR_TRUSTED=1`` env var lets the trust-marker check pass."""
+    loader = SourceFileLoader("raptor_cve_diff_e2e", str(LIBEXEC))
+    spec = importlib.util.spec_from_loader(loader.name, loader)
+    mod = importlib.util.module_from_spec(spec)
+    loader.exec_module(mod)
+    return mod
+
+
+def test_cve_diff_shim_sets_trajectory_env_var_before_pipeline_runs(
+    tmp_path, monkeypatch,
+):
+    """The shim must set RAPTOR_TRAJECTORY_DIR to the resolved
+    --output-dir BEFORE Pipeline.run is invoked. The agent loop
+    inside the pipeline reads this env var; if the assignment
+    happens too late (after Pipeline initialisation, in a different
+    function, etc.) operators get no trajectories.
+
+    We assert it from inside the patched Pipeline.run — that's the
+    exact moment the loop will later read the env var.
+    """
+    out_dir = tmp_path / "out"
+    # Defensive: the shim sets RAPTOR_TRAJECTORY_DIR via os.environ.
+    # Register the existing value (or absence) with monkeypatch so the
+    # mutation is undone at teardown instead of leaking forward.
+    monkeypatch.delenv("RAPTOR_TRAJECTORY_DIR", raising=False)
+
+    seen = {}
+
+    class _FakePipeline:
+        def __init__(self, **_kw):
+            self.agent = type("A", (), {"last_telemetry": None})()
+
+        def run(self, cve_id, work_dir):
+            # Capture state at the moment the pipeline runs — which
+            # is also when the agent loop would read the env var.
+            seen["trajectory_dir"] = os.environ.get("RAPTOR_TRAJECTORY_DIR")
+            seen["cve_id"] = cve_id
+            # Raise a known error so the shim returns cleanly without
+            # needing real GitHub / OSV / disk artefacts.
+            from cve_diff.core.exceptions import UnsupportedSource
+            raise UnsupportedSource("test stub: pipeline mocked")
+
+    mod = _load_shim()
+
+    argv = [
+        "raptor-cve-diff",
+        "run",
+        "CVE-2024-12345",
+        "--output-dir", str(out_dir),
+    ]
+    monkeypatch.setattr(sys, "argv", argv)
+
+    # Patch Pipeline at the import site. The shim imports inside the
+    # `main()` body so we patch the source module.
+    with patch("cve_diff.pipeline.Pipeline", _FakePipeline):
+        rc = mod.main()
+
+    # UnsupportedSource → exit code 4 (per the shim's error_map).
+    assert rc == 4, f"unexpected rc {rc}"
+
+    # The contract: env var was set to the resolved output dir BEFORE
+    # the pipeline began. If the assignment moved after or got
+    # dropped, this fails.
+    assert seen.get("cve_id") == "CVE-2024-12345"
+    assert seen.get("trajectory_dir") == str(out_dir), (
+        f"RAPTOR_TRAJECTORY_DIR not set to output_dir when Pipeline "
+        f"ran. Got {seen.get('trajectory_dir')!r} expected {str(out_dir)!r}"
+    )
+
+
+def test_cve_diff_shim_overrides_pre_set_trajectory_env_var(
+    tmp_path, monkeypatch,
+):
+    """If the operator already exported RAPTOR_TRAJECTORY_DIR, the
+    shim overrides it to --output-dir so trajectories land with the
+    rest of the run's artefacts."""
+    out_dir = tmp_path / "out"
+    foreign = tmp_path / "foreign"
+    foreign.mkdir()
+    monkeypatch.setenv("RAPTOR_TRAJECTORY_DIR", str(foreign))
+
+    seen = {}
+
+    class _FakePipeline:
+        def __init__(self, **_kw):
+            self.agent = type("A", (), {"last_telemetry": None})()
+
+        def run(self, cve_id, work_dir):
+            seen["trajectory_dir"] = os.environ.get("RAPTOR_TRAJECTORY_DIR")
+            from cve_diff.core.exceptions import UnsupportedSource
+            raise UnsupportedSource("test stub")
+
+    mod = _load_shim()
+
+    argv = [
+        "raptor-cve-diff", "run", "CVE-2024-99999",
+        "--output-dir", str(out_dir),
+    ]
+    monkeypatch.setattr(sys, "argv", argv)
+
+    with patch("cve_diff.pipeline.Pipeline", _FakePipeline):
+        mod.main()
+
+    # Override: env var points at --output-dir, NOT the operator's
+    # pre-set foreign value.
+    assert seen.get("trajectory_dir") == str(out_dir), (
+        f"shim did not override pre-set RAPTOR_TRAJECTORY_DIR. "
+        f"Got {seen.get('trajectory_dir')!r}"
+    )


### PR DESCRIPTION
Add core.trajectories.auto helper that writes a per-run trajectory.json under RAPTOR_TRAJECTORY_DIR when set, no-op otherwise. Wired into:

- packages/code_understanding/dispatch/hunt_dispatch  — success + CostBudgetExceeded + generic-exception paths.
- packages/code_understanding/dispatch/trace_dispatch — same triple exit-path coverage.
- packages/cve_diff/cve_diff/agent/loop — success, cost-cap, and generic-exception each persist with whatever messages survived (the cost-cap path is where a partial trajectory is most useful).
- libexec/raptor-understand, libexec/raptor-cve-diff — set RAPTOR_TRAJECTORY_DIR to the resolved --out before dispatch so trajectories land co-located with the run's other artefacts.

TrajectoryRecord.finding_id and cwe become optional so non-finding-driven loops (hunt, trace) can persist without synthetic IDs.

Defences:

- _sanitize_run_id replaces forbidden chars and collapses '..' so Bedrock model IDs (claude-3-haiku-20240307-v1:0) and OpenRouter slugs (vendor/model) land rather than getting silently dropped at the validator.
- write_trajectory realpath-checks the resolved write path stays under the operator-chosen base — blocks a planted <base>/trajectories symlink from steering writes outside the run dir. O_NOFOLLOW + O_EXCL on the final file with random-suffix retry on collision.
- Persist helpers swallow write failures (WARNING summary line, DEBUG-level traceback) so a trajectory write can never break the underlying ToolUseLoop result, and a read-only target doesn't flood the log with thousands of stack traces.

Tests: unit (success + failure + sanitisation + traversal + Bedrock id), per-dispatch wiring (success + cost-cap + exception), in-process E2E driving each libexec shim through SourceFileLoader, and a fresh-subprocess smoke for both shims to verify the env-var chain end-to-end.