### PR TITLE
fix(llm): daily quota circuit breaker, JSON retry, cost tracking on failure

### DIFF
--- a/core/llm/client.py
+++ b/core/llm/client.py
@@ -1440,10 +1440,6 @@ class LLMClient:
 
                         if _is_daily_quota_error(e):
                             self._daily_quota_exhausted.add(model_key)
-                            # escape_nonprintable on provider/model
-                            # — config-loaded strings, could carry
-                            # ANSI/BIDI/control bytes from a hostile
-                            # models.json edit. Defence in depth.
                             from core.security.log_sanitisation import escape_nonprintable as _esc
                             logger.warning(
                                 "Daily quota exhausted for %s/%s — "
@@ -1464,9 +1460,16 @@ class LLMClient:
                                 _esc(quota_guidance),
                             )
 
-                        # Sanitisation: redact_secrets covers API keys
-                        # and secrets; escape_nonprintable defangs
-                        # ANSI/control bytes; [:1024] caps the length.
+                        # Sanitisation is the BROADER of the two
+                        # available paths: redact_secrets covers more
+                        # patterns than _sanitize_log_message's API-key
+                        # regex; escape_nonprintable defangs ANSI/control
+                        # bytes; [:1024] caps the length. This was the
+                        # sanitisation the (now-demoted) provider ERROR
+                        # used; moving it to the surviving operator-
+                        # visible line preserves the safety properties
+                        # at the right level. See the retry-dedupe
+                        # adversarial-review notes for rationale.
                         from core.security.log_sanitisation import (
                             escape_nonprintable as _esc_np,
                         )
@@ -1764,6 +1767,13 @@ class LLMClient:
 
                     except Exception as e:
                         last_error = e
+                        # Schema reliability signal — only record the model as
+                        # schema-failing when the error class points at a
+                        # response-shape problem (parse / schema-mismatch /
+                        # validation), not at infra (network 5xx, timeouts,
+                        # quota). Otherwise we'd attribute provider flakes as
+                        # this model's schema unreliability and the SCHEMA_VALID
+                        # cell would drift to nonsense.
                         if not (_is_quota_error(e) or _is_retryable_error(e)):
                             self._record_schema_validity(model.model_name, success=False)
 
@@ -1778,6 +1788,10 @@ class LLMClient:
                             break
                         elif _is_quota_error(e):
                             quota_guidance = _get_quota_guidance(model.model_name, model.provider)
+                            # escape_nonprintable on provider/model
+                            # — config-loaded strings, could carry
+                            # ANSI/BIDI/control bytes from a hostile
+                            # models.json edit. Defence in depth.
                             from core.security.log_sanitisation import escape_nonprintable as _esc
                             logger.warning(
                                 "Quota error for %s/%s:%s",
@@ -1785,6 +1799,8 @@ class LLMClient:
                                 _esc(quota_guidance),
                             )
 
+                        # Broader sanitisation — same rationale as the
+                        # ``generate`` retry loop above.
                         from core.security.log_sanitisation import (
                             escape_nonprintable as _esc_np,
                         )

--- a/core/llm/client.py
+++ b/core/llm/client.py
@@ -219,6 +219,20 @@ def _is_quota_error(error: Exception) -> bool:
     ])
 
 
+def _is_daily_quota_error(error: Exception) -> bool:
+    """Detect daily/long-horizon quota exhaustion vs transient rate limits.
+
+    Daily quotas (e.g. Gemini's per_day limit) won't clear for hours.
+    Retrying wastes API calls and wall-clock time.
+    """
+    error_str = str(error).lower()
+    return _is_quota_error(error) and any(
+        marker in error_str
+        for marker in ("per_day", "per day", "daily", "retry in 6h", "retry in 5h",
+                        "retry in 4h", "retry in 3h", "retry in 2h", "retry in 1h")
+    )
+
+
 def _is_retryable_error(error: Exception) -> bool:
     """Check if an error is transient and worth retrying.
 
@@ -226,7 +240,11 @@ def _is_retryable_error(error: Exception) -> bool:
     Non-retryable: schema validation, auth errors (401/403), bad request (400),
     Instructor failures, Pydantic validation errors.
     """
-    # Rate limits are retryable (with backoff)
+    # Daily quotas are NOT retryable — won't clear for hours
+    if _is_daily_quota_error(error):
+        return False
+
+    # Per-minute rate limits are retryable (with backoff)
     if _is_quota_error(error):
         return True
 
@@ -242,6 +260,15 @@ def _is_retryable_error(error: Exception) -> bool:
     retryable_patterns = ("timeout", "connection", "502", "503", "504",
                           "internal server error", "service unavailable")
     if any(p in error_str for p in retryable_patterns):
+        return True
+
+    # JSON parse failures from LLM output are retryable — the model
+    # generated malformed JSON but may succeed on a different sample.
+    if isinstance(error, json.JSONDecodeError):
+        return True
+    json_parse_patterns = ("unterminated string", "expecting value",
+                           "expecting property name", "invalid \\escape")
+    if any(p in error_str for p in json_parse_patterns):
         return True
 
     # Everything else is non-retryable (schema errors, 400, 401, 403, 404,
@@ -404,6 +431,11 @@ class LLMClient:
         # surfaced in /codeql's summary so the scorecard's effect on
         # cost shows up as a concrete line.
         self.short_circuits = 0
+        # Models whose daily quota is exhausted. Keyed by
+        # (provider, model_name). Checked before each attempt
+        # so we skip straight to fallback instead of burning
+        # 3 retries on guaranteed 429s.
+        self._daily_quota_exhausted: set[tuple[str, str]] = set()
         self._stats_lock = threading.RLock()
         # Per-cache-key locks. Two threads issuing the same cache key
         # serialise on its lock so only one calls the provider; the
@@ -1305,6 +1337,14 @@ class LLMClient:
                 if not model.enabled:
                     continue
 
+                model_key = (model.provider, model.model_name)
+                if model_key in self._daily_quota_exhausted:
+                    logger.debug(
+                        "Skipping %s/%s — daily quota exhausted",
+                        model.provider, model.model_name,
+                    )
+                    continue
+
                 attempts_count += 1
 
                 if model_idx == 0:
@@ -1398,7 +1438,20 @@ class LLMClient:
                     except Exception as e:
                         last_error = e
 
-                        if _is_quota_error(e):
+                        if _is_daily_quota_error(e):
+                            self._daily_quota_exhausted.add(model_key)
+                            # escape_nonprintable on provider/model
+                            # — config-loaded strings, could carry
+                            # ANSI/BIDI/control bytes from a hostile
+                            # models.json edit. Defence in depth.
+                            from core.security.log_sanitisation import escape_nonprintable as _esc
+                            logger.warning(
+                                "Daily quota exhausted for %s/%s — "
+                                "skipping for remainder of session",
+                                _esc(model.provider), _esc(model.model_name),
+                            )
+                            break
+                        elif _is_quota_error(e):
                             quota_guidance = _get_quota_guidance(model.model_name, model.provider)
                             # escape_nonprintable on provider/model
                             # — config-loaded strings, could carry
@@ -1411,16 +1464,9 @@ class LLMClient:
                                 _esc(quota_guidance),
                             )
 
-                        # Sanitisation is the BROADER of the two
-                        # available paths: redact_secrets covers more
-                        # patterns than _sanitize_log_message's API-key
-                        # regex; escape_nonprintable defangs ANSI/control
-                        # bytes; [:1024] caps the length. This was the
-                        # sanitisation the (now-demoted) provider ERROR
-                        # used; moving it to the surviving operator-
-                        # visible line preserves the safety properties
-                        # at the right level. See the retry-dedupe
-                        # adversarial-review notes for rationale.
+                        # Sanitisation: redact_secrets covers API keys
+                        # and secrets; escape_nonprintable defangs
+                        # ANSI/control bytes; [:1024] caps the length.
                         from core.security.log_sanitisation import (
                             escape_nonprintable as _esc_np,
                         )
@@ -1594,6 +1640,14 @@ class LLMClient:
                 if not model.enabled:
                     continue
 
+                model_key = (model.provider, model.model_name)
+                if model_key in self._daily_quota_exhausted:
+                    logger.debug(
+                        "Skipping %s/%s (structured) — daily quota exhausted",
+                        model.provider, model.model_name,
+                    )
+                    continue
+
                 attempts_count += 1
 
                 if model_idx == 0:
@@ -1633,7 +1687,21 @@ class LLMClient:
                                 prompt, schema, system_prompt, **kwargs,
                             )
                         except Exception:
-                            self._release_budget(_BUDGET_RESERVATION)
+                            # The provider may have made an API call (e.g.
+                            # fallback called generate()) before the JSON
+                            # parse failed. Record any cost incurred so
+                            # tracking stays accurate.
+                            cost_delta = provider.total_cost - cost_before
+                            if cost_delta > 0:
+                                with self._stats_lock:
+                                    self.total_cost += cost_delta - _BUDGET_RESERVATION
+                                    self.request_count += 1
+                                    if task_type:
+                                        self.task_type_costs[task_type] = (
+                                            self.task_type_costs.get(task_type, 0.0) + cost_delta
+                                        )
+                            else:
+                                self._release_budget(_BUDGET_RESERVATION)
                             raise
                         duration = time.monotonic() - t_start
 
@@ -1696,22 +1764,20 @@ class LLMClient:
 
                     except Exception as e:
                         last_error = e
-                        # Schema reliability signal — only record the model as
-                        # schema-failing when the error class points at a
-                        # response-shape problem (parse / schema-mismatch /
-                        # validation), not at infra (network 5xx, timeouts,
-                        # quota). Otherwise we'd attribute provider flakes as
-                        # this model's schema unreliability and the SCHEMA_VALID
-                        # cell would drift to nonsense.
                         if not (_is_quota_error(e) or _is_retryable_error(e)):
                             self._record_schema_validity(model.model_name, success=False)
 
-                        if _is_quota_error(e):
+                        if _is_daily_quota_error(e):
+                            self._daily_quota_exhausted.add(model_key)
+                            from core.security.log_sanitisation import escape_nonprintable as _esc
+                            logger.warning(
+                                "Daily quota exhausted for %s/%s — "
+                                "skipping for remainder of session",
+                                _esc(model.provider), _esc(model.model_name),
+                            )
+                            break
+                        elif _is_quota_error(e):
                             quota_guidance = _get_quota_guidance(model.model_name, model.provider)
-                            # escape_nonprintable on provider/model
-                            # — config-loaded strings, could carry
-                            # ANSI/BIDI/control bytes from a hostile
-                            # models.json edit. Defence in depth.
                             from core.security.log_sanitisation import escape_nonprintable as _esc
                             logger.warning(
                                 "Quota error for %s/%s:%s",
@@ -1719,8 +1785,6 @@ class LLMClient:
                                 _esc(quota_guidance),
                             )
 
-                        # Broader sanitisation — same rationale as the
-                        # ``generate`` retry loop above.
                         from core.security.log_sanitisation import (
                             escape_nonprintable as _esc_np,
                         )

--- a/core/llm/tests/test_structured_response_cache.py
+++ b/core/llm/tests/test_structured_response_cache.py
@@ -98,6 +98,7 @@ def _client(
     client._key_locks = OrderedDict()
     client._key_locks_guard = threading.Lock()
     client._key_locks_cap = 4096
+    client._daily_quota_exhausted = set()
     return client
 
 

--- a/core/llm/tests/test_structured_response_cache.py
+++ b/core/llm/tests/test_structured_response_cache.py
@@ -94,11 +94,11 @@ def _client(
     client.total_cost = 0.0
     client.request_count = 0
     client.task_type_costs = {}
+    client._daily_quota_exhausted = set()
     client._stats_lock = threading.RLock()
     client._key_locks = OrderedDict()
     client._key_locks_guard = threading.Lock()
     client._key_locks_cap = 4096
-    client._daily_quota_exhausted = set()
     return client
 
 

--- a/packages/codeql/tests/test_scorecard_wiring.py
+++ b/packages/codeql/tests/test_scorecard_wiring.py
@@ -104,6 +104,7 @@ def _build_llm(tmp_path) -> "object":
     client.request_count = 0
     client.task_type_costs = {}
     client.short_circuits = 0
+    client._daily_quota_exhausted = set()
     client._stats_lock = threading.RLock()
     client._key_locks = OrderedDict()
     client._key_locks_guard = threading.Lock()

--- a/packages/llm_analysis/tests/test_prefilter_wiring.py
+++ b/packages/llm_analysis/tests/test_prefilter_wiring.py
@@ -102,6 +102,7 @@ def _build_llm(tmp_path):
     client.request_count = 0
     client.task_type_costs = {}
     client.short_circuits = 0
+    client._daily_quota_exhausted = set()
     client._stats_lock = threading.RLock()
     client._key_locks = OrderedDict()
     client._key_locks_guard = threading.Lock()

--- a/packages/sca/tests/test_scorecard_wiring.py
+++ b/packages/sca/tests/test_scorecard_wiring.py
@@ -114,6 +114,7 @@ def _build_llm(scorecard_path: Path):
     client.total_cost = 0.0
     client.request_count = 0
     client.task_type_costs = {}
+    client._daily_quota_exhausted = set()
     client._stats_lock = threading.RLock()
     client._key_locks = {}
     client._key_locks_guard = threading.Lock()


### PR DESCRIPTION
Three LLM client reliability fixes:

1. Daily quota circuit breaker: detect daily quota exhaustion (Gemini per_day limits) on first 429 and skip that model for the remainder of the session. Saves thousands of wasted API calls when a quota resets in hours, not seconds.

2. JSON parse errors retryable: JSONDecodeError and malformed-JSON errors were treated as non-retryable, so a single bad output from the model killed all retries and cascaded to errors on every subsequent call. Now recognized as retryable.

3. Cost tracking on structured generation failure: when the provider fallback path made an API call before JSON parsing failed, the cost was tracked in the provider but never reconciled to client.total_cost. Runs with errors showed $0.00 cost.