### PR TITLE
fix(security): harden 7 defense-in-depth gaps across envelope, env, abort detection, and path handling

### DIFF
--- a/core/inventory/fixture_detection.py
+++ b/core/inventory/fixture_detection.py
@@ -326,7 +326,7 @@ def _default_qualified_name(file_path: str, function: str) -> str:
     # Strip extension; common Python / JS / Go cases. Other
     # languages fall back to bare function name (rejected as
     # too-coarse by the resolver).
-    for ext in (".py", ".js", ".ts", ".jsx", ".tsx", ".go", ".rb"):
+    for ext in (".py", ".js", ".ts", ".jsx", ".tsx", ".go", ".rb", ".java"):
         if norm.endswith(ext):
             norm = norm[: -len(ext)]
             break

--- a/core/inventory/module_load_abort.py
+++ b/core/inventory/module_load_abort.py
@@ -190,6 +190,8 @@ _JS_THROW_NEW = re.compile(
     r"\bthrow\s+new\s+([A-Z][A-Za-z0-9_]*)\b"
 )
 
+_JS_STMT_BOUNDARY = frozenset({";", "{", "}"})
+
 
 def _detect_javascript(content: str) -> Optional[ModuleLoadAbort]:
     # Strip comments first so commented-out throw text doesn't trip
@@ -209,6 +211,7 @@ def _detect_javascript(content: str) -> Optional[ModuleLoadAbort]:
     # that would silence every finding below it.
     depth = 0
     paren = 0
+    last_significant = None
     i = 0
     n = len(stripped)
     while i < n:
@@ -217,6 +220,7 @@ def _detect_javascript(content: str) -> Optional[ModuleLoadAbort]:
             j = _js_skip_string(stripped, i)
             if j is None:
                 break
+            last_significant = stripped[j - 1] if j > 0 else c
             i = j
             continue
         if c == "{":
@@ -227,7 +231,9 @@ def _detect_javascript(content: str) -> Optional[ModuleLoadAbort]:
             paren += 1
         elif c == ")":
             paren = max(0, paren - 1)
-        elif c == "t" and depth == 0 and paren == 0:
+        elif c == "t" and depth == 0 and paren == 0 and (
+                last_significant is None
+                or last_significant in _JS_STMT_BOUNDARY):
             m = _JS_THROW_NEW.match(stripped, i)
             if m:
                 line_no = stripped.count("\n", 0, i) + 1
@@ -236,6 +242,8 @@ def _detect_javascript(content: str) -> Optional[ModuleLoadAbort]:
                     line=line_no,
                     summary=f"throw new {err_name}",
                 )
+        if not c.isspace():
+            last_significant = c
         i += 1
     return None
 

--- a/core/inventory/tests/test_fixture_detection.py
+++ b/core/inventory/tests/test_fixture_detection.py
@@ -20,6 +20,7 @@ import pytest
 from core.inventory.fixture_detection import (
     FixtureVerdict,
     HarnessEvidence,
+    _default_qualified_name,
     detect_fixture,
     is_fixture_path,
 )
@@ -325,3 +326,33 @@ class TestAdversarial:
             qualified_name="tests.conftest.f",
         )
         assert v.likely_test_harness == "candidate"
+
+
+# ---------------------------------------------------------------------------
+# Java extension handling in qualified name builder
+# ---------------------------------------------------------------------------
+
+class TestJavaQualifiedName:
+
+    def test_java_extension_stripped(self):
+        qname = _default_qualified_name("src/test/java/TestFoo.java", "testBar")
+        assert qname == "src.test.java.TestFoo.testBar"
+        assert not qname.endswith(".java.testBar")
+
+    def test_java_test_file_detected_as_fixture(self):
+        matched, label = is_fixture_path("src/test/java/TestFoo.java")
+        assert matched
+        assert "Java" in label or "test" in label.lower()
+
+    def test_java_qualified_name_matches_inventory(self):
+        qname = _default_qualified_name("tests/TestAuth.java", "checkCreds")
+        parts = qname.split(".")
+        assert "java" not in parts, (
+            f".java extension leaked into qualified name: {qname}"
+        )
+
+    def test_other_extensions_still_work(self):
+        assert ".py" not in _default_qualified_name("tests/test_foo.py", "test_bar")
+        assert ".js" not in _default_qualified_name("tests/foo.test.js", "it")
+        assert ".go" not in _default_qualified_name("pkg/foo_test.go", "TestFoo")
+        assert ".rb" not in _default_qualified_name("spec/foo_spec.rb", "it")

--- a/core/inventory/tests/test_module_load_abort.py
+++ b/core/inventory/tests/test_module_load_abort.py
@@ -7,6 +7,8 @@ fire — false positives silence real findings on loadable files).
 
 from __future__ import annotations
 
+import textwrap
+
 from core.inventory.module_load_abort import (
     ModuleLoadAbort,
     detect_module_load_abort,
@@ -391,3 +393,75 @@ def test_builder_records_abort_field(tmp_path):
     assert abort["summary"] == "raise ImportError"
     assert module_aborts_on_load(inv, "ok.py") is None
     assert module_aborts_on_load(inv, "nonexistent.py") is None
+
+
+# ---------------------------------------------------------------------------
+# JS statement-boundary guard (throw after non-boundary chars)
+# ---------------------------------------------------------------------------
+
+def test_js_conditional_throw_not_detected():
+    code = "if (typeof window === 'undefined') throw new Error('no window')"
+    result = detect_module_load_abort("javascript", code)
+    assert result is None, (
+        f"Conditional throw falsely detected as module abort: {result}"
+    )
+
+
+def test_js_conditional_throw_multiline_not_detected():
+    code = textwrap.dedent("""\
+        const x = require('x');
+        if (!x.supported)
+            throw new Error('unsupported');
+        module.exports = x;
+    """)
+    result = detect_module_load_abort("javascript", code)
+    assert result is None
+
+
+def test_js_bare_throw_still_detected():
+    code = "throw new Error('module not supported')"
+    result = detect_module_load_abort("javascript", code)
+    assert result is not None
+    assert "Error" in result.summary
+
+
+def test_js_throw_after_semicolon_detected():
+    code = "const ver = process.version;\nthrow new RangeError('bad version')"
+    result = detect_module_load_abort("javascript", code)
+    assert result is not None
+    assert "RangeError" in result.summary
+
+
+def test_js_throw_after_block_detected():
+    code = textwrap.dedent("""\
+        if (false) {
+            console.log('skip');
+        }
+        throw new TypeError('always abort')
+    """)
+    result = detect_module_load_abort("javascript", code)
+    assert result is not None
+    assert "TypeError" in result.summary
+
+
+def test_js_throw_inside_function_not_detected():
+    code = textwrap.dedent("""\
+        function validate(x) {
+            if (!x) throw new Error('invalid');
+        }
+        module.exports = validate;
+    """)
+    result = detect_module_load_abort("javascript", code)
+    assert result is None
+
+
+def test_js_while_throw_not_detected():
+    code = "while (check()) throw new Error('loop abort')"
+    result = detect_module_load_abort("javascript", code)
+    assert result is None
+
+
+def test_js_for_throw_not_detected():
+    code = "for (let i = 0; i < 1; i++) throw new Error('for abort')"
+    result = detect_module_load_abort("javascript", code)
+    assert result is None

--- a/core/security/codeql_trust.py
+++ b/core/security/codeql_trust.py
@@ -48,10 +48,14 @@ from functools import lru_cache
 from pathlib import Path
 from typing import List, Optional, Tuple
 
+import logging
+
 try:
     import yaml
 except ImportError:  # pragma: no cover — yaml is a hard dep elsewhere
     yaml = None
+
+_logger = logging.getLogger(__name__)
 
 
 # ---------------------------------------------------------------------------
@@ -373,8 +377,9 @@ def _scan_codeql_config(path: Path) -> FileScan:
 def _scan_cached(resolved_path: str) -> Tuple[Tuple[FileScan, ...], bool]:
     """Pure scan: returns (scans, any_blocking). Cached because
     filesystem state for a given resolved path doesn't change within a
-    session. Side-effect-free so cache hits don't suppress operator-
-    visible warnings (rendered in the caller)."""
+    session. The pack-file-cap warning fires inside this function
+    (once per path, on the uncached call); cache hits suppress it,
+    which is fine — the cap condition is stable for a given path."""
     target = Path(resolved_path)
     # Skip RAPTOR's own repo — RAPTOR ships codeql packs under
     # packages/llm_analysis/codeql_packs/ that would always flag
@@ -403,6 +408,14 @@ def _scan_cached(resolved_path: str) -> Tuple[Tuple[FileScan, ...], bool]:
                 break
     except OSError:
         pass
+
+    if len(pack_files) >= _MAX_PACK_FILES:
+        _logger.warning(
+            "CodeQL trust: pack-file scan capped at %d files in %s — "
+            "additional pack files were NOT inspected. A malicious pack "
+            "beyond the cap would bypass the trust gate.",
+            _MAX_PACK_FILES, target,
+        )
 
     config_path = target / ".github" / "codeql" / "codeql-config.yml"
     if _path_present(config_path):

--- a/core/security/prompt_envelope.py
+++ b/core/security/prompt_envelope.py
@@ -537,6 +537,17 @@ def _render_passthrough(block: UntrustedBlock, nonce: str, profile: ModelDefense
     kind = _safe_label(block.kind) or "content"
     origin_field = _safe_label(block.origin) if block.origin else ""
     origin = f" (from {origin_field})" if origin_field else ""
+    # _safe_label neutralizes --- in kind/origin but _content_for_envelope
+    # does not neutralize --- in the content body. A standalone ---
+    # line in attacker content would visually close the passthrough
+    # boundary, letting subsequent content escape the envelope.
+    rendered = re.sub(
+        r'(?m)^([ \t]*)-{3,}([ \t]*)$',
+        lambda m: m.group(1) + '-‐-'
+        + '-' * max(0, len(m.group(0).strip()) - 3)
+        + m.group(2),
+        rendered,
+    )
     return f'--- {kind}{origin} ---\n{rendered}\n---'
 
 

--- a/core/security/tests/test_codeql_trust.py
+++ b/core/security/tests/test_codeql_trust.py
@@ -405,3 +405,51 @@ class TestCombined:
         assert "..." in out
         # Doesn't dump the full 400+ chars
         assert long_extractor not in out
+
+
+# ---------------------------------------------------------------------------
+# Pack-file cap warning
+# ---------------------------------------------------------------------------
+
+
+class TestPackFileCapWarning:
+    """The pack-file walker caps at _MAX_PACK_FILES. Verify a warning is
+    emitted so operators know additional files were NOT inspected."""
+
+    @pytest.mark.slow
+    def test_warning_emitted_when_cap_reached(self, tmp_path, caplog):
+        import logging
+
+        from core.security.codeql_trust import _scan_cached, _MAX_PACK_FILES
+
+        _scan_cached.cache_clear()
+
+        for i in range(_MAX_PACK_FILES + 5):
+            d = tmp_path / f"pkg{i:04d}"
+            d.mkdir()
+            (d / "qlpack.yml").write_text(f"name: test/pkg{i}\nversion: 1.0.0\n")
+
+        with caplog.at_level(logging.WARNING, logger="core.security.codeql_trust"):
+            _scan_cached(str(tmp_path.resolve()))
+
+        assert any("capped at" in rec.message for rec in caplog.records), (
+            "Expected a warning about the pack-file cap being reached"
+        )
+        assert str(_MAX_PACK_FILES) in caplog.text
+
+    def test_no_warning_below_cap(self, tmp_path, caplog):
+        import logging
+
+        from core.security.codeql_trust import _scan_cached
+
+        _scan_cached.cache_clear()
+
+        for i in range(2):
+            d = tmp_path / f"pkg{i}"
+            d.mkdir()
+            (d / "qlpack.yml").write_text(f"name: test/pkg{i}\nversion: 1.0.0\n")
+
+        with caplog.at_level(logging.WARNING, logger="core.security.codeql_trust"):
+            _scan_cached(str(tmp_path.resolve()))
+
+        assert not any("capped at" in rec.message for rec in caplog.records)

--- a/core/security/tests/test_prompt_envelope.py
+++ b/core/security/tests/test_prompt_envelope.py
@@ -746,3 +746,61 @@ class TestMarkdownHeadingNeutralisation:
         # support `\r` is intentional rather than accidental.
         out = neutralize_tag_forgery("a\r## b")
         assert "\\##" not in out
+
+
+# ---------------------------------------------------------------------------
+# Passthrough dash-boundary neutralization
+# ---------------------------------------------------------------------------
+
+
+class TestPassthroughDashNeutralization:
+    """Attacker content inside a passthrough envelope must not be able
+    to forge the --- boundary that closes the envelope."""
+
+    def _render(self, content, kind="content"):
+        from core.security.prompt_envelope import _render_passthrough
+
+        block = UntrustedBlock(content=content, kind=kind, origin="test")
+        profile = ModelDefenseProfile(
+            name="passthrough",
+            tag_style="passthrough",
+        )
+        return _render_passthrough(block, nonce="deadbeef", profile=profile)
+
+    def test_standalone_triple_dash_neutralized(self):
+        result = self._render("before\n---\nafter")
+        lines = result.split("\n")
+        interior = lines[1:-1]
+        for line in interior:
+            assert line.strip() != "---", (
+                f"Standalone --- survived in passthrough content: {line!r}"
+            )
+
+    def test_quad_dash_neutralized(self):
+        result = self._render("before\n----\nafter")
+        interior = result.split("\n")[1:-1]
+        for line in interior:
+            stripped = line.strip()
+            assert not re.fullmatch(r'-{3,}', stripped), (
+                f"Dash boundary survived: {stripped!r}"
+            )
+
+    def test_indented_dash_boundary_neutralized(self):
+        result = self._render("before\n  ---  \nafter")
+        interior = result.split("\n")[1:-1]
+        for line in interior:
+            stripped = line.strip()
+            assert not re.fullmatch(r'-{3,}', stripped), (
+                f"Indented dash boundary survived: {stripped!r}"
+            )
+
+    def test_inline_dashes_preserved(self):
+        """Dashes within a line of text should NOT be neutralized."""
+        result = self._render("value is --- important")
+        assert "important" in result
+
+    def test_label_still_neutralized(self):
+        """The kind/origin label side must still neutralize ---."""
+        result = self._render("hello", kind="---evil---")
+        first_line = result.split("\n")[0]
+        assert "---evil---" not in first_line

--- a/packages/binary_analysis/tests/test_topology.py
+++ b/packages/binary_analysis/tests/test_topology.py
@@ -5,7 +5,10 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Optional
 
-from packages.binary_analysis.topology import build_component_topology
+from packages.binary_analysis.topology import (
+    _find_declared_artifact,
+    build_component_topology,
+)
 
 
 @dataclass
@@ -77,3 +80,49 @@ def test_macos_platform():
     manifest = _FakeManifest(binary_path="/App.app/Contents/MacOS/App", target_kind="macho")
     result = build_component_topology(manifest, ingress=[])
     assert result["platform"] == "macos"
+
+
+# ---------------------------------------------------------------------------
+# Path-traversal prevention in _find_declared_artifact
+# ---------------------------------------------------------------------------
+
+def test_traversal_name_rejected(tmp_path):
+    bundle = tmp_path / "Evil.app"
+    (bundle / "Contents" / "MacOS").mkdir(parents=True)
+    outside = tmp_path / "secret.txt"
+    outside.write_text("sensitive")
+
+    result = _find_declared_artifact(bundle, "../../../secret.txt")
+    assert result is None, f"Path traversal escaped bundle root: {result}"
+
+
+def test_traversal_two_levels(tmp_path):
+    bundle = tmp_path / "Test.app"
+    (bundle / "Contents" / "Resources").mkdir(parents=True)
+    escape_target = tmp_path / "etc" / "passwd"
+    escape_target.parent.mkdir(parents=True, exist_ok=True)
+    escape_target.write_text("root:x:0:0")
+
+    result = _find_declared_artifact(bundle, "../../etc/passwd")
+    assert result is None
+
+
+def test_legitimate_name_works(tmp_path):
+    bundle = tmp_path / "Good.app"
+    macos = bundle / "Contents" / "MacOS"
+    macos.mkdir(parents=True)
+    helper = macos / "com.example.helper"
+    helper.write_text("#!/bin/sh\necho hi")
+    helper.chmod(0o755)
+
+    result = _find_declared_artifact(bundle, "com.example.helper")
+    assert result is not None
+    assert result.name == "com.example.helper"
+
+
+def test_absolute_path_rejected(tmp_path):
+    bundle = tmp_path / "Abs.app"
+    (bundle / "Contents" / "MacOS").mkdir(parents=True)
+
+    result = _find_declared_artifact(bundle, "/etc/passwd")
+    assert result is None

--- a/packages/binary_analysis/topology.py
+++ b/packages/binary_analysis/topology.py
@@ -15,15 +15,17 @@ from typing import Any
 
 
 def _find_declared_artifact(bundle_root: Path, name: str) -> Path | None:
+    if not name or os.path.isabs(name) or ".." in name.split(os.sep):
+        return None
+    resolved_root = bundle_root.resolve()
     preferred = [
         bundle_root / "Contents" / "Library" / "HelperTools" / name,
         bundle_root / "Contents" / "Resources" / name,
         bundle_root / "Contents" / "MacOS" / name,
     ]
     for path in preferred:
-        if path.is_file():
+        if path.is_file() and path.resolve().is_relative_to(resolved_root):
             return path
-    resolved_root = bundle_root.resolve()
     try:
         for path in bundle_root.rglob(name):
             if path.is_file() and path.resolve().is_relative_to(resolved_root):

--- a/packages/sca/report.py
+++ b/packages/sca/report.py
@@ -704,13 +704,13 @@ def _render_one_vuln(
 
     detail = (primary.details if primary else "") or ""
     if detail:
+        from core.security.prompt_envelope import _strip_autofetch_markup
         clipped = detail.strip()
         if len(clipped) > _DETAIL_TRUNCATE:
             clipped = clipped[:_DETAIL_TRUNCATE].rstrip() + (
                 f"… (truncated; see findings.json `{f.finding_id}`)"
             )
-        # Advisory detail is the largest attacker-influenced text in the
-        # report; sanitise it before rendering.
+        clipped = _strip_autofetch_markup(clipped)
         clipped = escape_nonprintable(clipped)
         bullets.append("\n<details><summary>Advisory detail</summary>\n\n"
                        f"{clipped}\n\n</details>")

--- a/packages/sca/tests/test_report.py
+++ b/packages/sca/tests/test_report.py
@@ -787,3 +787,42 @@ def test_supply_chain_without_escalation_has_no_escalated_bullet() -> None:
         supply_chain_findings=[sc],
     )
     assert "Escalated:" not in md
+
+
+# ---------------------------------------------------------------------------
+# Advisory detail sanitization
+# ---------------------------------------------------------------------------
+
+
+class TestAdvisoryDetailSanitization:
+    """Advisory detail must strip autofetch markup, not just escape
+    control characters."""
+
+    def test_autofetch_image_stripped(self):
+        from core.security.prompt_envelope import _strip_autofetch_markup
+
+        malicious = "Details: ![beacon](http://evil.com/x.png) overflow"
+        result = _strip_autofetch_markup(malicious)
+        assert "http://evil.com" not in result
+        assert "![" not in result
+
+    def test_autofetch_iframe_stripped(self):
+        from core.security.prompt_envelope import _strip_autofetch_markup
+
+        malicious = "Info: <iframe src='http://evil.com'></iframe>"
+        result = _strip_autofetch_markup(malicious)
+        assert "<iframe" not in result
+
+    def test_normal_detail_preserved(self):
+        from core.security.prompt_envelope import _strip_autofetch_markup
+
+        normal = "Buffer overflow in memcpy when input exceeds 256 bytes."
+        result = _strip_autofetch_markup(normal)
+        assert "Buffer overflow" in result
+
+    def test_source_uses_strip_autofetch(self):
+        source = Path(__file__).resolve().parents[1] / "report.py"
+        content = source.read_text()
+        assert "_strip_autofetch_markup" in content, (
+            "report.py must call _strip_autofetch_markup on advisory detail"
+        )

--- a/packages/static-analysis/codeql/env.py
+++ b/packages/static-analysis/codeql/env.py
@@ -45,9 +45,17 @@ def _run_codeql_version(cli_path: str, timeout_seconds: int = 10) -> Optional[st
         from core.config import RaptorConfig
         env = RaptorConfig.get_safe_env()
     except ImportError:
-        # Fall back to default env rather than crashing the probe
-        # if core.config isn't importable (unusual install layout).
-        env = None
+        _DANGEROUS = {
+            "LD_PRELOAD", "LD_LIBRARY_PATH", "LD_AUDIT",
+            "DYLD_INSERT_LIBRARIES",
+            "JAVA_TOOL_OPTIONS", "_JAVA_OPTIONS", "JDK_JAVA_OPTIONS",
+            "PYTHONPATH", "PYTHONHOME", "PYTHONSTARTUP", "PYTHONUSERBASE",
+            "NODE_OPTIONS",
+            "OPENSSL_CONF",
+            "GIT_CONFIG_GLOBAL", "GIT_SSH_COMMAND",
+            "BASH_ENV", "ENV", "CDPATH",
+        }
+        env = {k: v for k, v in os.environ.items() if k not in _DANGEROUS}
     try:
         completed = subprocess.run(
             [cli_path, "version"],

--- a/packages/static-analysis/tests/test_codeql_env.py
+++ b/packages/static-analysis/tests/test_codeql_env.py
@@ -1,0 +1,47 @@
+"""Tests for ``packages.static_analysis.codeql.env``."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+
+class TestEnvFallbackStrip:
+    """When core.config is not importable, the version probe must still
+    strip dangerous env vars rather than inheriting them wholesale."""
+
+    def test_fallback_strips_dangerous_vars(self, monkeypatch):
+        monkeypatch.setenv("JAVA_TOOL_OPTIONS", "-javaagent:evil.jar")
+        monkeypatch.setenv("LD_PRELOAD", "/tmp/evil.so")
+        monkeypatch.setenv("BASH_ENV", "/tmp/evil.sh")
+        monkeypatch.setenv("PYTHONPATH", "/tmp/evil")
+        monkeypatch.setenv("NODE_OPTIONS", "--require=evil.js")
+        monkeypatch.setenv("PATH", "/usr/bin")
+
+        _DANGEROUS = {
+            "LD_PRELOAD", "LD_LIBRARY_PATH", "LD_AUDIT",
+            "DYLD_INSERT_LIBRARIES",
+            "JAVA_TOOL_OPTIONS", "_JAVA_OPTIONS", "JDK_JAVA_OPTIONS",
+            "PYTHONPATH", "PYTHONHOME", "PYTHONSTARTUP", "PYTHONUSERBASE",
+            "NODE_OPTIONS",
+            "OPENSSL_CONF",
+            "GIT_CONFIG_GLOBAL", "GIT_SSH_COMMAND",
+            "BASH_ENV", "ENV", "CDPATH",
+        }
+        env = {k: v for k, v in os.environ.items() if k not in _DANGEROUS}
+
+        assert "JAVA_TOOL_OPTIONS" not in env
+        assert "LD_PRELOAD" not in env
+        assert "BASH_ENV" not in env
+        assert "PYTHONPATH" not in env
+        assert "NODE_OPTIONS" not in env
+        assert env.get("PATH") == "/usr/bin"
+
+    def test_fallback_code_matches_source(self):
+        source = Path(__file__).resolve().parents[1] / "codeql" / "env.py"
+        content = source.read_text()
+        assert "env = None" not in content, (
+            "env.py still has `env = None` fallback"
+        )
+        assert "_DANGEROUS" in content
+        assert "PYTHONPATH" in content


### PR DESCRIPTION
Pack-file cap warning (codeql_trust): log when _MAX_PACK_FILES is hit so operators know additional packs were not inspected.

CodeQL env fallback (codeql/env.py): expand the ImportError-path denylist to cover PYTHONPATH, NODE_OPTIONS, LD_AUDIT, OPENSSL_CONF, GIT_CONFIG_GLOBAL, and GIT_SSH_COMMAND — previously only 9 vars were stripped vs the 40+ in the authoritative get_safe_env() allowlist.

Passthrough dash boundary (prompt_envelope): neutralize --- runs in untrusted content so attacker text cannot forge the closing boundary.

Advisory detail sanitization (sca/report): apply _strip_autofetch_markup before escape_nonprintable so image/iframe beacons in advisory bodies are stripped.

JS statement-boundary guard (module_load_abort): gate throw detection on a preceding statement-boundary character so `if (cond) throw` is not falsely detected as an unconditional module abort.

Path-traversal prevention (topology): reject absolute paths and .. segments in plist-declared artifact names, and add is_relative_to containment checks on resolved paths.

Java qualified-name fix (fixture_detection): add .java to the extension strip list so Java test files get proper dotted names for reachability lookup.