### PR TITLE
fix(sandbox): restore target_run profile silently dropped by #833

### DIFF
--- a/core/sandbox/profiles.py
+++ b/core/sandbox/profiles.py
@@ -32,6 +32,19 @@ FRIDA_PROFILE = "frida"
 # strict:       same policy intent as full, but fail-closed if the host cannot
 #               provide the platform isolation backend. On Linux target/output
 #               isolation also requires mount namespaces.
+# target_run:   posture for spawning a harness-authored target binary
+#               that needs to expose a local listener (loopback TCP, UDS,
+#               etc.). Same Landlock + seccomp posture as ``full`` but
+#               ``block_network=False`` so the listener is reachable to
+#               the spawning harness. Callers that want isolation FROM
+#               the host's loopback (not just FROM the wider network)
+#               pair this profile with ``core/sandbox/
+#               netns_coordinator.py`` to put the listener in a shared
+#               isolated net-ns; the coordinator overrides
+#               ``block_network=True`` + ``inherit_netns=True`` per call,
+#               so the profile's loopback setting is irrelevant on that
+#               path. Defence-in-depth still comes from Landlock (caller
+#               passes ``allowed_tcp_ports=[port]`` per call) and seccomp.
 # debug:        full, but seccomp permits ptrace so gdb/rr can trace the
 #               target. Use for /crash-analysis. Target AND debugger run
 #               in the same sandbox — debugger forks target as a descendant
@@ -52,6 +65,7 @@ FRIDA_PROFILE = "frida"
 PROFILES = types.MappingProxyType({
     "full":         types.MappingProxyType({"block_network": True,  "use_landlock": True,  "seccomp": "full"}),
     "strict":       types.MappingProxyType({"block_network": True,  "use_landlock": True,  "seccomp": "full"}),
+    "target_run":   types.MappingProxyType({"block_network": False, "use_landlock": True,  "seccomp": "full"}),
     "debug":        types.MappingProxyType({"block_network": True,  "use_landlock": True,  "seccomp": "debug"}),
     FRIDA_PROFILE:  types.MappingProxyType({"block_network": False, "use_landlock": True,  "seccomp": "frida"}),
     "network-only": types.MappingProxyType({"block_network": True,  "use_landlock": False, "seccomp": ""}),

--- a/core/sandbox/tests/test_audit_cli_flags.py
+++ b/core/sandbox/tests/test_audit_cli_flags.py
@@ -233,7 +233,8 @@ class TestProfileSet:
     def test_canonical_profiles(self):
         from core.sandbox.profiles import PROFILES
         assert set(PROFILES) == {
-            "full", "strict", "debug", "frida", "network-only", "none",
+            "full", "strict", "target_run", "debug", "frida",
+            "network-only", "none",
         }
 
     def test_no_audit_mode_field_in_profile_dicts(self):

--- a/core/sandbox/tests/test_coordinator_isolation.py
+++ b/core/sandbox/tests/test_coordinator_isolation.py
@@ -48,19 +48,31 @@ COORDINATOR = REPO / "core" / "sandbox" / "netns_coordinator.py"
 
 
 def _coordinator_works() -> bool:
-    """Run a trivial echo probe through the coordinator. If we get a
-    well-formed response, the substrate is operational on this host.
-    Caches the result so we don't re-probe per test."""
+    """Probe the coordinator end-to-end. Returns True only when:
+
+      1. The coordinator binary exists.
+      2. A trivial spawn request returns a well-formed response with
+         ``target.returncode == 0``.
+      3. The two children end up in the SAME netns — the substrate's
+         core promise. A host whose userns/apparmor posture lets the
+         coordinator spawn but blocks netns inheritance would pass
+         the spawn check while every downstream sharing assertion in
+         this module would fail; gate that here instead of failing
+         them noisily.
+
+    Caches the result so we don't re-probe per test.
+    """
     if not COORDINATOR.is_file():
         return False
+    probe = "import os; print(os.readlink('/proc/self/ns/net'))"
     request = {
         "target": {
-            "cmd": [sys.executable, "-c", "print('ok')"],
+            "cmd": [sys.executable, "-c", probe],
             "env": {}, "timeout_s": 5.0, "profile": "target_run",
             "block_network": True, "allowed_tcp_ports": [],
         },
         "exploit": {
-            "cmd": [sys.executable, "-c", "pass"],
+            "cmd": [sys.executable, "-c", probe],
             "env": {}, "timeout_s": 5.0, "profile": "target_run",
             "block_network": True, "allowed_tcp_ports": [],
         },
@@ -82,7 +94,18 @@ def _coordinator_works() -> bool:
         resp = json.loads(out.decode())
         if resp.get("error"):
             return False
-        return resp.get("target", {}).get("returncode") == 0
+        if resp.get("target", {}).get("returncode") != 0:
+            return False
+        try:
+            target_ns = base64.b64decode(
+                resp["target"]["stdout_b64"],
+            ).decode().strip()
+            exploit_ns = base64.b64decode(
+                resp["exploit"]["stdout_b64"],
+            ).decode().strip()
+        except Exception:
+            return False
+        return bool(target_ns) and target_ns == exploit_ns
     except Exception:
         return False
 

--- a/core/sandbox/tests/test_sandbox.py
+++ b/core/sandbox/tests/test_sandbox.py
@@ -868,6 +868,36 @@ class TestDebugProfile(unittest.TestCase):
         self.assertEqual(mod_state._cli_sandbox_profile, "debug")
 
 
+class TestTargetRunProfile(unittest.TestCase):
+    """The target_run profile is the documented posture for spawning a
+    harness-authored target binary that needs a local listener
+    (loopback TCP / UDS) reachable to the spawning harness. Same
+    Landlock + seccomp posture as ``full`` but ``block_network=False``.
+
+    Pinned here because the profile was silently dropped from main
+    once before — losing it breaks every subprocess-target consumer
+    (the engine's TCP/argv/stdin adapter tests fail with
+    ``ValueError: Unknown sandbox profile 'target_run'``).
+    """
+
+    def test_profile_is_registered(self):
+        from core.sandbox import PROFILES
+        self.assertIn("target_run", PROFILES)
+        self.assertFalse(PROFILES["target_run"]["block_network"])
+        self.assertTrue(PROFILES["target_run"]["use_landlock"])
+        self.assertEqual(PROFILES["target_run"]["seccomp"], "full")
+
+    def test_cli_target_run_profile_accepted(self):
+        """`--sandbox target_run` parses and applies."""
+        import argparse
+        from core.sandbox import add_cli_args, apply_cli_args, state as mod_state
+        parser = argparse.ArgumentParser()
+        add_cli_args(parser)
+        args = parser.parse_args(["--sandbox", "target_run"])
+        apply_cli_args(args)
+        self.assertEqual(mod_state._cli_sandbox_profile, "target_run")
+
+
 class TestProfilesImmutable(unittest.TestCase):
     """PROFILES is exposed via __all__ — it must be immutable so callers
     can't corrupt the module for all subsequent sandbox() invocations."""


### PR DESCRIPTION
PR #830 added the ``target_run`` profile to ``PROFILES`` (posture for spawning a harness-authored target binary with a local listener: same Landlock + seccomp as ``full`` but ``block_network=False``). PR #833 (frida) inadvertently removed that entry along with the leading-block comment that documented the profile. The regression silently disabled every consumer that opts into ``profile="target_run"`` — the engine's subprocess-target adapters (TCP / argv / stdin) all hit ``ValueError: Unknown sandbox profile 'target_run'`` at the sandbox call site.

The whole ``test_coordinator_isolation.py`` module had been masking the regression: its module-level ``skipif`` runs a probe that submits ``profile="target_run"`` and skips on failure — so once target_run disappeared, the probe failed and every test in the file silently skipped. CI showed "1032 sandbox tests pass" while 12 coordinator tests were quietly skipped, the engine couldn't spawn subprocess targets, and nothing pointed at the cause.

Changes:

  - ``core/sandbox/profiles.py``: restore the ``target_run`` entry and its docstring block (verbatim from #830). Same isolation knobs.
  - ``core/sandbox/tests/test_sandbox.py``: new ``TestTargetRunProfile`` pinning the entry + the CLI accepts ``--sandbox target_run``. Class-level docstring records the regression so a future delete is loud.
  - ``core/sandbox/tests/test_audit_cli_flags.py``: update ``test_canonical_profiles`` to include ``target_run`` in the pinned profile set.
  - ``core/sandbox/tests/test_coordinator_isolation.py``: strengthen ``_coordinator_works()`` to probe the substrate's actual promise (both children land in the SAME netns) rather than just spawning. A host that can spawn but can't share netns now skips cleanly with the documented reason instead of failing one test while the rest of the module passes.

Verification: 1022 sandbox tests pass / 32 skipped / 0 fail.