### PR TITLE
fix(exploit-feasibility): improve format string mitigation handling

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -165,7 +165,7 @@ SINK: executeQuery(query)
 **Problem Solved**: Traditional tools (checksec, readelf) show what protections exist but not what's actually possible. This package answers:
 - Can I write to that GOT entry? (Full RELRO blocks both GOT AND .fini_array)
 - Will my ROP chain work? (strcpy null bytes break x86_64 addresses)
-- Does %n work? (glibc 2.38+ may block it - tested empirically)
+- Does %n work? Tri-state verdict (works / disabled / conditional-on-call-site) from a two-probe empirical test: baseline `-U_FORTIFY_SOURCE` compile establishes glibc's baseline `%n` capability; FORTIFY-with-writable-format compile confirms host runtime behavior. Cross-checked against target ELF's `__printf_chk` presence and optional source-tree `_FORTIFY_SOURCE` level. Conditional verdict surfaces case-analysis prose for the LLM to case-split by call site.
 
 **Key Features**:
 - Empirical verification (actually tests %n, doesn't just check version)

--- a/docs/exploit-feasibility.md
+++ b/docs/exploit-feasibility.md
@@ -7,7 +7,7 @@ This guide explains how to use RAPTOR's exploit feasibility analysis to determin
 You find a format string vulnerability. You try:
 1. GOT overwrite → blocked by Full RELRO
 2. __malloc_hook → removed in glibc 2.34
-3. %n writes → blocked by glibc 2.38
+3. %n writes → blocked when target is compiled with `_FORTIFY_SOURCE>=2` AND format string is in writable memory
 4. Multi-gadget ROP → strcpy null bytes break addresses
 
 **Hours wasted.** The feasibility analysis would have told you in seconds that none of these work.
@@ -71,7 +71,7 @@ WHAT WOULD HELP
 - GOT overwrite: Blocked (Full RELRO)
 - .fini_array: Blocked (Full RELRO puts it in read-only segment)
 - __malloc_hook: Removed (glibc 2.34+)
-- %n writes: May be blocked (glibc 2.38+)
+- %n writes: CONDITIONAL. Blocked only when target compiled with `_FORTIFY_SOURCE>=2` AND the vulnerable printf's format-string argument lives in writable memory. `.rodata` format literals work under FORTIFY. Unfortified builds work regardless of glibc version. Check `printf_n_availability_detail` in the report for the case analysis.
 
 **What might work:**
 - Overwrite return address on stack (if you can reach it)
@@ -257,7 +257,7 @@ This package emphasizes **empirical verification**:
 
 | Check | Theoretical | Empirical |
 |-------|-------------|-----------|
-| %n works? | Check glibc version | Actually try printf with %n |
+| %n works? | Check glibc version | Empirical two-probe test: baseline `-U_FORTIFY_SOURCE` + FORTIFY-with-writable-format; cross-checked against target ELF's `__printf_chk` presence and (optionally) source_intel's `fortify_source_level`. Tri-state verdict: True (disabled), False (works), None (conditional on call-site format-string memory class). |
 | ASLR entropy | Read /proc/sys/kernel/randomize_va_space | Sample multiple addresses |
 | ROP gadgets | Count total gadgets | Filter by bad bytes, count usable |
 | Hooks available | Check glibc version | Check if symbols exist in nm output |
@@ -280,7 +280,7 @@ The package supports different exploitation contexts via **target profiles**:
 
 ### Remote CTF Challenges
 
-Your local system has glibc 2.42 (blocks %n), but the CTF challenge runs on Ubuntu 20.04 (glibc 2.31):
+Your local system has glibc 2.42 with FORTIFY defaults (blocks writable-format `%n`), but the CTF challenge runs on Ubuntu 20.04 (glibc 2.31, no FORTIFY):
 
 ```python
 from packages.exploit_feasibility import (

--- a/docs/exploitability-validation-integration.md
+++ b/docs/exploitability-validation-integration.md
@@ -92,9 +92,9 @@ Investing in exploit development for any of these wastes significant time.
 │                                         │   │
 │  Analyze binary constraints:            │   │
 │  - Full RELRO? → GOT blocked            │   │
-│  - glibc 2.38? → %n blocked             │   │
+│  - FORTIFY + writable-format? → %n block│   │
 │  - strcpy? → null bytes block ROP       │   │
-│  - Unknown glibc? → empirical %n test   │   │
+│  - Always run two-probe %n test         │   │
 │  - No checksec? → verdict UNKNOWN       │   │
 │                                         │   │
 │  RESULT: verdict + chain_breaks +       │   │
@@ -198,8 +198,10 @@ This avoids conflating "the bug is real and triggerable" with "the bug gives you
 |-----------|----------------|----------------|
 | double_free (no mitigations) | exploitable | code_execution |
 | null_deref (userland) | exploitable | dos |
-| format_string (%n available) | exploitable | code_execution |
-| format_string (%n blocked) | difficult | info_leak |
+| format_string (%n verified available) | exploitable | code_execution |
+| format_string (%n conditional, no full RELRO) | likely_exploitable | code_execution |
+| format_string (%n conditional, full RELRO) | difficult | code_execution |
+| format_string (%n verified blocked) | unlikely | info_leak |
 | type_confusion | exploitable | code_execution |
 
 ## Structured Exploitation Paths
@@ -289,15 +291,17 @@ ctx = load_exploit_context(context_file)
 
 ### FeasibilityReport.glibc_n_disabled
 
-Type: `Optional[bool]` (not `bool`)
+Type: `Optional[bool]` — the reconciler returns a **tri-state** verdict.
 
 | Value | Meaning |
 |-------|---------|
-| `None` | Unknown — glibc detection failed, empirical test may resolve |
-| `True` | Confirmed disabled (glibc >= 2.38 or empirical test failed) |
-| `False` | Confirmed working (empirical test passed) |
+| `True` | Verified disabled at runtime (glibc's `%n` non-functional even with `-U_FORTIFY_SOURCE`). Rare — only under a hostile glibc rebuild. |
+| `False` | Verified working on this target's build posture (target compiled without `_FORTIFY_SOURCE≥2`, or host FORTIFY runtime does not enforce). |
+| `None` | **CONDITIONAL**: target is FORTIFY-compiled AND host FORTIFY blocks writable-format `%n`. Availability depends on the vulnerable printf's format-string memory class — `.rodata` format literal works, writable buffer (heap/stack/.bss/.data) blocked. Consult `printf_n_availability_detail` in the result for the case-analysis prose and inspect the specific call site to decide. |
 
-When glibc detection fails (containers, minimal images), the empirical `%n` test is automatically attempted on local targets. Remote targets conservatively assume `True` (disabled).
+The verdict is derived from a two-probe empirical test cross-checked against target FORTIFY posture (ELF `__printf_chk` dyn-sym presence, or `source_intel`'s `fortify_source_level` when supplied to `analyze_binary(build_flags=...)`). Version alone does NOT determine `%n` availability — the previously-shipped version-only heuristic that flagged glibc≥2.38 as unconditionally disabled has been retracted. Downstream consumers **must** treat `None` as "conditional, not blocked" — pre-refactor code that used `if glibc_n_disabled:` (Python truthy) silently promoted the CONDITIONAL case to "works" on fortified targets. Explicit `is True` / `is False` / `is None` reads are required.
+
+Remote targets (where empirical tests can't run) conservatively assume `True` (disabled) with confidence `assumed`.
 
 ### Chain Breaks Tagging
 

--- a/packages/exploit_feasibility/analyzer.py
+++ b/packages/exploit_feasibility/analyzer.py
@@ -39,10 +39,13 @@ Usage:
 import os
 import re
 import subprocess
-from core.sandbox import run as _sandbox_run, run_trusted as _run_trusted
+from core.sandbox import run_trusted as _run_trusted
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, TYPE_CHECKING, Tuple
+
+if TYPE_CHECKING:
+    from core.build.build_flags import BuildFlagsContext
 
 from core.logging import get_logger
 from .exploit_context import ExploitContext
@@ -354,7 +357,8 @@ class FeasibilityReport:
     # Detailed findings
     glibc_version: str = ""
     glibc_major_minor: float = 0.0
-    glibc_n_disabled: Optional[bool] = None  # None="unknown", True="disabled", False="works"
+    glibc_n_disabled: Optional[bool] = None  # None="conditional/unknown", True="disabled", False="works"
+    printf_n_availability_detail: Optional[str] = None  # human-readable case analysis when the verdict depends on target build/call-site
     glibc_mitigations: Optional[GlibcMitigations] = None  # Comprehensive glibc mitigation tracking
 
     binary_protections: Dict[str, bool] = field(default_factory=dict)
@@ -455,6 +459,7 @@ class FeasibilityReport:
             "environment_requirements": self.environment_requirements,
             "glibc_version": self.glibc_version,
             "glibc_n_disabled": self.glibc_n_disabled,
+            "printf_n_availability_detail": self.printf_n_availability_detail,
             "binary_protections": self.binary_protections,
             "kernel_mitigations": self.kernel_mitigations,
             "raw_checksec": self.raw_checksec,  # Raw checksec output for LLM context
@@ -942,7 +947,8 @@ class FeasibilityAnalyzer:
     def __init__(
         self,
         binary_path: Optional[Path] = None,
-        profile: Optional[TargetProfile] = None
+        profile: Optional[TargetProfile] = None,
+        build_flags: Optional["BuildFlagsContext"] = None,
     ):
         """
         Initialize the mitigation analyzer.
@@ -951,6 +957,15 @@ class FeasibilityAnalyzer:
             binary_path: Path to binary being analyzed (optional for system-only checks)
             profile: Pre-configured target profile (for remote/web/kernel contexts).
                     If provided, takes precedence over binary_path for context.
+            build_flags: Optional compile-time flag context from source_intel
+                    (``core.build.build_flags.BuildFlagsContext``). When
+                    supplied, ``_reconcile_n_availability`` uses
+                    ``fortify_source_level`` as an authoritative override for
+                    the ELF-derived ``binary_protections['fortify']`` signal —
+                    the source-level extractor sees the actual
+                    ``-D_FORTIFY_SOURCE=N`` flag rather than inferring FORTIFY
+                    from the presence of ``__printf_chk`` in the dynamic
+                    symbol table.
         """
         # Set up profile (provided profile takes precedence)
         if profile:
@@ -970,6 +985,9 @@ class FeasibilityAnalyzer:
         if self.binary and not self.binary.exists():
             logger.warning(f"Binary not found: {binary_path}")
             self.binary = None
+
+        # Optional build-flags context — see docstring.
+        self.build_flags = build_flags
 
         # Select analysis strategy based on profile context
         self.strategy = get_analysis_strategy(self.profile)
@@ -1134,6 +1152,13 @@ class FeasibilityAnalyzer:
         else:
             logger.info("No binary specified - skipping binary protection checks")
 
+        # 2b. Reconcile glibc %n baseline probe against target's FORTIFY
+        # posture to produce the target-specific verdict. Runs even when
+        # no binary is available — reconciler handles the target_fortify=None
+        # case explicitly and downgrades to a conditional verdict.
+        if not is_cross_platform:
+            self._reconcile_n_availability(report)
+
         # 3. Check kernel mitigations (skip for cross-platform binaries)
         if not is_cross_platform:
             logger.info("Checking kernel mitigations...")
@@ -1224,24 +1249,31 @@ class FeasibilityAnalyzer:
                 if report.profile:
                     report.profile.glibc_version = f"{major}.{minor}"
 
-                # Check for %n disabled (glibc 2.38+)
+                # Check for %n disabled (glibc 2.38+ under FORTIFY).
+                #
+                # IMPORTANT: version alone does NOT determine %n
+                # availability. glibc 2.38+ only blocks %n under
+                # _FORTIFY_SOURCE>=2 AND when the format string lives
+                # in writable memory. Unfortified targets, or format
+                # strings in .rodata (string literals), still allow %n.
+                # The empirical probe below (compiled with
+                # -U_FORTIFY_SOURCE) is the authority; the version
+                # heuristic only surfaces a PROVISIONAL warning that
+                # the probe either confirms or retracts.
                 if version >= self.GLIBC_N_DISABLED_VERSION:
-                    report.glibc_n_disabled = True
+                    # Provisional — the empirical probe at
+                    # _test_n_specifier() authoritatively decides.
+                    report.glibc_n_disabled = None  # unknown pending probe
                     confidence_note = f" ({confidence})" if confidence != "detected" else ""
-                    report.blockers.append(
-                        f"glibc {version}{confidence_note}: %n format specifier DISABLED at runtime "
-                        f"(not a compile-time option - cannot be bypassed with compiler flags)"
+                    report.warnings.append(
+                        f"glibc {version}{confidence_note}: %n MAY be blocked under "
+                        f"_FORTIFY_SOURCE>=2 when the format string is in writable memory. "
+                        f"Not a version-only property. Empirical probe below determines the "
+                        f"authoritative value for this build. To bypass FORTIFY: compile "
+                        f"target with -U_FORTIFY_SOURCE, or place the format string in "
+                        f".rodata (glibc's FORTIFY only rejects writable-memory format strings)."
                     )
-                    report.bypass_suggestions.extend([
-                        "Use Docker/container with older glibc (e.g., Ubuntu 20.04 with glibc 2.31)",
-                        "Use chroot with older glibc libraries",
-                        "Statically link binary with older glibc",
-                        "Find alternative write primitive (not format string %n)",
-                        "Use LD_PRELOAD with custom printf implementation (complex)",
-                    ])
-                    report.environment_requirements.append(
-                        f"Requires glibc < {self.GLIBC_N_DISABLED_VERSION} for format string %n writes"
-                    )
+                    report.confidence['glibc_n_disabled'] = 'version_heuristic_provisional'
 
                 # Check for hooks removed (glibc 2.34+)
                 if version >= 2.34:
@@ -1379,10 +1411,19 @@ int main() {
             # the confidence as 'inferred' (heuristic only) so the
             # operator can tell.
             try:
-                compile_result = _sandbox_run(
+                # Trusted-input compile: source is a fixed literal
+                # we wrote ourselves — no attacker-controlled bytes.
+                # The full untrusted sandbox (mount NS + Landlock)
+                # HIDES the tmpfile we just wrote (mount NS gives gcc
+                # a fresh /tmp), so `run()` silently fails with "No
+                # such file or directory" and the probe never
+                # observes reality — the historic reason %n
+                # verification was silently a no-op. Use
+                # `run_trusted` which applies safe_env + rlimits
+                # while preserving the caller's filesystem view.
+                compile_result = _run_trusted(
                     ["gcc", "-o", bin_path, src_path, "-w", "-U_FORTIFY_SOURCE"],
-                    block_network=True, target=work_dir, output=work_dir,
-                    capture_output=True, text=True, timeout=10
+                    capture_output=True, text=True, timeout=10,
                 )
             except FileNotFoundError:
                 logger.warning(
@@ -1392,94 +1433,105 @@ int main() {
                 report.confidence['glibc_n_disabled'] = 'inferred'
                 return
 
-            if compile_result.returncode == 0:
-                # Run the test — executes untrusted binary, full sandbox.
-                run_result = _sandbox_run(
-                    [bin_path],
-                    block_network=True, target=work_dir, output=work_dir,
-                    capture_output=True, text=True, timeout=5
+            if compile_result.returncode != 0:
+                logger.warning(
+                    "%n verification: probe compile failed (rc=%d): %s",
+                    compile_result.returncode,
+                    (compile_result.stderr or "")[:200],
                 )
+                report.confidence['glibc_n_disabled'] = 'inferred'
+                return
 
-                if run_result.returncode == 0:
-                    logger.info("VERIFIED: %n format specifier IS working")
-                    # Remove the %n-disabled blocker if we added one.
-                    #
-                    # Pre-fix the filter was `"%n" not in b` —
-                    # matched ANY blocker containing the substring
-                    # `%n`. That over-matched future blockers like:
-                    #
-                    #   "%nl format specifier disabled"  (hypothetical)
-                    #   "Format string %nfoo not supported"
-                    #   "scanf %ns directive blocked"
-                    #
-                    # — none of which are about the GLIBC-INTRINSIC
-                    # %n disablement we just verified the opposite
-                    # of. The substring filter would silently drop
-                    # them too, masking unrelated blockers.
-                    #
-                    # Anchor the match to the specific blocker
-                    # message we know we emit at line ~1230:
-                    # "%n format specifier DISABLED at runtime".
-                    # Future-proof against minor rewordings by
-                    # matching on the unique sub-phrase "%n format
-                    # specifier" — narrow enough to avoid the
-                    # over-match, broad enough to survive small
-                    # message edits.
-                    report.blockers = [
-                        b for b in report.blockers
-                        if "%n format specifier" not in b
-                    ]
-                    report.glibc_n_disabled = False
-                    # Update glibc_mitigations if present
+            # Trusted-input probe binary: the source we compiled
+            # is a fixed literal we wrote, so the resulting ELF
+            # has no attacker-controlled bytes. Same reason as
+            # the compile above — full sandbox would hide the
+            # binary from itself. Use run_trusted for the probe.
+            run_result = _run_trusted(
+                [bin_path],
+                capture_output=True, text=True, timeout=5,
+            )
+
+            if run_result.returncode == 0:
+                logger.info("VERIFIED: %n format specifier IS working")
+                # Remove the %n-disabled blocker if we added one.
+                #
+                # Pre-fix the filter was `"%n" not in b` —
+                # matched ANY blocker containing the substring
+                # `%n`. That over-matched future blockers like:
+                #
+                #   "%nl format specifier disabled"  (hypothetical)
+                #   "Format string %nfoo not supported"
+                #   "scanf %ns directive blocked"
+                #
+                # — none of which are about the GLIBC-INTRINSIC
+                # %n disablement we just verified the opposite
+                # of. The substring filter would silently drop
+                # them too, masking unrelated blockers.
+                #
+                # Anchor the match to the specific blocker
+                # message we know we emit at line ~1230:
+                # "%n format specifier DISABLED at runtime".
+                # Future-proof against minor rewordings by
+                # matching on the unique sub-phrase "%n format
+                # specifier" — narrow enough to avoid the
+                # over-match, broad enough to survive small
+                # message edits.
+                report.blockers = [
+                    b for b in report.blockers
+                    if "%n format specifier" not in b
+                ]
+                report.glibc_n_disabled = False
+                # Update glibc_mitigations if present
+                if report.glibc_mitigations:
+                    report.glibc_mitigations.format_n_disabled = False
+                    report.glibc_mitigations.format_n_verified = True
+                    # Rebuild mitigations with verified status
+                    report.glibc_mitigations.__post_init__()
+            else:
+                # Distinguish "%n actually blocked" from "test
+                # crashed for an unrelated reason". glibc 2.38+'s
+                # disabled-mode emits SIGABRT (`-6`, runtime exit
+                # code 134) with a specific "%n in writable format
+                # string" message. Anything else (SIGSEGV from a
+                # bad-address %n write, linker error, generic
+                # exit-1) is ambiguous: %n MAY be working, but
+                # the test path didn't validate it cleanly.
+                #
+                # Pre-fix any non-zero returncode set
+                # `format_n_verified = True` and `glibc_n_disabled
+                # = True` — claiming verification on a SIGSEGV the
+                # test code itself caused. Operators then saw
+                # "VERIFIED disabled" and gave up on %n exploits
+                # against binaries where %n actually worked but
+                # the test binary crashed for an unrelated reason.
+                rc = run_result.returncode
+                looks_like_glibc_block = (
+                    rc == 134  # 128 + SIGABRT (canonical glibc
+                               # disabled-mode signal)
+                    or "format string" in (run_result.stderr or "").lower()
+                )
+                if looks_like_glibc_block:
+                    logger.warning(
+                        "VERIFIED: %n format specifier is NOT working "
+                        f"(returncode={rc}, matches glibc block signature)"
+                    )
+                    if report.glibc_n_disabled is not True:
+                        report.glibc_n_disabled = True
+                        report.blockers.append(
+                            "VERIFIED: %n format specifier does not write (runtime disabled)"
+                        )
                     if report.glibc_mitigations:
-                        report.glibc_mitigations.format_n_disabled = False
+                        report.glibc_mitigations.format_n_disabled = True
                         report.glibc_mitigations.format_n_verified = True
-                        # Rebuild mitigations with verified status
                         report.glibc_mitigations.__post_init__()
                 else:
-                    # Distinguish "%n actually blocked" from "test
-                    # crashed for an unrelated reason". glibc 2.38+'s
-                    # disabled-mode emits SIGABRT (`-6`, runtime exit
-                    # code 134) with a specific "%n in writable format
-                    # string" message. Anything else (SIGSEGV from a
-                    # bad-address %n write, linker error, generic
-                    # exit-1) is ambiguous: %n MAY be working, but
-                    # the test path didn't validate it cleanly.
-                    #
-                    # Pre-fix any non-zero returncode set
-                    # `format_n_verified = True` and `glibc_n_disabled
-                    # = True` — claiming verification on a SIGSEGV the
-                    # test code itself caused. Operators then saw
-                    # "VERIFIED disabled" and gave up on %n exploits
-                    # against binaries where %n actually worked but
-                    # the test binary crashed for an unrelated reason.
-                    rc = run_result.returncode
-                    looks_like_glibc_block = (
-                        rc == 134  # 128 + SIGABRT (canonical glibc
-                                   # disabled-mode signal)
-                        or "format string" in (run_result.stderr or "").lower()
+                    logger.warning(
+                        f"%n verification inconclusive: returncode={rc} "
+                        f"does not match canonical glibc block signature; "
+                        f"glibc_n_disabled value reflects version heuristic only"
                     )
-                    if looks_like_glibc_block:
-                        logger.warning(
-                            "VERIFIED: %n format specifier is NOT working "
-                            f"(returncode={rc}, matches glibc block signature)"
-                        )
-                        if report.glibc_n_disabled is not True:
-                            report.glibc_n_disabled = True
-                            report.blockers.append(
-                                "VERIFIED: %n format specifier does not write (runtime disabled)"
-                            )
-                        if report.glibc_mitigations:
-                            report.glibc_mitigations.format_n_disabled = True
-                            report.glibc_mitigations.format_n_verified = True
-                            report.glibc_mitigations.__post_init__()
-                    else:
-                        logger.warning(
-                            f"%n verification inconclusive: returncode={rc} "
-                            f"does not match canonical glibc block signature; "
-                            f"glibc_n_disabled value reflects version heuristic only"
-                        )
-                        report.confidence['glibc_n_disabled'] = 'inconclusive'
+                    report.confidence['glibc_n_disabled'] = 'inconclusive'
 
         except Exception as e:
             logger.debug(f"Could not verify %n behavior: {e}")
@@ -1495,6 +1547,290 @@ int main() {
                         os.unlink(p)
                     except OSError:
                         pass  # File cleanup failure is non-critical
+
+    def _probe_fortify_blocks_writable_n(self) -> Optional[bool]:
+        """Compile a FORTIFY-enabled probe with the format string in
+        writable memory and check whether the host runtime aborts.
+
+        Returns:
+            True — FORTIFY on this host aborts writable-format ``%n``
+                (the modern glibc + FORTIFY behaviour).
+            False — FORTIFY on this host does NOT block writable-format
+                ``%n`` (older glibc, disabled FORTIFY runtime, or a
+                platform where FORTIFY doesn't cover printf).
+            None — probe couldn't run (no gcc, sandbox error, etc.).
+
+        This is the second-half of accurate %n detection. Paired with
+        the baseline probe in :meth:`_verify_printf_n`, it lets the
+        reconciler answer target-specific questions like "does %n work
+        against this target's actual build posture" instead of only
+        "does glibc runtime support %n at all".
+        """
+        # -O2 is required for FORTIFY to activate at compile time —
+        # __printf_chk substitution happens under the optimiser.
+        test_code = '''
+#include <stdio.h>
+#include <string.h>
+int main(void) {
+    int x = 12345;
+    char buf[64];
+    strcpy(buf, "hello%n");
+    printf(buf, &x);
+    return (x == 5) ? 0 : 1;
+}
+'''
+        import tempfile
+        src_path = None
+        bin_path = None
+        try:
+            with tempfile.NamedTemporaryFile(mode='w', suffix='.c', delete=False) as f:
+                src_path = f.name
+                f.write(test_code)
+            bin_path = src_path.rsplit('.c', 1)[0] + '.fortify'
+
+            try:
+                # Trusted-input compile/run: source is a fixed
+                # literal we wrote — no attacker bytes. Untrusted
+                # sandbox mount NS would hide the tempfile.
+                compile_result = _run_trusted(
+                    ["gcc", "-O2", "-D_FORTIFY_SOURCE=2", "-w",
+                     "-o", bin_path, src_path],
+                    capture_output=True, text=True, timeout=10,
+                )
+            except FileNotFoundError:
+                logger.warning(
+                    "FORTIFY %n probe skipped: gcc not in PATH"
+                )
+                return None
+
+            if compile_result.returncode != 0:
+                logger.warning(
+                    "FORTIFY %n probe skipped: compile failed (%s)",
+                    (compile_result.stderr or "")[:200],
+                )
+                return None
+
+            run_result = _run_trusted(
+                [bin_path],
+                capture_output=True, text=True, timeout=5,
+            )
+            rc = run_result.returncode
+            stderr_lc = (run_result.stderr or "").lower()
+
+            # SIGABRT (128 + 6 = 134) with the "%n in writable" glibc
+            # message is the canonical FORTIFY-blocks-%n signature.
+            aborted = (
+                rc == 134
+                or "%n in writable" in stderr_lc
+                or "format string" in stderr_lc
+            )
+            if aborted:
+                logger.info(
+                    "FORTIFY probe: host FORTIFY aborts writable-format %%n "
+                    "(rc=%d)", rc,
+                )
+                return True
+
+            # Probe program returned 0 iff %n actually wrote 5 —
+            # meaning FORTIFY did NOT intercept on this host.
+            if rc == 0:
+                logger.info(
+                    "FORTIFY probe: host FORTIFY does NOT block writable-format %%n"
+                )
+                return False
+
+            # Anything else: SIGSEGV, generic non-zero, unrelated error.
+            # We can't confidently say FORTIFY blocked; return None.
+            logger.warning(
+                "FORTIFY probe inconclusive: rc=%d does not match canonical "
+                "block signature and %%n did not write successfully",
+                rc,
+            )
+            return None
+        except Exception as e:
+            logger.debug("FORTIFY probe: unexpected error: %s", e)
+            return None
+        finally:
+            for p in (src_path, bin_path):
+                if p:
+                    try:
+                        os.unlink(p)
+                    except OSError:
+                        pass
+
+    def _reconcile_n_availability(self, report: FeasibilityReport):
+        """Cross-check the glibc %n baseline probe against the target's
+        FORTIFY posture and produce a target-specific verdict.
+
+        Prerequisite state (set by earlier analysis passes):
+
+          * :meth:`_verify_printf_n` ran an empirical probe with
+            ``-U_FORTIFY_SOURCE`` and set ``glibc_n_disabled`` to
+            ``True`` (glibc runtime kills %n even without FORTIFY)
+            or ``False`` (glibc runtime executes %n when FORTIFY is
+            out of the way). ``None`` means the probe couldn't run.
+
+          * :meth:`_check_binary_protections` populated
+            ``binary_protections['fortify']`` from the target's ELF
+            dynamic symbols (``__printf_chk`` / ``__*_chk`` entries
+            → True; absent → False; couldn't inspect → key missing).
+
+        Decision table (baseline_probe × target_fortify):
+
+          * baseline=True (glibc kills %n) → stays True. FORTIFY
+            irrelevant; %n is dead at the runtime level.
+          * baseline=False, target unfortified → stays False. %n is
+            available; no downstream FORTIFY intercept.
+          * baseline=False, target fortified → depends on FORMAT
+            STRING MEMORY CLASS. Run a FORTIFY probe on the host to
+            confirm the runtime blocks writable-format %n. If it does,
+            set to None (conditional): writable-format printf(userbuf)
+            blocked, .rodata-format printf("...",userbuf) still works.
+            If FORTIFY doesn't block (rare), stays False.
+          * baseline=False, target FORTIFY unknown → None with a
+            "target FORTIFY posture undetected" note.
+          * baseline=None (probe couldn't run) → stays None, no
+            reconciliation possible.
+
+        The final ``glibc_n_disabled`` value is target-specific
+        (accurate for THIS target's build posture and this host's
+        runtime, given the caveat that per-call-site format-string
+        memory class is not statically inspected).
+        """
+        baseline = report.glibc_n_disabled
+        # Prefer compile-time evidence when source_intel supplied it — the
+        # source-level extractor sees the actual ``-D_FORTIFY_SOURCE=N`` flag
+        # in the target's build system (compile_commands.json / Makefile /
+        # kconfig). The ELF-derived ``binary_protections['fortify']`` infers
+        # FORTIFY from the presence of ``__printf_chk`` in the dynamic symbol
+        # table — accurate for typical builds but noisier for stripped
+        # binaries, LTO'd builds where the chk-substitution was inlined
+        # away, and cross-compiled targets. When both are present they
+        # usually agree; when they disagree, trust the source-level signal
+        # and surface the mismatch in ``confidence``.
+        target_fortify = report.binary_protections.get('fortify')
+        source_fortify: Optional[bool] = None
+        bf = getattr(self, 'build_flags', None)
+        if bf is not None:
+            level = getattr(bf, 'fortify_source_level', None)
+            if level is not None:
+                # glibc: level 2/3 intercepts writable-format %n; level 0/1
+                # does not. Kernel FORTIFY doesn't intercept %n at all (no
+                # printf in the kernel-analysis path), but for glibc-target
+                # analysis the caller wouldn't hand us a kconfig context.
+                if getattr(bf, 'source', None) == 'kconfig':
+                    # Not applicable to userspace %n; ignore.
+                    source_fortify = None
+                else:
+                    source_fortify = level >= 2
+                if source_fortify is not None:
+                    if (target_fortify is not None
+                            and source_fortify != target_fortify):
+                        report.warnings.append(
+                            f"FORTIFY signal disagreement: source_intel reports "
+                            f"_FORTIFY_SOURCE={level} (fortified={source_fortify}); "
+                            f"ELF dyn-syms suggest fortified={target_fortify}. "
+                            f"Trusting source-level signal."
+                        )
+                    # Source-level wins when it produced a concrete signal.
+                    target_fortify = source_fortify
+
+        if baseline is True:
+            report.printf_n_availability_detail = (
+                "%n is disabled at the glibc runtime level on this host — "
+                "target FORTIFY posture is irrelevant, the format-string "
+                "write primitive is unavailable regardless of build flags "
+                "or format-string memory class."
+            )
+            return
+
+        if baseline is None:
+            report.printf_n_availability_detail = (
+                "%n baseline probe could not run (missing gcc or sandbox "
+                "error); target-specific FORTIFY reconciliation skipped."
+            )
+            return
+
+        # baseline is False → glibc executes %n when FORTIFY is bypassed.
+        if target_fortify is False:
+            report.printf_n_availability_detail = (
+                "%n is available on this target: glibc runtime supports "
+                "the write primitive and the target was compiled WITHOUT "
+                "_FORTIFY_SOURCE, so no runtime intercept. Format-string "
+                "memory class does not matter."
+            )
+            report.confidence['glibc_n_disabled'] = 'reconciled_target_specific'
+            return
+
+        if target_fortify is None:
+            report.printf_n_availability_detail = (
+                "%n status is CONDITIONAL: glibc runtime supports the "
+                "write primitive on this host, but the target's "
+                "_FORTIFY_SOURCE posture could not be determined from "
+                "the ELF. Under FORTIFY, writable-memory format strings "
+                "block %n and .rodata format strings do not; inspect the "
+                "specific vulnerable printf call site to decide."
+            )
+            report.glibc_n_disabled = None
+            report.confidence['glibc_n_disabled'] = 'reconciled_target_unknown'
+            return
+
+        # target_fortify is True → run FORTIFY probe to confirm host
+        # behaviour, then set the conditional verdict.
+        fortify_blocks = self._probe_fortify_blocks_writable_n()
+
+        if fortify_blocks is True:
+            report.glibc_n_disabled = None
+            report.printf_n_availability_detail = (
+                "%n status is CONDITIONAL on the format-string memory "
+                "class at the vulnerable printf site. Target is compiled "
+                "with _FORTIFY_SOURCE and this host's glibc aborts (SIGABRT) "
+                "on writable-memory format strings passed to printf-family "
+                "functions. Case analysis: "
+                "(a) printf(user_controlled_buf) — BLOCKED, FORTIFY "
+                "detects writable format and aborts; "
+                "(b) printf(\".rodata_literal_%s\", user_controlled_buf) "
+                "— %n IS AVAILABLE, FORTIFY does not intercept .rodata "
+                "formats; "
+                "(c) unfortified rebuild (-U_FORTIFY_SOURCE) — %n available "
+                "regardless of format origin. "
+                "Inspect the specific call site in the target's source to "
+                "choose the correct chain."
+            )
+            report.confidence['glibc_n_disabled'] = 'reconciled_conditional'
+            # Retract any earlier absolute blocker/warning — the correct
+            # framing is a conditional verdict, not a hard block.
+            report.blockers = [
+                b for b in report.blockers
+                if "%n format specifier" not in b
+                and "%n disabled" not in b
+                and "%n in glibc" not in b
+            ]
+            report.warnings.append(
+                "%n conditional-verdict: writable-format printf calls "
+                "blocked by FORTIFY on this target; rodata-format calls "
+                "unblocked. Static call-site inspection required for "
+                "definitive answer."
+            )
+        elif fortify_blocks is False:
+            report.printf_n_availability_detail = (
+                "%n is AVAILABLE on this target: target reports FORTIFY "
+                "compile posture but this host's runtime does NOT intercept "
+                "writable-format %n (older glibc, disabled FORTIFY runtime, "
+                "or platform mismatch). The %n write primitive works."
+            )
+            report.confidence['glibc_n_disabled'] = 'reconciled_fortify_ineffective'
+        else:
+            # fortify_blocks is None — probe couldn't run.
+            report.glibc_n_disabled = None
+            report.printf_n_availability_detail = (
+                "%n status is CONDITIONAL (unverified): glibc runtime "
+                "supports %n and target is compiled with FORTIFY, but the "
+                "FORTIFY probe on this host could not run (missing gcc or "
+                "sandbox error). Assume writable-format printf is blocked "
+                "and .rodata-format printf works unless overridden."
+            )
+            report.confidence['glibc_n_disabled'] = 'reconciled_probe_unavailable'
 
     def _check_binary_protections(self, report: FeasibilityReport):
         """
@@ -3941,15 +4277,34 @@ int main() {
         vuln_lower = vuln_type.lower()
         primitive = ExploitPrimitive(name=vuln_type)
 
-        # Format string write (%n)
+        # Format string write (%n).
+        #
+        # Tri-state on ``glibc_n_disabled``:
+        #   * ``False``  → %n empirically works on this target's build → mark write True.
+        #   * ``True``   → verified disabled → write False.
+        #   * ``None``   → CONDITIONAL: depends on format-string memory class
+        #     at the vulnerable call site (writable-format blocked under FORTIFY,
+        #     .rodata-format works). Substrate cannot make an absolute call
+        #     without inspecting the specific printf site; leave write False
+        #     and surface the case-analysis via ``printf_n_availability_detail``.
+        # Pre-fix used ``is not True`` which mis-promoted the CONDITIONAL case
+        # to write=True on fortified targets.
         if any(x in vuln_lower for x in ['format_string_write', 'format_write', 'printf']):
-            primitive.arbitrary_write = report.glibc_n_disabled is not True
+            primitive.arbitrary_write = report.glibc_n_disabled is False
             primitive.arbitrary_read = True  # %s, %p always work
             primitive.info_leak = True
             primitive.write_size = "1-8 bytes per write (hhn/hn/n)"
             primitive.write_count = "multiple"
             primitive.requires_leak = report.binary_protections.get('pie', False)
-            primitive.notes = "Write via %n, read via %p/%s. If %n blocked, read-only."
+            if report.glibc_n_disabled is None:
+                primitive.notes = (
+                    "Write via %n CONDITIONAL on target's compile-time FORTIFY "
+                    "posture AND the vulnerable printf's format-string memory "
+                    "class. See report.printf_n_availability_detail for the "
+                    "case analysis; inspect the specific call site to decide."
+                )
+            else:
+                primitive.notes = "Write via %n, read via %p/%s. If %n blocked, read-only."
 
         # Format string read (info leak)
         elif any(x in vuln_lower for x in ['format_string_read', 'format_read', 'format_leak']):

--- a/packages/exploit_feasibility/api.py
+++ b/packages/exploit_feasibility/api.py
@@ -17,7 +17,10 @@ Usage:
 """
 
 from pathlib import Path
-from typing import Dict, List, Optional, Tuple, Any
+from typing import Dict, List, Optional, TYPE_CHECKING, Tuple, Any
+
+if TYPE_CHECKING:
+    from core.build.build_flags import BuildFlagsContext
 
 from core.logging import get_logger
 
@@ -133,7 +136,8 @@ def _mechanism_mitigation_facts(result: Dict[str, Any],
 def analyze_binary(binary_path: str, output_dir: str = None,
                    vuln_type: str = None, extended: bool = True,
                    target_capabilities: Optional[List[str]] = None,
-                   active_mitigations: Optional[List] = None) -> Dict[str, Any]:
+                   active_mitigations: Optional[List] = None,
+                   build_flags: Optional["BuildFlagsContext"] = None) -> Dict[str, Any]:
     """
     Run mitigation analysis on a binary.
 
@@ -142,6 +146,13 @@ def analyze_binary(binary_path: str, output_dir: str = None,
         output_dir: Directory to save analysis results (optional)
         vuln_type: Vulnerability type for specific checks (optional)
         extended: Run extended analysis (libc offsets, ROP gadgets, etc.)
+        build_flags: Optional compile-time flag context (typically produced
+                    by ``core.build.build_flags.extract_flags`` running over
+                    the target's source tree). When supplied, the %n verdict
+                    reconciler uses ``fortify_source_level`` as an
+                    authoritative override for the ELF-derived
+                    ``__printf_chk`` heuristic. See
+                    ``FeasibilityAnalyzer._reconcile_n_availability``.
 
     Returns:
         Dictionary with analysis results:
@@ -177,7 +188,9 @@ def analyze_binary(binary_path: str, output_dir: str = None,
     profile = _get_profile_for_vuln_type(vuln_type, str(binary_path) if binary_path else None)
 
     # Run analysis with appropriate profile
-    analyzer = FeasibilityAnalyzer(binary_path=binary_path, profile=profile)
+    analyzer = FeasibilityAnalyzer(
+        binary_path=binary_path, profile=profile, build_flags=build_flags,
+    )
     report = analyzer.full_analysis(vuln_type=vuln_type, extended=extended)
 
     # Build clean result dict
@@ -199,6 +212,13 @@ def analyze_binary(binary_path: str, output_dir: str = None,
 
     # Add runtime-verified glibc info
     result['glibc_n_disabled'] = getattr(report, 'glibc_n_disabled', None)
+    # Case-analysis prose when ``glibc_n_disabled is None`` (CONDITIONAL).
+    # Consumers should render this into any LLM prompt that touches format
+    # string exploitation so the model can case-split on the actual call
+    # site rather than treating None as "unknown/blocked".
+    result['printf_n_availability_detail'] = getattr(
+        report, 'printf_n_availability_detail', None,
+    )
     result['glibc_version'] = getattr(report, 'glibc_version', None)
 
     # Add cross-platform detection results
@@ -663,15 +683,31 @@ def analyze_binary(binary_path: str, output_dir: str = None,
     # Get verified %n status from the analysis we just ran
     # This is critical: empirical test overrides glibc version-based assumptions
     # For cross-platform binaries, host glibc info is irrelevant — skip it
+    #
+    # Tri-state on ``glibc_n_disabled``:
+    #   * ``False``  → %n verified working → True.
+    #   * ``True``   → verified disabled → False.
+    #   * ``None``   → CONDITIONAL: writable-format blocked by FORTIFY,
+    #     rodata-format works. Leave as None — downstream must not
+    #     promote to True (which would remove the mitigation from
+    #     ``graph.active_mitigations`` and mis-mark the write primitive
+    #     available). Pre-fix used ``not report.glibc_n_disabled`` which
+    #     evaluated ``not None == True`` and mis-promoted the CONDITIONAL
+    #     case to "verified working" on fortified targets.
     glibc_n_verified_working = None
     if not is_cross_platform:
         if report.glibc_mitigations and report.glibc_mitigations.format_n_verified:
-            # We ran the empirical test - trust its result
-            glibc_n_verified_working = not report.glibc_mitigations.format_n_disabled
-        elif report.glibc_n_disabled is not None:
-            # Fall back to the report's glibc_n_disabled flag
-            # Only set when we actually know (not None = unknown)
-            glibc_n_verified_working = not report.glibc_n_disabled
+            # We ran the empirical test — trust its tri-state.
+            if report.glibc_mitigations.format_n_disabled is True:
+                glibc_n_verified_working = False
+            elif report.glibc_mitigations.format_n_disabled is False:
+                glibc_n_verified_working = True
+            # None (conditional) leaves ``glibc_n_verified_working=None``.
+        elif report.glibc_n_disabled is True:
+            glibc_n_verified_working = False
+        elif report.glibc_n_disabled is False:
+            glibc_n_verified_working = True
+        # ``glibc_n_disabled is None`` leaves ``glibc_n_verified_working=None``.
 
     if vuln_type:
         # When a specific vuln_type is provided, only analyze that type.
@@ -868,8 +904,12 @@ def assess_technique_viability_from_result(result: Dict[str, Any]) -> Dict[str, 
     for t in arch_blocked:
         blocked.append({'technique': t, 'reason': f'null bytes at position {null_pos}'})
 
-    # Get other blockers from warnings/protections
-    warnings = result.get('warnings', [])
+    # Get other blockers from protections. ``warnings`` was previously
+    # scanned by the ``glibc_n_disabled is None`` fallback branch below;
+    # now that the version-only heuristic no longer emits ``%n``
+    # blockers/warnings unconditionally, that scan is unreachable and
+    # ``warnings`` is unused here — reconciler-driven tri-state is
+    # authoritative.
     protections = result.get('protections', {})
     glibc_mits = result.get('glibc_mitigations', {})
     kernel_mits = result.get('kernel_mitigations', {})
@@ -889,9 +929,11 @@ def assess_technique_viability_from_result(result: Dict[str, Any]) -> Dict[str, 
         if not protections.get('pie'):
             arch_viable.append("Fixed addresses (no PIE)")
 
-    # Get runtime-verified %n status
+    # Get runtime-verified %n status. ``glibc_version`` was previously
+    # read as a co-signal for the ``None`` fallback branch that
+    # short-circuited on ``version >= 2.38``; that branch was retired
+    # once the reconciler owned the tri-state verdict end-to-end.
     glibc_n_disabled = result.get('glibc_n_disabled')
-    glibc_version = glibc_mits.get('version', 0.0)
 
     # Track additional requirements for techniques that need primitives
     additional_requirements = []
@@ -906,14 +948,21 @@ def assess_technique_viability_from_result(result: Dict[str, Any]) -> Dict[str, 
         # Format string checks
         # ─────────────────────────────────────────────────────────────────────
         if 'format string' in tech_lower and '%n' in tech_lower:
+            # Tri-state (see analyzer.py:_reconcile_n_availability):
+            #   * True   → substrate verified %n dead at runtime → dominate.
+            #   * False  → substrate verified %n works → do not dominate.
+            #   * None   → CONDITIONAL (writable-format blocked under
+            #     FORTIFY, .rodata-format works). Do NOT dominate — the
+            #     technique's availability depends on the specific call site
+            #     which the substrate can't inspect. Downstream (LLM, primer
+            #     text) uses ``printf_n_availability_detail`` to case-split.
+            # Pre-fix ``elif glibc_n_disabled is None and version >= 2.38:``
+            # branch treated ``None`` as "assume disabled" and matched on a
+            # warnings-substring heuristic — that heuristic was the leftover
+            # of the version-only false positive. Removed.
             if glibc_n_disabled is True:
                 dominated = True
                 reason = 'VERIFIED: %n disabled at runtime'
-            elif glibc_n_disabled is None and glibc_version >= 2.38:
-                n_disabled = any('%n' in w.lower() and 'disabled' in w.lower() for w in warnings)
-                if n_disabled:
-                    dominated = True
-                    reason = 'glibc 2.38+ disables %n by default'
 
         # ─────────────────────────────────────────────────────────────────────
         # Hook overwrite checks (glibc 2.34+)

--- a/packages/exploit_feasibility/finding_mapper.py
+++ b/packages/exploit_feasibility/finding_mapper.py
@@ -324,18 +324,70 @@ def _assess_buffer_overflow(finding: Dict, c: Dict) -> FeasibilityAssessment:
 def _assess_format_string(finding: Dict, c: Dict) -> FeasibilityAssessment:
     has_full_relro = c.get('protections', {}).get('full_relro', False)
     has_pie = c.get('protections', {}).get('pie', False)
+    has_fortify = c.get('protections', {}).get('fortify')
+    # Tri-state on ``glibc_n_disabled`` (see analyzer.py:_reconcile_n_availability):
+    #   * ``True``   → verified disabled (probe or fortify-blocks-all-writable-formats).
+    #   * ``False``  → verified working on this target's build posture.
+    #   * ``None``   → substrate returned no definitive answer. Two sub-cases:
+    #     (a) Reconciler produced a CONDITIONAL verdict (target fortified,
+    #         host FORTIFY blocks writable-format). ``printf_n_availability_detail``
+    #         will be populated with the case analysis.
+    #     (b) No probe ran (no binary supplied, or substrate call was skipped).
+    #         Fall back to the fortify signal: unfortified target → assume
+    #         %n works (matches historic optimistic default); fortified or
+    #         unknown-fortify → conditional / conservative.
+    # Pre-fix used ``if n_disabled:`` which treated the CONDITIONAL ``None``
+    # as falsy → verdict silently flipped to ``exploitable`` on fortified
+    # targets. See PR "improving format string mitigation handling".
     n_disabled = c.get('glibc_n_disabled')
+    n_detail = c.get('printf_n_availability_detail')
+    # Interpret ``None`` in light of what we know about the target's
+    # FORTIFY compile posture. This lets legacy callers that pass
+    # ``glibc_n_disabled=None`` alongside ``fortify=False`` (no probe
+    # was run but target is provably unfortified) keep the optimistic
+    # "%n works" default.
+    if n_disabled is None:
+        if has_fortify is False:
+            # Target verifiably unfortified → %n works regardless of
+            # what the substrate probe said (or didn't).
+            n_disabled_effective = False
+        elif has_fortify is True:
+            # Target verifiably fortified → conditional (may work under
+            # rodata-format calls, blocked otherwise).
+            n_disabled_effective = None
+        else:
+            # Both n_disabled and fortify are unknown. Cannot decide;
+            # treat conservatively as conditional. When we lack any
+            # signal (no binary, remote target substrate skipped
+            # locally), the ``analyze_binary`` upstream typically sets
+            # ``glibc_n_disabled=True`` on remote targets — so this
+            # sub-branch mostly captures the "finding_mapper called
+            # with hand-authored context" case.
+            n_disabled_effective = None
+    else:
+        n_disabled_effective = n_disabled
     best = _get_best_target(c)
 
     blockers = []
-    if n_disabled:
-        blockers.append('%n format specifier disabled by glibc — no write primitive')
+    if n_disabled_effective is True:
+        blockers.append('%n format specifier disabled — no write primitive')
+    elif n_disabled_effective is None:
+        # Conditional: keep the LLM informed but don't over-block.
+        note = '%n write CONDITIONAL on format-string memory class at call site'
+        if n_detail:
+            note = f"{note} ({n_detail[:200]})"
+        blockers.append(note)
     if has_full_relro:
         blockers.append('Full RELRO — GOT and .fini_array are read-only')
 
-    if n_disabled:
+    if n_disabled_effective is True:
         verdict = 'unlikely'
         impact = 'info_leak'
+    elif n_disabled_effective is None:
+        # Conditional — some call sites work, some don't. Neither fully
+        # exploitable nor blocked; force downstream to inspect the site.
+        verdict = 'likely_exploitable' if not has_full_relro else 'difficult'
+        impact = 'code_execution'
     elif has_full_relro:
         verdict = 'difficult'
         impact = 'code_execution'
@@ -347,7 +399,7 @@ def _assess_format_string(finding: Dict, c: Dict) -> FeasibilityAssessment:
         impact = 'code_execution'
 
     paths = []
-    if not n_disabled:
+    if n_disabled_effective is False:
         if not has_full_relro and best:
             paths.append(_make_path(
                 'GOT overwrite via %n',
@@ -355,6 +407,17 @@ def _assess_format_string(finding: Dict, c: Dict) -> FeasibilityAssessment:
             ))
         if not has_pie:
             paths.append(_make_path('%n write to fixed address', 'fixed addresses (no PIE)'))
+    elif n_disabled_effective is None:
+        # Conditional — expose both branches so downstream / LLM can
+        # pick based on the target's actual call site.
+        paths.append(_make_path(
+            '%n write IF format string is in .rodata (literal)',
+            'inspect the vulnerable printf call site',
+        ))
+        paths.append(_make_path(
+            'info leak via %p/%x (works regardless of FORTIFY)',
+            'stack contents',
+        ))
     else:
         paths.append(_make_path('info leak via %p/%x format specifiers', 'stack contents (read-only)'))
 

--- a/packages/exploit_feasibility/mitigations.py
+++ b/packages/exploit_feasibility/mitigations.py
@@ -7,7 +7,7 @@ Tracks system-level mitigations and their impact on exploitation.
 
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import List
+from typing import List, Optional
 
 
 class MitigationImpact(Enum):
@@ -90,7 +90,16 @@ class GlibcMitigations:
     hooks_removed: bool = False             # 2.34+ (__malloc_hook, __free_hook)
     vtable_verification: bool = False       # 2.34+ (stricter _IO_vtable checks)
     io_file_jumps_hardened: bool = False    # 2.35+
-    format_n_disabled: bool = False         # 2.38+ (verified at runtime)
+    # Tri-state (None = conditional, True = disabled, False = works). ``None``
+    # is used when the target is compiled with FORTIFY and the host runtime
+    # blocks writable-format %n — some call sites work (.rodata format),
+    # others don't (writable format). See analyzer._reconcile_n_availability.
+    # NB: kept as ``Optional[bool]`` for backwards compat — pre-fix code that
+    # tests ``if format_n_disabled:`` will see ``None`` as falsy (i.e. "not
+    # disabled"), which is wrong for the CONDITIONAL case. Downstream reads
+    # should switch to explicit tri-state checks (``is True`` / ``is False``
+    # / ``is None``).
+    format_n_disabled: Optional[bool] = False
     format_n_verified: bool = False         # Whether we actually tested %n
 
     # Detailed mitigation info
@@ -206,20 +215,59 @@ class GlibcMitigations:
                 alternatives=["House of Apple techniques", "_IO_wfile_* chains"]
             ))
 
-        # 2.38+: %n disabled (but we verify at runtime)
+        # 2.38+: %n conditionally blocked under FORTIFY-with-writable-format.
+        # The version alone does NOT determine %n availability — see
+        # analyzer._reconcile_n_availability for the target-specific verdict.
+        # Pre-fix branch set ``format_n_disabled = True`` unconditionally when
+        # ``format_n_verified`` was False, then propagated that bad verdict
+        # through ``blocked_techniques`` and ``impact``. Now:
+        #   * ``format_n_verified=False`` → we don't know yet (probe/reconcile
+        #     hasn't run); leave the field at its default and describe the
+        #     mitigation as CONDITIONAL rather than a hard block.
+        #   * ``format_n_verified=True`` → trust the tri-state that
+        #     the reconciler wrote.
         if self.version >= 2.38:
-            if not self.format_n_verified:
-                self.format_n_disabled = True
+            if self.format_n_verified and self.format_n_disabled is True:
+                impact = MitigationImpact.BLOCKS_TECHNIQUE
+                blocked = ["Format string arbitrary write via %n"]
+                description = (
+                    "%n verified DISABLED at runtime — no format-string write "
+                    "primitive on this target."
+                )
+            elif self.format_n_verified and self.format_n_disabled is False:
+                impact = MitigationImpact.COMPLICATES
+                blocked = []
+                description = (
+                    "%n verified WORKING on this target's build posture."
+                )
+            else:
+                # Not verified, or reconciler returned None (conditional).
+                impact = MitigationImpact.COMPLICATES
+                blocked = []
+                description = (
+                    "%n availability depends on target's compile-time FORTIFY "
+                    "posture AND format-string memory class at the vulnerable "
+                    "printf call site. Substrate cannot decide absolutely "
+                    "without call-site inspection — see "
+                    "printf_n_availability_detail."
+                )
             self.active_mitigations.append(GlibcMitigation(
-                name="%n Format Specifier Disabled",
+                name="%n Format Specifier Conditional",
                 version_introduced=2.38,
-                impact=MitigationImpact.BLOCKS_TECHNIQUE if self.format_n_disabled else MitigationImpact.COMPLICATES,
+                impact=impact,
                 affected_vuln_classes=["format_string_write"],
-                description="%n disabled by default via FORTIFY or environment",
-                blocked_techniques=["Format string arbitrary write via %n"] if self.format_n_disabled else [],
-                bypass_requirements=["Cannot bypass in most configurations"],
-                alternatives=["Use %s for arbitrary read", "Stack-based format string for leak only",
-                            "Target older glibc via container/chroot"]
+                description=description,
+                blocked_techniques=blocked,
+                bypass_requirements=[
+                    "Rebuild target with -U_FORTIFY_SOURCE",
+                    "Vulnerable printf uses .rodata format string literal",
+                    "Older glibc via container/chroot",
+                ],
+                alternatives=[
+                    "Use %s for arbitrary read",
+                    "Stack-based format string for leak-only",
+                    "Chain into a separate memory-corruption primitive for the write",
+                ]
             ))
 
     def get_mitigations_for_vuln(self, vuln_class: str) -> List[GlibcMitigation]:

--- a/packages/exploit_feasibility/tests/test_reconcile_n.py
+++ b/packages/exploit_feasibility/tests/test_reconcile_n.py
@@ -1,0 +1,325 @@
+"""Tests for the ``%n`` verdict reconciler + downstream consumers.
+
+Covers the tri-state semantics of ``FeasibilityReport.glibc_n_disabled``:
+
+* ``True``   → verified disabled at runtime.
+* ``False``  → verified working on this target.
+* ``None``   → CONDITIONAL: depends on format-string memory class at the
+  vulnerable call site (writable-format blocked under FORTIFY, .rodata
+  format works).
+
+The reconciler decision table (analyzer._reconcile_n_availability):
+
+    baseline probe × target_fortify × host FORTIFY probe → verdict
+
+Also covers the source_intel override wire — when ``build_flags`` is
+supplied, ``fortify_source_level`` takes precedence over the ELF-derived
+``__printf_chk`` heuristic.
+
+And the downstream consumers that used to silently mis-treat ``None``:
+``api._api_verdict`` graph-mitigation removal, ``finding_mapper`` verdict
+mapping, ``analyzer._analyze_primitives`` arbitrary_write flag.
+"""
+
+from unittest.mock import patch
+
+
+from core.build.build_flags import BuildFlagsContext
+from packages.exploit_feasibility.analyzer import (
+    FeasibilityAnalyzer,
+    FeasibilityReport,
+)
+from packages.exploit_feasibility.finding_mapper import _assess_format_string
+
+
+def _make_report(**overrides) -> FeasibilityReport:
+    """Build a bare ``FeasibilityReport`` with the fields the reconciler
+    reads. Callers override just the axes they're testing."""
+    r = FeasibilityReport()
+    r.binary_protections = overrides.pop("binary_protections", {"fortify": None})
+    r.glibc_n_disabled = overrides.pop("glibc_n_disabled", False)
+    r.blockers = overrides.pop("blockers", [])
+    r.warnings = overrides.pop("warnings", [])
+    r.confidence = overrides.pop("confidence", {})
+    for k, v in overrides.items():
+        setattr(r, k, v)
+    return r
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Reconciler decision table
+# ─────────────────────────────────────────────────────────────────────
+
+class TestReconcilerDecisionTable:
+
+    def test_baseline_true_stays_true(self):
+        """glibc probe says %n dead → verdict stays True regardless of FORTIFY."""
+        analyzer = FeasibilityAnalyzer()
+        report = _make_report(glibc_n_disabled=True,
+                              binary_protections={"fortify": True})
+        analyzer._reconcile_n_availability(report)
+        assert report.glibc_n_disabled is True
+        assert "disabled at the glibc runtime level" in report.printf_n_availability_detail
+
+    def test_baseline_none_stays_none_probe_couldnt_run(self):
+        """Probe couldn't run (None) → cannot reconcile, verdict stays None."""
+        analyzer = FeasibilityAnalyzer()
+        report = _make_report(glibc_n_disabled=None,
+                              binary_protections={"fortify": True})
+        analyzer._reconcile_n_availability(report)
+        assert report.glibc_n_disabled is None
+        assert "baseline probe could not run" in report.printf_n_availability_detail
+
+    def test_baseline_false_target_unfortified_stays_false(self):
+        """Probe: %n works, target NOT fortified → verdict False (works)."""
+        analyzer = FeasibilityAnalyzer()
+        report = _make_report(glibc_n_disabled=False,
+                              binary_protections={"fortify": False})
+        analyzer._reconcile_n_availability(report)
+        assert report.glibc_n_disabled is False
+        assert "compiled WITHOUT _FORTIFY_SOURCE" in report.printf_n_availability_detail
+        assert report.confidence["glibc_n_disabled"] == "reconciled_target_specific"
+
+    def test_baseline_false_target_fortify_unknown_goes_conditional(self):
+        """Probe: %n works, target FORTIFY status unknown → CONDITIONAL."""
+        analyzer = FeasibilityAnalyzer()
+        report = _make_report(glibc_n_disabled=False,
+                              binary_protections={"fortify": None})
+        analyzer._reconcile_n_availability(report)
+        assert report.glibc_n_disabled is None
+        assert "CONDITIONAL" in report.printf_n_availability_detail
+        assert report.confidence["glibc_n_disabled"] == "reconciled_target_unknown"
+
+    def test_baseline_false_fortified_target_fortify_probe_blocks(self):
+        """Probe: %n works, target fortified, host FORTIFY DOES block →
+        CONDITIONAL (writable-format blocked, rodata works)."""
+        analyzer = FeasibilityAnalyzer()
+        report = _make_report(glibc_n_disabled=False,
+                              binary_protections={"fortify": True})
+        with patch.object(analyzer, "_probe_fortify_blocks_writable_n",
+                          return_value=True):
+            analyzer._reconcile_n_availability(report)
+        assert report.glibc_n_disabled is None
+        assert "CONDITIONAL" in report.printf_n_availability_detail
+        assert "writable" in report.printf_n_availability_detail.lower()
+        assert ".rodata" in report.printf_n_availability_detail
+        assert report.confidence["glibc_n_disabled"] == "reconciled_conditional"
+
+    def test_baseline_false_fortified_target_fortify_probe_ineffective(self):
+        """Probe: %n works, target fortified, host FORTIFY does NOT block →
+        %n available (FORTIFY runtime ineffective on this host)."""
+        analyzer = FeasibilityAnalyzer()
+        report = _make_report(glibc_n_disabled=False,
+                              binary_protections={"fortify": True})
+        with patch.object(analyzer, "_probe_fortify_blocks_writable_n",
+                          return_value=False):
+            analyzer._reconcile_n_availability(report)
+        assert report.glibc_n_disabled is False
+        assert "AVAILABLE" in report.printf_n_availability_detail
+        assert report.confidence["glibc_n_disabled"] == "reconciled_fortify_ineffective"
+
+    def test_baseline_false_fortified_target_fortify_probe_unavailable(self):
+        """Probe: %n works, target fortified, host FORTIFY probe couldn't run →
+        CONDITIONAL, conservative default."""
+        analyzer = FeasibilityAnalyzer()
+        report = _make_report(glibc_n_disabled=False,
+                              binary_protections={"fortify": True})
+        with patch.object(analyzer, "_probe_fortify_blocks_writable_n",
+                          return_value=None):
+            analyzer._reconcile_n_availability(report)
+        assert report.glibc_n_disabled is None
+        assert "CONDITIONAL" in report.printf_n_availability_detail
+        assert report.confidence["glibc_n_disabled"] == "reconciled_probe_unavailable"
+
+    def test_reconciler_retracts_stale_blockers_on_conditional(self):
+        """Old ``%n format specifier DISABLED`` blocker must be retracted
+        when reconciler moves to conditional — else downstream sees a
+        contradictory (blocker-present + non-True verdict)."""
+        analyzer = FeasibilityAnalyzer()
+        report = _make_report(
+            glibc_n_disabled=False,
+            binary_protections={"fortify": True},
+            blockers=[
+                "%n format specifier DISABLED at runtime (version heuristic)",
+                "Full RELRO — GOT read-only",
+            ],
+        )
+        with patch.object(analyzer, "_probe_fortify_blocks_writable_n",
+                          return_value=True):
+            analyzer._reconcile_n_availability(report)
+        assert not any("%n format specifier" in b for b in report.blockers)
+        # Unrelated blockers must survive.
+        assert any("RELRO" in b for b in report.blockers)
+
+
+# ─────────────────────────────────────────────────────────────────────
+# source_intel wire
+# ─────────────────────────────────────────────────────────────────────
+
+class TestSourceIntelOverride:
+
+    def test_build_flags_fortify_2_overrides_elf_unfortified(self):
+        """source_intel says FORTIFY=2 but ELF dyn-syms show fortify=False.
+        Source-level wins → target treated as fortified → CONDITIONAL."""
+        bf = BuildFlagsContext(
+            source="compile_commands.json",
+            extraction_confidence="high",
+            fortify_source_level=2,
+        )
+        analyzer = FeasibilityAnalyzer(build_flags=bf)
+        report = _make_report(glibc_n_disabled=False,
+                              binary_protections={"fortify": False})
+        with patch.object(analyzer, "_probe_fortify_blocks_writable_n",
+                          return_value=True):
+            analyzer._reconcile_n_availability(report)
+        assert report.glibc_n_disabled is None
+        # Disagreement was flagged in warnings.
+        assert any("FORTIFY signal disagreement" in w for w in report.warnings)
+
+    def test_build_flags_fortify_0_overrides_elf_fortified(self):
+        """source_intel says FORTIFY=0 but ELF dyn-syms show fortify=True.
+        Source-level wins → target treated as unfortified → verdict False."""
+        bf = BuildFlagsContext(
+            source="compile_commands.json",
+            extraction_confidence="high",
+            fortify_source_level=0,
+        )
+        analyzer = FeasibilityAnalyzer(build_flags=bf)
+        report = _make_report(glibc_n_disabled=False,
+                              binary_protections={"fortify": True})
+        analyzer._reconcile_n_availability(report)
+        assert report.glibc_n_disabled is False
+        assert any("FORTIFY signal disagreement" in w for w in report.warnings)
+
+    def test_build_flags_kconfig_source_ignored_for_userspace(self):
+        """A kconfig-derived BuildFlagsContext is not applicable to
+        userspace %n analysis. Reconciler falls back to ELF signal."""
+        bf = BuildFlagsContext(
+            source="kconfig",
+            extraction_confidence="high",
+            fortify_source_level=2,
+        )
+        analyzer = FeasibilityAnalyzer(build_flags=bf)
+        report = _make_report(glibc_n_disabled=False,
+                              binary_protections={"fortify": False})
+        analyzer._reconcile_n_availability(report)
+        # Fell back to ELF (False), so verdict says %n works.
+        assert report.glibc_n_disabled is False
+
+    def test_no_build_flags_uses_elf_signal(self):
+        """Baseline path: no build_flags supplied → ELF signal used unmodified."""
+        analyzer = FeasibilityAnalyzer()  # no build_flags
+        report = _make_report(glibc_n_disabled=False,
+                              binary_protections={"fortify": False})
+        analyzer._reconcile_n_availability(report)
+        assert report.glibc_n_disabled is False
+
+
+# ─────────────────────────────────────────────────────────────────────
+# finding_mapper tri-state consumer
+# ─────────────────────────────────────────────────────────────────────
+
+class TestFindingMapperTriState:
+
+    def _ctx(self, **overrides):
+        return {
+            "protections": overrides.pop("protections", {}),
+            "glibc_n_disabled": overrides.pop("glibc_n_disabled", False),
+            "printf_n_availability_detail": overrides.pop("detail", None),
+        }
+
+    def test_n_disabled_true_verdict_unlikely(self):
+        assessment = _assess_format_string(
+            finding={}, c=self._ctx(glibc_n_disabled=True),
+        )
+        assert assessment.verdict == "unlikely"
+        assert assessment.impact == "info_leak"
+
+    def test_n_disabled_false_verdict_exploitable_when_clean(self):
+        assessment = _assess_format_string(
+            finding={},
+            c=self._ctx(glibc_n_disabled=False, protections={"full_relro": False}),
+        )
+        assert assessment.verdict == "exploitable"
+        assert assessment.impact == "code_execution"
+
+    def test_n_disabled_none_with_fortify_true_is_conditional(self):
+        """Regression: pre-fix ``if n_disabled:`` treated None as falsy and
+        silently promoted to ``exploitable`` on fortified targets. Now
+        must land at ``likely_exploitable`` with a CONDITIONAL blocker."""
+        assessment = _assess_format_string(
+            finding={},
+            c=self._ctx(
+                glibc_n_disabled=None,
+                detail=(
+                    "%n status is CONDITIONAL on the format-string "
+                    "memory class at the vulnerable printf site."
+                ),
+                protections={"full_relro": False, "pie": True, "fortify": True},
+            ),
+        )
+        assert assessment.verdict != "exploitable"
+        assert assessment.verdict == "likely_exploitable"
+        assert assessment.impact == "code_execution"
+        assert any("CONDITIONAL" in b for b in assessment.blockers)
+
+    def test_n_disabled_none_with_fortify_false_falls_back_to_works(self):
+        """Legacy caller passes ``glibc_n_disabled=None`` (no probe ran)
+        with ``fortify=False``. That combination is provably ``%n works``
+        — target is unfortified regardless of what the substrate said.
+        Preserves the historic optimistic default for callers who pass
+        None-as-unknown alongside a definite fortify signal."""
+        assessment = _assess_format_string(
+            finding={},
+            c=self._ctx(
+                glibc_n_disabled=None,
+                protections={"full_relro": False, "pie": False, "fortify": False},
+            ),
+        )
+        assert assessment.verdict == "exploitable"
+        assert assessment.impact == "code_execution"
+
+    def test_n_disabled_none_with_full_relro_and_fortify_is_difficult(self):
+        assessment = _assess_format_string(
+            finding={},
+            c=self._ctx(
+                glibc_n_disabled=None,
+                protections={"full_relro": True, "pie": True, "fortify": True},
+            ),
+        )
+        assert assessment.verdict == "difficult"
+
+    def test_n_disabled_none_exposes_both_branches_in_paths(self):
+        """CONDITIONAL must show BOTH ".rodata works" and "info leak"
+        paths so downstream can case-split by call site."""
+        assessment = _assess_format_string(
+            finding={},
+            c=self._ctx(
+                glibc_n_disabled=None,
+                protections={"full_relro": False, "fortify": True},
+            ),
+        )
+        techniques = [p.technique for p in assessment.exploitation_paths]
+        assert any("rodata" in t.lower() for t in techniques)
+        assert any("info leak" in t.lower() for t in techniques)
+
+
+# ─────────────────────────────────────────────────────────────────────
+# JSON output stability
+# ─────────────────────────────────────────────────────────────────────
+
+class TestReportSerialization:
+
+    def test_to_dict_includes_printf_n_availability_detail(self):
+        report = _make_report(
+            glibc_n_disabled=None,
+            printf_n_availability_detail="test-detail",
+        )
+        d = report.to_dict()
+        assert "printf_n_availability_detail" in d
+        assert d["printf_n_availability_detail"] == "test-detail"
+
+    def test_to_dict_glibc_n_disabled_serializes_none(self):
+        report = _make_report(glibc_n_disabled=None)
+        d = report.to_dict()
+        assert d["glibc_n_disabled"] is None

--- a/packages/exploitability_validation/orchestrator.py
+++ b/packages/exploitability_validation/orchestrator.py
@@ -1350,6 +1350,16 @@ class ValidationOrchestrator:
                     analyze_binary,
                     save_exploit_context
                 )
+                # Optional source_intel wire: hand the reconciler the
+                # target's compile-time _FORTIFY_SOURCE level so it can
+                # override the ELF-derived ``__printf_chk`` heuristic
+                # when they disagree. ``extract_flags`` is defensive —
+                # returns an empty BuildFlagsContext on missing build
+                # metadata, in which case the reconciler falls back to
+                # the ELF signal (pre-wire behavior). Safe to always
+                # attempt.
+                from core.build.build_flags import extract_flags
+                _target_build_flags = extract_flags(Path(self.config.target_path))
             except ImportError:
                 affected_ids = [f.get("id", "?") for f in memory_corruption_findings]
                 logger.warning(
@@ -1430,11 +1440,22 @@ class ValidationOrchestrator:
                 try:
                     # CACHE KEY MUST mirror analyze_binary parameters.
                     # See the WARNING comment above.
+                    # ``build_flags`` is intentionally NOT in the key
+                    # because it's invariant across findings within a
+                    # single orchestrator run (derived from
+                    # ``self.config.target_path`` above the loop). If
+                    # that ever changes — e.g. per-finding target-path
+                    # scoping — add ``id(_target_build_flags)`` (or
+                    # its hash) to the key.
                     cache_key = f"{binary_path}:{finding.get('vuln_type', '')}"
                     if cache_key in analysis_cache:
                         result = analysis_cache[cache_key]
                     else:
-                        result = analyze_binary(binary_path, vuln_type=finding.get("vuln_type"))
+                        result = analyze_binary(
+                            binary_path,
+                            vuln_type=finding.get("vuln_type"),
+                            build_flags=_target_build_flags,
+                        )
                         analysis_cache[cache_key] = result
 
                     raw_verdict = normalize_status(result.get("verdict", "unknown"))

--- a/raptor_agentic.py
+++ b/raptor_agentic.py
@@ -1702,12 +1702,29 @@ Examples:
         try:
             from packages.exploit_feasibility import analyze_binary, format_analysis_summary
 
+            # Optional source_intel wire: hand the reconciler the
+            # target's compile-time _FORTIFY_SOURCE level (extracted
+            # from compile_commands.json / Makefile / kconfig by
+            # ``core.build.build_flags.extract_flags``) so the %n
+            # verdict can override the ELF-derived ``__printf_chk``
+            # heuristic when they disagree. Defensive — returns an
+            # empty BuildFlagsContext on missing build metadata, which
+            # leaves the reconciler's pre-wire behaviour intact.
+            from core.build.build_flags import extract_flags
+            _agentic_build_flags = extract_flags(
+                Path(args.repo) if args.repo else Path.cwd()
+            )
+
             # --binary is action='append' (list) for binary-oracle's
             # hybrid multi-binary case; mitigation analysis is per-binary,
             # so analyse the FIRST declared binary.
             binary_path = (
                 str(Path(args.binary[0])) if args.binary else None)
-            mitigation_result = analyze_binary(binary_path, output_dir=str(out_dir))
+            mitigation_result = analyze_binary(
+                binary_path,
+                output_dir=str(out_dir),
+                build_flags=_agentic_build_flags,
+            )
 
             # Display formatted summary
             print(format_analysis_summary(mitigation_result, verbose=True))


### PR DESCRIPTION
Retracts a version-only heuristic that claimed glibc >= 2.38 unconditionally disables `%n`, which was factually wrong (it depends on `_FORTIFY_SOURCE` compile flag AND format-string memory class, not glibc version). Fixes the empirical probe that had been silently a no-op — the untrusted sandbox mount namespace hid the probe tempfile from gcc, so the probe fell back to the version heuristic for months. Adds a FORTIFY-with-writable-format probe, cross-checks against the target's compile posture (via ELF `__printf_chk` or a build_flags override), and produces a tri-state verdict with case-analysis prose in `printf_n_availability_detail`.

Ripples through downstream consumers that pre-fix silently treated the substrate's `None` as truthy-falsy: `finding_mapper._assess_format_string` (silently promoted CONDITIONAL to `exploitable`), `analyzer._analyze_primitives` (marked `arbitrary_write=True` on fortified targets), and `api.find_exploit_paths` (removed the mitigation from `graph.active_mitigations` on None). All now use explicit tri-state reads; `finding_mapper` falls back to the `fortify` protection flag when `glibc_n_disabled=None` from callers that pass no probe data (preserves the historic optimistic default for provably-unfortified targets).

Wires the source_intel FORTIFY signal into the reconciler: `analyze_binary` gains an optional `build_flags: BuildFlagsContext` param that, when supplied, takes precedence over the ELF-inferred `__printf_chk` heuristic. Plumbed through `raptor_agentic.py` and `packages/exploitability_validation/orchestrator.py` at their `analyze_binary` call sites via `core.build.build_flags.extract_flags`. Defensive — returns empty context when no build metadata is available, leaving pre-wire behavior intact.

Adds 19 tests covering the reconciler decision table (baseline_probe × target_fortify × host FORTIFY probe), the source_intel override (fortify_source_level takes precedence, kconfig source ignored for userspace), the finding_mapper tri-state (including the fortify-fallback semantics), and JSON serialization stability.

Docs updated: `docs/exploit-feasibility.md`, `docs/README.md`, and `docs/exploitability-validation-integration.md` no longer claim "glibc 2.38 disables %n"; the truth table now documents the tri-state semantics and the callers' obligation to use explicit `is True` / `is False` / `is None` reads.