### PR TITLE
feat(inventory): add Scala tree-sitter grammar; sync the banner probe

### DIFF
--- a/core/inventory/extractors.py
+++ b/core/inventory/extractors.py
@@ -1212,6 +1212,15 @@ def _ts_language(lang: str):
             return Language(ts.language_php())
         elif lang == "lua":
             import tree_sitter_lua as ts
+        elif lang == "scala":
+            # Without this branch .scala fell through to the regex
+            # extractor: no ``line_end`` on any function, and roughly a
+            # third fewer functions found. ``line_end`` is what the
+            # source-slicing consumers key on, so a JVM target like
+            # Kafka (Scala broker core, Java clients) silently got a
+            # partial inventory on its Scala half only. Same failure
+            # shape as the cpp and typescript branches above.
+            import tree_sitter_scala as ts
         else:
             return None
         return Language(ts.language())
@@ -1268,6 +1277,13 @@ class TreeSitterExtractor:
         # ``function_signature_item`` — intentionally excluded (no code).
         "rust": ("function_item",),
         "lua": ("function_declaration", "function_definition"),
+        # Scala: ``def`` with a body is ``function_definition`` — NOT
+        # Java's ``method_declaration``. Reusing the Java node names
+        # here extracts zero functions from a file that parses cleanly.
+        # An abstract trait/interface ``def`` with no body parses as
+        # ``function_declaration`` and is intentionally excluded (no
+        # code to review), matching the Rust rule above.
+        "scala": ("function_definition",),
     }
 
     _CLASS_TYPES = {
@@ -1289,6 +1305,10 @@ class TreeSitterExtractor:
         # ``trait T`` with ``T`` (for default methods).
         "rust": ("impl_item", "trait_item"),
         "lua": (),
+        # Scala hosts methods in all three; ``object`` is where the
+        # singleton/companion helpers live, which is a lot of a typical
+        # Scala service's logic.
+        "scala": ("class_definition", "object_definition", "trait_definition"),
     }
 
     def __init__(self, language: str):
@@ -2116,6 +2136,13 @@ class TreeSitterExtractor:
         return None
 
 
+# Languages ``_ts_language`` has a loader branch for. Probed to build the
+# startup banner's grammar list; keep in sync with that branch.
+_TS_PROBE_LANGUAGES = (
+    "python", "java", "javascript", "typescript", "tsx", "c", "cpp",
+    "go", "rust", "csharp", "ruby", "php", "lua", "scala",
+)
+
 _cached_ts_languages: Optional[List[str]] = None
 
 
@@ -2128,7 +2155,12 @@ def _get_ts_languages() -> List[str]:
         _cached_ts_languages = []
         return []
     available = []
-    for lang in ("python", "java", "javascript", "c", "go", "lua"):
+    # Every language ``_ts_language`` can load. This list drifted behind
+    # the loader — cpp, typescript, rust, csharp, ruby and php all had
+    # working branches but were absent here, so the startup banner
+    # under-reported what the inventory could actually parse. Keep the
+    # two in sync when adding a grammar.
+    for lang in _TS_PROBE_LANGUAGES:
         if _ts_language(lang):
             available.append(lang)
     _cached_ts_languages = available

--- a/core/inventory/tests/test_extractors.py
+++ b/core/inventory/tests/test_extractors.py
@@ -5,7 +5,7 @@ import pytest
 from core.inventory.extractors import (
     FunctionInfo, FunctionMetadata,
     PythonExtractor, JavaExtractor, CExtractor, GoExtractor,
-    JavaScriptExtractor, LuaExtractor,
+    JavaScriptExtractor, LuaExtractor, TreeSitterExtractor,
     extract_functions, extract_items, _TS_AVAILABLE, _get_ts_languages,
 )
 
@@ -686,3 +686,116 @@ class TestLuaExtractor:
         funcs = extract_functions("controller.lua", "lua", code)
         assert len(funcs) == 1
         assert funcs[0].name == "dispatch"
+
+
+# ---------------------------------------------------------------------------
+# Scala (tree-sitter). Regression guard for the regex-fallback gap: .scala had
+# no loader branch, so it silently degraded to regex — fewer functions and no
+# line_end, which disables every span-based consumer.
+# ---------------------------------------------------------------------------
+
+_SCALA_SRC = '''package kafka.server
+
+import scala.collection.Map
+
+object ConfigHelper {
+  def normalize(name: String): String = {
+    name.trim.toLowerCase
+  }
+}
+
+class ConfigAdminManager(nodeId: Int) {
+
+  def preprocess(request: AlterConfigsRequest): Map[String, String] = {
+    val out = Map.empty[String, String]
+    out
+  }
+
+  private def validateBrokerConfigChange(props: Properties): Unit = {
+    if (props.isEmpty) {
+      throw new InvalidRequestException("empty")
+    }
+  }
+}
+
+trait Reconfigurable {
+  def reconfigure(configs: Map[String, _]): Unit
+}
+'''
+
+
+def _has_tree_sitter_scala() -> bool:
+    try:
+        import tree_sitter_scala  # noqa: F401
+        return True
+    except ImportError:
+        return False
+
+
+@pytest.mark.skipif(
+    not _has_tree_sitter_scala(),
+    reason="tree_sitter_scala grammar not installed",
+)
+class TestScalaExtraction:
+    def _extract(self):
+        return extract_functions("ConfigAdminManager.scala", "scala", _SCALA_SRC)
+
+    def test_finds_defs_in_class_object_and_trait(self):
+        names = {f.name for f in self._extract()}
+        assert {"normalize", "preprocess", "validateBrokerConfigChange"} <= names
+
+    def test_every_function_has_a_line_span(self):
+        """The whole point: the regex fallback returned line_end=None, which
+        silently disables source-slicing consumers."""
+        fns = self._extract()
+        assert fns
+        for f in fns:
+            assert f.line_start, f.name
+            assert f.line_end, f.name
+            assert f.line_end >= f.line_start, f.name
+
+    def test_span_covers_the_body(self):
+        fn = next(f for f in self._extract() if f.name == "validateBrokerConfigChange")
+        body = "\n".join(_SCALA_SRC.splitlines()[fn.line_start - 1:fn.line_end])
+        assert "InvalidRequestException" in body
+
+    def test_scala_uses_function_definition_not_java_node_names(self):
+        """Scala `def` is function_definition; reusing Java's
+        method_declaration extracts zero from a cleanly-parsed file."""
+        assert TreeSitterExtractor._FUNC_TYPES["scala"] == ("function_definition",)
+        assert "method_declaration" not in TreeSitterExtractor._FUNC_TYPES["scala"]
+
+    def test_abstract_trait_def_is_excluded(self):
+        """An abstract `def` with no body is `function_declaration`, not
+        `function_definition` — no code to review. Same rule as Rust's
+        `function_signature_item`. The regex fallback wrongly includes it."""
+        assert "reconfigure" not in {f.name for f in self._extract()}
+
+    def test_regex_fallback_has_no_line_end(self):
+        """Pins the defect this branch fixes. Deliberately does NOT compare
+        counts: on a tiny fixture the regex can over-match (it picks up the
+        abstract def), while on real files tree-sitter finds substantially
+        more. The invariant that always holds, and the one span-based
+        consumers depend on, is that the fallback yields no line_end."""
+        import core.inventory.extractors as _E
+        saved = _E._TS_AVAILABLE
+        _E._TS_AVAILABLE = False
+        try:
+            rx = extract_functions("ConfigAdminManager.scala", "scala", _SCALA_SRC)
+        finally:
+            _E._TS_AVAILABLE = saved
+        assert rx, "fallback should still find something"
+        assert not any(f.line_end for f in rx)
+        assert all(f.line_end for f in self._extract())
+
+
+class TestTsProbeMatchesLoader:
+    def test_probe_list_covers_every_loader_branch(self):
+        """The banner list drifted behind the loader — cpp/typescript/rust/
+        csharp/ruby/php had working branches but were never probed, so the
+        doctor under-reported what the inventory could parse."""
+        from core.inventory.extractors import _TS_PROBE_LANGUAGES
+        for lang in TreeSitterExtractor._FUNC_TYPES:
+            assert lang in _TS_PROBE_LANGUAGES, (
+                f"{lang} has node types but is not probed for the banner"
+            )

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,7 +33,13 @@ instructor==1.15.1
 # pip install botocore
 
 # Optional: Rich inventory metadata (decorators, annotations, visibility, typed params)
+# Without a grammar a language falls back to the regex extractor, which finds
+# fewer functions and no line_end — so anything that slices source by span
+# degrades silently. Install the grammars for the languages you scan.
 # pip install tree-sitter tree-sitter-python tree-sitter-java tree-sitter-javascript tree-sitter-c tree-sitter-go
+# JVM targets (Scala broker/service code alongside Java): tree-sitter-scala
+# Others with loader support: tree-sitter-cpp tree-sitter-typescript
+#   tree-sitter-rust tree-sitter-c-sharp tree-sitter-ruby tree-sitter-php tree-sitter-lua
 
 # Optional: For enhanced dataflow visualization (recommended)
 tabulate==0.10.0


### PR DESCRIPTION
# Add the Scala tree-sitter grammar (and sync the startup banner probe)

## What this is for

`core/inventory/extractors.py` picks an extractor per language: **tree-sitter → Python AST → regex**. `_ts_language()` is an explicit `elif` chain of `import tree_sitter_<lang>` branches, and `.scala` had no branch — so every Scala file fell through to the regex extractor.

That degradation is **silent**. The file is still discovered, still inventoried, still counted in coverage. It is just inventoried thinly, and — the part that actually bites — **without line spans**.

This is the same failure this chain has already hit twice, and the existing comments in the file say so:

- `cpp` used to load `tree_sitter_c`, which cannot parse class/method/template/namespace shapes → inline methods and out-of-line destructors were silently dropped.
- `typescript` used to load `tree_sitter_javascript`, which errors on type annotations → a typed file produced `ERROR` nodes and extracted **zero** functions.

Scala is the third instance of the same class.

## The measurement

Against the Kafka target in `targets/kafka` — 278 Scala files, the broker core:

| | functions | with `line_end` |
|---|---:|---:|
| regex fallback (before) | 4,928 | **0** |
| tree-sitter (after) | 5,829 | 5,827 |
| **net** | **+901 (+18%)** | **0% → 100%** |

**15 files went from zero functions found to a populated inventory.**

Per-file, the gain is very uneven — it concentrates exactly where Scala stops looking like Java:

| file | before | after | |
|---|---:|---:|---|
| `KTable.scala` | 4 | 47 | **+1075%** |
| `KStream.scala` | 11 | 49 | **+345%** |
| `KafkaConfig.scala` | 27 | 64 | **+137%** |
| `DynamicBrokerConfig.scala` | 45 | 79 | **+76%** |
| `ConfigAdminManager.scala` | 9 | 14 | **+56%** |
| `KafkaApis.scala` | 120 | 138 | **+15%** |

Trait-heavy DSL code (the Streams `KTable`/`KStream` API) is where the regex is worst — it keys on shapes that idiomatic Scala often doesn't have.

### Why `line_end` matters more than the count

Going from 0 → 5,827 spans is the bigger half of this change. Every consumer that slices source by span skips a function that has no `line_end`:

- gap source hydration (the mechanical pattern detectors read the sliced body),
- per-function context assembly,
- the annotation staleness hash.

So those passes were **no-ops on Scala** no matter how the run was configured — and nothing said so. On a JVM target like Kafka, whose broker core is Scala and whose clients are Java, that means analysis quality quietly differed by *half the codebase*, in a way the operator could not see from the output.

A concrete instance: `DynamicBrokerConfig.scala` (+76%) sits on a real exploit path we have a live receipt for — `resolveVariableConfigs` is the hop that passes attacker-supplied properties onward. Two thirds of that file's functions were in the inventory before; now all of them are.

## Implementation notes

**Node types are not Java's.** Scala `def` with a body is `function_definition`; Java uses `method_declaration`. Reusing the Java names extracts **zero** from a file that parses perfectly — a silent-empty failure rather than a loud one, which is why the node types were confirmed empirically against the real grammar rather than assumed.

**Abstract `def`s are excluded on purpose.** A trait method with no body parses as `function_declaration`, not `function_definition`. There is no code to review, so it stays out — matching the existing Rust rule (`function_signature_item` is excluded for the same reason). This is the one case where the regex fallback returns *more* rows than tree-sitter, and the extra row is noise.

**`_CLASS_TYPES` covers class, object and trait.** All three host methods; `object` in particular holds a lot of a typical Scala service's logic (singletons and companions).

## Drive-by fix: the banner under-reported 7 languages

Found while wiring this up. `_get_ts_languages()` — which produces the startup banner's `lang: tree-sitter ✓ (…)` line — iterated a hardcoded tuple:

```python
for lang in ("python", "java", "javascript", "c", "go", "lua"):
```

while `_ts_language()` had working branches for **13**. So `cpp`, `typescript`, `tsx`, `rust`, `csharp`, `ruby` and `php` all parsed correctly but were never advertised. The doctor was under-reporting what the inventory could actually do.

Both now read one `_TS_PROBE_LANGUAGES` constant, and a test asserts every language with node types is in the probe list, so the two cannot drift apart again.

Banner before → after: **6 → 14 languages**.

## Compatibility

The grammar stays an **optional** dependency, exactly as the other grammars are — `requirements.txt` documents it as a `pip install` line rather than pinning it. With `tree-sitter-scala` absent, `_ts_language("scala")` returns `None` and behaviour is byte-identical to today. Nothing becomes a hard requirement.

The `requirements.txt` comment also now states the consequence of a missing grammar (fewer functions, no `line_end`, silent degradation) and lists the other loader-supported grammars, so the next person doesn't have to read `extractors.py` to find out which languages are covered.

## Testing

- **New:** `TestScalaExtraction` — finds `def`s across class/object/trait, asserts every function has a valid span, asserts the span actually covers the body, pins `function_definition` (with an explicit assertion that Java's `method_declaration` is *not* used), and pins that the regex fallback yields no `line_end`. Plus `TestTsProbeMatchesLoader` for the drift fix. Grammar-gated with the same `_has_tree_sitter_*` pattern already used for cpp.
- One test deliberately does **not** compare raw counts: on a small fixture the regex can over-match (it picks up the abstract `def`), while on real files tree-sitter finds substantially more. The invariant that always holds — and the one span-based consumers depend on — is the `line_end` presence, so that is what is asserted.
- **Parse quality:** 277 / 278 Kafka Scala files parse with **zero `ERROR` nodes** (99.6%).
- `core/inventory` + `core/ast`: **558 passed**.
- Downstream consumers `core/audit` + `core/analysis`: **4011 passed**.
- One pre-existing unrelated failure (`test_java_framework_entry_verdicts`) confirmed failing identically with these changes stashed; the 6 `test_binary_oracle_autodetect` failures are the known environment-dependent ones.
- `ruff check core/inventory/` clean.

## Scope

Deliberately narrow: one grammar branch, its node types, the probe-list fix, and tests. No change to extraction logic, no change to any consumer, no new hard dependency.
