### PR TITLE
feat(semgrep): nosemgrep inline-suppression awareness

### DIFF
--- a/.claude/skills/exploitability-validation/stage-b-process.md
+++ b/.claude/skills/exploitability-validation/stage-b-process.md
@@ -111,6 +111,9 @@ The prep output tells you how many findings were fast-pathed and how many need f
 IMPORTANT: For every step below, check and update documentation.
 
 **[B-3.0] Bug-class lenses**
+
+**Developer-suppression claims (nosemgrep).** If a finding carries `nosemgrep_suppression` with a `justification`, treat the justification as a developer claim to test. Seed a hypothesis whose claim is the developer's assertion (e.g., "Developer asserts: constant-time compare, no taint") and whose predictions verify or refute the specific claim. The developer may be right — in which case the hypothesis confirms with corroborating attribution. Or they may be wrong — in which case the pipeline catches a real bug hiding behind a false suppression. Either outcome is valuable. Record the hypothesis source as `"nosemgrep"` in the hypothesis's `id` prefix (e.g., `H-nosemgrep-FIND-001`).
+
 Before constructing hypotheses for a finding, load the matching CWE strategies:
 ```bash
 libexec/raptor-pick-strategies \

--- a/core/__init__.py
+++ b/core/__init__.py
@@ -64,10 +64,10 @@ def __getattr__(name: str) -> Any:
         raise AttributeError(f"module 'core' has no attribute {name!r}")
     submod_name, attr_name = spec
     import importlib
-    # nosemgrep: python.lang.security.audit.non-literal-import.non-literal-import
     # ``submod_name`` is from the module-level ``_LAZY_EXPORTS``
     # dict (constant in this file) — not attacker-controlled.
     # PEP 562 lazy re-export.
+    # nosemgrep: python.lang.security.audit.non-literal-import.non-literal-import
     submod = importlib.import_module(submod_name)
     value = getattr(submod, attr_name)
     # Cache on this module so subsequent accesses bypass __getattr__.

--- a/core/dataflow/run_corpus.py
+++ b/core/dataflow/run_corpus.py
@@ -105,11 +105,11 @@ def load_validator(spec: str) -> Validator:
         raise ValueError(
             f"validator spec must be `module.path:ClassName`, got {spec!r}"
         )
-    # nosemgrep: python.lang.security.audit.non-literal-import.non-literal-import
     # ``module_path`` is from the operator's ``--validator`` CLI
     # flag. The operator invoking RAPTOR can already execute any
     # Python; importing the validator they explicitly named adds
     # no privilege. Not a public API, not attacker-controllable.
+    # nosemgrep: python.lang.security.audit.non-literal-import.non-literal-import
     module = importlib.import_module(module_path)
     cls = getattr(module, class_name)
     instance = cls()

--- a/core/json/__init__.py
+++ b/core/json/__init__.py
@@ -54,10 +54,10 @@ def __getattr__(name: str) -> Any:
         )
     submod_name, attr_name = spec
     import importlib
-    # nosemgrep: python.lang.security.audit.non-literal-import.non-literal-import
     # ``submod_name`` is from the module-level ``_LAZY_EXPORTS``
     # dict (constant in this file) — not attacker-controlled.
     # PEP 562 lazy re-export.
+    # nosemgrep: python.lang.security.audit.non-literal-import.non-literal-import
     submod = importlib.import_module(submod_name)
     value = getattr(submod, attr_name)
     # Cache on this module so subsequent accesses bypass __getattr__.

--- a/core/llm/detection.py
+++ b/core/llm/detection.py
@@ -140,10 +140,9 @@ def _get_available_ollama_models() -> List[str]:
 
     _ollama_checked = True
     try:
-        # nosemgrep: sinks.raptor.web.ssrf.dynamic-url
         # ``ollama_url`` is validated via ``_validate_ollama_url``
         # (line 82); operator-config-supplied + scheme-locked.
-        response = requests.get(f"{ollama_url}/api/tags", timeout=2)
+        response = requests.get(f"{ollama_url}/api/tags", timeout=2)  # nosemgrep: sinks.raptor.web.ssrf.dynamic-url
         if response.status_code == 200:
             data = response.json()
             _cached_ollama_models = [model['name'] for model in data.get('models', [])]

--- a/core/llm/dispatcher/server.py
+++ b/core/llm/dispatcher/server.py
@@ -250,10 +250,9 @@ class LLMDispatcher:
 
         # L1 — filesystem isolation.
         self._sock_dir = Path(tempfile.mkdtemp(prefix=f"raptor-llm-{run_id}-"))
-        # nosemgrep: python.lang.security.audit.insecure-file-permissions
         # 0o700 = owner-only — the socket lives here and must not be
         # group/other-readable on a multi-user host.
-        os.chmod(self._sock_dir, 0o700)
+        os.chmod(self._sock_dir, 0o700)  # nosemgrep: python.lang.security.audit.insecure-file-permissions
         self.socket_path = self._sock_dir / "llm.sock"
 
         # Audit log
@@ -516,12 +515,12 @@ class LLMDispatcher:
         else:
             level = logging.INFO
         # Always log via stdlib logger for terminal visibility.
-        # nosemgrep: python.lang.security.audit.logging.logger-credential-leak.python-logger-credential-disclosure
         # ``ev.token_id`` is a 12-character correlation prefix (see
         # ``AuditEvent.token_id`` docstring) — explicitly NOT the
         # full token. Operator visibility for the auth flow needs
         # SOME identifier; the prefix gives correlation without
         # disclosure.
+        # nosemgrep: python.lang.security.audit.logging.logger-credential-leak.python-logger-credential-disclosure
         _logger.log(
             level,
             "llm-dispatcher %s %s pid=%s uid=%s token=%s label=%s%s",

--- a/core/llm/model_resolution.py
+++ b/core/llm/model_resolution.py
@@ -162,9 +162,8 @@ def _fetch_inventory(api_key: str) -> list[str]:
     """
     import requests
 
-    # nosemgrep: sinks.raptor.web.ssrf.dynamic-url
     # Hardcoded Anthropic API hostname — not SSRF.
-    r = requests.get(
+    r = requests.get(  # nosemgrep: sinks.raptor.web.ssrf.dynamic-url
         "https://api.anthropic.com/v1/models",
         headers={"x-api-key": api_key, "anthropic-version": "2023-06-01"},
         timeout=5,

--- a/core/oci/auth.py
+++ b/core/oci/auth.py
@@ -77,11 +77,11 @@ def lookup_credentials(registry: str) -> Optional[BasicCredentials]:
     """
     creds = _from_env(registry)
     if creds is not None:
-        # nosemgrep: python.lang.security.audit.logging.logger-credential-leak.python-logger-credential-disclosure
         # Only the registry hostname is interpolated; the env-var
         # NAMES (``RAPTOR_OCI_<HOST>_USER`` / ``_PASSWORD``) are
         # documentation strings, not their values. No credentials
         # disclosed.
+        # nosemgrep: python.lang.security.audit.logging.logger-credential-leak.python-logger-credential-disclosure
         logger.info(
             "core.oci.auth: using env-var credentials for %s "
             "(RAPTOR_OCI_<HOST>_USER / _PASSWORD)", registry,

--- a/core/project/cli.py
+++ b/core/project/cli.py
@@ -888,11 +888,11 @@ def main():
                     ) as tf:
                         tf_path = tf.name
                         tf.write(p.notes or "")
-                    # nosemgrep: python.lang.security.audit.dangerous-subprocess-use-tainted-env-args.dangerous-subprocess-use-tainted-env-args
                     # Operator-launched editor invocation. The
                     # ``EDITOR`` env var is the operator's own
                     # choice; if it's compromised they have bigger
                     # problems than RAPTOR launching it.
+                    # nosemgrep: python.lang.security.audit.dangerous-subprocess-use-tainted-env-args.dangerous-subprocess-use-tainted-env-args
                     result = subprocess.run(editor_argv + [tf_path])
                     if result.returncode != 0:
                         print("Editor exited with error. Notes unchanged.")

--- a/core/sandbox/_landlock_audit.py
+++ b/core/sandbox/_landlock_audit.py
@@ -468,10 +468,10 @@ def run_landlock_audit(
                     str(target_pid), str(audit_run_dir),
                     str(t_ready_w), config_path,
                 ]
-                # nosemgrep: python.lang.security.audit.dangerous-os-exec-tainted-env-args.dangerous-os-exec-tainted-env-args
                 # tracer_env is a hand-crafted dict with 2 keys only
                 # (PYTHONPATH + PATH). No inheritance — strictly
                 # safer than the default os.environ-copy path.
+                # nosemgrep: python.lang.security.audit.dangerous-os-exec-tainted-env-args.dangerous-os-exec-tainted-env-args
                 os.execvpe(sys.executable, tracer_argv, tracer_env)
             except FileNotFoundError:
                 os._exit(127)

--- a/core/sandbox/_spawn.py
+++ b/core/sandbox/_spawn.py
@@ -1538,10 +1538,10 @@ def run_sandboxed(
                     ]
                     if _audit_config_path is not None:
                         tracer_argv.append(_audit_config_path)
-                    # nosemgrep: python.lang.security.audit.dangerous-os-exec-tainted-env-args.dangerous-os-exec-tainted-env-args
                     # tracer_env is hand-crafted: 2 keys
                     # (PYTHONPATH + PATH), no inheritance. Explicitly
                     # safer than os.environ-copy.
+                    # nosemgrep: python.lang.security.audit.dangerous-os-exec-tainted-env-args.dangerous-os-exec-tainted-env-args
                     os.execvpe(
                         sys.executable, tracer_argv, tracer_env,
                     )

--- a/core/sandbox/calibrate.py
+++ b/core/sandbox/calibrate.py
@@ -448,9 +448,8 @@ def _save_to_cache(fingerprint: str, profile: SandboxProfile) -> None:
     """Persist a profile. mode 0600, dir mode 0700."""
     try:
         _CACHE_DIR.mkdir(parents=True, exist_ok=True)
-        # nosemgrep: python.lang.security.audit.insecure-file-permissions
         # 0o700 = owner-only — most restrictive POSIX mode.
-        os.chmod(_CACHE_DIR, 0o700)
+        os.chmod(_CACHE_DIR, 0o700)  # nosemgrep: python.lang.security.audit.insecure-file-permissions
     except OSError as exc:
         logger.warning("calibrate: cache dir setup failed: %s", exc)
         return
@@ -460,8 +459,8 @@ def _save_to_cache(fingerprint: str, profile: SandboxProfile) -> None:
     # (the shared primitive's default 0o644 would widen; the cache is
     # owner-scoped, not shared). Primitive adds fsync-file + fsync-
     # parent-dir durability the old direct-write lacked.
-    # nosemgrep: python.lang.security.audit.insecure-file-permissions
     # 0o600 = owner-only file mode.
+    # nosemgrep: python.lang.security.audit.insecure-file-permissions
     try:
         write_text_atomically(
             path, profile.to_json(),

--- a/core/sandbox/mount.py
+++ b/core/sandbox/mount.py
@@ -90,9 +90,8 @@ def _build_mount_script(target: Optional[str], output: Optional[str]) -> Optiona
             os.write(fd, ("\n".join(lines) + "\n").encode())
         finally:
             os.close(fd)
-        # nosemgrep: python.lang.security.audit.insecure-file-permissions
         # 0o700 = owner-only (executable bind-mount helper script).
-        os.chmod(path, 0o700)
+        os.chmod(path, 0o700)  # nosemgrep: python.lang.security.audit.insecure-file-permissions
     except OSError:
         try:
             os.unlink(path)

--- a/core/security/prompt_envelope.py
+++ b/core/security/prompt_envelope.py
@@ -311,11 +311,11 @@ def nonce_leaked_in(nonce: str, text: str) -> bool:
 #   ­     — soft hyphen
 #   ‪-E   — bidi embedding / override controls  # nosemgrep: contains-bidirectional-characters
 #   ⁦-9   — bidi isolate controls  # nosemgrep: contains-bidirectional-characters
-# nosemgrep: generic.unicode.security.bidi.contains-bidirectional-characters
 # RAPTOR's anti-BiDi defense: ``_BYPASS_CHAR_RE`` IS the
 # defense — by definition contains the BiDi/control characters
 # the rule wants to flag. Stripping them would defeat the
 # defense. Suppressed at every literal-occurring line below.
+# nosemgrep: generic.unicode.security.bidi.contains-bidirectional-characters
 _BYPASS_CHAR_RE = re.compile(
     '[\x00­​‌‍﻿'  # nosemgrep: contains-bidirectional-characters
     '‪‫‬‭‮'  # nosemgrep: contains-bidirectional-characters

--- a/core/startup/banner.py
+++ b/core/startup/banner.py
@@ -47,9 +47,8 @@ def read_random_quote() -> str:
     if path.exists():
         lines = [line.strip() for line in path.read_text().splitlines() if line.strip()]
         if lines:
-            # nosemgrep: crypto.prng.random-module.python
             # Decorative banner quote — non-cryptographic.
-            return random.choice(lines)
+            return random.choice(lines)  # nosemgrep: crypto.prng.random-module.python
     return '"Hack the planet!"'
 
 

--- a/packages/exploitability_validation/models.py
+++ b/packages/exploitability_validation/models.py
@@ -320,6 +320,9 @@ class Finding:
     checklist_verified: Optional[bool] = None  # C0: file+line found in inventory
     test_code_flag: Optional[bool] = None    # D0: file matches test/mock pattern
 
+    # Inline suppression (populated from SARIF properties.nosemgrep)
+    nosemgrep_suppression: Optional[dict] = None
+
     # Metadata
     disproved_because: Optional[str] = None
     candidate_reasoning: Optional[str] = None
@@ -379,6 +382,7 @@ class Finding:
             dedup_flag=d.get("dedup_flag"),
             checklist_verified=d.get("checklist_verified"),
             test_code_flag=d.get("test_code_flag"),
+            nosemgrep_suppression=d.get("nosemgrep_suppression"),
             disproved_because=d.get("disproved_because"),
             candidate_reasoning=d.get("candidate_reasoning"),
             message=d.get("message"),

--- a/packages/exploitability_validation/orchestrator.py
+++ b/packages/exploitability_validation/orchestrator.py
@@ -364,6 +364,7 @@ def convert_sarif_result(result: Dict, idx: int, tool_name: str,
         tool=tool_name,
         rule_id=rule_id,
         severity=result.get('level', 'warning'),
+        nosemgrep_suppression=result.get('properties', {}).get('nosemgrep'),
     ).to_dict()
     if snippet:
         finding['proof'] = {'vulnerable_code': snippet[:500]}

--- a/packages/semgrep/__init__.py
+++ b/packages/semgrep/__init__.py
@@ -16,6 +16,7 @@ from .runner import build_cmd, is_available, run_rule, run_rules, version
 from .models import SemgrepFinding, SemgrepResult
 from .findings import to_findings
 from .coverage import to_coverage_record
+from .nosemgrep import annotate_sarif, extract_nosemgrep
 
 __all__ = [
     "build_cmd",
@@ -27,4 +28,6 @@ __all__ = [
     "SemgrepResult",
     "to_findings",
     "to_coverage_record",
+    "annotate_sarif",
+    "extract_nosemgrep",
 ]

--- a/packages/semgrep/nosemgrep.py
+++ b/packages/semgrep/nosemgrep.py
@@ -1,0 +1,188 @@
+"""Extract nosemgrep inline-suppression annotations from source files.
+
+Semgrep's ``# nosemgrep`` comments let developers suppress specific rules
+on a per-line basis.  RAPTOR always scans with ``--disable-nosem`` so
+that suppressed findings still reach the SARIF output.  This module
+post-annotates those results with the developer's suppression metadata so
+downstream consumers (Claude, /validate, external SARIF viewers) can see
+that a finding was developer-suppressed — and optionally read the
+justification text.
+
+Public API:
+
+    annotate_sarif(sarif_data, repo_root)
+        Mutates *sarif_data* in place: each result whose source line (or the
+        line above) carries a nosemgrep comment gets a ``properties.nosemgrep``
+        dict with ``suppressed``, ``rule_ids``, ``justification``, and
+        ``comment_line``.  Returns the count of annotated results.
+
+    extract_nosemgrep(file_path, line)
+        Low-level: check a single source location for a nosemgrep comment.
+"""
+
+import logging
+import re
+from pathlib import Path
+from typing import Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+# Matches nosemgrep comments in any common style:
+#   # nosemgrep: rule-id1, rule-id2 justification text
+#   // nosemgrep: rule-id
+#   /* nosemgrep */
+#   // nosemgrep
+_NOSEMGREP_RE = re.compile(
+    r"""(?://|[#]|/\*)       # comment opener
+        \s*nosemgrep         # keyword
+        (?::[ \t]*           # optional colon + rule list
+          ([\w.:,/-]+)       # group 1: comma-separated rule IDs
+        )?
+        (?:[ \t]+(.+?))?     # group 2: justification text
+        (?:\s*\*/)?          # optional block-comment closer
+        \s*$""",
+    re.VERBOSE,
+)
+
+# Cache: path → list-of-lines (avoids re-reading the same file for
+# multiple findings in it).  Scoped to a single annotate_sarif() call
+# via the _FileCache helper.
+_MAX_CACHE_FILES = 512
+
+
+class _FileCache:
+    """LRU-ish file cache for source lines, scoped to one annotation pass."""
+
+    __slots__ = ("_store",)
+
+    def __init__(self) -> None:
+        self._store: Dict[str, Optional[List[str]]] = {}
+
+    def lines(self, path: str) -> Optional[List[str]]:
+        if path in self._store:
+            return self._store[path]
+        if len(self._store) >= _MAX_CACHE_FILES:
+            # Evict oldest entry (insertion-order dict).
+            self._store.pop(next(iter(self._store)))
+        try:
+            text = Path(path).read_text(errors="replace")
+            result = text.splitlines()
+        except OSError:
+            result = None
+        self._store[path] = result
+        return result
+
+
+def extract_nosemgrep(
+    file_path: Path,
+    line: int,
+    *,
+    _lines: Optional[List[str]] = None,
+) -> Optional[dict]:
+    """Check whether *line* (1-indexed) in *file_path* has a nosemgrep comment.
+
+    Checks the flagged line itself and the line immediately above it (both
+    are valid nosemgrep positions per Semgrep's spec).
+
+    Returns a dict ``{suppressed, rule_ids, justification, comment_line}``
+    if found, ``None`` otherwise.
+    """
+    if _lines is None:
+        try:
+            _lines = Path(file_path).read_text(errors="replace").splitlines()
+        except OSError:
+            return None
+
+    for offset in (0, -1):
+        idx = line - 1 + offset  # 1-indexed → 0-indexed
+        if 0 <= idx < len(_lines):
+            m = _NOSEMGREP_RE.search(_lines[idx])
+            if m:
+                # A nosemgrep on the line ABOVE only suppresses the line
+                # below when it's a standalone comment (no code before it).
+                # Inline nosemgrep (code + comment on same line) only
+                # suppresses that line itself.
+                if offset == -1:
+                    stripped = _lines[idx].lstrip()
+                    if not (
+                        stripped.startswith("#")
+                        or stripped.startswith("//")
+                        or stripped.startswith("/*")
+                    ):
+                        continue
+                raw_ids = m.group(1) or ""
+                justification = (m.group(2) or "").strip() or None
+                rule_ids = [
+                    r.strip() for r in raw_ids.split(",") if r.strip()
+                ]
+                return {
+                    "suppressed": True,
+                    "rule_ids": rule_ids,
+                    "justification": justification,
+                    "comment_line": idx + 1,
+                }
+    return None
+
+
+def annotate_sarif(sarif_data: dict, repo_root: str) -> int:
+    """Annotate SARIF results in place with nosemgrep suppression metadata.
+
+    For each result whose source line carries a ``# nosemgrep`` comment,
+    sets ``result["properties"]["nosemgrep"]`` to a dict with:
+      - ``suppressed`` (bool): always True
+      - ``rule_ids`` (list[str]): rule IDs named in the comment, or []
+      - ``justification`` (str | null): free-text after the rule IDs
+      - ``comment_line`` (int): 1-indexed line of the comment
+
+    Returns the number of results annotated.
+    """
+    root = Path(repo_root)
+    cache = _FileCache()
+    annotated = 0
+
+    for run in sarif_data.get("runs", []):
+        if not isinstance(run, dict):
+            continue
+        # nosemgrep is Semgrep-specific — skip CodeQL/Coccinelle runs.
+        tool_name = (
+            run.get("tool", {}).get("driver", {}).get("name", "")
+        ).lower()
+        if tool_name and "semgrep" not in tool_name:
+            continue
+        for result in run.get("results", []):
+            if not isinstance(result, dict):
+                continue
+            locations = result.get("locations", [])
+            if not locations:
+                continue
+            loc = locations[0]
+            if not isinstance(loc, dict):
+                continue
+            phys = loc.get("physicalLocation", {})
+            uri = phys.get("artifactLocation", {}).get("uri", "")
+            line = phys.get("region", {}).get("startLine", 0)
+            if not uri or not line:
+                continue
+
+            # Resolve the file path against repo root.
+            if uri.startswith("file://"):
+                abs_path = uri[7:]
+            else:
+                abs_path = str(root / uri)
+
+            lines = cache.lines(abs_path)
+            if lines is None:
+                continue
+
+            info = extract_nosemgrep(Path(abs_path), line, _lines=lines)
+            if info:
+                props = result.setdefault("properties", {})
+                props["nosemgrep"] = info
+                annotated += 1
+
+    if annotated:
+        logger.info(
+            "nosemgrep: annotated %d SARIF result(s) as developer-suppressed",
+            annotated,
+        )
+    return annotated

--- a/packages/semgrep/runner.py
+++ b/packages/semgrep/runner.py
@@ -84,6 +84,7 @@ def build_cmd(
         "--metrics", "off",
         "--error",
         "--sarif",
+        "--disable-nosem",
         "--timeout", str(rule_timeout),
     ]
     if json_output_path is not None:

--- a/packages/semgrep/tests/test_nosemgrep.py
+++ b/packages/semgrep/tests/test_nosemgrep.py
@@ -1,0 +1,246 @@
+"""Tests for nosemgrep inline-suppression extraction and SARIF annotation."""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
+
+from packages.semgrep.nosemgrep import annotate_sarif, extract_nosemgrep
+
+
+# ── extract_nosemgrep ────────────────────────────────────────────────────────
+
+
+class TestExtractNosemgrep:
+    def test_inline_same_line(self, tmp_path):
+        src = tmp_path / "a.py"
+        src.write_text("x = eval(inp)  # nosemgrep: python.eval-usage\n")
+        result = extract_nosemgrep(src, 1)
+        assert result is not None
+        assert result["suppressed"] is True
+        assert result["rule_ids"] == ["python.eval-usage"]
+        assert result["comment_line"] == 1
+
+    def test_comment_line_above(self, tmp_path):
+        src = tmp_path / "a.py"
+        src.write_text("# nosemgrep: rule-id reason text\nx = eval(inp)\n")
+        result = extract_nosemgrep(src, 2)
+        assert result is not None
+        assert result["rule_ids"] == ["rule-id"]
+        assert result["justification"] == "reason text"
+        assert result["comment_line"] == 1
+
+    def test_blanket_suppression(self, tmp_path):
+        src = tmp_path / "a.py"
+        src.write_text("x = eval(inp)  # nosemgrep\n")
+        result = extract_nosemgrep(src, 1)
+        assert result is not None
+        assert result["rule_ids"] == []
+        assert result["justification"] is None
+
+    def test_multiple_rule_ids(self, tmp_path):
+        src = tmp_path / "a.py"
+        src.write_text("x = eval(inp)  # nosemgrep: rule-a,rule-b,rule-c\n")
+        result = extract_nosemgrep(src, 1)
+        assert result["rule_ids"] == ["rule-a", "rule-b", "rule-c"]
+
+    def test_c_style_comment(self, tmp_path):
+        src = tmp_path / "a.c"
+        src.write_text("strcpy(dst, src); // nosemgrep: cwe-120\n")
+        result = extract_nosemgrep(src, 1)
+        assert result is not None
+        assert result["rule_ids"] == ["cwe-120"]
+
+    def test_block_comment(self, tmp_path):
+        src = tmp_path / "a.c"
+        src.write_text("strcpy(dst, src); /* nosemgrep: cwe-120 */\n")
+        result = extract_nosemgrep(src, 1)
+        assert result is not None
+
+    def test_no_nosemgrep(self, tmp_path):
+        src = tmp_path / "a.py"
+        src.write_text("x = eval(inp)\ny = 42\n")
+        assert extract_nosemgrep(src, 1) is None
+        assert extract_nosemgrep(src, 2) is None
+
+    def test_missing_file(self, tmp_path):
+        assert extract_nosemgrep(tmp_path / "missing.py", 1) is None
+
+    def test_line_out_of_range(self, tmp_path):
+        src = tmp_path / "a.py"
+        src.write_text("x = 1\n")
+        assert extract_nosemgrep(src, 100) is None
+
+    def test_justification_with_colon_in_rule(self, tmp_path):
+        src = tmp_path / "a.py"
+        src.write_text(
+            "x = eval(inp)  # nosemgrep: python.lang.eval-usage safe constant\n"
+        )
+        result = extract_nosemgrep(src, 1)
+        assert result["rule_ids"] == ["python.lang.eval-usage"]
+        assert result["justification"] == "safe constant"
+
+    def test_preloaded_lines(self, tmp_path):
+        lines = ["x = eval(inp)  # nosemgrep: rule-id reason"]
+        result = extract_nosemgrep(tmp_path / "unused.py", 1, _lines=lines)
+        assert result is not None
+        assert result["rule_ids"] == ["rule-id"]
+
+
+# ── annotate_sarif ───────────────────────────────────────────────────────────
+
+
+def _make_sarif_data(results, tool_name=None):
+    run = {"results": results}
+    if tool_name:
+        run["tool"] = {"driver": {"name": tool_name}}
+    return {"runs": [run]}
+
+
+def _make_result(uri, line):
+    return {
+        "ruleId": "test.rule",
+        "message": {"text": "test"},
+        "level": "warning",
+        "locations": [{
+            "physicalLocation": {
+                "artifactLocation": {"uri": uri},
+                "region": {"startLine": line},
+            },
+        }],
+    }
+
+
+class TestAnnotateSarif:
+    def test_annotates_suppressed_result(self, tmp_path):
+        src = tmp_path / "a.py"
+        src.write_text("x = eval(inp)  # nosemgrep: test.rule safe use\n")
+        result = _make_result("a.py", 1)
+        sarif = _make_sarif_data([result])
+
+        count = annotate_sarif(sarif, str(tmp_path))
+
+        assert count == 1
+        nosem = result["properties"]["nosemgrep"]
+        assert nosem["suppressed"] is True
+        assert nosem["rule_ids"] == ["test.rule"]
+        assert nosem["justification"] == "safe use"
+
+    def test_skips_unsuppressed_result(self, tmp_path):
+        src = tmp_path / "a.py"
+        src.write_text("x = eval(inp)\n")
+        result = _make_result("a.py", 1)
+        sarif = _make_sarif_data([result])
+
+        count = annotate_sarif(sarif, str(tmp_path))
+
+        assert count == 0
+        assert "properties" not in result or "nosemgrep" not in result.get("properties", {})
+
+    def test_mixed_results(self, tmp_path):
+        src = tmp_path / "a.py"
+        src.write_text("x = eval(inp)  # nosemgrep\ny = eval(inp)\n")
+        r1 = _make_result("a.py", 1)
+        r2 = _make_result("a.py", 2)
+        sarif = _make_sarif_data([r1, r2])
+
+        count = annotate_sarif(sarif, str(tmp_path))
+
+        assert count == 1
+        assert "nosemgrep" in r1.get("properties", {})
+        assert "nosemgrep" not in r2.get("properties", {})
+
+    def test_missing_file_graceful(self, tmp_path):
+        result = _make_result("missing.py", 1)
+        sarif = _make_sarif_data([result])
+
+        count = annotate_sarif(sarif, str(tmp_path))
+        assert count == 0
+
+    def test_preserves_existing_properties(self, tmp_path):
+        src = tmp_path / "a.py"
+        src.write_text("x = eval(inp)  # nosemgrep\n")
+        result = _make_result("a.py", 1)
+        result["properties"] = {"cwe": "CWE-94"}
+        sarif = _make_sarif_data([result])
+
+        annotate_sarif(sarif, str(tmp_path))
+
+        assert result["properties"]["cwe"] == "CWE-94"
+        assert result["properties"]["nosemgrep"]["suppressed"] is True
+
+    def test_file_uri_prefix(self, tmp_path):
+        src = tmp_path / "a.py"
+        src.write_text("x = eval(inp)  # nosemgrep\n")
+        abs_path = str(src)
+        result = _make_result(f"file://{abs_path}", 1)
+        sarif = _make_sarif_data([result])
+
+        count = annotate_sarif(sarif, str(tmp_path))
+        assert count == 1
+
+    def test_skips_codeql_run(self, tmp_path):
+        src = tmp_path / "a.py"
+        src.write_text("x = eval(inp)  # nosemgrep\n")
+        result = _make_result("a.py", 1)
+        sarif = _make_sarif_data([result], tool_name="CodeQL")
+
+        count = annotate_sarif(sarif, str(tmp_path))
+        assert count == 0
+        assert "nosemgrep" not in result.get("properties", {})
+
+    def test_skips_coccinelle_run(self, tmp_path):
+        src = tmp_path / "a.c"
+        src.write_text("strcpy(dst, src); // nosemgrep\n")
+        result = _make_result("a.c", 1)
+        sarif = _make_sarif_data([result], tool_name="coccinelle")
+
+        count = annotate_sarif(sarif, str(tmp_path))
+        assert count == 0
+
+    def test_annotates_semgrep_run(self, tmp_path):
+        src = tmp_path / "a.py"
+        src.write_text("x = eval(inp)  # nosemgrep\n")
+        result = _make_result("a.py", 1)
+        sarif = _make_sarif_data([result], tool_name="Semgrep OSS")
+
+        count = annotate_sarif(sarif, str(tmp_path))
+        assert count == 1
+
+    def test_annotates_unnamed_tool_run(self, tmp_path):
+        """Runs without tool.driver.name (legacy SARIF) are assumed semgrep."""
+        src = tmp_path / "a.py"
+        src.write_text("x = eval(inp)  # nosemgrep\n")
+        result = _make_result("a.py", 1)
+        sarif = _make_sarif_data([result])  # no tool_name
+
+        count = annotate_sarif(sarif, str(tmp_path))
+        assert count == 1
+
+    def test_mixed_tool_runs(self, tmp_path):
+        """Only semgrep run annotated, CodeQL run skipped."""
+        src = tmp_path / "a.py"
+        src.write_text("x = eval(inp)  # nosemgrep\n")
+        r_sem = _make_result("a.py", 1)
+        r_cql = _make_result("a.py", 1)
+        sarif = {
+            "runs": [
+                {"tool": {"driver": {"name": "Semgrep OSS"}}, "results": [r_sem]},
+                {"tool": {"driver": {"name": "CodeQL"}}, "results": [r_cql]},
+            ]
+        }
+
+        count = annotate_sarif(sarif, str(tmp_path))
+        assert count == 1
+        assert "nosemgrep" in r_sem.get("properties", {})
+        assert "nosemgrep" not in r_cql.get("properties", {})
+
+
+# ── build_cmd flag ───────────────────────────────────────────────────────────
+
+
+class TestBuildCmdDisableNosemgrep:
+    def test_disable_nosemgrep_in_cmd(self):
+        from packages.semgrep.runner import build_cmd
+        cmd = build_cmd(Path("/src"), "p/security-audit")
+        assert "--disable-nosem" in cmd

--- a/packages/static-analysis/scanner.py
+++ b/packages/static-analysis/scanner.py
@@ -1839,6 +1839,14 @@ def main():
         ),
     )
 
+    ap.add_argument(
+        "--show-suppressed", action="store_true",
+        dest="show_suppressed",
+        help="Include nosemgrep-suppressed findings in the output summary. "
+             "The SARIF always contains all findings regardless of this flag; "
+             "it only controls the presentation layer.",
+    )
+
     from core.sandbox import add_cli_args, apply_cli_args
     add_cli_args(ap)
     args = ap.parse_args()
@@ -2083,6 +2091,7 @@ def main():
         merged = out_dir / "combined.sarif"
         exclude_globs = args.exclude_dir
         excluded_count = 0
+        nosemgrep_count = 0
         if sarif_inputs:
             logger.info(f"Merging {len(sarif_inputs)} SARIF files...")
             try:
@@ -2099,6 +2108,14 @@ def main():
                         f"--exclude-dir dropped {excluded_count} results "
                         f"from combined.sarif ({exclude_globs})"
                     )
+                # Annotate SARIF results whose source lines carry
+                # nosemgrep inline-suppression comments.  The annotation
+                # lives in result.properties.nosemgrep so any downstream
+                # consumer (/validate, external SARIF viewers) can see
+                # that a finding was developer-suppressed.
+                nosemgrep_count = semgrep_pkg.annotate_sarif(
+                    merged_data, str(repo_path),
+                )
                 save_json(merged, merged_data)
                 logger.info(f"Merged SARIF created: {merged}")
             except Exception as e:
@@ -2120,9 +2137,22 @@ def main():
         # tracked this, nothing failed") rather than absent-key
         # (couldn't-be-bothered).
         metrics["semgrep_failed_packs"] = semgrep_failed
+        metrics["nosemgrep_suppressed_count"] = nosemgrep_count
+        metrics["show_suppressed"] = getattr(args, "show_suppressed", False)
         save_json(out_dir / "scan_metrics.json", metrics)
 
-        logger.info(f"Scan complete: {metrics['total_findings']} findings in {metrics['total_files_scanned']} files")
+        if nosemgrep_count:
+            _active = metrics['total_findings'] - nosemgrep_count
+            logger.info(
+                f"Scan complete: {_active} findings + "
+                f"{nosemgrep_count} developer-suppressed "
+                f"in {metrics['total_files_scanned']} files"
+            )
+        else:
+            logger.info(
+                f"Scan complete: {metrics['total_findings']} findings "
+                f"in {metrics['total_files_scanned']} files"
+            )
 
         # Write coverage records and derive total_files_scanned from them
         try:

--- a/semgrep/nosemgrep.py
+++ b/semgrep/nosemgrep.py
@@ -1,0 +1,188 @@
+"""Extract nosemgrep inline-suppression annotations from source files.
+
+Semgrep's ``# nosemgrep`` comments let developers suppress specific rules
+on a per-line basis.  RAPTOR always scans with ``--disable-nosem`` so
+that suppressed findings still reach the SARIF output.  This module
+post-annotates those results with the developer's suppression metadata so
+downstream consumers (Claude, /validate, external SARIF viewers) can see
+that a finding was developer-suppressed — and optionally read the
+justification text.
+
+Public API:
+
+    annotate_sarif(sarif_data, repo_root)
+        Mutates *sarif_data* in place: each result whose source line (or the
+        line above) carries a nosemgrep comment gets a ``properties.nosemgrep``
+        dict with ``suppressed``, ``rule_ids``, ``justification``, and
+        ``comment_line``.  Returns the count of annotated results.
+
+    extract_nosemgrep(file_path, line)
+        Low-level: check a single source location for a nosemgrep comment.
+"""
+
+import logging
+import re
+from pathlib import Path
+from typing import Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+# Matches nosemgrep comments in any common style:
+#   # nosemgrep: rule-id1, rule-id2 justification text
+#   // nosemgrep: rule-id
+#   /* nosemgrep */
+#   // nosemgrep
+_NOSEMGREP_RE = re.compile(
+    r"""(?://|[#]|/\*)       # comment opener
+        \s*nosemgrep         # keyword
+        (?::[ \t]*           # optional colon + rule list
+          ([\w.:,/-]+)       # group 1: comma-separated rule IDs
+        )?
+        (?:[ \t]+(.+?))?     # group 2: justification text
+        (?:\s*\*/)?          # optional block-comment closer
+        \s*$""",
+    re.VERBOSE,
+)
+
+# Cache: path → list-of-lines (avoids re-reading the same file for
+# multiple findings in it).  Scoped to a single annotate_sarif() call
+# via the _FileCache helper.
+_MAX_CACHE_FILES = 512
+
+
+class _FileCache:
+    """LRU-ish file cache for source lines, scoped to one annotation pass."""
+
+    __slots__ = ("_store",)
+
+    def __init__(self) -> None:
+        self._store: Dict[str, Optional[List[str]]] = {}
+
+    def lines(self, path: str) -> Optional[List[str]]:
+        if path in self._store:
+            return self._store[path]
+        if len(self._store) >= _MAX_CACHE_FILES:
+            # Evict oldest entry (insertion-order dict).
+            self._store.pop(next(iter(self._store)))
+        try:
+            text = Path(path).read_text(errors="replace")
+            result = text.splitlines()
+        except OSError:
+            result = None
+        self._store[path] = result
+        return result
+
+
+def extract_nosemgrep(
+    file_path: Path,
+    line: int,
+    *,
+    _lines: Optional[List[str]] = None,
+) -> Optional[dict]:
+    """Check whether *line* (1-indexed) in *file_path* has a nosemgrep comment.
+
+    Checks the flagged line itself and the line immediately above it (both
+    are valid nosemgrep positions per Semgrep's spec).
+
+    Returns a dict ``{suppressed, rule_ids, justification, comment_line}``
+    if found, ``None`` otherwise.
+    """
+    if _lines is None:
+        try:
+            _lines = Path(file_path).read_text(errors="replace").splitlines()
+        except OSError:
+            return None
+
+    for offset in (0, -1):
+        idx = line - 1 + offset  # 1-indexed → 0-indexed
+        if 0 <= idx < len(_lines):
+            m = _NOSEMGREP_RE.search(_lines[idx])
+            if m:
+                # A nosemgrep on the line ABOVE only suppresses the line
+                # below when it's a standalone comment (no code before it).
+                # Inline nosemgrep (code + comment on same line) only
+                # suppresses that line itself.
+                if offset == -1:
+                    stripped = _lines[idx].lstrip()
+                    if not (
+                        stripped.startswith("#")
+                        or stripped.startswith("//")
+                        or stripped.startswith("/*")
+                    ):
+                        continue
+                raw_ids = m.group(1) or ""
+                justification = (m.group(2) or "").strip() or None
+                rule_ids = [
+                    r.strip() for r in raw_ids.split(",") if r.strip()
+                ]
+                return {
+                    "suppressed": True,
+                    "rule_ids": rule_ids,
+                    "justification": justification,
+                    "comment_line": idx + 1,
+                }
+    return None
+
+
+def annotate_sarif(sarif_data: dict, repo_root: str) -> int:
+    """Annotate SARIF results in place with nosemgrep suppression metadata.
+
+    For each result whose source line carries a ``# nosemgrep`` comment,
+    sets ``result["properties"]["nosemgrep"]`` to a dict with:
+      - ``suppressed`` (bool): always True
+      - ``rule_ids`` (list[str]): rule IDs named in the comment, or []
+      - ``justification`` (str | null): free-text after the rule IDs
+      - ``comment_line`` (int): 1-indexed line of the comment
+
+    Returns the number of results annotated.
+    """
+    root = Path(repo_root)
+    cache = _FileCache()
+    annotated = 0
+
+    for run in sarif_data.get("runs", []):
+        if not isinstance(run, dict):
+            continue
+        # nosemgrep is Semgrep-specific — skip CodeQL/Coccinelle runs.
+        tool_name = (
+            run.get("tool", {}).get("driver", {}).get("name", "")
+        ).lower()
+        if tool_name and "semgrep" not in tool_name:
+            continue
+        for result in run.get("results", []):
+            if not isinstance(result, dict):
+                continue
+            locations = result.get("locations", [])
+            if not locations:
+                continue
+            loc = locations[0]
+            if not isinstance(loc, dict):
+                continue
+            phys = loc.get("physicalLocation", {})
+            uri = phys.get("artifactLocation", {}).get("uri", "")
+            line = phys.get("region", {}).get("startLine", 0)
+            if not uri or not line:
+                continue
+
+            # Resolve the file path against repo root.
+            if uri.startswith("file://"):
+                abs_path = uri[7:]
+            else:
+                abs_path = str(root / uri)
+
+            lines = cache.lines(abs_path)
+            if lines is None:
+                continue
+
+            info = extract_nosemgrep(Path(abs_path), line, _lines=lines)
+            if info:
+                props = result.setdefault("properties", {})
+                props["nosemgrep"] = info
+                annotated += 1
+
+    if annotated:
+        logger.info(
+            "nosemgrep: annotated %d SARIF result(s) as developer-suppressed",
+            annotated,
+        )
+    return annotated

--- a/semgrep/tests/test_nosemgrep.py
+++ b/semgrep/tests/test_nosemgrep.py
@@ -1,0 +1,246 @@
+"""Tests for nosemgrep inline-suppression extraction and SARIF annotation."""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
+
+from packages.semgrep.nosemgrep import annotate_sarif, extract_nosemgrep
+
+
+# ── extract_nosemgrep ────────────────────────────────────────────────────────
+
+
+class TestExtractNosemgrep:
+    def test_inline_same_line(self, tmp_path):
+        src = tmp_path / "a.py"
+        src.write_text("x = eval(inp)  # nosemgrep: python.eval-usage\n")
+        result = extract_nosemgrep(src, 1)
+        assert result is not None
+        assert result["suppressed"] is True
+        assert result["rule_ids"] == ["python.eval-usage"]
+        assert result["comment_line"] == 1
+
+    def test_comment_line_above(self, tmp_path):
+        src = tmp_path / "a.py"
+        src.write_text("# nosemgrep: rule-id reason text\nx = eval(inp)\n")
+        result = extract_nosemgrep(src, 2)
+        assert result is not None
+        assert result["rule_ids"] == ["rule-id"]
+        assert result["justification"] == "reason text"
+        assert result["comment_line"] == 1
+
+    def test_blanket_suppression(self, tmp_path):
+        src = tmp_path / "a.py"
+        src.write_text("x = eval(inp)  # nosemgrep\n")
+        result = extract_nosemgrep(src, 1)
+        assert result is not None
+        assert result["rule_ids"] == []
+        assert result["justification"] is None
+
+    def test_multiple_rule_ids(self, tmp_path):
+        src = tmp_path / "a.py"
+        src.write_text("x = eval(inp)  # nosemgrep: rule-a,rule-b,rule-c\n")
+        result = extract_nosemgrep(src, 1)
+        assert result["rule_ids"] == ["rule-a", "rule-b", "rule-c"]
+
+    def test_c_style_comment(self, tmp_path):
+        src = tmp_path / "a.c"
+        src.write_text("strcpy(dst, src); // nosemgrep: cwe-120\n")
+        result = extract_nosemgrep(src, 1)
+        assert result is not None
+        assert result["rule_ids"] == ["cwe-120"]
+
+    def test_block_comment(self, tmp_path):
+        src = tmp_path / "a.c"
+        src.write_text("strcpy(dst, src); /* nosemgrep: cwe-120 */\n")
+        result = extract_nosemgrep(src, 1)
+        assert result is not None
+
+    def test_no_nosemgrep(self, tmp_path):
+        src = tmp_path / "a.py"
+        src.write_text("x = eval(inp)\ny = 42\n")
+        assert extract_nosemgrep(src, 1) is None
+        assert extract_nosemgrep(src, 2) is None
+
+    def test_missing_file(self, tmp_path):
+        assert extract_nosemgrep(tmp_path / "missing.py", 1) is None
+
+    def test_line_out_of_range(self, tmp_path):
+        src = tmp_path / "a.py"
+        src.write_text("x = 1\n")
+        assert extract_nosemgrep(src, 100) is None
+
+    def test_justification_with_colon_in_rule(self, tmp_path):
+        src = tmp_path / "a.py"
+        src.write_text(
+            "x = eval(inp)  # nosemgrep: python.lang.eval-usage safe constant\n"
+        )
+        result = extract_nosemgrep(src, 1)
+        assert result["rule_ids"] == ["python.lang.eval-usage"]
+        assert result["justification"] == "safe constant"
+
+    def test_preloaded_lines(self, tmp_path):
+        lines = ["x = eval(inp)  # nosemgrep: rule-id reason"]
+        result = extract_nosemgrep(tmp_path / "unused.py", 1, _lines=lines)
+        assert result is not None
+        assert result["rule_ids"] == ["rule-id"]
+
+
+# ── annotate_sarif ───────────────────────────────────────────────────────────
+
+
+def _make_sarif_data(results, tool_name=None):
+    run = {"results": results}
+    if tool_name:
+        run["tool"] = {"driver": {"name": tool_name}}
+    return {"runs": [run]}
+
+
+def _make_result(uri, line):
+    return {
+        "ruleId": "test.rule",
+        "message": {"text": "test"},
+        "level": "warning",
+        "locations": [{
+            "physicalLocation": {
+                "artifactLocation": {"uri": uri},
+                "region": {"startLine": line},
+            },
+        }],
+    }
+
+
+class TestAnnotateSarif:
+    def test_annotates_suppressed_result(self, tmp_path):
+        src = tmp_path / "a.py"
+        src.write_text("x = eval(inp)  # nosemgrep: test.rule safe use\n")
+        result = _make_result("a.py", 1)
+        sarif = _make_sarif_data([result])
+
+        count = annotate_sarif(sarif, str(tmp_path))
+
+        assert count == 1
+        nosem = result["properties"]["nosemgrep"]
+        assert nosem["suppressed"] is True
+        assert nosem["rule_ids"] == ["test.rule"]
+        assert nosem["justification"] == "safe use"
+
+    def test_skips_unsuppressed_result(self, tmp_path):
+        src = tmp_path / "a.py"
+        src.write_text("x = eval(inp)\n")
+        result = _make_result("a.py", 1)
+        sarif = _make_sarif_data([result])
+
+        count = annotate_sarif(sarif, str(tmp_path))
+
+        assert count == 0
+        assert "properties" not in result or "nosemgrep" not in result.get("properties", {})
+
+    def test_mixed_results(self, tmp_path):
+        src = tmp_path / "a.py"
+        src.write_text("x = eval(inp)  # nosemgrep\ny = eval(inp)\n")
+        r1 = _make_result("a.py", 1)
+        r2 = _make_result("a.py", 2)
+        sarif = _make_sarif_data([r1, r2])
+
+        count = annotate_sarif(sarif, str(tmp_path))
+
+        assert count == 1
+        assert "nosemgrep" in r1.get("properties", {})
+        assert "nosemgrep" not in r2.get("properties", {})
+
+    def test_missing_file_graceful(self, tmp_path):
+        result = _make_result("missing.py", 1)
+        sarif = _make_sarif_data([result])
+
+        count = annotate_sarif(sarif, str(tmp_path))
+        assert count == 0
+
+    def test_preserves_existing_properties(self, tmp_path):
+        src = tmp_path / "a.py"
+        src.write_text("x = eval(inp)  # nosemgrep\n")
+        result = _make_result("a.py", 1)
+        result["properties"] = {"cwe": "CWE-94"}
+        sarif = _make_sarif_data([result])
+
+        annotate_sarif(sarif, str(tmp_path))
+
+        assert result["properties"]["cwe"] == "CWE-94"
+        assert result["properties"]["nosemgrep"]["suppressed"] is True
+
+    def test_file_uri_prefix(self, tmp_path):
+        src = tmp_path / "a.py"
+        src.write_text("x = eval(inp)  # nosemgrep\n")
+        abs_path = str(src)
+        result = _make_result(f"file://{abs_path}", 1)
+        sarif = _make_sarif_data([result])
+
+        count = annotate_sarif(sarif, str(tmp_path))
+        assert count == 1
+
+    def test_skips_codeql_run(self, tmp_path):
+        src = tmp_path / "a.py"
+        src.write_text("x = eval(inp)  # nosemgrep\n")
+        result = _make_result("a.py", 1)
+        sarif = _make_sarif_data([result], tool_name="CodeQL")
+
+        count = annotate_sarif(sarif, str(tmp_path))
+        assert count == 0
+        assert "nosemgrep" not in result.get("properties", {})
+
+    def test_skips_coccinelle_run(self, tmp_path):
+        src = tmp_path / "a.c"
+        src.write_text("strcpy(dst, src); // nosemgrep\n")
+        result = _make_result("a.c", 1)
+        sarif = _make_sarif_data([result], tool_name="coccinelle")
+
+        count = annotate_sarif(sarif, str(tmp_path))
+        assert count == 0
+
+    def test_annotates_semgrep_run(self, tmp_path):
+        src = tmp_path / "a.py"
+        src.write_text("x = eval(inp)  # nosemgrep\n")
+        result = _make_result("a.py", 1)
+        sarif = _make_sarif_data([result], tool_name="Semgrep OSS")
+
+        count = annotate_sarif(sarif, str(tmp_path))
+        assert count == 1
+
+    def test_annotates_unnamed_tool_run(self, tmp_path):
+        """Runs without tool.driver.name (legacy SARIF) are assumed semgrep."""
+        src = tmp_path / "a.py"
+        src.write_text("x = eval(inp)  # nosemgrep\n")
+        result = _make_result("a.py", 1)
+        sarif = _make_sarif_data([result])  # no tool_name
+
+        count = annotate_sarif(sarif, str(tmp_path))
+        assert count == 1
+
+    def test_mixed_tool_runs(self, tmp_path):
+        """Only semgrep run annotated, CodeQL run skipped."""
+        src = tmp_path / "a.py"
+        src.write_text("x = eval(inp)  # nosemgrep\n")
+        r_sem = _make_result("a.py", 1)
+        r_cql = _make_result("a.py", 1)
+        sarif = {
+            "runs": [
+                {"tool": {"driver": {"name": "Semgrep OSS"}}, "results": [r_sem]},
+                {"tool": {"driver": {"name": "CodeQL"}}, "results": [r_cql]},
+            ]
+        }
+
+        count = annotate_sarif(sarif, str(tmp_path))
+        assert count == 1
+        assert "nosemgrep" in r_sem.get("properties", {})
+        assert "nosemgrep" not in r_cql.get("properties", {})
+
+
+# ── build_cmd flag ───────────────────────────────────────────────────────────
+
+
+class TestBuildCmdDisableNosemgrep:
+    def test_disable_nosemgrep_in_cmd(self):
+        from packages.semgrep.runner import build_cmd
+        cmd = build_cmd(Path("/src"), "p/security-audit")
+        assert "--disable-nosem" in cmd


### PR DESCRIPTION
Semgrep scans now always use --disable-nosem so all findings reach the data layer regardless of inline suppressions. A new nosemgrep module extracts suppression metadata (rule IDs, justification, position) and stamps it into SARIF result.properties.nosemgrep for downstream consumers.

Presentation: /scan hides suppressed findings by default (--show-suppressed to reveal); /agentic and /validate always see everything. The validation pipeline seeds Stage B hypotheses from developer justifications, treating each as a testable claim.

Fixes 19 ineffective nosemgrep comments across 14 core/ files where justification lines created a gap between the suppression directive and the code — Semgrep only checks same-line (inline) or immediately preceding line (standalone).

22 files changed, 59 insertions(+), 23 deletions(-) (tracked)
\+ 2 new files: nosemgrep.py (188 lines), test_nosemgrep.py (23 tests)