### PR TITLE
Fix/agentic log level

### DIFF
--- a/core/logging/__init__.py
+++ b/core/logging/__init__.py
@@ -28,6 +28,31 @@ _RESERVED_LOGRECORD_NAMES = frozenset({
     "process", "message", "asctime",
 })
 
+CONSOLE_LOG_LEVELS = ("DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL")
+
+
+def _raptor_logger() -> logging.Logger:
+    return logging.getLogger("raptor")
+
+
+def _is_console_handler(handler: logging.Handler) -> bool:
+    return (
+        isinstance(handler, logging.StreamHandler)
+        and not isinstance(handler, logging.FileHandler)
+    )
+
+
+def _raptor_console_handlers() -> list[logging.Handler]:
+    return [handler for handler in _raptor_logger().handlers if _is_console_handler(handler)]
+
+
+def _raptor_root_console_handlers() -> list[logging.Handler]:
+    return [
+        handler for handler in logging.getLogger().handlers
+        if _is_console_handler(handler)
+        and getattr(handler, "_raptor_root_handler", False)
+    ]
+
 
 class JSONFormatter(logging.Formatter):
     """Format log records as JSON for structured logging."""
@@ -193,10 +218,7 @@ class RaptorLogger:
         # but the file handler's eager initialisation has been a
         # source of bugs before — see the audit-trail filename
         # comment above).
-        if not any(
-            isinstance(h, logging.StreamHandler) and getattr(h, "_raptor_root_handler", False)
-            for h in root_logger.handlers
-        ):
+        if not _raptor_root_console_handlers():
             root_console = logging.StreamHandler(sys.stderr)
             root_console.setLevel(logging.INFO)
             root_console.setFormatter(console_formatter)
@@ -351,3 +373,28 @@ def get_logger(name: Optional[str] = None) -> "logging.Logger":
     # audit handlers attached to the base "raptor" logger.
     safe_name = name if name.startswith("raptor.") else f"raptor.{name}"
     return logging.getLogger(safe_name)
+
+
+def set_console_log_level(level: int, *, include_root: bool = False) -> None:
+    """Set operator-facing console verbosity without touching file audit logs."""
+    # Ensure RAPTOR handlers exist before mutating them.
+    RaptorLogger()
+
+    for handler in _raptor_console_handlers():
+        handler.setLevel(level)
+
+    if not include_root:
+        return
+
+    root_logger = logging.getLogger()
+    for handler in _raptor_root_console_handlers():
+        handler.setLevel(level)
+    root_logger.setLevel(level)
+
+
+def configure_run_logging(log_level: Optional[str], verbose: bool) -> None:
+    """Apply run-level console logging flags."""
+    if log_level:
+        set_console_log_level(getattr(logging, log_level.upper()), include_root=True)
+    elif verbose:
+        set_console_log_level(logging.DEBUG)

--- a/packages/llm_analysis/tests/test_verbose_flag.py
+++ b/packages/llm_analysis/tests/test_verbose_flag.py
@@ -16,9 +16,25 @@ import logging
 
 def _apply_verbose_wiring(log) -> None:
     """Mirror the snippet at raptor_agentic.py:main when --verbose."""
-    for h in log.logger.handlers:
-        if isinstance(h, logging.StreamHandler) and not isinstance(h, logging.FileHandler):
-            h.setLevel(logging.DEBUG)
+    from raptor_agentic import _configure_run_logging
+    _configure_run_logging(log_level=None, verbose=True)
+
+
+def _console_handlers(log):
+    return [
+        h for h in log.logger.handlers
+        if isinstance(h, logging.StreamHandler)
+        and not isinstance(h, logging.FileHandler)
+    ]
+
+
+def _raptor_root_console_handlers():
+    return [
+        h for h in logging.getLogger().handlers
+        if isinstance(h, logging.StreamHandler)
+        and not isinstance(h, logging.FileHandler)
+        and getattr(h, "_raptor_root_handler", False)
+    ]
 
 
 class TestVerboseWiring:
@@ -34,11 +50,7 @@ class TestVerboseWiring:
 
         _apply_verbose_wiring(log)
 
-        stream_handlers = [
-            h for h in log.logger.handlers
-            if isinstance(h, logging.StreamHandler)
-            and not isinstance(h, logging.FileHandler)
-        ]
+        stream_handlers = _console_handlers(log)
         assert stream_handlers, "expected at least one console StreamHandler"
         for h in stream_handlers:
             assert h.level == logging.DEBUG
@@ -68,3 +80,34 @@ class TestVerboseWiring:
         for h in log.logger.handlers:
             if isinstance(h, logging.StreamHandler) and not isinstance(h, logging.FileHandler):
                 assert h.level == logging.DEBUG
+
+    def test_log_level_warning_quiets_console_and_root_handlers(self):
+        from core.logging import get_logger
+        from raptor_agentic import _configure_run_logging
+
+        log = get_logger()
+        root_logger = logging.getLogger()
+        root_before = root_logger.level
+        console = _console_handlers(log)
+        root_console = _raptor_root_console_handlers()
+        console_before = [h.level for h in console]
+        root_console_before = [h.level for h in root_console]
+
+        try:
+            for h in console + root_console:
+                h.setLevel(logging.INFO)
+            root_logger.setLevel(logging.INFO)
+
+            _configure_run_logging(log_level="WARNING", verbose=False)
+
+            assert console, "expected at least one console StreamHandler"
+            assert root_console, "expected RAPTOR root console StreamHandler"
+            assert all(h.level == logging.WARNING for h in console)
+            assert all(h.level == logging.WARNING for h in root_console)
+            assert root_logger.level == logging.WARNING
+        finally:
+            for h, level in zip(console, console_before):
+                h.setLevel(level)
+            for h, level in zip(root_console, root_console_before):
+                h.setLevel(level)
+            root_logger.setLevel(root_before)

--- a/packages/llm_analysis/tests/test_verbose_flag.py
+++ b/packages/llm_analysis/tests/test_verbose_flag.py
@@ -13,18 +13,31 @@ from __future__ import annotations
 
 import logging
 
+import pytest
 
-def _apply_verbose_wiring(log) -> None:
+
+def _apply_verbose_wiring() -> None:
     """Mirror the snippet at raptor_agentic.py:main when --verbose."""
     from raptor_agentic import _configure_run_logging
     _configure_run_logging(log_level=None, verbose=True)
 
 
-def _console_handlers(log):
+def _raptor_logger() -> logging.Logger:
+    return logging.getLogger("raptor")
+
+
+def _console_handlers():
     return [
-        h for h in log.logger.handlers
+        h for h in _raptor_logger().handlers
         if isinstance(h, logging.StreamHandler)
         and not isinstance(h, logging.FileHandler)
+    ]
+
+
+def _file_handlers():
+    return [
+        h for h in _raptor_logger().handlers
+        if isinstance(h, logging.FileHandler)
     ]
 
 
@@ -38,57 +51,48 @@ def _raptor_root_console_handlers():
 
 
 class TestVerboseWiring:
-    def test_verbose_bumps_console_streamhandlers_to_debug(self):
+    @pytest.fixture(autouse=True)
+    def _init_raptor_logging(self):
         from core.logging import get_logger
-        log = get_logger()
+        get_logger()
 
+    def test_verbose_bumps_console_streamhandlers_to_debug(self):
         # Force any console StreamHandlers back to INFO so we can see
         # the wiring flip them.
-        for h in log.logger.handlers:
-            if isinstance(h, logging.StreamHandler) and not isinstance(h, logging.FileHandler):
-                h.setLevel(logging.INFO)
+        for h in _console_handlers():
+            h.setLevel(logging.INFO)
 
-        _apply_verbose_wiring(log)
+        _apply_verbose_wiring()
 
-        stream_handlers = _console_handlers(log)
+        stream_handlers = _console_handlers()
         assert stream_handlers, "expected at least one console StreamHandler"
         for h in stream_handlers:
             assert h.level == logging.DEBUG
 
     def test_verbose_does_not_affect_file_handler(self):
-        from core.logging import get_logger
-        log = get_logger()
-        file_handlers = [
-            h for h in log.logger.handlers
-            if isinstance(h, logging.FileHandler)
-        ]
+        file_handlers = _file_handlers()
         if not file_handlers:
             # In some test envs no file handler is attached; nothing to assert.
             return
         before_levels = [h.level for h in file_handlers]
 
-        _apply_verbose_wiring(log)
+        _apply_verbose_wiring()
 
         after_levels = [h.level for h in file_handlers]
         assert before_levels == after_levels
 
     def test_verbose_idempotent(self):
-        from core.logging import get_logger
-        log = get_logger()
-        _apply_verbose_wiring(log)
-        _apply_verbose_wiring(log)  # second call is a no-op
-        for h in log.logger.handlers:
-            if isinstance(h, logging.StreamHandler) and not isinstance(h, logging.FileHandler):
-                assert h.level == logging.DEBUG
+        _apply_verbose_wiring()
+        _apply_verbose_wiring()  # second call is a no-op
+        for h in _console_handlers():
+            assert h.level == logging.DEBUG
 
     def test_log_level_warning_quiets_console_and_root_handlers(self):
-        from core.logging import get_logger
         from raptor_agentic import _configure_run_logging
 
-        log = get_logger()
         root_logger = logging.getLogger()
         root_before = root_logger.level
-        console = _console_handlers(log)
+        console = _console_handlers()
         root_console = _raptor_root_console_handlers()
         console_before = [h.level for h in console]
         root_console_before = [h.level for h in root_console]

--- a/packages/llm_analysis/tests/test_verbose_flag.py
+++ b/packages/llm_analysis/tests/test_verbose_flag.py
@@ -18,36 +18,25 @@ import pytest
 
 def _apply_verbose_wiring() -> None:
     """Mirror the snippet at raptor_agentic.py:main when --verbose."""
-    from raptor_agentic import _configure_run_logging
-    _configure_run_logging(log_level=None, verbose=True)
-
-
-def _raptor_logger() -> logging.Logger:
-    return logging.getLogger("raptor")
+    from core.logging import configure_run_logging
+    configure_run_logging(log_level=None, verbose=True)
 
 
 def _console_handlers():
-    return [
-        h for h in _raptor_logger().handlers
-        if isinstance(h, logging.StreamHandler)
-        and not isinstance(h, logging.FileHandler)
-    ]
+    from core.logging import _raptor_console_handlers
+    return _raptor_console_handlers()
 
 
 def _file_handlers():
     return [
-        h for h in _raptor_logger().handlers
+        h for h in logging.getLogger("raptor").handlers
         if isinstance(h, logging.FileHandler)
     ]
 
 
 def _raptor_root_console_handlers():
-    return [
-        h for h in logging.getLogger().handlers
-        if isinstance(h, logging.StreamHandler)
-        and not isinstance(h, logging.FileHandler)
-        and getattr(h, "_raptor_root_handler", False)
-    ]
+    from core.logging import _raptor_root_console_handlers
+    return _raptor_root_console_handlers()
 
 
 class TestVerboseWiring:
@@ -88,7 +77,7 @@ class TestVerboseWiring:
             assert h.level == logging.DEBUG
 
     def test_log_level_warning_quiets_console_and_root_handlers(self):
-        from raptor_agentic import _configure_run_logging
+        from core.logging import configure_run_logging
 
         root_logger = logging.getLogger()
         root_before = root_logger.level
@@ -102,7 +91,7 @@ class TestVerboseWiring:
                 h.setLevel(logging.INFO)
             root_logger.setLevel(logging.INFO)
 
-            _configure_run_logging(log_level="WARNING", verbose=False)
+            configure_run_logging(log_level="WARNING", verbose=False)
 
             assert console, "expected at least one console StreamHandler"
             assert root_console, "expected RAPTOR root console StreamHandler"
@@ -115,3 +104,16 @@ class TestVerboseWiring:
             for h, level in zip(root_console, root_console_before):
                 h.setLevel(level)
             root_logger.setLevel(root_before)
+
+    def test_launcher_extracts_valid_agentic_log_level_without_consuming_args(self):
+        from raptor import _extract_agentic_log_level
+
+        args = ["--repo", "/tmp/target", "--log-level", "warning"]
+
+        assert _extract_agentic_log_level(args) == "WARNING"
+        assert args == ["--repo", "/tmp/target", "--log-level", "warning"]
+
+    def test_launcher_ignores_invalid_agentic_log_level_for_child_parser(self):
+        from raptor import _extract_agentic_log_level
+
+        assert _extract_agentic_log_level(["--log-level", "NOPE"]) is None

--- a/raptor.py
+++ b/raptor.py
@@ -137,6 +137,28 @@ def _extract_and_strip_max_cost_usd(args: list) -> tuple[float | None, list]:
     return (cap, out)
 
 
+def _extract_agentic_log_level(args: list) -> str | None:
+    """Return a valid agentic --log-level value without consuming argv.
+
+    The child parser remains the source of truth for invalid values. This
+    early extraction is only so parent lifecycle/dispatcher console logs obey
+    the operator's requested verbosity before raptor_agentic.py starts.
+    """
+    from core.logging import CONSOLE_LOG_LEVELS
+
+    for i, arg in enumerate(args):
+        if arg == "--log-level" and i + 1 < len(args):
+            candidate = args[i + 1].upper()
+        elif arg.startswith("--log-level="):
+            candidate = arg.split("=", 1)[1].upper()
+        else:
+            continue
+        if candidate in CONSOLE_LOG_LEVELS:
+            return candidate
+        return None
+    return None
+
+
 def _rewrite_target_arg(args: list, old: str, new: str) -> list:
     """Return ``args`` with the --repo/--binary/--url value ``old`` replaced by
     ``new`` (both ``--flag value`` and ``--flag=value`` forms)."""
@@ -910,6 +932,11 @@ def mode_agentic(args: list) -> int:
     # to set the cc_trust + codeql_trust overrides in its own process.
     if _TRUST_REPO_SEEN and '--trust-repo' not in args:
         args = ['--trust-repo'] + args
+
+    log_level = _extract_agentic_log_level(args)
+    if log_level:
+        from core.logging import configure_run_logging
+        configure_run_logging(log_level=log_level, verbose=False)
 
     return _run_with_lifecycle("agentic", agentic_script, args,
                               "Starting full autonomous workflow (Semgrep + CodeQL)...")

--- a/raptor_agentic.py
+++ b/raptor_agentic.py
@@ -15,6 +15,7 @@ Complete end-to-end autonomous security testing:
 """
 
 import argparse
+import logging
 import os
 import subprocess
 import sys
@@ -36,6 +37,36 @@ from core.schema_constants import VULN_TYPE_TO_CWE as _CWE_FROM_VULN_TYPE
 from core.security.cc_trust import check_repo_claude_trust, set_trust_override
 
 logger = get_logger()
+
+_CONSOLE_LOG_LEVELS = ("DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL")
+
+
+def _set_console_log_level(level: int, *, include_root: bool = False) -> None:
+    """Set operator-facing console verbosity without touching file audit logs."""
+    for handler in logger.logger.handlers:
+        if isinstance(handler, logging.StreamHandler) and not isinstance(handler, logging.FileHandler):
+            handler.setLevel(level)
+
+    if not include_root:
+        return
+
+    root_logger = logging.getLogger()
+    for handler in root_logger.handlers:
+        if (
+            isinstance(handler, logging.StreamHandler)
+            and not isinstance(handler, logging.FileHandler)
+            and getattr(handler, "_raptor_root_handler", False)
+        ):
+            handler.setLevel(level)
+    root_logger.setLevel(level)
+
+
+def _configure_run_logging(log_level: Optional[str], verbose: bool) -> None:
+    """Apply run-level console logging flags."""
+    if log_level:
+        _set_console_log_level(getattr(logging, log_level.upper()), include_root=True)
+    elif verbose:
+        _set_console_log_level(logging.DEBUG)
 
 
 def _tuning_default(key: str) -> int:
@@ -1294,6 +1325,15 @@ Examples:
                             "Surfaces per-LLM-call detail (cache hits, retries, "
                             "per-call cost/duration). Useful for debugging "
                             "multi-model dispatches or schema validation failures.")
+    parser.add_argument(
+        "--log-level",
+        choices=_CONSOLE_LOG_LEVELS,
+        type=str.upper,
+        help=(
+            "Set console log level for this run. Use WARNING to hide INFO "
+            "sandbox/proxy chatter; overrides --verbose."
+        ),
+    )
 
     # Fuzzing integration (Phase 5: dynamic confirmation)
     parser.add_argument("--fuzz", action="store_true",
@@ -1437,15 +1477,12 @@ Examples:
     if args.phase_timeout != RaptorConfig.DEFAULT_TIMEOUT:
         RaptorConfig.DEFAULT_TIMEOUT = args.phase_timeout if args.phase_timeout > 0 else None
 
-    # --verbose: drop the existing console StreamHandler from INFO to
-    # DEBUG so per-LLM-call detail (cache hits, retries, per-call
-    # cost/duration) becomes visible. Doesn't change the file handler
-    # (already DEBUG) — only what the operator sees on stderr.
-    if getattr(args, "verbose", False):
-        import logging
-        for h in logger.logger.handlers:
-            if isinstance(h, logging.StreamHandler) and not isinstance(h, logging.FileHandler):
-                h.setLevel(logging.DEBUG)
+    # Run-level console verbosity. File audit logging remains DEBUG;
+    # this only controls what the operator sees on stderr.
+    _configure_run_logging(
+        getattr(args, "log_level", None),
+        getattr(args, "verbose", False),
+    )
 
     # Propagate --trust-repo to every target-repo trust check so each
     # in-process consumer (cc_trust, codeql_trust, build_detector, ...)

--- a/raptor_agentic.py
+++ b/raptor_agentic.py
@@ -15,7 +15,6 @@ Complete end-to-end autonomous security testing:
 """
 
 import argparse
-import logging
 import os
 import subprocess
 import sys
@@ -30,48 +29,13 @@ sys.path.insert(0, str(Path(__file__).parent))
 
 from core.json import load_json, save_json
 from core.config import RaptorConfig
-from core.logging import get_logger
+from core.logging import CONSOLE_LOG_LEVELS, configure_run_logging, get_logger
 from core.sandbox import SANDBOX_ENGAGE_EXIT_CODE, SandboxSetupError
 from core.run.safe_io import safe_run_mkdir
 from core.schema_constants import VULN_TYPE_TO_CWE as _CWE_FROM_VULN_TYPE
 from core.security.cc_trust import check_repo_claude_trust, set_trust_override
 
 logger = get_logger()
-
-_CONSOLE_LOG_LEVELS = ("DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL")
-
-
-def _raptor_logger() -> logging.Logger:
-    return logging.getLogger("raptor")
-
-
-def _set_console_log_level(level: int, *, include_root: bool = False) -> None:
-    """Set operator-facing console verbosity without touching file audit logs."""
-    for handler in _raptor_logger().handlers:
-        if isinstance(handler, logging.StreamHandler) and not isinstance(handler, logging.FileHandler):
-            handler.setLevel(level)
-
-    if not include_root:
-        return
-
-    root_logger = logging.getLogger()
-    for handler in root_logger.handlers:
-        if (
-            isinstance(handler, logging.StreamHandler)
-            and not isinstance(handler, logging.FileHandler)
-            and getattr(handler, "_raptor_root_handler", False)
-        ):
-            handler.setLevel(level)
-    root_logger.setLevel(level)
-
-
-def _configure_run_logging(log_level: Optional[str], verbose: bool) -> None:
-    """Apply run-level console logging flags."""
-    if log_level:
-        _set_console_log_level(getattr(logging, log_level.upper()), include_root=True)
-    elif verbose:
-        _set_console_log_level(logging.DEBUG)
-
 
 def _tuning_default(key: str) -> int:
     from core.tuning import get_tuning
@@ -1331,7 +1295,7 @@ Examples:
                             "multi-model dispatches or schema validation failures.")
     parser.add_argument(
         "--log-level",
-        choices=_CONSOLE_LOG_LEVELS,
+        choices=CONSOLE_LOG_LEVELS,
         type=str.upper,
         help=(
             "Set console log level for this run. Use WARNING to hide INFO "
@@ -1483,7 +1447,7 @@ Examples:
 
     # Run-level console verbosity. File audit logging remains DEBUG;
     # this only controls what the operator sees on stderr.
-    _configure_run_logging(
+    configure_run_logging(
         getattr(args, "log_level", None),
         getattr(args, "verbose", False),
     )

--- a/raptor_agentic.py
+++ b/raptor_agentic.py
@@ -41,9 +41,13 @@ logger = get_logger()
 _CONSOLE_LOG_LEVELS = ("DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL")
 
 
+def _raptor_logger() -> logging.Logger:
+    return logging.getLogger("raptor")
+
+
 def _set_console_log_level(level: int, *, include_root: bool = False) -> None:
     """Set operator-facing console verbosity without touching file audit logs."""
-    for handler in logger.logger.handlers:
+    for handler in _raptor_logger().handlers:
         if isinstance(handler, logging.StreamHandler) and not isinstance(handler, logging.FileHandler):
             handler.setLevel(level)
 


### PR DESCRIPTION
## Summary

This splits out the agentic logging improvement from the larger Codex experiment.

It adds `--log-level` to `raptor_agentic.py` so operators can quiet console chatter, especially sandbox/proxy INFO output, without changing the DEBUG JSON audit log. `--verbose` remains supported as the existing DEBUG shortcut.

## Changes

- Add `--log-level {DEBUG,INFO,WARNING,ERROR,CRITICAL}` for agentic runs
- Refactor run-level console logging into `_configure_run_logging`
- Preserve DEBUG file audit logging
- Extend the existing verbose flag test to cover `--log-level WARNING`
- Avoid direct wrapper `.logger` access in the new helper/test code

## Validation

- `.venv/bin/python -m pytest packages/llm_analysis/tests/test_verbose_flag.py`
- `.venv/bin/python -m py_compile raptor_agentic.py packages/llm_analysis/tests/test_verbose_flag.py`
- `.venv/bin/python -m ruff check --select F401,F811,F821,F841 raptor_agentic.py packages/llm_analysis/tests/test_verbose_flag.py`

### Follow-up from manual run testing

Manual testing showed that applying `--log-level WARNING` only inside `raptor_agentic.py` left a surprising gap: parent-side lifecycle/dispatcher INFO logs could still appear before the agentic child parsed the flag. Operators experience `python raptor.py agentic ... --log-level WARNING` as one command, so seeing `[INFO] llm-dispatcher ...` lines at startup was unexpected.

This follow-up refactors the console log-level handling into `core.logging` and applies the requested agentic log level early in `raptor.py` before lifecycle/dispatcher startup, while leaving the flag in argv for `raptor_agentic.py` to validate and apply in the child process too. The change keeps file audit logging untouched and only affects operator-facing console verbosity.

Scope note: this is intentionally limited to agentic runs. It covers `python raptor.py agentic ... --log-level WARNING` and direct `python raptor_agentic.py ... --log-level WARNING` invocation. It does not add a global `--log-level` contract for pure scan/codeql/fuzz/web modes.