### PR TITLE
Fix/annotations and mock targets

### DIFF
--- a/core/run/metadata.py
+++ b/core/run/metadata.py
@@ -183,8 +183,10 @@ def _pid_alive(pid: int) -> bool:
     return "claude" in comm
 
 
-def start_run(output_dir: Path, command: str, extra: Dict[str, Any] = None,
-              target: str = None, target_identity: Dict[str, Any] = None) -> Path:
+def start_run(output_dir: Path, command: str,
+              extra: Optional[Dict[str, Any]] = None,
+              target: Optional[str] = None,
+              target_identity: Optional[Dict[str, Any]] = None) -> Path:
     """Write initial .raptor-run.json with status=running.
 
     Call this at the start of a command. Returns the output_dir (for chaining).

--- a/core/run/metadata.py
+++ b/core/run/metadata.py
@@ -537,8 +537,8 @@ def _finalize_sandbox_summary(output_dir: Path) -> None:
 #    file. Misleading.
 # Finalizing first preserves the data; status update is just the signal.
 
-def complete_run(output_dir: Path, extra: Dict[str, Any] = None,
-                 manifest: Dict[str, Any] = None) -> None:
+def complete_run(output_dir: Path, extra: Optional[Dict[str, Any]] = None,
+                 manifest: Optional[Dict[str, Any]] = None) -> None:
     """Update .raptor-run.json to status=completed.
 
     ``manifest`` merges end-of-run provenance into the manifest sealed at
@@ -652,7 +652,8 @@ def _snapshot_run_coverage(output_dir: Path) -> None:
         log.debug("_snapshot_run_coverage failed for %s", output_dir, exc_info=True)
 
 
-def fail_run(output_dir: Path, error: str = None, extra: Dict[str, Any] = None,
+def fail_run(output_dir: Path, error: Optional[str] = None,
+             extra: Optional[Dict[str, Any]] = None,
              record_timing: bool = True) -> None:
     """Update .raptor-run.json to status=failed."""
     extra = extra or {}
@@ -662,15 +663,16 @@ def fail_run(output_dir: Path, error: str = None, extra: Dict[str, Any] = None,
     _update_status(output_dir, STATUS_FAILED, extra, record_timing=record_timing)
 
 
-def cancel_run(output_dir: Path, extra: Dict[str, Any] = None) -> None:
+def cancel_run(output_dir: Path, extra: Optional[Dict[str, Any]] = None) -> None:
     """Update .raptor-run.json to status=cancelled."""
     _finalize_sandbox_summary(output_dir)
     _update_status(output_dir, STATUS_CANCELLED, extra)
 
 
 @contextlib.contextmanager
-def tracked_run(output_dir: Path, command: str, extra: Dict[str, Any] = None,
-                target: str = None):
+def tracked_run(output_dir: Path, command: str,
+                extra: Optional[Dict[str, Any]] = None,
+                target: Optional[str] = None):
     """Context manager for run lifecycle. Writes metadata automatically.
 
     Usage:
@@ -804,9 +806,10 @@ def generate_run_metadata(run_dir: Path) -> None:
 _TERMINAL_STATUSES = frozenset({STATUS_COMPLETED, STATUS_FAILED, STATUS_CANCELLED})
 
 
-def _update_status(output_dir: Path, status: str, extra: Dict[str, Any] = None,
+def _update_status(output_dir: Path, status: str,
+                   extra: Optional[Dict[str, Any]] = None,
                    record_timing: bool = True,
-                   manifest: Dict[str, Any] = None) -> None:
+                   manifest: Optional[Dict[str, Any]] = None) -> None:
     """Update the status field in .raptor-run.json.
 
     When record_timing is True (default), also records end_timestamp and

--- a/core/run/output.py
+++ b/core/run/output.py
@@ -104,8 +104,9 @@ def resolve_default_target() -> Optional[str]:
     return env or None
 
 
-def get_output_dir(command: str, target_name: str = "", explicit_out: str = None,
-                   target_path: str = None) -> Path:
+def get_output_dir(command: str, target_name: str = "",
+                   explicit_out: Optional[str] = None,
+                   target_path: Optional[str] = None) -> Path:
     """Resolve the output directory for a command run.
 
     Priority:

--- a/packages/llm_analysis/tests/test_orchestrator.py
+++ b/packages/llm_analysis/tests/test_orchestrator.py
@@ -115,7 +115,7 @@ def _make_cc_result(finding_id, exploitable=True, score=0.85):
 
 
 def _mock_subprocess_ok(results_by_call):
-    """Create a subprocess.run mock that returns the right result
+    """Create a run_untrusted_networked mock that returns the right result
     for each finding.
 
     ``results_by_call`` may be either:
@@ -198,7 +198,7 @@ class TestOrchestrate:
 
         with patch.dict(os.environ, {"CLAUDECODE": "1"}), \
              patch("packages.llm_analysis.orchestrator.shutil.which", return_value="/usr/bin/claude"), \
-             patch("packages.llm_analysis.cc_dispatch.subprocess.run",
+             patch("core.sandbox.run_untrusted_networked",
                    side_effect=_mock_subprocess_ok([cc_result])):
             result = orchestrate(
                 prep_report_path=report_path,
@@ -270,7 +270,7 @@ class TestOrchestrate:
 
         with patch.dict(os.environ, {}, clear=True), \
              patch("packages.llm_analysis.orchestrator.shutil.which", return_value="/usr/bin/claude"), \
-             patch("packages.llm_analysis.cc_dispatch.subprocess.run",
+             patch("core.sandbox.run_untrusted_networked",
                    side_effect=_mock_subprocess_ok(cc_results)):
             result = orchestrate(
                 prep_report_path=report_path,
@@ -313,7 +313,7 @@ class TestOrchestrate:
 
         with patch.dict(os.environ, {}, clear=True), \
              patch("packages.llm_analysis.orchestrator.shutil.which", return_value="/usr/bin/claude"), \
-             patch("packages.llm_analysis.cc_dispatch.subprocess.run",
+             patch("core.sandbox.run_untrusted_networked",
                    side_effect=_mock_subprocess_ok(cc_results)):
             result = orchestrate(
                 prep_report_path=report_path,
@@ -376,7 +376,7 @@ class TestOrchestrate:
 
         with patch.dict(os.environ, {}, clear=True), \
              patch("packages.llm_analysis.orchestrator.shutil.which", return_value="/usr/bin/claude"), \
-             patch("packages.llm_analysis.cc_dispatch.subprocess.run", side_effect=mock_run):
+             patch("core.sandbox.run_untrusted_networked", side_effect=mock_run):
             result = orchestrate(
                 prep_report_path=report_path,
                 repo_path=tmp_path,
@@ -999,7 +999,7 @@ class TestWeakenedDefenses:
         with patch.dict(os.environ, {}, clear=True), \
              patch("packages.llm_analysis.orchestrator.shutil.which",
                    return_value="/usr/bin/claude"), \
-             patch("packages.llm_analysis.cc_dispatch.subprocess.run",
+             patch("core.sandbox.run_untrusted_networked",
                    side_effect=_mock_subprocess_ok([cc_result])):
             result = orchestrate(
                 prep_report_path=report_path,


### PR DESCRIPTION
## Summary

As per discussion in PR #851 - This splits out two small cleanup fixes from the broader experimental branch:

- fixes several `test_orchestrator.py` mocks to patch the actual sandbox dispatch call site now used by `cc_dispatch.py`
- tightens optional metadata/output annotations from `str = None` to `Optional[str] = None`

## Rationale

The mock target updates make the tests exercise the code path they intend to intercept. On current main, `cc_dispatch.py` uses `core.sandbox.run_untrusted_networked`, so patching `packages.llm_analysis.cc_dispatch.subprocess.run` no longer observes those calls.

The annotation updates are type-only cleanup and should not change runtime behavior.

## Validation

```bash
.venv/bin/python -m py_compile \
  core/run/metadata.py \
  core/run/output.py \
  packages/llm_analysis/tests/test_orchestrator.py

.venv/bin/python -m ruff check --select F401,F811,F821,F841 \
  core/run/metadata.py \
  core/run/output.py \
  packages/llm_analysis/tests/test_orchestrator.py

.venv/bin/python -m pytest packages/llm_analysis/tests/test_orchestrator.py
```

`test_orchestrator.py`: 58 passed.