### PR TITLE
fix(sca): collapse Cargo workspace members in transitive expansion

### DIFF
--- a/packages/sca/tests/test_transitive.py
+++ b/packages/sca/tests/test_transitive.py
@@ -25,6 +25,8 @@ from unittest.mock import MagicMock
 from packages.sca.models import Confidence, Dependency, Manifest, PinStyle
 from packages.sca.resolvers import ResolverResult
 from packages.sca.transitive import (
+    _collapse_cargo_workspaces,
+    _is_cargo_workspace_root,
     expand_missing_transitives,
 )
 
@@ -619,3 +621,70 @@ def test_medium_confidence_typosquat_does_not_skip(tmp_path, monkeypatch):
     _, statuses = expand_missing_transitives(manifests, direct)
     # Medium confidence → cascade still runs (different status).
     assert statuses[0].method != "skipped_typosquat_refused"
+
+
+# ---------------------------------------------------------------------------
+# Cargo workspace collapse
+# ---------------------------------------------------------------------------
+
+
+def test_is_cargo_workspace_root(tmp_path):
+    root = tmp_path / "Cargo.toml"
+    root.write_text("[workspace]\nmembers = ['a']\n")
+    assert _is_cargo_workspace_root(root) is True
+
+    member = tmp_path / "a" / "Cargo.toml"
+    member.parent.mkdir()
+    member.write_text("[package]\nname = 'a'\n")
+    assert _is_cargo_workspace_root(member) is False
+
+
+def test_is_cargo_workspace_root_missing_file(tmp_path):
+    assert _is_cargo_workspace_root(tmp_path / "nonexistent") is False
+
+
+def test_collapse_cargo_workspaces_drops_members(tmp_path):
+    """Workspace members with a lockfile at the root get collapsed."""
+    root = tmp_path / "ws"
+    root.mkdir()
+    (root / "Cargo.toml").write_text("[workspace]\nmembers = ['a', 'b']\n")
+    (root / "Cargo.lock").write_text("# lock\n")
+    a_dir = root / "a"
+    a_dir.mkdir()
+    (a_dir / "Cargo.toml").write_text("[package]\nname = 'a'\n")
+    b_dir = root / "b"
+    b_dir.mkdir()
+    (b_dir / "Cargo.toml").write_text("[package]\nname = 'b'\n")
+
+    m_a = _manifest("Cargo", a_dir / "Cargo.toml")
+    m_b = _manifest("Cargo", b_dir / "Cargo.toml")
+    lockfile_dirs = {
+        ("Cargo", root): _manifest("Cargo", root / "Cargo.lock", is_lockfile=True),
+    }
+    by_eco_dir = {
+        ("Cargo", a_dir): [m_a],
+        ("Cargo", b_dir): [m_b],
+    }
+    result = _collapse_cargo_workspaces(by_eco_dir, lockfile_dirs)
+    assert ("Cargo", a_dir) not in result
+    assert ("Cargo", b_dir) not in result
+
+
+def test_collapse_cargo_workspaces_keeps_non_cargo(tmp_path):
+    """Non-Cargo entries pass through untouched."""
+    pip_dir = tmp_path / "py"
+    pip_dir.mkdir()
+    m = _manifest("PyPI", pip_dir / "requirements.txt")
+    by_eco_dir = {("PyPI", pip_dir): [m]}
+    result = _collapse_cargo_workspaces(by_eco_dir, {})
+    assert ("PyPI", pip_dir) in result
+
+
+def test_collapse_cargo_workspaces_keeps_standalone(tmp_path):
+    """A standalone Cargo project (no workspace parent) stays."""
+    proj = tmp_path / "standalone"
+    proj.mkdir()
+    (proj / "Cargo.toml").write_text("[package]\nname = 'solo'\n")
+    m = _manifest("Cargo", proj / "Cargo.toml")
+    result = _collapse_cargo_workspaces({("Cargo", proj): [m]}, {})
+    assert ("Cargo", proj) in result

--- a/packages/sca/transitive.py
+++ b/packages/sca/transitive.py
@@ -67,6 +67,67 @@ class TransitiveStatus:
     failures: int = 0
 
 
+def _is_cargo_workspace_root(cargo_toml: Path) -> bool:
+    """True if *cargo_toml* declares ``[workspace]``."""
+    try:
+        text = cargo_toml.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return False
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped == "[workspace]":
+            return True
+    return False
+
+
+def _collapse_cargo_workspaces(
+    by_eco_dir: Dict[Tuple[str, Path], List["Manifest"]],
+    lockfile_dirs: Dict[Tuple[str, Path], "Manifest"],
+) -> Dict[Tuple[str, Path], List["Manifest"]]:
+    """Remap Cargo workspace members to their workspace root.
+
+    A workspace member (``core/zkpox/guest/Cargo.toml``) doesn't own a
+    ``Cargo.lock`` — the lock lives at the workspace root
+    (``core/zkpox/Cargo.lock``). Spawning ``cargo update`` on the member
+    alone copies only the member's manifest without the workspace root,
+    producing wrong results or an outright failure.
+
+    Walk each Cargo entry's parent chain looking for a ``Cargo.toml``
+    with ``[workspace]`` that has a sibling ``Cargo.lock``. If found,
+    drop the member entry — the root's lockfile is already parsed by
+    the pipeline's lockfile-present gate.
+    """
+    out: Dict[Tuple[str, Path], List["Manifest"]] = {}
+    for (eco, project_dir), eco_manifests in by_eco_dir.items():
+        if eco != "Cargo":
+            out[(eco, project_dir)] = eco_manifests
+            continue
+        # Check if this entry is itself a workspace root with a lockfile
+        if ("Cargo", project_dir) in lockfile_dirs:
+            out[(eco, project_dir)] = eco_manifests
+            continue
+        # Walk parents for a workspace root with a Cargo.lock
+        collapsed = False
+        parent = project_dir.parent
+        for _ in range(10):
+            if parent == parent.parent:
+                break
+            root_toml = parent / "Cargo.toml"
+            if root_toml.exists() and _is_cargo_workspace_root(root_toml):
+                if (parent / "Cargo.lock").exists():
+                    logger.debug(
+                        "sca.transitive: collapsing Cargo member %s "
+                        "into workspace root %s (lockfile present)",
+                        project_dir, parent,
+                    )
+                    collapsed = True
+                    break
+            parent = parent.parent
+        if not collapsed:
+            out[(eco, project_dir)] = eco_manifests
+    return out
+
+
 def expand_missing_transitives(
     manifests: Sequence[Manifest],
     direct_deps: Sequence[Dependency],
@@ -123,6 +184,14 @@ def expand_missing_transitives(
         if m.ecosystem == "Inline":
             continue
         by_eco_dir.setdefault((m.ecosystem, m.path.parent), []).append(m)
+
+    # Cargo workspace collapse: workspace members (guest/, prover/, …)
+    # don't carry their own Cargo.lock — only the workspace root does.
+    # Without collapsing, each member spawns a standalone `cargo update`
+    # that copies only the member's Cargo.toml, fails or resolves a
+    # wrong dep graph, and wastes CI time. Detect workspace membership
+    # by walking parent dirs for a Cargo.toml containing [workspace].
+    by_eco_dir = _collapse_cargo_workspaces(by_eco_dir, lockfile_dirs)
 
     # Pre-resolution typosquat gate. The cascade resolver will fetch
     # PyPI / npm / etc. metadata for every name in the manifest — if


### PR DESCRIPTION
Workspace members (guest/, prover/, verifier/) don't carry their own Cargo.lock — only the workspace root does. Discovery found each Cargo.toml independently, so each member spawned a standalone `cargo update` copying only its own manifest without the workspace root — wrong dep graph and wasted CI time (3 redundant sandboxed cargo invocations on PR #470).

Walk parent dirs for a [workspace] Cargo.toml with a sibling Cargo.lock; drop member entries whose root lockfile is already parsed by the pipeline.