### PR TITLE
fix(exploit_feasibility): review follow-ups for mechanism-coverage PR

### DIFF
--- a/packages/exploit_feasibility/api.py
+++ b/packages/exploit_feasibility/api.py
@@ -90,7 +90,7 @@ def _get_profile_for_vuln_type(vuln_type: str = None, binary_path: str = None):
 # =============================================================================
 
 def _mechanism_active_mitigation_ids(result: Dict[str, Any],
-                                     explicit: Optional[List[str]] = None) -> List[str]:
+                                     explicit: Optional[List] = None) -> List[str]:
     """Translate detected/declared mitigations into MITIGATION_COVERAGE vocabulary
     for the mechanism-coverage engine.
 
@@ -105,7 +105,7 @@ def _mechanism_active_mitigation_ids(result: Dict[str, Any],
 
 
 def _mechanism_mitigation_facts(result: Dict[str, Any],
-                                explicit: Optional[List[str]] = None):
+                                explicit: Optional[List] = None):
     """Provenance-tagged mitigation facts for the mechanism engine: caller-supplied
     mitigations (strings = operator_declared, or provenance dicts) plus
     binary-observed ELF protections. Never derived from the kernel_mitigations
@@ -133,7 +133,7 @@ def _mechanism_mitigation_facts(result: Dict[str, Any],
 def analyze_binary(binary_path: str, output_dir: str = None,
                    vuln_type: str = None, extended: bool = True,
                    target_capabilities: Optional[List[str]] = None,
-                   active_mitigations: Optional[List[str]] = None) -> Dict[str, Any]:
+                   active_mitigations: Optional[List] = None) -> Dict[str, Any]:
     """
     Run mitigation analysis on a binary.
 

--- a/packages/exploit_feasibility/mechanism_registry.py
+++ b/packages/exploit_feasibility/mechanism_registry.py
@@ -13,10 +13,10 @@ import logging
 import warnings
 from typing import Dict, List
 
-logger = logging.getLogger(__name__)
-
 from .mechanism_coverage import Mechanism, MITIGATION_COVERAGE
 from .primitives import get_primitive_definitions
+
+logger = logging.getLogger(__name__)
 
 
 class UnknownToken(ValueError):

--- a/packages/exploit_feasibility/mechanism_techniques.py
+++ b/packages/exploit_feasibility/mechanism_techniques.py
@@ -52,6 +52,7 @@ def available_mechanism_techniques(
     """
     from .mitigation_provenance import (
         normalize_mitigations, posture_active_ids, demotion_active_ids,
+        best_source_by_id,
     )
     caps = {c for c in (target_capabilities or ()) if isinstance(c, str)}
     if not caps:
@@ -60,7 +61,7 @@ def available_mechanism_techniques(
     facts = normalize_mitigations(active_mitigations)
     posture_ids = posture_active_ids(facts)
     trusted_ids = demotion_active_ids(facts)
-    src_by_id = {f.id: f.source for f in facts}
+    src_by_id = best_source_by_id(facts)
 
     def _annotate(ids):
         return [{"id": i,

--- a/packages/exploit_feasibility/mitigation_provenance.py
+++ b/packages/exploit_feasibility/mitigation_provenance.py
@@ -130,3 +130,24 @@ def advisory_only_ids(raw) -> Set[str]:
     advisory ('mitigation may be present; runtime activation unknown')."""
     return {f.id for f in normalize_mitigations(raw)
             if f.plausibly_active() and not f.drives_demotion()}
+
+
+_SOURCE_RANK = {s: i for i, s in enumerate(
+    ["operator_declared", "build_config", "binary_observed", "source_heuristic"]
+)}
+
+
+def best_source_by_id(
+    facts: Iterable[MitigationFact],
+) -> dict[str, str]:
+    """Map each mitigation id to its highest-trust source.
+
+    When duplicate ids appear (e.g. both an operator-declared and a
+    source-heuristic fact for ``kcfi``), the trusted source wins.
+    """
+    out: dict[str, str] = {}
+    for f in facts:
+        prev = out.get(f.id)
+        if prev is None or _SOURCE_RANK.get(f.source, 99) < _SOURCE_RANK.get(prev, 99):
+            out[f.id] = f.source
+    return out

--- a/packages/exploit_feasibility/tests/test_mitigation_provenance.py
+++ b/packages/exploit_feasibility/tests/test_mitigation_provenance.py
@@ -80,3 +80,42 @@ class TestMalformedNeverUpgradesTrust:
         # a bare operator fact without source is still operator-declared/trusted
         raw = [{"id": "kcfi", "state": "active"}]
         assert demotion_active_ids(raw) == {"kcfi"}
+
+
+class TestBestSourceById:
+    """When duplicate ids appear with different provenance, the highest-trust
+    source must win — not last-writer."""
+
+    def test_trusted_wins_over_heuristic(self):
+        from ..mitigation_provenance import best_source_by_id, MitigationFact
+        facts = [
+            MitigationFact(id="kcfi", source="source_heuristic"),
+            MitigationFact(id="kcfi", source="operator_declared"),
+        ]
+        assert best_source_by_id(facts)["kcfi"] == "operator_declared"
+
+    def test_trusted_wins_regardless_of_order(self):
+        from ..mitigation_provenance import best_source_by_id, MitigationFact
+        facts = [
+            MitigationFact(id="kcfi", source="operator_declared"),
+            MitigationFact(id="kcfi", source="source_heuristic"),
+        ]
+        assert best_source_by_id(facts)["kcfi"] == "operator_declared"
+
+    def test_build_config_beats_heuristic(self):
+        from ..mitigation_provenance import best_source_by_id, MitigationFact
+        facts = [
+            MitigationFact(id="smep", source="source_heuristic"),
+            MitigationFact(id="smep", source="build_config"),
+        ]
+        assert best_source_by_id(facts)["smep"] == "build_config"
+
+    def test_distinct_ids_preserved(self):
+        from ..mitigation_provenance import best_source_by_id, MitigationFact
+        facts = [
+            MitigationFact(id="kcfi", source="operator_declared"),
+            MitigationFact(id="smep", source="binary_observed"),
+        ]
+        m = best_source_by_id(facts)
+        assert m["kcfi"] == "operator_declared"
+        assert m["smep"] == "binary_observed"

--- a/packages/exploitability_validation/orchestrator.py
+++ b/packages/exploitability_validation/orchestrator.py
@@ -1106,7 +1106,7 @@ class ValidationOrchestrator:
                 # finding declares a bypass mechanism that an active target
                 # mitigation blocks. Explicit-only — flows when the run carries
                 # target mitigations; None (default) is a safe no-op.
-                active_mitigations=getattr(self.config, "active_mitigations", None),
+                active_mitigations=self.config.active_mitigations,
             )
             # Stage F path verification: every attack path whose
             # sink is alive (not demoted) gets a substrate_evidence

--- a/packages/exploitability_validation/reachability.py
+++ b/packages/exploitability_validation/reachability.py
@@ -124,7 +124,7 @@ def demote_unreachable_paths(
     *,
     inventory: Optional[Dict[str, Any]] = None,
     allow_unreachable: bool = False,
-    active_mitigations: Optional[List[str]] = None,
+    active_mitigations: Optional[List] = None,
 ) -> int:
     """Walk ``attack_paths``, demote any whose entry function is
     NOT_CALLED. Mutates the list in place. Returns the count of
@@ -174,10 +174,12 @@ def demote_unreachable_paths(
     # hard demotion; a source-heuristic hit, an "unknown" state, or an "inactive"
     # fact is excluded — "not observed" is never treated as "absent" or "active".
     # Accepts flat strings (back-compat = operator_declared/active). [2nd-opinion]
-    from packages.exploit_feasibility.mitigation_provenance import demotion_facts
+    from packages.exploit_feasibility.mitigation_provenance import (
+        demotion_facts, best_source_by_id,
+    )
     _facts = demotion_facts(active_mitigations)
     active_mits = {f.id for f in _facts}
-    _source_by_id = {f.id: f.source for f in _facts}
+    _source_by_id = best_source_by_id(_facts)
 
     # Pass 1 — mechanism-coverage demotion (explicit-only, soft). An active
     # mitigation that BLOCKS a finding's declared bypass mechanism makes its
@@ -237,6 +239,8 @@ def demote_unreachable_paths(
     # Pass 2 — static reachability demotion (dead-code findings).
     for path in attack_paths:
         if not isinstance(path, dict):
+            continue
+        if id(path) in _demoted:
             continue
         finding_id = path.get("finding_id") or path.get("finding")
         if not isinstance(finding_id, str):


### PR DESCRIPTION
E402: move logger assignment after imports in mechanism_registry.

Defensive getattr: replace getattr(self.config, "active_mitigations", None) with direct attribute access — the field is defined on PipelineConfig with a None default.

Double-demotion: skip Pass 2 for paths already demoted by Pass 1 (mechanism-coverage). Proximity was idempotent via min(), but the blocker list accumulated redundant entries.

Mixed-provenance duplicates: add best_source_by_id() helper so that when both a trusted and heuristic fact exist for the same mitigation id, the highest-trust source wins (not last-writer). Used in both mechanism_techniques surfacing and reachability demotion.

Type annotations: widen active_mitigations from List[str] to List (accepts str | dict | MitigationFact) on analyze_binary, demote_unreachable_paths, and the two internal helpers.