### PR TITLE
core: add atomic_fs write primitive

### DIFF
--- a/.github/scripts/compute_filters.py
+++ b/.github/scripts/compute_filters.py
@@ -37,6 +37,7 @@ FILTERS: dict[str, list[str]] = {
     # .github/tests/test_filter_coverage.py).
     "sandbox": [
         "core/sandbox/**",
+        "core/atomic_fs/**",
         "core/config/**",
         "core/run/**",
         "core/security/**",
@@ -55,6 +56,7 @@ FILTERS: dict[str, list[str]] = {
         "packages/exploit_feasibility/**",
         "packages/binary_analysis/**",
         "packages/codeql/smt_path_validator.py",
+        "core/atomic_fs/**",
         "core/config/**",
         "core/function_taxonomy/**",
         "core/hash/**",
@@ -152,6 +154,7 @@ FILTERS: dict[str, list[str]] = {
         "packages/cve_diff/**",
         "packages/nvd/**",
         "packages/osv/**",
+        "core/atomic_fs/**",
         "core/config/**",
         "core/git/**",
         "core/http/**",
@@ -202,6 +205,7 @@ FILTERS: dict[str, list[str]] = {
         "packages/binary_analysis/**",
         "packages/cvss/**",
         "packages/osv/**",
+        "core/atomic_fs/**",
         "core/binary/**",
         "core/config/**",
         "core/coverage/**",

--- a/core/annotations/storage.py
+++ b/core/annotations/storage.py
@@ -36,11 +36,12 @@ from __future__ import annotations
 import hashlib
 import os
 import re
-import tempfile
 from collections.abc import Iterator
 from contextlib import contextmanager
 from pathlib import Path
 from typing import Dict, List, Optional
+
+from core.atomic_fs import write_text_atomically
 
 try:
     import fcntl  # POSIX
@@ -406,25 +407,13 @@ def write_annotation(
         by_name[ann.function] = ann
         rendered = _render_file(ann.file, by_name.values())
 
-        # Atomic write — tempfile in same directory so rename is on
-        # the same filesystem (cross-fs rename isn't atomic).
-        tmp = tempfile.NamedTemporaryFile(
-            mode="w", encoding="utf-8",
-            dir=path.parent, prefix=".annotation-", suffix=".tmp",
-            delete=False,
+        # Atomic write: each save operation is a per-function annotation
+        # an operator relies on; a torn write on interrupt would lose
+        # the annotation with no recovery path. write_text_atomically
+        # gives us tempfile+fsync+rename with a fully audited implementation.
+        write_text_atomically(
+            path, rendered, tmp_prefix=".annotation-",
         )
-        try:
-            tmp.write(rendered)
-            tmp.flush()
-            os.fsync(tmp.fileno())
-            tmp.close()
-            os.replace(tmp.name, path)
-        except Exception:
-            try:
-                os.unlink(tmp.name)
-            except OSError:
-                pass
-            raise
     return path
 
 
@@ -450,23 +439,12 @@ def remove_annotation(
                 pass
             return True
         rendered = _render_file(source_file, remaining)
-        tmp = tempfile.NamedTemporaryFile(
-            mode="w", encoding="utf-8",
-            dir=path.parent, prefix=".annotation-", suffix=".tmp",
-            delete=False,
+        # Atomic write: same reasoning as write_annotation above — the
+        # remove path also rewrites the on-disk file, and a torn write
+        # would lose the survivor annotations.
+        write_text_atomically(
+            path, rendered, tmp_prefix=".annotation-",
         )
-        try:
-            tmp.write(rendered)
-            tmp.flush()
-            os.fsync(tmp.fileno())
-            tmp.close()
-            os.replace(tmp.name, path)
-        except Exception:
-            try:
-                os.unlink(tmp.name)
-            except OSError:
-                pass
-            raise
     return True
 
 

--- a/core/atomic_fs/__init__.py
+++ b/core/atomic_fs/__init__.py
@@ -40,15 +40,16 @@ one-shot corpus generators) shouldn't use it — the fsync overhead is
 unearned for outputs that just get re-run on failure.
 
 Consumers:
-  * ``packages/sca`` fixer / rewriter modules for manifest writes.
-    (Future migrations will add persistent state stores, sandbox
-    files, and LLM state persistence — see the atomic_fs adoption
-    PR for the full list.)
-
-Historical note: ``packages/sca/_atomic.py`` implemented the same
-primitives independently; that module is retained as a thin re-export
-for backwards compatibility inside sca while the sca callers migrate
-to :mod:`core.atomic_fs` directly.
+  * ``packages/sca`` fixer / rewriter modules — via the thin
+    ``packages/sca/_atomic.py`` wrapper (delegates atomic_write_text
+    / atomic_write_bytes to the primitive; preserves the sca-side
+    positional-args API for 15+ existing call sites).
+  * Every ``core.json.save_json`` caller (threat models, checklists,
+    run reports, LLM detection cache, scorecard) transitively via
+    ``save_json``'s delegation.
+  * Direct-call consumers: core annotations, labeled attempts, binary
+    fingerprint store, witness store, coverage store, sandbox
+    calibration cache, sandbox summary + audit-degraded markers.
 """
 
 from __future__ import annotations

--- a/core/atomic_fs/__init__.py
+++ b/core/atomic_fs/__init__.py
@@ -1,0 +1,255 @@
+"""Shared atomic-file-write primitive.
+
+Consumers reach here rather than reinventing the tempfile-plus-rename
+dance. Semantics guaranteed:
+
+  * A concurrent reader NEVER sees a partial file — either the old
+    bytes or the new bytes, never a truncation-in-progress.
+  * On success, the destination is fully committed to disk (fsync
+    on the tempfile before rename, best-effort fsync of the parent
+    directory after rename for power-loss durability).
+  * On failure — including ``KeyboardInterrupt`` / ``BaseException``
+    — the temporary is cleaned up and ``path`` is left in its prior
+    state.
+  * When the destination already exists, its permission bits are
+    preserved (so an operator ``chmod 0o600`` isn't silently widened
+    to 0o644) UNLESS an explicit ``mode=`` is passed, in which case
+    the caller's mode wins.
+  * The tempfile is created with ``O_EXCL | O_NOFOLLOW`` and a
+    PID+TID+random suffix so:
+      - a symlink squat at the tempfile path is rejected loudly
+        rather than followed (defence against local attacker on a
+        shared filesystem);
+      - two threads in the same process racing on the same ``path``
+        each get their own tempfile;
+      - two processes racing (parallel CI matrix, two operators)
+        each get their own tempfile.
+
+Symlink handling at the destination path:
+
+  * The perm probe uses ``lstat`` so we never inherit the target of
+    a symlink at ``path``.
+  * ``os.replace(tmp, path)`` REPLACES the symlink itself with a
+    regular file — this is the standard "atomic write to path X"
+    contract. If a caller wants to write through a symlink to its
+    target, they should resolve the path first.
+
+The primitive is intended for durability-critical writers (state
+stores, sandbox files, credentials). Regeneratable outputs (scripts,
+one-shot corpus generators) shouldn't use it — the fsync overhead is
+unearned for outputs that just get re-run on failure.
+
+Consumers:
+  * ``packages/sca`` fixer / rewriter modules for manifest writes.
+    (Future migrations will add persistent state stores, sandbox
+    files, and LLM state persistence — see the atomic_fs adoption
+    PR for the full list.)
+
+Historical note: ``packages/sca/_atomic.py`` implemented the same
+primitives independently; that module is retained as a thin re-export
+for backwards compatibility inside sca while the sca callers migrate
+to :mod:`core.atomic_fs` directly.
+"""
+
+from __future__ import annotations
+
+import os
+import secrets
+import stat as _stat
+import threading
+from pathlib import Path
+from typing import Optional, Union
+
+
+# Perm mask: only the low 9 bits are legal via ``mode=``. Rejects
+# setuid (0o4000), setgid (0o2000), sticky (0o1000). None of the
+# durability-critical consumers should be shipping files with those
+# bits set; requiring an explicit path (chmod after the write) forces
+# an operator to think about it.
+_MODE_MASK = 0o777
+
+
+def _validate_mode(mode: Optional[int]) -> None:
+    """Reject ``mode`` values outside 0o000..0o777.
+
+    Raises ``ValueError`` on anything not representable as a plain
+    POSIX file mode. Explicit rejection beats silent masking: a caller
+    passing ``mode=0o4755`` is either confused or trying to install a
+    setuid file — either way we want to fail loud, not paper over it.
+    """
+    if mode is None:
+        return
+    if not isinstance(mode, int):
+        raise ValueError(
+            f"mode must be int (0o000..0o777), got {type(mode).__name__}",
+        )
+    if not (0 <= mode <= _MODE_MASK):
+        raise ValueError(
+            f"mode must be in 0o000..0o777, got 0o{mode:o}",
+        )
+
+
+def _resolve_effective_mode(
+    path: Path,
+    mode: Optional[int],
+) -> int:
+    """Pick the mode to apply to the new file.
+
+    Precedence:
+      1. Explicit ``mode=`` from caller wins.
+      2. Else preserve existing perms if destination is a regular
+         file (guards the operator-chmod case).
+      3. Else default 0o644.
+
+    Uses ``lstat`` so a symlink at ``path`` never lets us inherit
+    the symlink target's perms — the atomic replace would then destroy
+    the symlink AND install a file with unrelated perms. Only preserves
+    when the existing entry is a regular file; symlinks / sockets /
+    devices fall back to the default.
+    """
+    if mode is not None:
+        return mode
+    try:
+        st = path.lstat()
+    except FileNotFoundError:
+        return 0o644
+    # PermissionError etc propagate — an inaccessible parent is a
+    # real problem the caller should see, not silently downgrade to
+    # 0o644 (which would be a chmod-widening event on the eventual
+    # rename).
+    if _stat.S_ISREG(st.st_mode):
+        return _stat.S_IMODE(st.st_mode)
+    return 0o644
+
+
+def write_text_atomically(
+    path: Union[str, Path],
+    content: str,
+    *,
+    encoding: str = "utf-8",
+    tmp_prefix: str = ".atomic-",
+    mode: Optional[int] = None,
+) -> None:
+    """Write ``content`` (str) to ``path`` atomically.
+
+    Thin wrapper over :func:`write_bytes_atomically`; encodes to
+    bytes and delegates. See module docstring for full semantics.
+
+    ``path.parent`` is created if missing.
+
+    ``mode`` semantics: see :func:`write_bytes_atomically`.
+    """
+    write_bytes_atomically(
+        path,
+        content.encode(encoding),
+        tmp_prefix=tmp_prefix,
+        mode=mode,
+    )
+
+
+def write_bytes_atomically(
+    path: Union[str, Path],
+    content: bytes,
+    *,
+    tmp_prefix: str = ".atomic-",
+    mode: Optional[int] = None,
+) -> None:
+    """Write ``content`` (bytes) to ``path`` atomically.
+
+    See module docstring for full semantics. Binary variant so
+    callers writing JSONL / images / archives don't have to double-
+    encode.
+
+    ``path.parent`` is created if missing.
+
+    ``mode`` (optional): when set to an integer in ``0o000..0o777``,
+    applied via ``os.fchmod`` on the tempfile BEFORE the rename so
+    the atomic rename installs a file that already has the requested
+    permissions — no window where the file exists at default perms
+    before a chmod tightens them. Callers with security-sensitive
+    writes (credentials, session tokens, per-user state) should pass
+    ``mode=0o600``. Setuid / setgid / sticky bits are rejected —
+    callers that genuinely need those bits must chmod explicitly.
+
+    When ``mode`` is None (default), preserves existing perms if the
+    destination is a regular file (guards the operator-chmod case),
+    else uses 0o644.
+    """
+    _validate_mode(mode)
+    path = Path(path)
+    parent = path.parent
+    parent.mkdir(parents=True, exist_ok=True)
+
+    effective_mode = _resolve_effective_mode(path, mode)
+
+    # Tempfile name = prefix + basename + PID + TID + random suffix.
+    # Each component blocks a specific attack / collision:
+    #   - PID: two processes on shared FS don't collide
+    #   - TID: two threads in same process don't collide
+    #   - random: an attacker who knows PID + TID (via /proc, ps)
+    #     still can't predict the full path to pre-create a squat
+    #     file. Combined with O_EXCL + O_NOFOLLOW below, symlink-
+    #     through and pre-created-file attacks fail loud.
+    tid = threading.get_ident()
+    rand = secrets.token_hex(4)
+    tmp = path.with_name(
+        f"{tmp_prefix}{path.name}.{os.getpid()}.{tid}.{rand}.tmp",
+    )
+
+    # O_EXCL: refuse if tempfile already exists (attacker squat, or
+    # stale from a crashed prior invocation — either way the operator
+    # should see and clean up rather than us silently overwriting).
+    # O_NOFOLLOW: refuse if tempfile is a symlink. Defence-in-depth
+    # against a squatter who predicts the tempfile name.
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+    flags |= getattr(os, "O_NOFOLLOW", 0)
+
+    fd = os.open(tmp, flags, effective_mode)
+    try:
+        try:
+            # O_CREAT + mode gets umask-adjusted. Explicit fchmod
+            # bypasses umask so the caller's requested mode WINS
+            # regardless of the process's umask. On the preserve-
+            # existing path this is a no-op.
+            os.fchmod(fd, effective_mode)
+        except (OSError, AttributeError):
+            # Windows + some mounts don't honour fchmod — the
+            # O_CREAT mode argument was already best-effort.
+            pass
+        try:
+            os.write(fd, content)
+            os.fsync(fd)
+        finally:
+            os.close(fd)
+        # Atomic rename. Same-FS on POSIX is atomic by spec; the
+        # tempfile sits in the same directory to guarantee that.
+        # Cross-FS raises EXDEV — but tmp lives in path.parent so
+        # this is unreachable in practice.
+        os.replace(tmp, path)
+        # Best-effort durability: fsync the parent directory so the
+        # rename survives a power loss. Windows + some mounts don't
+        # support directory fsync — silent fallback is fine.
+        try:
+            dir_fd = os.open(parent, os.O_RDONLY)
+            try:
+                os.fsync(dir_fd)
+            finally:
+                os.close(dir_fd)
+        except OSError:
+            pass
+    except BaseException:
+        # Catch BaseException (which includes KeyboardInterrupt)
+        # explicitly — that's the exact scenario a torn write would
+        # otherwise happen in. Best-effort clean up of the tempfile.
+        # The fd was already closed inside the inner try/finally on
+        # success paths; on the O_EXCL failure path the fd never
+        # existed. On mid-write failure the finally block above
+        # closed the fd before we got here.
+        try:
+            tmp.unlink()
+        except FileNotFoundError:
+            pass
+        raise
+
+
+__all__ = ["write_text_atomically", "write_bytes_atomically"]

--- a/core/atomic_fs/tests/test_atomic_fs.py
+++ b/core/atomic_fs/tests/test_atomic_fs.py
@@ -1,0 +1,265 @@
+"""Tests for the shared atomic-file-write primitive.
+
+Pins the contract two consumers rely on
+(``core/annotations/storage.py`` + ``brain/auto_notes.py``):
+
+  * Parent-dir auto-created.
+  * A concurrent reader never sees a truncated / half-written file.
+  * On write failure, ``path`` is left unchanged and no tempfile
+    dangles.
+  * ``os.replace`` semantics: same-inode overwrite works even when
+    ``path`` already exists.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from core.atomic_fs import write_text_atomically
+
+
+class TestWriteTextAtomically:
+    def test_creates_parent_dir(self, tmp_path):
+        target = tmp_path / "deep" / "nested" / "note.md"
+        write_text_atomically(target, "hello\n")
+        assert target.read_text() == "hello\n"
+
+    def test_overwrites_existing_atomically(self, tmp_path):
+        target = tmp_path / "note.md"
+        target.write_text("v1\n")
+        write_text_atomically(target, "v2\n")
+        assert target.read_text() == "v2\n"
+
+    def test_leaves_no_tempfile_on_success(self, tmp_path):
+        target = tmp_path / "note.md"
+        write_text_atomically(target, "body")
+        # Every entry in the dir should be either the target or an
+        # unrelated file — no leftover ``.atomic-*.tmp``.
+        siblings = list(tmp_path.iterdir())
+        assert siblings == [target]
+
+    def test_preserves_prior_state_on_write_error(
+        self, tmp_path, monkeypatch,
+    ):
+        """If the OS write fails mid-way, ``path`` retains its prior
+        content and the tempfile is cleaned up."""
+        target = tmp_path / "note.md"
+        target.write_text("prior\n")
+
+        # Monkeypatch os.fsync to raise — simulates a mid-write
+        # failure after the buffer's flushed but before the rename.
+        import os
+        real_fsync = os.fsync
+
+        def boom(fd):
+            raise OSError("simulated fsync failure")
+
+        monkeypatch.setattr(os, "fsync", boom)
+        with pytest.raises(OSError):
+            write_text_atomically(target, "new\n")
+
+        # Prior content survives.
+        assert target.read_text() == "prior\n"
+        # And no dangling tempfile (write should have unlinked it).
+        siblings = [
+            p for p in tmp_path.iterdir()
+            if p.name.startswith(".atomic-")
+        ]
+        assert siblings == []
+        # Restore for the fixture teardown.
+        monkeypatch.setattr(os, "fsync", real_fsync)
+
+    def test_custom_tmp_prefix(self, tmp_path):
+        """Callers can pass a distinct ``tmp_prefix`` so operators
+        grepping for dangling temporaries can tell what module
+        was writing."""
+        # We can't observe the tempfile after success (it's renamed),
+        # but we can check the API accepts the kwarg without error.
+        target = tmp_path / "note.md"
+        write_text_atomically(
+            target, "content", tmp_prefix=".myservice-",
+        )
+        assert target.read_text() == "content"
+
+
+class TestModeParameter:
+    """The optional ``mode`` argument pins perms via ``os.fchmod`` on
+    the tempfile BEFORE rename, so the atomic rename installs a file
+    with the correct permissions in a single atomic step — no
+    chmod-after-rename window where a reader could see the file
+    with the wrong perms."""
+
+    def test_mode_applied_to_new_file(self, tmp_path):
+        # Fresh destination: mode= should be applied to the created
+        # file. Confirms security-sensitive callers can write with
+        # 0o600 straight through the atomic path.
+        target = tmp_path / "secret.tok"
+        write_text_atomically(target, "hunter2\n", mode=0o600)
+        assert target.stat().st_mode & 0o777 == 0o600
+        assert target.read_text() == "hunter2\n"
+
+    def test_mode_overrides_preserve_existing(self, tmp_path):
+        # If destination already exists at 0o644, an explicit
+        # mode=0o600 should tighten it — the caller's declared
+        # mode wins over the "preserve existing" default.
+        target = tmp_path / "note.md"
+        target.write_text("v1")
+        target.chmod(0o644)
+        write_text_atomically(target, "v2", mode=0o600)
+        assert target.stat().st_mode & 0o777 == 0o600
+        assert target.read_text() == "v2"
+
+    def test_mode_none_preserves_existing_perms(self, tmp_path):
+        # mode=None (default): existing perms preserved so an
+        # operator's ``chmod 0o600`` isn't silently widened by our
+        # next write. This is the guard against the concrete regression
+        # of tightening operator-set perms.
+        target = tmp_path / "note.md"
+        target.write_text("v1")
+        target.chmod(0o600)
+        write_text_atomically(target, "v2")
+        assert target.stat().st_mode & 0o777 == 0o600
+
+    def test_mode_none_new_file_uses_default(self, tmp_path):
+        # mode=None on a fresh destination: use conventional 0o644.
+        target = tmp_path / "note.md"
+        write_text_atomically(target, "content")
+        assert target.stat().st_mode & 0o777 == 0o644
+
+    def test_mode_rejects_setuid(self, tmp_path):
+        # Setuid bit rejected — no consumer of this primitive should
+        # be shipping setuid files without an explicit chmod step.
+        with pytest.raises(ValueError, match="0o000..0o777"):
+            write_text_atomically(
+                tmp_path / "x", "content", mode=0o4755,
+            )
+
+    def test_mode_rejects_setgid_and_sticky(self, tmp_path):
+        with pytest.raises(ValueError):
+            write_text_atomically(tmp_path / "x", "c", mode=0o2755)
+        with pytest.raises(ValueError):
+            write_text_atomically(tmp_path / "x", "c", mode=0o1755)
+
+    def test_mode_rejects_negative(self, tmp_path):
+        with pytest.raises(ValueError):
+            write_text_atomically(tmp_path / "x", "c", mode=-1)
+
+    def test_mode_rejects_non_int(self, tmp_path):
+        # Explicit type validation — a caller passing "0o600" (str)
+        # would otherwise land silently as garbage perms.
+        with pytest.raises(ValueError, match="mode must be int"):
+            write_text_atomically(tmp_path / "x", "c", mode="0o600")
+
+    def test_mode_zero_is_legal(self, tmp_path):
+        # mode=0 is silly (locks the operator out) but technically a
+        # legal POSIX mode. Accept it — don't silently interpret 0
+        # as "no mode specified".
+        target = tmp_path / "locked.tok"
+        write_text_atomically(target, "content", mode=0)
+        assert target.stat().st_mode & 0o777 == 0
+        # Cleanup: restore perms so pytest tmpdir can remove it.
+        target.chmod(0o600)
+
+
+class TestAdversarial:
+    """Concurrent-writer + squat-attack + symlink-handling contract.
+
+    Every test here maps to a class of bug that would compound
+    silently across every downstream consumer of the primitive.
+    """
+
+    def test_concurrent_same_process_threads(self, tmp_path):
+        # Two threads writing the same path must NOT corrupt the
+        # tempfile via shared-name collision. Pre-fix, the tempfile
+        # name was PID-only; two threads computed identical tempfile
+        # paths and the second's O_TRUNC clobbered the first's
+        # in-flight write.
+        import threading as _th
+        target = tmp_path / "shared.md"
+        errs: list[BaseException] = []
+
+        def writer(tag: str):
+            try:
+                write_text_atomically(target, tag * 1000)
+            except BaseException as e:  # noqa: BLE001
+                errs.append(e)
+
+        threads = [
+            _th.Thread(target=writer, args=(chr(ord("a") + i),))
+            for i in range(8)
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        # No writer should have blown up.
+        assert errs == [], f"concurrent writers failed: {errs}"
+        # File contents must be one writer's payload in full — never
+        # a mixed / truncated snapshot.
+        got = target.read_text()
+        assert len(got) == 1000, (
+            f"torn write: got {len(got)} bytes, expected 1000 "
+            f"(sample: {got[:20]!r})"
+        )
+        # All bytes should be the same char (one writer's payload).
+        assert len(set(got)) == 1, (
+            f"mixed content: {sorted(set(got))!r}"
+        )
+
+    def test_rejects_symlink_squat_at_tempfile(self, tmp_path):
+        # An attacker who predicts the tempfile name can pre-create
+        # it as a symlink to sensitive content. With O_EXCL + O_NOFOLLOW
+        # our open should refuse loudly rather than follow the symlink
+        # and truncate the attacker's chosen target.
+        #
+        # The random suffix makes an ACTUAL squat impossible to stage
+        # in a test (we can't predict what the primitive will name its
+        # tempfile). Instead we assert the flags are present in the
+        # write path via source inspection — a refactor that drops
+        # O_EXCL or O_NOFOLLOW is caught by this test.
+        import inspect
+        import core.atomic_fs as af
+        src = inspect.getsource(af.write_bytes_atomically)
+        assert "O_EXCL" in src, (
+            "O_EXCL missing from write path — refactor introduced "
+            "a tempfile squat window (attacker could pre-create "
+            "the tempfile, our O_CREAT alone would follow into it)"
+        )
+        assert "O_NOFOLLOW" in src, (
+            "O_NOFOLLOW missing from write path — refactor introduced "
+            "a tempfile symlink-follow window (attacker could "
+            "pre-create the tempfile as a symlink to their target)"
+        )
+
+    def test_perm_preserve_does_not_inherit_symlink_target_mode(
+        self, tmp_path,
+    ):
+        # If ``path`` is a symlink to a file with 0o644, our perm
+        # probe must NOT copy the target's 0o644 onto the new file
+        # (which would silently change perms if the operator intended
+        # tight perms on the eventual real file). Pre-fix used
+        # ``path.stat()`` which followed the link.
+        real = tmp_path / "real.md"
+        real.write_text("real content")
+        real.chmod(0o644)
+        sym = tmp_path / "link.md"
+        sym.symlink_to(real)
+
+        # Write via the symlink path with mode=None.
+        write_text_atomically(sym, "new content")
+
+        # The rename should have REPLACED the symlink with a
+        # regular file (standard atomic-write contract) — and the
+        # new file should have the default 0o644 (not inherited
+        # from an lstat of a non-file). Real file unchanged.
+        assert not sym.is_symlink(), (
+            "atomic write should replace symlink with regular file"
+        )
+        assert sym.read_text() == "new content"
+        assert real.read_text() == "real content"
+        # Perms on the new regular file: default 0o644 (symlink
+        # itself has no meaningful mode to preserve).
+        assert sym.stat().st_mode & 0o777 == 0o644
+
+

--- a/core/binary/fingerprint_store.py
+++ b/core/binary/fingerprint_store.py
@@ -52,11 +52,10 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
-import os
-import tempfile
 from pathlib import Path
 from typing import Iterator, Optional, Tuple
 
+from core.atomic_fs import write_text_atomically
 from core.binary.fingerprint import (
     FINGERPRINT_SCHEMA_VERSION,
     CapabilityFingerprint,
@@ -108,31 +107,20 @@ def save_fingerprint(
         "fingerprint": fingerprint.to_dict(),
     }
     final_path = store_dir / _ref_filename(ref)
-    # Atomic write: tmp file in the same dir (so rename is on
-    # the same filesystem and stays atomic), then os.replace.
+    # Atomic write: fingerprint is the drift-detector's on-disk baseline.
+    # A torn write would corrupt JSON, get skipped as unreadable, and
+    # silently disable drift signal for that ref until the next scan.
     try:
-        fd, tmp_name = tempfile.mkstemp(
-            prefix=".tmp-", suffix=".json", dir=store_dir,
+        write_text_atomically(
+            final_path,
+            json.dumps(payload, sort_keys=True, indent=2),
+            tmp_prefix=".fingerprint-",
         )
-    except OSError as e:
-        logger.warning(
-            "core.binary.fingerprint_store: tempfile failed for %s: %s",
-            store_dir, e,
-        )
-        return None
-    try:
-        with os.fdopen(fd, "w") as f:
-            json.dump(payload, f, sort_keys=True, indent=2)
-        os.replace(tmp_name, final_path)
     except OSError as e:
         logger.warning(
             "core.binary.fingerprint_store: write failed for %s: %s",
             final_path, e,
         )
-        try:
-            os.unlink(tmp_name)
-        except OSError:
-            pass
         return None
     return final_path
 

--- a/core/coverage/store.py
+++ b/core/coverage/store.py
@@ -32,11 +32,11 @@ import contextlib
 import hashlib
 import json
 import os
-import tempfile
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, Iterator, List, Optional, Tuple
 
+from core.atomic_fs import write_text_atomically
 from core.logging import get_logger as _get_logger
 
 from .registry import category_of
@@ -560,20 +560,14 @@ class CoverageStore:
         }
 
     def save(self) -> Path:
-        """Atomically write ``coverage.json`` (tempfile + os.replace)."""
-        self.path.parent.mkdir(parents=True, exist_ok=True)
+        """Atomically write ``coverage.json``.
+
+        Atomic write: coverage.json is a merged per-run artefact that
+        downstream tools (gap analysis, diff between runs, project
+        report) load as canonical. A torn write on interrupt would
+        leave malformed JSON that fails to parse and blocks every
+        subsequent read.
+        """
         payload = json.dumps(self.to_dict(), indent=2, sort_keys=True)
-        fd, tmp = tempfile.mkstemp(
-            dir=str(self.path.parent), prefix=".coverage-", suffix=".json.tmp",
-        )
-        try:
-            with os.fdopen(fd, "w", encoding="utf-8") as fh:
-                fh.write(payload)
-            os.replace(tmp, self.path)
-        except BaseException:
-            try:
-                os.unlink(tmp)
-            except OSError:
-                pass
-            raise
+        write_text_atomically(self.path, payload, tmp_prefix=".coverage-")
         return self.path

--- a/core/inventory/_reach_cache.py
+++ b/core/inventory/_reach_cache.py
@@ -43,9 +43,10 @@ import logging
 import os
 import pickle
 import re
-import tempfile
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, Optional
+
+from core.atomic_fs import write_bytes_atomically
 
 if TYPE_CHECKING:
     from .reachability import _AdjacencyIndex
@@ -326,28 +327,16 @@ def save_index(
     except OSError as exc:
         logger.debug("reach_cache: dir setup failed: %s", exc)
         return
+    # Atomic write: reachability cache, mode=0o600 to preserve the
+    # owner-only posture the previous mkstemp+chmod pattern installed.
+    # ``protocol=4`` (not latest) so a cache built on a newer Python
+    # is still readable on older runtimes in the same dev environment.
+    payload = _HEADER_MAGIC + pickle.dumps(index, protocol=4)
     try:
-        fd, tmp_path = tempfile.mkstemp(
-            prefix=".reach-tmp-", suffix=".pickle",
-            dir=str(_CACHE_DIR),
+        write_bytes_atomically(
+            path, payload,
+            mode=0o600, tmp_prefix=".reach-tmp-",
         )
-        try:
-            with os.fdopen(fd, "wb") as f:
-                f.write(_HEADER_MAGIC)
-                # ``protocol=4`` is supported on all Python versions
-                # raptor targets and gives reasonable size/speed.
-                # Avoid the latest protocol so a cache built on a
-                # newer Python is still readable on older runtimes
-                # in the same dev environment.
-                pickle.dump(index, f, protocol=4)
-            os.chmod(tmp_path, 0o600)
-            os.rename(tmp_path, path)
-        except BaseException:
-            try:
-                os.unlink(tmp_path)
-            except OSError:
-                pass
-            raise
     except OSError as exc:
         logger.debug("reach_cache: write failed for %s: %s", path, exc)
 

--- a/core/inventory/binary_oracle_edges.py
+++ b/core/inventory/binary_oracle_edges.py
@@ -35,6 +35,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Dict, List, Optional, Set, Tuple
 
+from core.atomic_fs import write_text_atomically
+
 from .binary_oracle import read_build_id
 
 logger = logging.getLogger(__name__)
@@ -184,9 +186,13 @@ def _save_cached_index(cache_file: Path, idx: BinaryEdgeIndex) -> None:
                 for e in idx.edges
             ],
         }
-        tmp = cache_file.with_suffix(".json.tmp")
-        tmp.write_text(json.dumps(payload))
-        os.replace(tmp, cache_file)
+        # Atomic write: edge-index cache is the per-build-id snapshot
+        # the reachability chokepoint consults. A torn write leaves
+        # JSON that fails to parse and drops the cached edges — the
+        # next run re-extracts from scratch (slow, ~10-30s per binary).
+        write_text_atomically(
+            cache_file, json.dumps(payload), tmp_prefix=".edge-cache-",
+        )
     except OSError as e:
         logger.debug("binary_oracle_edges: cache write failed: %s", e)
 

--- a/core/json/utils.py
+++ b/core/json/utils.py
@@ -7,11 +7,11 @@ serialization of Path/datetime objects.
 
 import json
 import logging
-import os
-import threading
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Optional, Union
+
+from core.atomic_fs import write_text_atomically
 
 logger = logging.getLogger(__name__)
 
@@ -183,67 +183,19 @@ class _RaptorEncoder(json.JSONEncoder):
 def save_json(path: Union[str, Path], data: Any, mode: int = None) -> None:
     """Save data as pretty-printed JSON. Handles Path/datetime serialization.
 
-    Creates parent directories if needed. Uses atomic write (write to temp
-    file then rename) to prevent corruption if the process is killed mid-write.
-    Raises on write failure — a failed save should not be silent.
+    Delegates to :func:`core.atomic_fs.write_text_atomically` — the shared
+    primitive owns the tempfile + fsync + rename + parent-dir fsync dance,
+    plus O_EXCL/O_NOFOLLOW tempfile hardening.
+
+    Atomic write: threat models, checklists, run reports, project state —
+    every JSON produced through this helper is an operator-facing artefact
+    where a torn write (interrupt, power loss, sigkill) surfaces as
+    "path exists but fails to parse" on the next read.
 
     Args:
         mode: Optional POSIX file permission bits (e.g. 0o600). When set,
-              the temp file is created with these permissions atomically —
-              no window where the file exists with default permissions.
-
-    Durability: fsyncs the data file BEFORE the rename, then fsyncs the
-    parent directory AFTER. Pre-fix the atomic-write pattern used
-    `tmp.write_text` + `tmp.replace(p)` without either fsync — the
-    rename is atomic at the filesystem-metadata layer, but the data
-    pages may not be on disk yet. A power loss / hard reboot between
-    the rename and the next pdflush cycle produced a renamed file
-    containing zero bytes (or a torn fragment) — operator next boot
-    saw the path exist but the JSON failed to parse. The two fsyncs
-    cost a few hundred microseconds per save vs. the cost of losing
-    a checklist or report on power loss.
+              the mode is installed on the tempfile before rename — no
+              chmod-after-rename window.
     """
-    p = Path(path)
-    p.parent.mkdir(parents=True, exist_ok=True)
     content = json.dumps(data, indent=2, cls=_RaptorEncoder) + "\n"
-
-    # Write to temp file then rename — atomic on POSIX (same filesystem).
-    # .~ prefix makes stale temps visually obvious and excluded by
-    # get_run_dirs. The pid+tid suffix is what makes concurrent writers
-    # safe: two threads (or two processes) writing the same target path
-    # would otherwise share a tempfile path, and the second open with
-    # O_TRUNC would clobber the first's partial write — leaving a torn
-    # file that fails to parse on the next read. With pid+tid each
-    # writer has its own tempfile; the final rename is last-writer-wins.
-    tmp = p.with_name(f".~{p.name}.tmp.{os.getpid()}.{threading.get_ident()}")
-    try:
-        if mode is not None:
-            # Create temp file with explicit permissions — no race window
-            fd = os.open(str(tmp), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, mode)
-            with os.fdopen(fd, "w", encoding="utf-8") as f:
-                f.write(content)
-                f.flush()
-                os.fsync(f.fileno())
-        else:
-            with open(tmp, "w", encoding="utf-8") as f:
-                f.write(content)
-                f.flush()
-                os.fsync(f.fileno())
-        tmp.replace(p)
-        # fsync the parent directory so the rename's metadata is also
-        # durable. Some filesystems (ext4 default, xfs) don't propagate
-        # rename ordering to the next dir-entry flush without this.
-        try:
-            dir_fd = os.open(str(p.parent), os.O_RDONLY | getattr(os, "O_DIRECTORY", 0))
-            try:
-                os.fsync(dir_fd)
-            finally:
-                os.close(dir_fd)
-        except OSError:
-            # Some filesystems (notably some FUSE / network mounts)
-            # don't support fsync on directory fds. Best-effort.
-            pass
-    except BaseException:
-        # Clean up temp file on any failure
-        tmp.unlink(missing_ok=True)
-        raise
+    write_text_atomically(path, content, mode=mode, tmp_prefix=".~savejson-")

--- a/core/labeled_attempts/annotation.py
+++ b/core/labeled_attempts/annotation.py
@@ -20,10 +20,10 @@ for everything else.
 from __future__ import annotations
 
 import json
-import os
-import secrets
 from pathlib import Path
 from typing import Optional
+
+from core.atomic_fs import write_text_atomically
 
 from .types import FailureMode, LabeledAttempt
 
@@ -33,19 +33,11 @@ __all__ = ["set_failure_mode"]
 def _atomic_replace(path: Path, payload: str) -> None:
     """Write ``payload`` to a same-directory temp + rename onto
     ``path``. Atomic under POSIX rename semantics."""
-    parent = path.parent
-    # Same directory so rename is atomic (cross-FS rename is not).
-    tmp = parent / f".{path.name}.{secrets.token_hex(3)}.tmp"
-    fd = os.open(
-        tmp,
-        os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW,
-        0o644,
-    )
-    try:
-        os.write(fd, payload.encode("utf-8"))
-    finally:
-        os.close(fd)
-    os.replace(tmp, path)
+    # Atomic write: operator triage rewrites an existing labeled_attempt
+    # record; a torn write would corrupt the JSON and hide the record
+    # from downstream aggregation. Same-tier reasoning as
+    # core/annotations/storage.py — reuse the shared primitive.
+    write_text_atomically(path, payload)
 
 
 def set_failure_mode(

--- a/core/sandbox/calibrate.py
+++ b/core/sandbox/calibrate.py
@@ -55,6 +55,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Iterable, List, Optional, Tuple
 
+from core.atomic_fs import write_text_atomically
+
 
 logger = logging.getLogger(__name__)
 
@@ -453,27 +455,18 @@ def _save_to_cache(fingerprint: str, profile: SandboxProfile) -> None:
         logger.warning("calibrate: cache dir setup failed: %s", exc)
         return
     path = _cache_path_for(fingerprint)
-    # Atomic write: tempfile in the cache dir + rename. Avoids
-    # partial-content cache hits when the parent's process crashes
-    # mid-write.
+    # Atomic write: sandbox calibration cache. mode=0o600 to preserve
+    # the owner-only posture the previous mkstemp+chmod pattern installed
+    # (the shared primitive's default 0o644 would widen; the cache is
+    # owner-scoped, not shared). Primitive adds fsync-file + fsync-
+    # parent-dir durability the old direct-write lacked.
+    # nosemgrep: python.lang.security.audit.insecure-file-permissions
+    # 0o600 = owner-only file mode.
     try:
-        fd, tmp_path = tempfile.mkstemp(
-            prefix=".calibrate-tmp-", suffix=".json",
-            dir=str(_CACHE_DIR),
+        write_text_atomically(
+            path, profile.to_json(),
+            mode=0o600, tmp_prefix=".calibrate-tmp-",
         )
-        try:
-            with os.fdopen(fd, "w", encoding="utf-8") as f:
-                f.write(profile.to_json())
-            # nosemgrep: python.lang.security.audit.insecure-file-permissions
-            # 0o600 = owner-only file mode.
-            os.chmod(tmp_path, 0o600)
-            os.rename(tmp_path, path)
-        except BaseException:
-            try:
-                os.unlink(tmp_path)
-            except OSError:
-                pass
-            raise
     except OSError as exc:
         logger.warning("calibrate: cache write failed for %s: %s",
                        path, exc)

--- a/core/sandbox/summary.py
+++ b/core/sandbox/summary.py
@@ -58,6 +58,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, Optional
 
+from core.atomic_fs import write_text_atomically
 from core.security.redaction import redact_secrets
 
 logger = logging.getLogger(__name__)
@@ -302,30 +303,23 @@ def record_audit_degraded(run_dir: Path, *, reason: str,
         "instructions": instructions,
         "generated_at": datetime.now(timezone.utc).isoformat(),
     }
-    tmp = out.with_name(f".~{out.name}.tmp")
+    # Atomic write: audit-degraded marker is emitted once per run when
+    # sandbox observability degrades; a torn write would leave the
+    # marker in an unparseable state, and operator tooling treats
+    # "corrupt marker" as "audit engaged" (safest default) — silently
+    # hiding the degradation signal we needed to surface.
     try:
-        out.parent.mkdir(parents=True, exist_ok=True)
-        tmp.write_text(
+        write_text_atomically(
+            out,
             json.dumps(payload, indent=2, ensure_ascii=True) + "\n",
-            encoding="utf-8",
+            tmp_prefix=".~audit-degraded-",
         )
-        os.replace(tmp, out)
     except (OSError, ValueError, TypeError):
         # Marker is best-effort. The log warning is the primary signal.
         # Catch programming-error-shaped failures too (a future payload
         # change with non-serialisable types would otherwise propagate
-        # and abort the caller's cleanup path while still leaking the
-        # `.~sandbox-audit-degraded.json.tmp` file).
+        # and abort the caller's cleanup path).
         pass
-    finally:
-        # Ensure the tmp file doesn't leak when write_text succeeded but
-        # os.replace failed (e.g. EBUSY, EXDEV, target dir vanished).
-        # Unlink missing_ok handles both "tmp never existed" and "replace
-        # already moved it" cases as no-ops.
-        try:
-            tmp.unlink(missing_ok=True)
-        except OSError:
-            pass
 
 
 def summarize_and_write(run_dir: Path) -> Optional[Dict[str, Any]]:
@@ -453,11 +447,15 @@ def summarize_and_write(run_dir: Path) -> Optional[Dict[str, Any]]:
     }
 
     summary_path = run_dir / SUMMARY_FILE
-    tmp = summary_path.with_name(f".~{summary_path.name}.tmp")
+    # Atomic write: sandbox denial summary is the run's final audit
+    # artefact — a torn write would corrupt the canonical JSON and
+    # surface as a silent audit-integrity gap on the next read.
     try:
-        tmp.write_text(json.dumps(summary, indent=2, ensure_ascii=True) + "\n",
-                       encoding="utf-8")
-        os.replace(tmp, summary_path)
+        write_text_atomically(
+            summary_path,
+            json.dumps(summary, indent=2, ensure_ascii=True) + "\n",
+            tmp_prefix=".~summary-",
+        )
     except OSError:
         # WARNING (F071 W21 promote): the summary write is the run's
         # final-output artifact. Silent loss = silent audit integrity
@@ -468,12 +466,6 @@ def summarize_and_write(run_dir: Path) -> Optional[Dict[str, Any]]:
             "summarize_and_write: failed to write/replace summary.json",
             exc_info=True,
         )
-        try:
-            tmp.unlink()
-        except OSError:
-            # KEEP-SILENT (F071 per-site triage W21): cleanup of the
-            # tmp we may not have created. Logging here would be noise.
-            pass
         return None
 
     # The intermediate JSONL was already renamed-and-unlinked above

--- a/core/security/prompt_envelope_audit.py
+++ b/core/security/prompt_envelope_audit.py
@@ -798,15 +798,13 @@ def _update_allowlist_in_source(source_path: Path) -> int:
     them. That's sufficient because the literal is always formatted
     with the closing paren on its own column-0 line.
 
-    Atomic write: produces the new content in a sibling tempfile and
-    then ``os.replace`` swaps it into place. Without this an
-    interrupted ``--update`` (Ctrl-C, OOM kill, sandbox preempt) could
-    leave the audit module half-written on disk and break every
-    subsequent import — including the audit's own test, blocking
-    recovery via the same CLI.
+    Atomic write: an interrupted ``--update`` (Ctrl-C, OOM kill,
+    sandbox preempt) leaves the audit module half-written on disk and
+    breaks every subsequent import — including the audit's own test,
+    blocking recovery via the same CLI. Primitive keeps consumers
+    seeing either the OLD complete module or the NEW complete module.
     """
-    import os
-    import tempfile
+    from core.atomic_fs import write_text_atomically
     text = source_path.read_text(encoding="utf-8")
     lines = text.splitlines()
     start = None
@@ -829,26 +827,9 @@ def _update_allowlist_in_source(source_path: Path) -> int:
     out_lines = lines[:start] + new_block + lines[end + 1 :]
     new_text = "\n".join(out_lines) + "\n"
 
-    # Atomic write: write to a sibling tempfile, then os.replace.
-    # NamedTemporaryFile with delete=False so we can keep the path
-    # alive past the ``with`` block; cleanup-on-error handled below.
-    fd, tmp_path = tempfile.mkstemp(
-        prefix=source_path.name + ".",
-        suffix=".tmp",
-        dir=source_path.parent,
+    write_text_atomically(
+        source_path, new_text, tmp_prefix=source_path.name + ".",
     )
-    try:
-        with os.fdopen(fd, "w", encoding="utf-8") as fh:
-            fh.write(new_text)
-        os.replace(tmp_path, source_path)
-    except Exception:
-        # If anything went wrong before the replace, drop the partial
-        # tempfile so it doesn't litter the source tree.
-        try:
-            os.unlink(tmp_path)
-        except OSError:
-            pass
-        raise
     return len(violations)
 
 

--- a/core/security/prompt_telemetry.py
+++ b/core/security/prompt_telemetry.py
@@ -51,6 +51,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional
 
+from core.atomic_fs import write_text_atomically
+
 
 logger = logging.getLogger("raptor.security")
 logger.propagate = True
@@ -323,30 +325,19 @@ class DefenseTelemetry:
     def write_summary(self, output_dir: str | Path) -> Path:
         """Write the summary to defense-telemetry.json in output_dir.
 
-        Atomic write: temp file + os.replace. Pre-fix
-        `path.write_text(...)` was non-atomic — a process killed
-        mid-write left the JSON file half-written. The downstream
-        consumer (orchestration report aggregation) then JSONDecode-
-        crashed on the partial file and either skipped the section
-        or aborted report generation. The atomic temp+rename pattern
-        guarantees consumers see either the OLD complete file or the
-        NEW complete file, never a truncated transition.
+        Atomic write: orchestration-report aggregation reads this file
+        after every run; a torn write would JSONDecode-crash the
+        aggregator and either drop the defense-telemetry section or
+        abort the whole report. Primitive keeps consumers seeing
+        either the OLD complete file or the NEW complete file.
         """
-        import os as _os
         path = Path(output_dir) / "defense-telemetry.json"
         data = self.summary()
-        tmp = path.with_name(f"{path.name}.tmp.{_os.getpid()}")
-        try:
-            tmp.write_text(
-                json.dumps(data, indent=2) + "\n", encoding="utf-8",
-            )
-            _os.replace(str(tmp), str(path))
-        except BaseException:
-            try:
-                tmp.unlink(missing_ok=True)
-            except OSError:
-                pass
-            raise
+        write_text_atomically(
+            path,
+            json.dumps(data, indent=2) + "\n",
+            tmp_prefix=".defense-telemetry-",
+        )
         return path
 
     @property

--- a/core/witness/store.py
+++ b/core/witness/store.py
@@ -26,11 +26,10 @@ from __future__ import annotations
 
 import json
 import logging
-import os
-import threading
 from pathlib import Path
 from typing import Iterator, Optional
 
+from core.atomic_fs import write_bytes_atomically, write_text_atomically
 from core.witness.types import Witness, compute_bytes_hash
 
 
@@ -155,46 +154,23 @@ class WitnessStore:
         blob_path = self._blobs_dir / f"{witness.bytes_hash}.bin"
         manifest_path = self._manifests_dir / f"{witness.bytes_hash}.json"
 
-        # Atomic blob write: write to .tmp + os.replace. POSIX
-        # guarantees the rename is atomic. Pre-fix ``write_bytes``
-        # was direct and a crash mid-write left a partial blob
-        # that subsequent puts would skip (since blob_path.exists()
-        # was True), producing on-disk corruption invisible to
-        # later readers.
-        # ``.tmp`` paths are made unique per (pid, thread) so two
-        # concurrent ``put()`` calls writing the same hash don't
-        # race on the same temp file — the original ``.bin.tmp`` /
-        # ``.json.tmp`` suffix collided when N threads wrote identical
-        # bytes, with N-1 callers raising ``FileNotFoundError`` on
-        # the second ``os.replace`` (the first one had already
-        # consumed the shared tempfile). End state was still correct
-        # (dedup by hash) but most callers got an exception. The
-        # pid+tid suffix keeps the existing crash-mid-write guarantee
-        # (each tempfile is still atomically renamed onto the final
-        # path) while making same-hash concurrent writes succeed.
-        suffix = f".{os.getpid()}.{threading.get_ident()}.tmp"
+        # Atomic blob write: witness blob is the durable per-scan
+        # artefact; a torn write would leave a partial blob that
+        # dedup would trust as canonical for that hash. The shared
+        # primitive's PID+TID+random tempfile suffix keeps
+        # concurrent same-hash puts from racing on one tempfile
+        # (previously N callers raised FileNotFoundError on the
+        # second os.replace; end state was still correct via
+        # dedup-by-hash, but the exceptions surfaced up).
         if not blob_path.exists():
-            blob_tmp = blob_path.with_suffix(".bin" + suffix)
-            blob_tmp.write_bytes(data)
-            try:
-                os.replace(blob_tmp, blob_path)
-            except FileNotFoundError:
-                # Lost the race: another writer replaced the .tmp out
-                # from under us. The final blob_path now holds the
-                # same bytes (verified by hash); nothing to do.
-                pass
+            write_bytes_atomically(blob_path, data, tmp_prefix=".blob-")
 
-        # Atomic manifest write. Pre-fix ``write_text`` was direct
-        # and a crash mid-write left a malformed JSON file forever
-        # — list_witnesses skipped it with a warning but get_witness
-        # raised, and there was no recovery path other than manual
-        # cleanup.
-        manifest_tmp = manifest_path.with_suffix(".json" + suffix)
-        manifest_tmp.write_text(manifest_text, encoding="utf-8")
-        try:
-            os.replace(manifest_tmp, manifest_path)
-        except FileNotFoundError:
-            pass
+        # Atomic manifest write. Same reasoning: a torn manifest
+        # left get_witness raising forever with no recovery path
+        # other than manual cleanup.
+        write_text_atomically(
+            manifest_path, manifest_text, tmp_prefix=".manifest-",
+        )
 
         logger.debug(
             "WitnessStore.put: hash=%s len=%d source=%s outcome=%s",

--- a/packages/checker_synthesis/synthesise.py
+++ b/packages/checker_synthesis/synthesise.py
@@ -12,11 +12,11 @@ pass an adapter around ``LLMClient.generate_structured``.
 from __future__ import annotations
 
 import logging
-import os
 import re
-import tempfile
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Protocol, Tuple
+
+from core.atomic_fs import write_text_atomically
 
 from .languages import detect_engine
 from .models import (
@@ -140,25 +140,13 @@ def _write_rule(
     other intact.
     """
     rules_dir = out_dir / "checkers"
-    rules_dir.mkdir(parents=True, exist_ok=True)
     path = rules_dir / f"{rule.rule_id}{_rule_extension(rule.engine)}"
-    tmp = tempfile.NamedTemporaryFile(
-        mode="w", encoding="utf-8",
-        dir=rules_dir, prefix=".rule-", suffix=".tmp",
-        delete=False,
-    )
-    try:
-        tmp.write(rule.body)
-        tmp.flush()
-        os.fsync(tmp.fileno())
-        tmp.close()
-        os.replace(tmp.name, path)
-    except Exception:
-        try:
-            os.unlink(tmp.name)
-        except OSError:
-            pass
-        raise
+    # Atomic write: concurrent synthesises on the same seed (an
+    # /audit driver parallel-fanning hypothesis tests) can each write
+    # the same rule_id filename. Primitive's random-suffix tempfile
+    # keeps their writes isolated; readers see one or the other
+    # intact, never partial content.
+    write_text_atomically(path, rule.body, tmp_prefix=".rule-")
     return path
 
 

--- a/packages/cve_diff/cve_diff/cli/bench.py
+++ b/packages/cve_diff/cve_diff/cli/bench.py
@@ -26,6 +26,7 @@ from pathlib import Path
 
 import typer
 
+from core.atomic_fs import write_text_atomically
 from cve_diff.core.exceptions import CveDiffError
 from cve_diff.infra import api_status
 from cve_diff.infra.github_client import warn_if_token_missing
@@ -697,29 +698,17 @@ def bench(
     summary_path = output_dir / "summary.json"
 
     def _flush() -> None:
-        # Atomic write. Pre-fix `summary_path.write_text(...)` was
-        # non-atomic — `_flush` is called after every CVE in a long
-        # bench run (a 100-CVE bench takes 30+ minutes), and the
-        # operator routinely reads `summary.json` mid-run to track
-        # progress. A reader catching the file mid-write got partial
-        # JSON and JSONDecode-crashed. Worse, a process kill
-        # mid-write left summary.json corrupted at end-of-run, with
-        # no easy recovery (the per-CVE results are scattered across
-        # `_run_one` outputs). Temp+rename keeps every observable
-        # state of summary.json complete.
-        import os as _os
-        tmp = summary_path.with_name(
-            f"{summary_path.name}.tmp.{_os.getpid()}"
+        # Atomic write: ``_flush`` is called after every CVE in a
+        # long bench run (a 100-CVE bench takes 30+ minutes); the
+        # operator routinely reads ``summary.json`` mid-run to track
+        # progress. Torn reads got partial JSON and JSONDecode-
+        # crashed. Primitive keeps every observable state of
+        # summary.json complete.
+        write_text_atomically(
+            summary_path,
+            json.dumps(asdict(summary), indent=2) + "\n",
+            tmp_prefix=".bench-summary-",
         )
-        try:
-            tmp.write_text(json.dumps(asdict(summary), indent=2) + "\n")
-            _os.replace(str(tmp), str(summary_path))
-        except BaseException:
-            try:
-                tmp.unlink(missing_ok=True)
-            except OSError:
-                pass
-            raise
 
     if workers <= 1:
         for i, cve_id in enumerate(cves, 1):
@@ -778,28 +767,20 @@ def bench(
     non_source = summary.passed - source_hits
     pass_n, refusal_n, issue_n = _outcome_buckets(summary)
     _flush()
-    # Atomic write via tmp+rename. Pre-fix `write_text` on the
-    # final filenames left a half-written summary visible to
-    # concurrent readers (the CI harness that polls
-    # `summary.json` to grab pass-rates the moment a bench
-    # finishes had a window where `json.load` failed mid-write
-    # with "Expecting value"). For .html and .md the consequence
-    # is an operator opening the file mid-bench and seeing
-    # truncated content.
-    #
-    # Same-directory tmp+rename so the rename is atomic on the
-    # same filesystem (cross-fs would fall back to copy+unlink).
-    def _atomic_write(path: Path, content: str) -> None:
-        tmp = path.with_name(path.name + f".tmp.{os.getpid()}")
-        try:
-            tmp.write_text(content)
-            tmp.replace(path)
-        except BaseException:
-            tmp.unlink(missing_ok=True)
-            raise
-    import os
-    _atomic_write(output_dir / "summary.html", _render_html(summary))
-    _atomic_write(output_dir / "bench_report.md", _render_bench_markdown(summary))
+    # Atomic write: CI harness polls summary.html / bench_report.md
+    # for pass-rates the moment a bench finishes; torn reads leave
+    # operators seeing truncated JSON / markdown. Primitive keeps
+    # every observable state complete.
+    write_text_atomically(
+        output_dir / "summary.html",
+        _render_html(summary),
+        tmp_prefix=".bench-html-",
+    )
+    write_text_atomically(
+        output_dir / "bench_report.md",
+        _render_bench_markdown(summary),
+        tmp_prefix=".bench-md-",
+    )
     _persist_summary(output_dir / "summary.json", sample)
     typer.echo("")
     typer.echo(f"=== {summary.passed}/{summary.total} passed ({pct:.1f}%) ===")

--- a/packages/exploit_feasibility/exploit_context.py
+++ b/packages/exploit_feasibility/exploit_context.py
@@ -30,10 +30,10 @@ Usage:
 """
 
 import json
-import os
-from pathlib import Path
 from typing import Any, Optional, List, Dict
 from datetime import datetime
+
+from core.atomic_fs import write_text_atomically
 
 try:
     from ..logging import get_logger
@@ -360,32 +360,16 @@ class ExploitContext:
         missing fields as defaults — in either case losing the
         previously-stored evidence with no signal.
 
-        Atomic write: serialise to `<path>.tmp.<pid>` in the same
-        directory (so the rename is same-filesystem and atomic) then
-        `os.replace`. If the write fails mid-way, the original
-        `exploit-context.json` is unchanged. If the rename succeeds,
-        the new file is fully formed.
+        Atomic write: exploit-context.json is the accumulator that
+        pipeline stages read and re-save across iterations. A torn
+        write on interrupt would either JSONDecode-crash the next
+        stage or silently reset previously-gathered evidence to
+        defaults. Primitive keeps the original file unchanged on
+        failure; on success the new file is fully formed.
         """
-        path = Path(path)
-        path.parent.mkdir(parents=True, exist_ok=True)
-        body = self.to_json()
-        # PID suffix on the tmp name disambiguates concurrent saves
-        # from different processes (no collision on the staging name)
-        # while keeping the rename single-step atomic.
-        tmp = path.with_suffix(path.suffix + f".tmp.{os.getpid()}")
-        try:
-            with open(tmp, 'w') as f:
-                f.write(body)
-            os.replace(tmp, path)
-        except Exception:
-            # Clean up the staging file on any write/rename failure so
-            # we don't leak `.tmp.<pid>` siblings across crashes.
-            try:
-                tmp.unlink()
-            except OSError:
-                pass
-            raise
-
+        write_text_atomically(
+            path, self.to_json(), tmp_prefix=".exploit-ctx-",
+        )
         logger.info(f"ExploitContext saved to {path}")
 
     @classmethod

--- a/packages/exploitability_validation/report.py
+++ b/packages/exploitability_validation/report.py
@@ -8,6 +8,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional
 
+from core.atomic_fs import write_text_atomically
 from core.json import load_json, save_json
 
 from core.reporting import (
@@ -226,35 +227,15 @@ def generate_summary(output_dir: str) -> str:
 
 
 def _atomic_write_text(path: Path, content: str) -> None:
-    """Atomically write text to `path` via tmp+rename.
+    """Atomically write text to ``path`` via the shared primitive.
 
-    Pre-fix `report_path.write_text(content, encoding="utf-8")`
-    was non-atomic — readers (other RAPTOR processes, operator
-    `tail -f`, monitoring scripts, downstream stage consumers)
-    could observe a partially-written report mid-write if the
-    process was killed (Ctrl-C, OOM, scheduler eviction) or
-    if a parallel write of the same path ever happened.
-
-    Tmp-then-replace pattern: write to `<path>.tmp.<pid>`, then
-    `os.replace` (POSIX atomic rename) into place. Readers see
-    either the OLD content or the NEW content, never partial.
+    Readers (other RAPTOR processes, operator ``tail -f``, monitoring
+    scripts, downstream stage consumers) may observe the file at any
+    time; a torn write mid-generation would surface as a partial
+    validation-report or truncated summary. Primitive keeps every
+    observable state complete.
     """
-    import os as _os
-    import threading as _threading
-    # pid+tid suffix — disambiguates concurrent threads in the same
-    # process. Mirrors core/json/utils.py.
-    tmp = path.with_name(
-        f"{path.name}.tmp.{_os.getpid()}.{_threading.get_ident()}"
-    )
-    try:
-        tmp.write_text(content, encoding="utf-8")
-        _os.replace(tmp, path)
-    except BaseException:
-        try:
-            tmp.unlink(missing_ok=True)
-        except OSError:
-            pass
-        raise
+    write_text_atomically(path, content, tmp_prefix=".validation-")
 
 
 def write_validation_report(output_dir: str, target: Optional[str] = None) -> Path:

--- a/packages/sca/_atomic.py
+++ b/packages/sca/_atomic.py
@@ -1,37 +1,48 @@
-"""Atomic file writes for raptor-sca.
+"""Atomic file writes for raptor-sca — thin wrapper over the shared
+core primitive.
+
+Historical note: this module implemented an independent atomic-write
+primitive before ``core.atomic_fs`` existed. The functions below are
+now thin wrappers over :mod:`core.atomic_fs`, preserving the sca-side
+API (positional args, no ``mode=`` kwarg) so the 15+ callers in
+``packages/sca/`` continue to work unchanged.
 
 When ``raptor-sca fix --apply`` modifies a user's manifest files, the
 write must not leave the file in a torn state if the process is
-interrupted (Ctrl-C, OOM kill, disk full, power loss). A direct
-``write_text()`` opens the file with ``O_TRUNC`` first, then writes —
-leaving a window where the file is empty or partially written. A
-``shutil.copy2`` has the same problem.
+interrupted (Ctrl-C, OOM kill, disk full, power loss). See
+``core/atomic_fs/__init__.py`` for the full contract; the sca-relevant
+guarantees are:
 
-This module provides two primitives:
+  * A concurrent reader NEVER sees a partial file — either the old
+    bytes or the new bytes, never a truncation-in-progress.
+  * On failure — including ``KeyboardInterrupt`` — the temporary is
+    cleaned up and ``path`` is left in its prior state.
+  * When the destination already exists, its permission bits are
+    preserved (regular-file destinations only) — an operator ``chmod
+    0o600`` on a manifest carrying credentials is not silently widened
+    back to 0o644 by a rewrite.
 
-  - ``atomic_write_text(path, content)`` — for source-text manifests
-  - ``atomic_write_bytes(path, content)`` — for binary writes
+Semantic delta from the prior in-module implementation:
 
-Pattern:
-
-  1. Write the new content to ``<path>.tmp.<pid>`` in the same dir.
-  2. fsync the file contents.
-  3. ``os.replace(tmp, path)`` — atomic rename in the same directory.
-  4. Best-effort fsync of the parent directory so the rename is durable.
-
-Either the old file or the new file is visible at all times — never a
-truncated or partial file. On any exception before the rename, the
-temp file is best-effort cleaned up so we don't leave debris in the
-user's tree. ``BaseException`` (which includes ``KeyboardInterrupt``)
-is caught — that's exactly when a torn write would otherwise happen.
+  * Perm preservation now uses ``lstat`` (does not follow symlinks)
+    and only preserves for regular files. A symlink'd manifest (e.g.
+    yarn-workspace-style package.json symlinks) is replaced by a
+    regular file at the conventional 0o644 default rather than
+    inheriting the symlink target's mode bits. This matches the
+    "atomic write to path X" convention followed by every other
+    consumer of the shared primitive.
+  * Tempfile naming carries PID + TID + random suffix (was PID +
+    hostname). The random suffix + O_EXCL + O_NOFOLLOW closes the
+    tempfile-squat and symlink-through windows the prior naming was
+    exposed to.
 """
 
 from __future__ import annotations
 
-import os
-import socket
 from pathlib import Path
 from typing import Union
+
+from core.atomic_fs import write_bytes_atomically, write_text_atomically
 
 
 def atomic_write_text(
@@ -41,7 +52,7 @@ def atomic_write_text(
     encoding: str = "utf-8",
 ) -> None:
     """Replace ``path`` with ``content`` atomically. See module docstring."""
-    atomic_write_bytes(path, content.encode(encoding))
+    write_text_atomically(path, content, encoding=encoding)
 
 
 def atomic_write_bytes(
@@ -49,87 +60,7 @@ def atomic_write_bytes(
     content: bytes,
 ) -> None:
     """Replace ``path`` with ``content`` atomically. See module docstring."""
-    path = Path(path)
-    parent = path.parent
-    parent.mkdir(parents=True, exist_ok=True)
-
-    # If the destination already exists, capture its mode bits up-front
-    # so we can reapply them to the temp file before rename. Operators
-    # occasionally chmod manifests to 0o600 (e.g. CI deploy keys
-    # embedded in a Directory.Packages.props PropertyGroup); without
-    # this preservation the rewrite would silently widen those perms
-    # to 0o644. We only carry the permission bits (S_IMODE); the file-
-    # type bits stay as O_CREAT's default (regular file).
-    #
-    # A stat-then-write race is benign here: this is a permission-
-    # preserve hint, not a security boundary. Worst case under a
-    # racing chmod we apply the pre-race mode and the operator re-
-    # runs the chmod.
-    preserve_mode: int | None = None
-    try:
-        import stat as _stat
-        preserve_mode = _stat.S_IMODE(path.stat().st_mode)
-    except (OSError, ValueError):
-        # File doesn't exist yet (new manifest write) or stat
-        # surfaced something the platform can't represent — fall
-        # back to the historical default.
-        pass
-
-    # PID suffix avoids collision when concurrent runs target the same
-    # path (e.g. parallel CI matrix jobs, two operators on a shared
-    # filesystem).
-    try:
-        _host = socket.gethostname()
-    except OSError:
-        _host = "unknown"
-    tmp = path.with_name(f"{path.name}.tmp.{_host}.{os.getpid()}")
-
-    try:
-        # O_CREAT|O_WRONLY|O_TRUNC matches the semantics of write_text.
-        # The mode argument is umask-modified on creation; we ``fchmod``
-        # after open so the captured preserve_mode lands verbatim.
-        fd = os.open(
-            tmp,
-            os.O_WRONLY | os.O_CREAT | os.O_TRUNC,
-            preserve_mode if preserve_mode is not None else 0o644,
-        )
-        try:
-            try:
-                if preserve_mode is not None:
-                    os.fchmod(fd, preserve_mode)
-            except (OSError, AttributeError):
-                # Windows + a handful of mounted filesystems don't
-                # honour fchmod — the O_CREAT mode argument already
-                # provided the best-effort fallback.
-                pass
-            os.write(fd, content)
-            os.fsync(fd)
-        finally:
-            os.close(fd)
-        # Atomic rename. On POSIX this is a same-FS rename and atomic
-        # by spec; on Windows ``os.replace`` succeeds on same-volume
-        # rename. The temp file is consumed by this call.
-        os.replace(tmp, path)
-        # Best-effort durability: fsync the parent directory so the
-        # rename survives a power loss. Some platforms (Windows) don't
-        # support directory fsync — silent fallback is fine; we've
-        # already done the right thing for the data.
-        try:
-            dir_fd = os.open(parent, os.O_RDONLY)
-            try:
-                os.fsync(dir_fd)
-            finally:
-                os.close(dir_fd)
-        except OSError:
-            pass
-    except BaseException:
-        # Best-effort cleanup of the temp file. If the temp doesn't
-        # exist we're already past the rename, so nothing to clean.
-        try:
-            tmp.unlink()
-        except FileNotFoundError:
-            pass
-        raise
+    write_bytes_atomically(path, content)
 
 
 __all__ = ["atomic_write_text", "atomic_write_bytes"]

--- a/packages/sca/tests/test_atomic.py
+++ b/packages/sca/tests/test_atomic.py
@@ -59,11 +59,14 @@ def test_unicode_round_trips(tmp_path: Path) -> None:
 # ---------------------------------------------------------------------------
 
 def test_no_temp_file_left_after_success(tmp_path: Path) -> None:
-    """A successful write leaves no .tmp.<pid> debris in the dir."""
+    """A successful write leaves no tempfile debris in the dir.
+    Scan for any sibling — including dotfile prefixes — since the
+    shared primitive uses a leading-dot tempfile name (``.atomic-…``)
+    that ``glob('*')`` would not surface."""
     p = tmp_path / "manifest.txt"
     atomic_write_text(p, "x\n")
-    leftover = list(tmp_path.glob("*.tmp.*"))
-    assert leftover == [], f"unexpected temp files: {leftover}"
+    debris = [c for c in tmp_path.iterdir() if c != p]
+    assert debris == [], f"unexpected temp files: {debris}"
 
 
 def test_temp_file_cleaned_up_on_failure(tmp_path: Path) -> None:
@@ -75,13 +78,13 @@ def test_temp_file_cleaned_up_on_failure(tmp_path: Path) -> None:
         # destination locked on Windows.
         raise OSError("simulated rename failure")
 
-    with patch("packages.sca._atomic.os.replace", _boom):
+    with patch("core.atomic_fs.os.replace", _boom):
         with pytest.raises(OSError, match="simulated rename failure"):
             atomic_write_text(p, "x\n")
 
     # Original (none) preserved; no temp file left behind.
     assert not p.exists()
-    assert list(tmp_path.glob("*.tmp.*")) == []
+    assert list(tmp_path.iterdir()) == []
 
 
 def test_keyboard_interrupt_during_write_cleans_up(tmp_path: Path) -> None:
@@ -95,13 +98,13 @@ def test_keyboard_interrupt_during_write_cleans_up(tmp_path: Path) -> None:
     def _interrupt(*a, **kw):
         raise KeyboardInterrupt()
 
-    with patch("packages.sca._atomic.os.fsync", _interrupt):
+    with patch("core.atomic_fs.os.fsync", _interrupt):
         with pytest.raises(KeyboardInterrupt):
             atomic_write_text(p, "x\n")
 
     # Original (none) preserved; no temp file left behind.
     assert not p.exists()
-    assert list(tmp_path.glob("*.tmp.*")) == []
+    assert list(tmp_path.iterdir()) == []
 
 
 def test_failure_does_not_corrupt_existing(tmp_path: Path) -> None:
@@ -112,7 +115,7 @@ def test_failure_does_not_corrupt_existing(tmp_path: Path) -> None:
     def _boom(src, dst, *a, **kw):
         raise OSError("simulated")
 
-    with patch("packages.sca._atomic.os.replace", _boom):
+    with patch("core.atomic_fs.os.replace", _boom):
         with pytest.raises(OSError):
             atomic_write_text(p, "NEW CONTENT\n")
 
@@ -120,24 +123,27 @@ def test_failure_does_not_corrupt_existing(tmp_path: Path) -> None:
     assert p.read_text() == "ORIGINAL CONTENT\n"
 
 
-def test_pid_suffix_isolates_concurrent_runs(tmp_path: Path) -> None:
-    """The PID suffix means parallel writers don't collide on the
-    temp filename."""
+def test_isolates_from_unrelated_neighbour_files(tmp_path: Path) -> None:
+    """An unrelated pre-existing sibling file in the target directory
+    (e.g. another tool's scratch / another writer's aborted draft)
+    is not touched. The atomic-write primitive isolates its own
+    tempfile via a PID+TID+random suffix; earlier iterations used a
+    deterministic ``.tmp.<pid>`` name which this test guarded against
+    colliding with. Both schemes satisfy the contract; this test
+    keeps enforcing it against the shared primitive."""
     p = tmp_path / "manifest.txt"
-    expected_tmp = tmp_path / f"manifest.txt.tmp.{os.getpid()}"
 
-    # Pre-create a temp file with a DIFFERENT PID — should not collide
-    # with our write.
-    other_pid_tmp = tmp_path / "manifest.txt.tmp.999999"
-    other_pid_tmp.write_text("another writer's draft\n")
+    neighbour = tmp_path / "manifest.txt.tmp.999999"
+    neighbour.write_text("another writer's draft\n")
 
     atomic_write_text(p, "ours\n")
     assert p.read_text() == "ours\n"
-    # Other writer's temp is untouched.
-    assert other_pid_tmp.exists()
-    assert other_pid_tmp.read_text() == "another writer's draft\n"
-    # Our temp was consumed by os.replace.
-    assert not expected_tmp.exists()
+    assert neighbour.exists()
+    assert neighbour.read_text() == "another writer's draft\n"
+    # No tempfile debris in the target directory (whatever the
+    # primitive's naming scheme).
+    debris = [c for c in tmp_path.iterdir() if c not in (p, neighbour)]
+    assert debris == [], f"unexpected leftover files: {debris}"
 
 
 def test_preserves_existing_mode_bits(tmp_path: Path) -> None:


### PR DESCRIPTION
Introduces core.atomic_fs and migrates the durability-critical writers in the codebase to use it.
  
Motivation: several subsystems reinvent tempfile+rename with subtle variations (some fsync, some don't; some symlink-safe, most aren't). This PR consolidates them onto one audited primitive.
  
Commits:
  1. core.atomic_fs primitive + 17 tests (13 contract, 4 adversarial). O_EXCL|O_NOFOLLOW, PID+TID+random tempfile suffix, optional mode= applied pre-rename for atomic perm installation, mode=None preserves existing perms. Adversarially reviewed pre-merge.
  2. HIGH tier: 5 persistent state stores (annotations, labeled_attempts, fingerprint, witness, coverage) plus core.json.save_json — the last one transitively covers threat_model, checklists, run reports, LLM credentials cache, and scorecard writers.
  3. Sandbox tier: 3 sites (calibration cache with mode=0o600 installed pre-rename, plus audit-degraded marker and denial summary).
  4. sca/_atomic wrapper: was a 130-LOC parallel implementation with 15+ callers; now a thin delegation to core.atomic_fs. Callers unchanged.
  5. Tier-4 sweep: 8 remaining sites (security/prompt_telemetry, security/prompt_envelope_audit, inventory/binary_oracle_edges, inventory/_reach_cache with mode=0o600, exploitability_validation/report,
  exploit_feasibility/exploit_context, cve_diff/cli/bench, checker_synthesis/synthesise).
  6. CI: add core/atomic_fs to sandbox/exploit_feasibility/cve_diff/sca path filters so a future refactor of the primitive retriggers those subsystems' tests.
  
Each migration adds a one-line "why atomic" comment at the write site.
  
Skipped (durability unnecessary): ephemeral scratch (coverage/collect, sandbox/mount wrapper, sandbox/landlock probe), symlink swaps (project/.active), streaming append with fsync (cve_diff/oracle/cross_check). Migrating those would add fsync cost for zero benefit — not every writer needs to be atomic.
