### PR TITLE
fix(sandbox): migrate network callers to run_untrusted_networked

### DIFF
--- a/core/git/clone.py
+++ b/core/git/clone.py
@@ -10,7 +10,8 @@ Two entry points:
     not reachable from a depth-1 clone of HEAD, so progressive-fetch
     cascades use this.
 
-Both wrap their ``git`` subprocess in ``core.sandbox.run_untrusted``:
+Both wrap their ``git`` subprocess in ``core.sandbox.run_untrusted_networked``
+(network calls) and ``core.sandbox.run_untrusted`` (local-only calls):
 
   - the egress proxy pinned to the small set of hostnames the URL
     allowlist permits (github.com / gitlab.com plus the known
@@ -295,7 +296,7 @@ def clone_repository(
     # braces — symmetric posture with the rest of the codebase.
     logger.info("git clone: %s -> %s", redact_url_secrets_only(url), target)
     try:
-        from core.sandbox import run_untrusted
+        from core.sandbox import run_untrusted_networked
     except ImportError:
         raise RuntimeError(
             "core.sandbox unavailable - git clone refuses to run "
@@ -303,13 +304,13 @@ def clone_repository(
         )
 
     target.parent.mkdir(parents=True, exist_ok=True)
-    proc = run_untrusted(
+    proc = run_untrusted_networked(
         cmd,
         target=str(target.parent),
         output=str(target.parent),
         env=get_safe_git_env(),
-        use_egress_proxy=True,
         proxy_hosts=_proxy_hosts_for_git(),
+        fake_home=True,
         timeout=RaptorConfig.GIT_CLONE_TIMEOUT,
         capture_output=True,
         text=True,
@@ -371,7 +372,7 @@ def fetch_commit(
         )
 
     try:
-        from core.sandbox import run_untrusted
+        from core.sandbox import run_untrusted, run_untrusted_networked
     except ImportError:
         raise RuntimeError(
             "core.sandbox unavailable - git fetch refuses to run "
@@ -384,22 +385,13 @@ def fetch_commit(
     timeout = RaptorConfig.GIT_CLONE_TIMEOUT
 
     # ``output`` is the sandbox's writable allowlist. Use ``repo_dir.parent``
-    # to match ``clone_repository``: with ``fake_home=True`` (the
-    # ``run_untrusted`` default), the sandbox materialises ``{output}/.home/``
-    # for the child's HOME. Passing ``repo_dir`` directly would put that
-    # ``.home/`` *inside* the repo, polluting the caller's working tree.
-    # The parent directory is one level wider but matches clone semantics
-    # exactly — ``.home/`` ends up sibling to ``repo_dir``.
+    # to match ``clone_repository``: ``fake_home=True`` materialises
+    # ``{output}/.home/`` for the child's HOME. Passing ``repo_dir``
+    # directly would put ``.home/`` *inside* the repo, polluting the
+    # caller's working tree.
     sandbox_target = str(repo_dir.parent)
 
     def _run(cmd: list, *, network: bool):
-        # ``git init`` and ``git remote`` are local-only; the sandbox
-        # still runs them through ``run_untrusted`` for env hygiene.
-        # The egress proxy is only engaged for the fetch step — local
-        # ops have no need for it. NB: ``use_egress_proxy=True`` MUST be
-        # paired with ``proxy_hosts`` for the proxy to start; passing
-        # ``proxy_hosts`` alone is a no-op (the sandbox keeps
-        # ``block_network=True`` and the child has no network at all).
         kwargs = dict(
             target=sandbox_target,
             output=sandbox_target,
@@ -409,8 +401,8 @@ def fetch_commit(
             text=True,
         )
         if network:
-            kwargs["use_egress_proxy"] = True
-            kwargs["proxy_hosts"] = proxy_hosts
+            return run_untrusted_networked(
+                cmd, proxy_hosts=proxy_hosts, fake_home=True, **kwargs)
         return run_untrusted(cmd, **kwargs)
 
     is_repo = (repo_dir / ".git").exists()
@@ -478,7 +470,7 @@ def ls_remote(
     """Run ``git ls-remote --heads --tags`` against ``url``.
 
     Read-only operation that returns the refs the remote advertises.
-    Sandbox-routed via ``run_untrusted`` with the egress proxy pinned
+    Sandbox-routed via ``run_untrusted_networked`` with the egress proxy pinned
     to ``proxy_hosts``. Caller supplies the allowlist because consumers
     of this helper cover wider forge sets than the github/gitlab pair
     ``clone_repository`` accepts (cve_diff's agent uses it to probe
@@ -589,7 +581,7 @@ def ls_remote(
         )
 
     try:
-        from core.sandbox import run_untrusted
+        from core.sandbox import run_untrusted_networked
     except ImportError:
         raise RuntimeError(
             "core.sandbox unavailable - git ls-remote refuses to run "
@@ -597,8 +589,8 @@ def ls_remote(
         )
 
     # ``ls-remote`` doesn't write to the host filesystem, but
-    # ``run_untrusted`` requires a non-empty ``output`` so Landlock
-    # engages and ``fake_home`` has somewhere to materialise.
+    # ``run_untrusted_networked`` requires a non-empty ``output`` so
+    # Landlock engages and ``fake_home`` has somewhere to materialise.
     # An ephemeral temp dir gives the sandbox a writable scratch
     # area that's discarded as soon as we leave the with-block.
     with tempfile.TemporaryDirectory(prefix="raptor-ls-remote-") as td:
@@ -620,13 +612,13 @@ def ls_remote(
         logger.info("git ls-remote: %s (allowlist=%s)",
                      redact_secrets(url),
                      ",".join(sorted(allowed_lower)))
-        proc = run_untrusted(
+        proc = run_untrusted_networked(
             ["git", "ls-remote", "--heads", "--tags", url],
             target=td,
             output=td,
             env=get_safe_git_env(),
-            use_egress_proxy=True,
             proxy_hosts=proxy_host_list,
+            fake_home=True,
             timeout=timeout,
             capture_output=True,
             text=True,

--- a/core/git/tests/test_clone.py
+++ b/core/git/tests/test_clone.py
@@ -23,7 +23,7 @@ def _completed(rc: int, stderr: str = "",
 
 def test_invalid_url_raises_before_subprocess(tmp_path: Path) -> None:
     """URL that fails allowlist must NOT reach the sandboxed runner."""
-    with patch("core.sandbox.run_untrusted") as mock_run:
+    with patch("core.sandbox.run_untrusted_networked") as mock_run:
         with pytest.raises(ValueError):
             clone_repository("https://evil.example.com/repo",
                               tmp_path / "out")
@@ -31,9 +31,9 @@ def test_invalid_url_raises_before_subprocess(tmp_path: Path) -> None:
 
 
 def test_successful_clone_calls_sandbox(tmp_path: Path) -> None:
-    """Allowlisted URL flows through ``run_untrusted`` with the right
-    flags - depth, no-tags, target/output set, proxy hosts pinned."""
-    with patch("core.sandbox.run_untrusted") as mock_run:
+    """Allowlisted URL flows through ``run_untrusted_networked`` with the
+    right flags - depth, no-tags, target/output set, proxy hosts pinned."""
+    with patch("core.sandbox.run_untrusted_networked") as mock_run:
         mock_run.return_value = _completed(0)
         ok = clone_repository(
             "https://github.com/foo/bar", tmp_path / "out",
@@ -48,7 +48,7 @@ def test_successful_clone_calls_sandbox(tmp_path: Path) -> None:
 
 
 def test_clone_failure_raises_runtime_error(tmp_path: Path) -> None:
-    with patch("core.sandbox.run_untrusted") as mock_run:
+    with patch("core.sandbox.run_untrusted_networked") as mock_run:
         mock_run.return_value = _completed(128, stderr="fatal: not found")
         with pytest.raises(RuntimeError, match="not found"):
             clone_repository("https://github.com/foo/bar",
@@ -56,15 +56,12 @@ def test_clone_failure_raises_runtime_error(tmp_path: Path) -> None:
 
 
 def test_clone_engages_egress_proxy(tmp_path: Path) -> None:
-    """``proxy_hosts=[...]`` only engages the egress proxy when paired
-    with ``use_egress_proxy=True``. Without the flag, the sandbox keeps
-    ``block_network=True`` and the child has no network at all — clones
-    silently fail. Pin both kwargs so future refactors can't drop one."""
-    with patch("core.sandbox.run_untrusted") as mock_run:
+    """``run_untrusted_networked`` implicitly engages the egress proxy.
+    Pin ``proxy_hosts`` so future refactors can't drop it."""
+    with patch("core.sandbox.run_untrusted_networked") as mock_run:
         mock_run.return_value = _completed(0)
         clone_repository("https://github.com/foo/bar", tmp_path / "out")
         kwargs = mock_run.call_args.kwargs
-        assert kwargs.get("use_egress_proxy") is True
         assert "github.com" == kwargs.get("proxy_hosts", [])[0]
 
 
@@ -87,7 +84,7 @@ def test_clone_engages_egress_proxy(tmp_path: Path) -> None:
 def test_clone_rejects_unsafe_target_path_before_subprocess(
     bad_path: Path,
 ) -> None:
-    with patch("core.sandbox.run_untrusted") as mock_run:
+    with patch("core.sandbox.run_untrusted_networked") as mock_run:
         with pytest.raises(ValueError):
             clone_repository("https://github.com/foo/bar", bad_path)
         mock_run.assert_not_called()
@@ -112,7 +109,7 @@ def test_fetch_rejects_unsafe_repo_dir_before_subprocess(
 
 
 def test_full_clone_drops_depth_flag(tmp_path: Path) -> None:
-    with patch("core.sandbox.run_untrusted") as mock_run:
+    with patch("core.sandbox.run_untrusted_networked") as mock_run:
         mock_run.return_value = _completed(0)
         clone_repository("https://github.com/foo/bar",
                           tmp_path / "out", depth=None)
@@ -139,32 +136,33 @@ def test_fetch_into_fresh_dir_runs_init_then_remote_then_fetch(
     tmp_path: Path,
 ) -> None:
     """Fresh repo_dir → init, remote add, fetch in that order with the
-    expected flags. Network call (fetch) carries proxy_hosts; local
-    calls (init / remote) do not."""
+    expected flags. Network call (fetch) goes through
+    ``run_untrusted_networked``; local calls (init / remote) go through
+    ``run_untrusted``."""
     repo = tmp_path / "repo"
-    with patch("core.sandbox.run_untrusted") as mock_run:
-        mock_run.return_value = _completed(0)
+    with patch("core.sandbox.run_untrusted") as mock_local, \
+         patch("core.sandbox.run_untrusted_networked") as mock_net:
+        mock_local.return_value = _completed(0)
+        mock_net.return_value = _completed(0)
         ok = fetch_commit(repo, "https://github.com/foo/bar",
                            _VALID_SHA, depth=5)
         assert ok is True
 
-    cmds = [c.args[0] for c in mock_run.call_args_list]
-    assert cmds[0][:4] == ["git", "-C", str(repo), "init"]
-    assert cmds[1][:4] == ["git", "-C", str(repo), "remote"]
-    assert cmds[1][4:] == ["add", "origin", "https://github.com/foo/bar"]
-    assert cmds[2][:5] == ["git", "-C", str(repo), "fetch", "--depth"]
-    assert cmds[2][5] == "5"
-    assert cmds[2][-2:] == ["origin", _VALID_SHA]
+    local_cmds = [c.args[0] for c in mock_local.call_args_list]
+    net_cmds = [c.args[0] for c in mock_net.call_args_list]
+    assert local_cmds[0][:4] == ["git", "-C", str(repo), "init"]
+    assert local_cmds[1][:4] == ["git", "-C", str(repo), "remote"]
+    assert local_cmds[1][4:] == ["add", "origin", "https://github.com/foo/bar"]
+    assert net_cmds[0][:5] == ["git", "-C", str(repo), "fetch", "--depth"]
+    assert net_cmds[0][5] == "5"
+    assert net_cmds[0][-2:] == ["origin", _VALID_SHA]
 
-    # Network step engages the egress proxy via use_egress_proxy=True
-    # paired with proxy_hosts; local steps don't engage either kwarg.
-    # ``proxy_hosts`` without ``use_egress_proxy=True`` is a no-op (the
-    # sandbox keeps block_network=True), so both must travel together.
-    init_kwargs = mock_run.call_args_list[0].kwargs
-    fetch_kwargs = mock_run.call_args_list[2].kwargs
+    # Local calls don't carry proxy_hosts.
+    init_kwargs = mock_local.call_args_list[0].kwargs
     assert "proxy_hosts" not in init_kwargs
-    assert "use_egress_proxy" not in init_kwargs
-    assert fetch_kwargs.get("use_egress_proxy") is True
+
+    # Network call carries proxy_hosts via run_untrusted_networked.
+    fetch_kwargs = mock_net.call_args.kwargs
     fetch_proxy_hosts = set(fetch_kwargs.get("proxy_hosts", []))
     assert {"github.com", "codeload.github.com"} <= fetch_proxy_hosts
 
@@ -172,12 +170,14 @@ def test_fetch_into_fresh_dir_runs_init_then_remote_then_fetch(
 def test_fetch_into_existing_repo_skips_init(tmp_path: Path) -> None:
     repo = tmp_path / "repo"
     (repo / ".git").mkdir(parents=True)
-    with patch("core.sandbox.run_untrusted") as mock_run:
-        mock_run.return_value = _completed(0)
+    with patch("core.sandbox.run_untrusted") as mock_local, \
+         patch("core.sandbox.run_untrusted_networked") as mock_net:
+        mock_local.return_value = _completed(0)
+        mock_net.return_value = _completed(0)
         fetch_commit(repo, "https://github.com/foo/bar", _VALID_SHA)
 
-    cmds = [c.args[0] for c in mock_run.call_args_list]
-    # First call should be ``remote add``, not ``init`` —
+    cmds = [c.args[0] for c in mock_local.call_args_list]
+    # First local call should be ``remote add``, not ``init`` —
     # the ``.git`` dir already exists.
     assert "init" not in cmds[0]
     assert cmds[0][3] == "remote"
@@ -197,23 +197,24 @@ def test_fetch_existing_origin_remote_falls_back_to_set_url(
             return _completed(128, stderr="error: remote origin already exists")
         return _completed(0)
 
-    with patch("core.sandbox.run_untrusted", side_effect=_side_effect) as mock_run:
+    with patch("core.sandbox.run_untrusted", side_effect=_side_effect) as mock_local, \
+         patch("core.sandbox.run_untrusted_networked") as mock_net:
+        mock_net.return_value = _completed(0)
         ok = fetch_commit(repo, "https://github.com/foo/bar", _VALID_SHA)
         assert ok is True
 
-    cmds = [c.args[0] for c in mock_run.call_args_list]
+    cmds = [c.args[0] for c in mock_local.call_args_list]
     add_seen = any(c[3:5] == ["remote", "add"] for c in cmds)
     set_url_seen = any(c[3:5] == ["remote", "set-url"] for c in cmds)
     assert add_seen and set_url_seen
 
 
 def test_fetch_failure_raises_runtime_error(tmp_path: Path) -> None:
-    def _side_effect(cmd, **kwargs):
-        if cmd[3] == "fetch":
-            return _completed(128, stderr="fatal: couldn't find remote ref")
-        return _completed(0)
-
-    with patch("core.sandbox.run_untrusted", side_effect=_side_effect):
+    with patch("core.sandbox.run_untrusted") as mock_local, \
+         patch("core.sandbox.run_untrusted_networked") as mock_net:
+        mock_local.return_value = _completed(0)
+        mock_net.return_value = _completed(
+            128, stderr="fatal: couldn't find remote ref")
         with pytest.raises(RuntimeError, match="couldn't find remote ref"):
             fetch_commit(tmp_path / "repo",
                          "https://github.com/foo/bar", _VALID_SHA)
@@ -225,7 +226,9 @@ def test_fetch_init_failure_raises_runtime_error(tmp_path: Path) -> None:
             return _completed(1, stderr="permission denied")
         return _completed(0)
 
-    with patch("core.sandbox.run_untrusted", side_effect=_side_effect):
+    with patch("core.sandbox.run_untrusted", side_effect=_side_effect), \
+         patch("core.sandbox.run_untrusted_networked") as mock_net:
+        mock_net.return_value = _completed(0)
         with pytest.raises(RuntimeError, match="git init failed"):
             fetch_commit(tmp_path / "repo",
                          "https://github.com/foo/bar", _VALID_SHA)
@@ -263,8 +266,10 @@ def test_fetch_rejects_bad_sha_before_subprocess(
 
 def test_fetch_accepts_short_sha(tmp_path: Path) -> None:
     """Git allows abbreviated SHAs of 4+ chars; we must too."""
-    with patch("core.sandbox.run_untrusted") as mock_run:
-        mock_run.return_value = _completed(0)
+    with patch("core.sandbox.run_untrusted") as mock_local, \
+         patch("core.sandbox.run_untrusted_networked") as mock_net:
+        mock_local.return_value = _completed(0)
+        mock_net.return_value = _completed(0)
         fetch_commit(tmp_path / "repo",
                      "https://github.com/foo/bar", "deadbe")
 
@@ -286,7 +291,9 @@ def test_fetch_remote_add_failure_surfaces_both_errors(
             return _completed(128, stderr="error: No such remote 'origin'")
         return _completed(0)
 
-    with patch("core.sandbox.run_untrusted", side_effect=_side_effect):
+    with patch("core.sandbox.run_untrusted", side_effect=_side_effect), \
+         patch("core.sandbox.run_untrusted_networked") as mock_net:
+        mock_net.return_value = _completed(0)
         with pytest.raises(RuntimeError) as exc:
             fetch_commit(repo, "https://github.com/foo/bar", _VALID_SHA)
         msg = str(exc.value)
@@ -300,19 +307,21 @@ def test_fetch_sandbox_writable_dir_is_parent_not_repo(
     """The sandbox ``output`` (writable allowlist + fake HOME root)
     must be ``repo_dir.parent``, not ``repo_dir`` itself.
 
-    Reason: ``run_untrusted`` defaults to ``fake_home=True`` which
-    materialises ``{output}/.home/`` for the child's HOME. If we
-    passed ``output=str(repo_dir)``, ``.home/`` would land *inside*
-    the fetched repo, polluting the caller's working tree. Matches
-    ``clone_repository``'s pattern (which has the same constraint
-    when target.parent is its writable scope)."""
+    Reason: ``fake_home=True`` materialises ``{output}/.home/`` for
+    the child's HOME. If we passed ``output=str(repo_dir)``,
+    ``.home/`` would land *inside* the fetched repo, polluting the
+    caller's working tree. Matches ``clone_repository``'s pattern
+    (which has the same constraint when target.parent is its writable
+    scope)."""
     repo = tmp_path / "work" / "repo"
-    with patch("core.sandbox.run_untrusted") as mock_run:
-        mock_run.return_value = _completed(0)
+    with patch("core.sandbox.run_untrusted") as mock_local, \
+         patch("core.sandbox.run_untrusted_networked") as mock_net:
+        mock_local.return_value = _completed(0)
+        mock_net.return_value = _completed(0)
         fetch_commit(repo, "https://github.com/foo/bar", _VALID_SHA)
 
     expected_parent = str(repo.parent)
-    for call in mock_run.call_args_list:
+    for call in list(mock_local.call_args_list) + list(mock_net.call_args_list):
         kwargs = call.kwargs
         assert kwargs["output"] == expected_parent
         assert kwargs["target"] == expected_parent
@@ -323,12 +332,14 @@ def test_fetch_passes_sanitised_env_and_timeout(tmp_path: Path) -> None:
     ``GIT_CLONE_TIMEOUT`` — no caller-controlled bypass."""
     from core.config import RaptorConfig
 
-    with patch("core.sandbox.run_untrusted") as mock_run:
-        mock_run.return_value = _completed(0)
+    with patch("core.sandbox.run_untrusted") as mock_local, \
+         patch("core.sandbox.run_untrusted_networked") as mock_net:
+        mock_local.return_value = _completed(0)
+        mock_net.return_value = _completed(0)
         fetch_commit(tmp_path / "repo",
                      "https://github.com/foo/bar", _VALID_SHA)
 
-    for call in mock_run.call_args_list:
+    for call in list(mock_local.call_args_list) + list(mock_net.call_args_list):
         kwargs = call.kwargs
         assert "GIT_TERMINAL_PROMPT" in kwargs["env"]
         assert kwargs["env"]["GIT_TERMINAL_PROMPT"] == "0"
@@ -346,7 +357,7 @@ def test_ls_remote_rejects_empty_proxy_hosts() -> None:
     """``proxy_hosts`` must be non-empty — the proxy would refuse
     every connection otherwise, so we surface a clear ValueError
     rather than a confusing transport failure."""
-    with patch("core.sandbox.run_untrusted") as mock_run:
+    with patch("core.sandbox.run_untrusted_networked") as mock_run:
         with pytest.raises(ValueError, match="proxy_hosts"):
             ls_remote("https://git.kernel.org/foo", proxy_hosts=[])
         mock_run.assert_not_called()
@@ -368,7 +379,7 @@ def test_ls_remote_rejects_bad_url_shapes(bad_url: str) -> None:
     """URL must be ``https://<host>/...`` with no userinfo. ``http://``
     is also rejected because the in-process egress proxy is
     HTTPS-CONNECT exclusively."""
-    with patch("core.sandbox.run_untrusted") as mock_run:
+    with patch("core.sandbox.run_untrusted_networked") as mock_run:
         with pytest.raises(ValueError):
             ls_remote(bad_url, proxy_hosts=_KERNEL_HOSTS)
         mock_run.assert_not_called()
@@ -377,7 +388,7 @@ def test_ls_remote_rejects_bad_url_shapes(bad_url: str) -> None:
 def test_ls_remote_rejects_url_host_outside_allowlist() -> None:
     """Pre-check is defence-in-depth — proxy enforces too — but we
     surface a clear error before the subprocess fires."""
-    with patch("core.sandbox.run_untrusted") as mock_run:
+    with patch("core.sandbox.run_untrusted_networked") as mock_run:
         with pytest.raises(ValueError, match="not in proxy_hosts"):
             ls_remote(
                 "https://evil.example.com/foo",
@@ -389,7 +400,7 @@ def test_ls_remote_rejects_url_host_outside_allowlist() -> None:
 def test_ls_remote_host_match_is_case_insensitive() -> None:
     """Hostnames are case-insensitive per RFC 1035; uppercase variants
     of allowlisted hosts must still pass."""
-    with patch("core.sandbox.run_untrusted") as mock_run:
+    with patch("core.sandbox.run_untrusted_networked") as mock_run:
         mock_run.return_value = _completed(0, stdout="")
         ls_remote(
             "https://Git.Kernel.Org/foo",
@@ -399,15 +410,12 @@ def test_ls_remote_host_match_is_case_insensitive() -> None:
 
 
 def test_ls_remote_engages_egress_proxy(tmp_path: Path) -> None:
-    """Sandbox call must pin both ``use_egress_proxy=True`` and
-    ``proxy_hosts``. Without the flag the proxy never starts and
-    ``run_untrusted``'s forced ``block_network=True`` would silently
-    drop the connection."""
-    with patch("core.sandbox.run_untrusted") as mock_run:
+    """``run_untrusted_networked`` implicitly engages the egress proxy.
+    Pin ``proxy_hosts`` so future refactors can't drop it."""
+    with patch("core.sandbox.run_untrusted_networked") as mock_run:
         mock_run.return_value = _completed(0)
         ls_remote("https://git.kernel.org/foo", proxy_hosts=_KERNEL_HOSTS)
         kwargs = mock_run.call_args.kwargs
-        assert kwargs.get("use_egress_proxy") is True
         assert "git.kernel.org" == kwargs.get("proxy_hosts", [])[0]
         assert kwargs.get("timeout") == 20  # default
 
@@ -428,7 +436,7 @@ def test_ls_remote_parses_refs() -> None:
         "0000\trefs/heads/short-sha\n"  # too short — strict regex rejects
         "12345678901234567890123456789012345678901234\trefs/x\n"  # too long
     )
-    with patch("core.sandbox.run_untrusted") as mock_run:
+    with patch("core.sandbox.run_untrusted_networked") as mock_run:
         mock_run.return_value = _completed(0, stdout=stdout)
         refs = ls_remote(
             "https://git.kernel.org/foo",
@@ -441,7 +449,7 @@ def test_ls_remote_parses_refs() -> None:
 
 
 def test_ls_remote_failure_raises_runtime_error() -> None:
-    with patch("core.sandbox.run_untrusted") as mock_run:
+    with patch("core.sandbox.run_untrusted_networked") as mock_run:
         mock_run.return_value = _completed(
             128, stderr="fatal: repository not found",
         )
@@ -456,7 +464,7 @@ def test_ls_remote_passes_sanitised_env() -> None:
     """``GIT_TERMINAL_PROMPT=0`` and the rest of ``get_git_env``
     must reach the subprocess so a malformed credential prompt
     can't hang the run."""
-    with patch("core.sandbox.run_untrusted") as mock_run:
+    with patch("core.sandbox.run_untrusted_networked") as mock_run:
         mock_run.return_value = _completed(0, stdout="")
         ls_remote("https://git.kernel.org/foo", proxy_hosts=_KERNEL_HOSTS)
         kwargs = mock_run.call_args.kwargs
@@ -464,7 +472,7 @@ def test_ls_remote_passes_sanitised_env() -> None:
 
 
 def test_ls_remote_custom_timeout_propagates() -> None:
-    with patch("core.sandbox.run_untrusted") as mock_run:
+    with patch("core.sandbox.run_untrusted_networked") as mock_run:
         mock_run.return_value = _completed(0, stdout="")
         ls_remote(
             "https://git.kernel.org/foo",
@@ -475,12 +483,12 @@ def test_ls_remote_custom_timeout_propagates() -> None:
 
 
 def test_ls_remote_propagates_filenotfounderror() -> None:
-    """If ``git`` isn't installed in the sandbox, ``run_untrusted``
-    surfaces ``FileNotFoundError`` and the helper lets it propagate.
-    Caller-trusted (raptor's CI environment always has git); test
-    pins the propagation contract so a future change that swallows
-    the exception is caught."""
-    with patch("core.sandbox.run_untrusted") as mock_run:
+    """If ``git`` isn't installed in the sandbox,
+    ``run_untrusted_networked`` surfaces ``FileNotFoundError`` and the
+    helper lets it propagate. Caller-trusted (raptor's CI environment
+    always has git); test pins the propagation contract so a future
+    change that swallows the exception is caught."""
+    with patch("core.sandbox.run_untrusted_networked") as mock_run:
         mock_run.side_effect = FileNotFoundError("git: command not found")
         with pytest.raises(FileNotFoundError):
             ls_remote(
@@ -490,11 +498,10 @@ def test_ls_remote_propagates_filenotfounderror() -> None:
 
 
 def test_ls_remote_propagates_timeout_expired() -> None:
-    """``subprocess.TimeoutExpired`` propagates from ``run_untrusted``
-    unchanged. Same contract as ``clone_repository`` and
-    ``fetch_commit`` — callers handling the (RuntimeError,
-    subprocess.TimeoutExpired) tuple cover both shapes."""
-    with patch("core.sandbox.run_untrusted") as mock_run:
+    """``subprocess.TimeoutExpired`` propagates from
+    ``run_untrusted_networked`` unchanged. Same contract as
+    ``clone_repository`` and ``fetch_commit``."""
+    with patch("core.sandbox.run_untrusted_networked") as mock_run:
         mock_run.side_effect = subprocess.TimeoutExpired(
             cmd=["git", "ls-remote"], timeout=20,
         )
@@ -516,7 +523,7 @@ def test_ls_remote_resilient_to_non_utf8_replacement_chars() -> None:
         "abc1234567890abc1234567890abc1234567890a\trefs/heads/main\n"
         "\ufffd\ufffd\ufffdabc1234567890abc1234567890abc1234567\trefs/garbage\n"
     )
-    with patch("core.sandbox.run_untrusted") as mock_run:
+    with patch("core.sandbox.run_untrusted_networked") as mock_run:
         mock_run.return_value = _completed(0, stdout=stdout)
         refs = ls_remote(
             "https://git.kernel.org/foo",
@@ -534,7 +541,7 @@ def test_ls_remote_uses_strict_40char_sha_regex() -> None:
     # SHA at the lower bound the caller-input regex would accept (8
     # chars) MUST be rejected by the output parser.
     stdout = "deadbeef\trefs/heads/short\n"
-    with patch("core.sandbox.run_untrusted") as mock_run:
+    with patch("core.sandbox.run_untrusted_networked") as mock_run:
         mock_run.return_value = _completed(0, stdout=stdout)
         refs = ls_remote(
             "https://git.kernel.org/foo",

--- a/core/inventory/binary_oracle_corpora/synthetic.py
+++ b/core/inventory/binary_oracle_corpora/synthetic.py
@@ -6,9 +6,11 @@ expected verdicts. No external deps; validates the precision harness
 end-to-end on known-correct cases and acts as a fast classifier sanity
 check.
 
-The fold case (``folded_a``/``folded_b``) depends on whether an ICF-
-capable linker is available; the driver asks the fixture's Makefile
-which mode it built in and adjusts the expected verdict accordingly.
+The fold case (``folded_a``/``folded_b``) checks the actual binary
+to see if both symbols share the same address (i.e. the linker's ICF
+pass actually merged them). This is more robust than checking the
+Makefile's ICF-mode flag, which only tests linker capability — some
+linker versions report ICF support but don't fold all eligible pairs.
 """
 
 from __future__ import annotations
@@ -24,6 +26,22 @@ FIXTURE_DIR = (Path(__file__).resolve().parents[1] / "tests" / "fixtures"
                / "binary_oracle")
 
 
+def _symbols_share_address(binary: Path, name_a: str, name_b: str) -> bool:
+    """Check whether two symbols share the same address in the binary."""
+    proc = subprocess.run(
+        ["nm", str(binary)], capture_output=True, text=True)
+    if proc.returncode != 0:
+        return False
+    addrs: Dict[str, str] = {}
+    for line in proc.stdout.splitlines():
+        parts = line.split()
+        if len(parts) >= 3:
+            addrs[parts[2]] = parts[0]
+    addr_a = addrs.get(name_a)
+    addr_b = addrs.get(name_b)
+    return addr_a is not None and addr_a == addr_b
+
+
 @dataclass
 class _SyntheticDriver:
     name: str = "synthetic"
@@ -33,15 +51,11 @@ class _SyntheticDriver:
     mode: Literal["synthetic"] = "synthetic"
 
     def prepare(self, work_dir: Path) -> Dict[str, Any]:
-        # Build the fixture (idempotent — make checks timestamps).
         subprocess.run(["make", "-s", "demo"], cwd=FIXTURE_DIR, check=True)
         binary = FIXTURE_DIR / "demo"
-        icf_mode = subprocess.run(
-            ["make", "-s", "print-icf-mode"], cwd=FIXTURE_DIR,
-            check=True, capture_output=True, text=True,
-        ).stdout.strip()
         folded_verdict: Classification = (
-            "folded" if icf_mode != "none" else "symbol_present"
+            "folded" if _symbols_share_address(binary, "folded_a", "folded_b")
+            else "symbol_present"
         )
         expected: Dict[str, Classification] = {
             "live_called":                "symbol_present",

--- a/core/sandbox/context.py
+++ b/core/sandbox/context.py
@@ -2597,6 +2597,7 @@ def run_untrusted(cmd: List[str], *, target: str = None, output: str = None,
         )
     _UNTRUSTED_ALLOWED_KWARGS = frozenset({
         "env", "cwd", "timeout", "capture_output", "text",
+        "encoding", "errors",
         "stdin", "input", "start_new_session", "pass_fds",
         "caller_label",
         "audit", "audit_verbose", "audit_run_dir",
@@ -2704,6 +2705,7 @@ def run_untrusted_networked(
         )
     _NETWORKED_ALLOWED_KWARGS = frozenset({
         "env", "cwd", "timeout", "capture_output", "text",
+        "encoding", "errors",
         "stdin", "input", "start_new_session", "pass_fds",
         "caller_label",
         "audit", "audit_verbose", "audit_run_dir",

--- a/packages/web/ffuf.py
+++ b/packages/web/ffuf.py
@@ -16,7 +16,7 @@ from typing import Any
 from urllib.parse import urljoin, urlparse
 
 from core.logging import get_logger
-from core.sandbox import run_untrusted
+from core.sandbox import run_untrusted_networked
 from core.security.redaction import is_secret_field_name, redact_secrets
 
 logger = get_logger()
@@ -224,13 +224,13 @@ class FfufRunner:
         redacted_cmd = self._redact_command(cmd)
         logger.info(f"Running sandboxed ffuf: {' '.join(redacted_cmd)}")
 
-        completed = run_untrusted(
+        completed = run_untrusted_networked(
             cmd,
             target=str(config.wordlist.parent),
             output=str(self.out_dir),
             readable_paths=[str(config.wordlist.parent)],
-            use_egress_proxy=True,
             proxy_hosts=[target_host],
+            fake_home=True,
             tool_paths=[str(Path(binary_path).parent)],
             caller_label="web-ffuf",
             timeout=config.max_runtime,

--- a/packages/web/tests/test_ffuf.py
+++ b/packages/web/tests/test_ffuf.py
@@ -156,7 +156,7 @@ def test_run_redacts_authenticated_ffuf_options_from_logs(
         output_path.write_text(json.dumps({"results": []}), encoding="utf-8")
         return SimpleNamespace(returncode=0, stderr="")
 
-    monkeypatch.setattr("packages.web.ffuf.run_untrusted", fake_run)
+    monkeypatch.setattr("packages.web.ffuf.run_untrusted_networked", fake_run)
     bearer = "Authorization: Bearer " + "a" * 32
     cookie = "session=" + "b" * 32
 
@@ -240,7 +240,7 @@ def test_run_uses_subprocess_argv_and_summarizes_json(tmp_path: Path, monkeypatc
         )
         return SimpleNamespace(returncode=0, stderr=None)
 
-    monkeypatch.setattr("packages.web.ffuf.run_untrusted", fake_run)
+    monkeypatch.setattr("packages.web.ffuf.run_untrusted_networked", fake_run)
 
     runner = FfufRunner("https://example.test", tmp_path)
     result = runner.run(FfufConfig(wordlist=wordlist, path_template="FUZZ"))
@@ -248,7 +248,6 @@ def test_run_uses_subprocess_argv_and_summarizes_json(tmp_path: Path, monkeypatc
     assert captured["cmd"][0] == "ffuf"
     assert captured["kwargs"]["capture_output"] is True
     assert captured["kwargs"]["text"] is True
-    assert captured["kwargs"]["use_egress_proxy"] is True
     assert captured["kwargs"]["proxy_hosts"] == ["example.test"]
     assert captured["kwargs"]["caller_label"] == "web-ffuf"
     assert result["returncode"] == 0
@@ -290,7 +289,7 @@ def test_run_limits_embedded_report_results_but_keeps_raw_count(
         )
         return SimpleNamespace(returncode=0, stderr="")
 
-    monkeypatch.setattr("packages.web.ffuf.run_untrusted", fake_run)
+    monkeypatch.setattr("packages.web.ffuf.run_untrusted_networked", fake_run)
 
     runner = FfufRunner("https://example.test", tmp_path)
     result = runner.run(FfufConfig(wordlist=wordlist, report_limit=2))


### PR DESCRIPTION
run_untrusted() now enforces a strict kwargs allowlist that rejects use_egress_proxy and proxy_hosts. Migrate all network-touching callers (clone_repository, fetch_commit, ls_remote, ffuf) to run_untrusted_networked, which provides egress-proxy isolation as its contract. Local-only calls (git init, remote add/set-url) stay on run_untrusted.

Add encoding/errors to both kwargs allowlists — standard subprocess.run kwargs that ls_remote needs for hostile-remote resilience.

Fix synthetic corpus fold detection: check the actual binary for shared symbol addresses instead of the Makefile's ICF capability flag, which can disagree with the linker's actual behavior.