### PR TITLE
sca: typosquat detector reads reviewed-legit allowlist; add pnpm

### DIFF
--- a/packages/sca/data/typosquat_reviewed_legit.json
+++ b/packages/sca/data/typosquat_reviewed_legit.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "Confirmed-legitimate near-name packages: real, independent projects whose names are one edit from a more-popular package (npm 'preact' vs 'react'). They are NOT typosquats and stay trusted in the popularity feeds. This file is NOT read by the detector (legit names are already trusted by popular-list membership) — it exists only to SUPPRESS these names from the typosquat-curation candidate queue (see typosquat_audit.py) so the recurring review delta de-noises to near-empty and a genuinely-new near-name stands out. Counterpart to typosquat_denylist.json (confirmed squats, which the detector DOES subtract). Adding here is FP-safe (changes nothing about trust); adding to the denylist is the FP-creating action and stays human-gated. Keys are ecosystem names; values map name -> {near_twin, decided_by, date, note}. Seeded from a 2026-05-28 audit of the npm top-5000 (all distance-1 candidates were legit except 'loadash', which is on the denylist).",
+  "_comment": "Confirmed-legitimate near-name packages: real, independent projects whose names are one edit from a more-popular package (npm 'preact' vs 'react'). They are NOT typosquats. READ BY TWO CONSUMERS: (1) the detector (typosquat.py _load_allowlist) short-circuits the distance check for names here — this is the durable FP suppression for legitimate near-names that may not appear in the upstream popularity feeds (e.g. pnpm is a CLI tool, not depended-upon, so npmrank omits it); (2) the curation audit (typosquat_audit.py) suppresses these from the review-delta queue. Counterpart to typosquat_denylist.json (confirmed squats, which the detector subtracts from the popular list). Adding here is FP-safe; adding to the denylist is the FP-creating action and stays human-gated. Keys are ecosystem names; values map name -> {near_twin, decided_by, date, note}.",
   "npm": {
     "preact": {"near_twin": "react", "decided_by": "human", "date": "2026-05-28", "note": "distinct project: fast 3kB React alternative"},
     "enquirer": {"near_twin": "inquirer", "decided_by": "human", "date": "2026-05-28", "note": "distinct, widely-used prompt library"},
@@ -10,7 +10,8 @@
     "inherit": {"near_twin": "inherits", "decided_by": "human", "date": "2026-05-28", "note": "real OOP-inheritance helper, distinct from inherits"},
     "rambda": {"near_twin": "ramda", "decided_by": "human", "date": "2026-05-28", "note": "deliberate lightweight ramda alternative; real project"},
     "jslint": {"near_twin": "eslint", "decided_by": "human", "date": "2026-05-28", "note": "Crockford's original linter; predates eslint"},
-    "reqwest": {"near_twin": "request", "decided_by": "human", "date": "2026-05-28", "note": "real AJAX library; deliberate pun name"}
+    "reqwest": {"near_twin": "request", "decided_by": "human", "date": "2026-05-28", "note": "real AJAX library; deliberate pun name"},
+    "pnpm": {"near_twin": "npm", "decided_by": "human", "date": "2026-06-25", "note": "pnpm package manager; top-3 JS package manager alongside npm and yarn"}
   },
   "PyPI": {},
   "Cargo": {},

--- a/packages/sca/supply_chain/tests/test_typosquat.py
+++ b/packages/sca/supply_chain/tests/test_typosquat.py
@@ -169,3 +169,10 @@ def test_scoped_npm_package_compared_against_bare_form() -> None:
     """``@evil/lodash`` should still flag against ``lodash``."""
     findings = scan_deps([_dep("@evil/lodash")])
     assert findings and findings[0].nearest_popular == "lodash"
+
+
+def test_allowlisted_near_name_not_flagged() -> None:
+    """A name in typosquat_reviewed_legit.json must never be flagged,
+    even though it's distance-1 from a popular package."""
+    findings = scan_deps([_dep("pnpm")])
+    assert findings == []

--- a/packages/sca/supply_chain/typosquat.py
+++ b/packages/sca/supply_chain/typosquat.py
@@ -46,6 +46,7 @@ _DATA_DIR = Path(__file__).resolve().parent.parent / "data" / "popular"
 # so neither is safe to auto-apply. Only hand-confirmed names go here → zero
 # false positives by construction.
 _DENYLIST_PATH = _DATA_DIR.parent / "typosquat_denylist.json"
+_ALLOWLIST_PATH = _DATA_DIR.parent / "typosquat_reviewed_legit.json"
 
 # Distances above this are not interesting; below it we always flag
 # (with severity scaled by distance).
@@ -104,6 +105,12 @@ _POPULAR_SET: Dict[str, set] = {}
 _DENYLIST_BY_ECO: Dict[str, set] = {}
 # Sentinel so a missing/!exists denylist file is loaded (and logged) once.
 _DENYLIST_RAW: Optional[Dict[str, set]] = None
+# Per-ecosystem allowlist sets (confirmed-legitimate near-names), loaded
+# once from ``_ALLOWLIST_PATH``. A name here short-circuits the distance
+# check in ``_check_one`` — it is NOT a typosquat regardless of edit
+# distance.
+_ALLOWLIST_BY_ECO: Dict[str, set] = {}
+_ALLOWLIST_RAW: Optional[Dict[str, set]] = None
 
 
 @dataclass(frozen=True)
@@ -158,6 +165,9 @@ def _check_one(dep: Dependency) -> Optional[TyposquatFinding]:
     # Set lookup is O(1) — was a linear scan via ``in popular``
     # against the underlying list before the index landed.
     if name_norm in _popular_set(dep.ecosystem):
+        return None
+
+    if name_norm in _load_allowlist(dep.ecosystem):
         return None
 
     candidates = [name_norm]
@@ -296,6 +306,38 @@ def _load_denylist(ecosystem: str) -> set:
     if cached is None:
         cached = _DENYLIST_RAW.get(ecosystem, set())
         _DENYLIST_BY_ECO[ecosystem] = cached
+    return cached
+
+
+def _load_allowlist(ecosystem: str) -> set:
+    """Return the lowercased allowlist name-set for ``ecosystem``.
+
+    Same file shape as the denylist (bare list or enriched map per eco),
+    loaded from ``typosquat_reviewed_legit.json``. A name here is a
+    confirmed-legitimate near-miss that the detector must never flag."""
+    global _ALLOWLIST_RAW
+    if _ALLOWLIST_RAW is None:
+        _ALLOWLIST_RAW = {}
+        try:
+            raw = _json.loads(_ALLOWLIST_PATH.read_text(encoding="utf-8"))
+        except FileNotFoundError:
+            raw = {}
+        except (OSError, _json.JSONDecodeError) as e:
+            logger.warning("sca.supply_chain.typosquat: failed to load "
+                           "allowlist %s: %s", _ALLOWLIST_PATH, e)
+            raw = {}
+        if isinstance(raw, dict):
+            for eco, names in raw.items():
+                if isinstance(names, list):
+                    _ALLOWLIST_RAW[eco] = {
+                        n.lower() for n in names if isinstance(n, str)}
+                elif isinstance(names, dict):
+                    _ALLOWLIST_RAW[eco] = {
+                        k.lower() for k in names if isinstance(k, str)}
+    cached = _ALLOWLIST_BY_ECO.get(ecosystem)
+    if cached is None:
+        cached = _ALLOWLIST_RAW.get(ecosystem, set())
+        _ALLOWLIST_BY_ECO[ecosystem] = cached
     return cached
 
 


### PR DESCRIPTION
The typosquat detector now consults typosquat_reviewed_legit.json as an allowlist — names there short-circuit _check_one before the distance check. Previously the file was only read by the curation audit queue; legitimate near-names like pnpm (distance-1 from npm) that don't appear in the upstream npmrank popularity feed had no durable suppression path — manual additions to the popular list were overwritten by the weekly refresh cron.

Add pnpm as the first allowlist entry. E2E confirmed: full SCA pipeline scan of a Dockerfile installing pnpm produces zero typosquat findings.