### PR TITLE
fix(audit): resolve Mode-2 synthesis hits to functions before graph build

### DIFF
--- a/core/audit/checker_synthesis.py
+++ b/core/audit/checker_synthesis.py
@@ -116,7 +116,10 @@ def synthesize_and_sweep(
     Args:
         outcome: ReviewOutcome with file, function, hypothesis, review_result.
         config: OrchestratorConfig with target_path, out_dir, codeql_db_path.
-        seen_keys: Set of file:function keys already in the workqueue.
+        seen_keys: Retained for logging only. Site-level dedup happens
+            downstream in ``orchestrator._synthesis_hits_to_gaps``, after
+            each site is resolved to its enclosing function — a set of
+            ``file:function`` keys cannot filter function-less sites.
         synthesis_count: How many syntheses have been done this run.
         max_per_run: Maximum synthesis attempts per run.
 
@@ -201,16 +204,31 @@ def synthesize_and_sweep(
     file_path = getattr(outcome, "file", "")
     function = getattr(outcome, "function", "")
 
+    # Emit every match, each carrying its origin. Two filters used to
+    # live here and both dropped real variants:
+    #
+    #   * the dedup key was `<matched file>:<seed function>` — the seed's
+    #     function name paired with a different file, which identifies
+    #     nothing, and matched `seen_keys` only by accident;
+    #   * `m.file != file_path` discarded every same-file match, so a
+    #     second vulnerable sibling in the same source file was lost.
+    #
+    # Sites are function-less by nature (a codebase-wide rule matches
+    # text), so both dedup and seed exclusion belong downstream in
+    # `orchestrator._synthesis_hits_to_gaps`, once each site has been
+    # resolved to its enclosing function. Excluding by line here would be
+    # wrong anyway: `outcome.line` is the function's line_start, not the
+    # vulnerable line, and is 0 when the inventory recorded none.
     new_hits = []
     for m in cs_result.matches:
-        key = f"{m.file}:{function}"
-        if key not in seen_keys and m.file != file_path:
-            new_hits.append({
-                "file": m.file,
-                "line": m.line,
-                "function": "",
-                "snippet": m.snippet or "",
-            })
+        new_hits.append({
+            "file": m.file,
+            "line": m.line,
+            "function": "",
+            "snippet": m.snippet or "",
+            "origin_file": file_path,
+            "origin_function": function,
+        })
 
     logger.info(
         "synthesis %s: %d sweep matches, %d new (deduped against %d seen)",

--- a/core/audit/gaps.py
+++ b/core/audit/gaps.py
@@ -196,6 +196,126 @@ def load_checklist(out_dir: Path) -> Dict[str, Any]:
         return {}
 
 
+def gap_for_site(
+    checklist: Dict[str, Any],
+    file_path: str,
+    line: int,
+    *,
+    priority: int = 1,
+) -> Optional[Dict[str, Any]]:
+    """Build a reviewable gap for the function enclosing ``file_path:line``.
+
+    Mechanical sweeps (Mode-2 checker synthesis, rule replay) report
+    *sites* — a file and a line — not functions. The review loop needs
+    the enclosing function, in the same shape ``compute_gaps`` emits, or
+    downstream consumers that index gaps by ``name`` blow up.
+
+    Returns None when no reviewable checklist function covers the line
+    (generated code, a header, a match outside any function body). The
+    caller should drop the site: without a function there is no context
+    slice to review.
+    """
+    if not file_path or line <= 0:
+        return None
+
+    # Tolerate a malformed checklist rather than raising. This runs in
+    # the synthesis second pass, after the main review loop but before
+    # the run's state is flushed, so an exception here costs the run its
+    # results. Fewer resolved gaps is the correct degradation.
+    files = checklist.get("files") if isinstance(checklist, dict) else None
+    if not isinstance(files, list):
+        return None
+
+    for file_info in files:
+        if not isinstance(file_info, dict):
+            continue
+        if file_info.get("path") != file_path:
+            continue
+
+        raw_items = file_info.get("items")
+        if raw_items is None:
+            raw_items = file_info.get("functions")
+        if not isinstance(raw_items, list):
+            continue
+
+        items = [
+            it for it in raw_items
+            if isinstance(it, dict)
+            and it.get("kind", "") in _REVIEWABLE_KINDS
+            and it.get("name")
+            and isinstance(it.get("line_start"), int)
+            and not isinstance(it.get("line_start"), bool)
+        ]
+        if not items:
+            continue
+
+        # Same two-phase resolution as
+        # core.orchestration.understand_bridge._find_containing_function,
+        # so a site resolves the same way whichever component asks.
+        #
+        # Strict: smallest containing span wins, so a nested function or
+        # closure is attributed to the innermost match rather than to the
+        # enclosing definition.
+        best: Optional[Dict[str, Any]] = None
+        best_span = None
+        for item in items:
+            line_start = item["line_start"]
+            line_end = item.get("line_end")
+            if not isinstance(line_end, int) or isinstance(line_end, bool):
+                continue
+            if not (line_start <= line <= line_end):
+                continue
+            span = line_end - line_start
+            if best_span is None or span < best_span or (
+                span == best_span and line_start > best["line_start"]
+            ):
+                best = dict(item)
+                best_span = span
+
+        # Fallback for inventories that record only the definition line:
+        # closest preceding line_start, bounded by the NEXT definition.
+        #
+        # A trailing definition with no next start has no derivable upper
+        # bound here — inventing one either truncates the function (so
+        # review and hydration miss its tail) or over-claims lines that
+        # belong to nothing. Those sites stay unresolved and are recorded
+        # in the unresolved-hits artifact, which is honest rather than
+        # quietly wrong.
+        if best is None:
+            starts = sorted({it["line_start"] for it in items})
+            preceding = [s for s in starts if s <= line]
+            if not preceding:
+                continue
+            chosen_start = preceding[-1]
+            candidates = [
+                it for it in items
+                if it["line_start"] == chosen_start
+                and it.get("line_end") is None
+            ]
+            later = [s for s in starts if s > chosen_start]
+            if not candidates or not later:
+                continue
+            best = dict(candidates[0])
+            best["line_end"] = later[0] - 1
+            best["span_inferred"] = True
+
+        gap = {
+            "file": file_path,
+            "name": best["name"],
+            "line_start": best["line_start"],
+            "line_end": best["line_end"],
+            "priority": priority,
+            "strategies": sorted(strategies_from_item(best, file_path)),
+            "is_stale": False,
+            "sloc": best["line_end"] - best["line_start"] + 1,
+        }
+        if best.get("span_inferred"):
+            gap["span_inferred"] = True
+        return gap
+
+    return None
+
+
 def load_context_map(out_dir: Path) -> Optional[Dict[str, Any]]:
     """Load context-map.json if present."""
     path = out_dir / "context-map.json"

--- a/core/audit/orchestrator.py
+++ b/core/audit/orchestrator.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import tempfile
 import subprocess
 import sys
 import threading as _threading
@@ -38,7 +39,7 @@ from .constraints import (
     save_constraints,
 )
 from .context import assemble_context
-from .gaps import compute_gaps, load_checklist, load_context_map, mark_checked, write_gaps
+from .gaps import compute_gaps, gap_for_site, load_checklist, load_context_map, mark_checked, write_gaps
 from .priority import (
     group_by_subsystem, load_flow_traces, load_fuzz_coverage as _load_fuzz_coverage_from_runs,
     load_tool_failures, score_functions,
@@ -1973,26 +1974,49 @@ def _run_audit_body(
         result.terminated_by = "llm_budget_exceeded"
 
     # --- Synthesis queue second pass ---
-    if shared.synthesis_queue and not executor_stats.budget_stopped:
-        synth_hits = list(shared.synthesis_queue)
-        shared.synthesis_queue.clear()
-        logger.info(
-            "synthesis pass: %d targets from mid-loop synthesis",
-            len(synth_hits),
-        )
-        synth_graph = TaskGraph.from_workqueue(synth_hits, call_edges)
-        run_executor_sync(
-            synth_graph, review_fn, shared, config, result,
-            executor_config,
-            joern_server=joern_server,
-            audit_log=audit_log,
-            workqueue=workqueue,
-            reviewed_set=reviewed_set,
-            start_time=start_time,
-            layer_disagreements=layer_disagreements,
-            on_progress=on_progress,
-            collector=collector,
-            budget_check=lambda: _check_budget(config, start_time, result),
+    #
+    # Optional enrichment, so it must never cost the run its results.
+    # Everything here runs after the main review loop but *before* the
+    # state sync-back and the single one-shot ``collector.flush()``
+    # below, so any exception raised in resolution, graph construction
+    # or the executor would discard the run's findings and its buffered
+    # audit log. Degrade to "second pass skipped" instead: the main pass
+    # has already earned its output.
+    try:
+        if shared.synthesis_queue and not executor_stats.budget_stopped:
+            synth_hits = list(shared.synthesis_queue)
+            shared.synthesis_queue.clear()
+            synth_gaps = _synthesis_hits_to_gaps(
+                synth_hits, checklist, config.out_dir,
+            )
+            logger.info(
+                "synthesis pass: %d targets from mid-loop synthesis "
+                "(%d hits resolved to reviewable functions)",
+                len(synth_hits), len(synth_gaps),
+            )
+        else:
+            synth_gaps = []
+
+        if synth_gaps:
+            synth_graph = TaskGraph.from_workqueue(synth_gaps, call_edges)
+            run_executor_sync(
+                synth_graph, review_fn, shared, config, result,
+                executor_config,
+                joern_server=joern_server,
+                audit_log=audit_log,
+                workqueue=workqueue,
+                reviewed_set=reviewed_set,
+                start_time=start_time,
+                layer_disagreements=layer_disagreements,
+                on_progress=on_progress,
+                collector=collector,
+                budget_check=lambda: _check_budget(config, start_time, result),
+            )
+    except Exception as exc:
+        logger.warning(
+            "synthesis second pass failed (%s: %s) — keeping main-pass "
+            "results and flushing buffered state",
+            type(exc).__name__, exc, exc_info=True,
         )
 
     # --- Sync mutable state back from SharedState ---
@@ -3715,6 +3739,121 @@ def _batch_trivial(
             remaining.extend(items)
 
     return batches, remaining
+
+
+def _synthesis_hits_to_gaps(
+    hits: List[Dict[str, Any]],
+    checklist: Dict[str, Any],
+    out_dir: Optional[Path] = None,
+) -> List[Dict[str, Any]]:
+    """Resolve Mode-2 sweep hits into reviewable gaps.
+
+    Checker synthesis reports *sites* — ``{file, line, function: "",
+    snippet}`` — because a codebase-wide rule matches text, not
+    functions. The review loop is keyed on functions, so each site is
+    resolved to the checklist function that encloses it.
+
+    A site that resolves to no reviewable function (a top-level
+    initializer, a macro, generated code, a checklist entry with no
+    line span) cannot become a review task — but it is still tool
+    signal, so it is written to ``unresolved-synthesis-hits.json``
+    rather than discarded.
+
+    Functions reviewed in an earlier round or run are deliberately NOT
+    skipped: a synthesized checker encodes a pattern that was unknown
+    when they were reviewed, which is exactly when re-review pays.
+    """
+    gaps: List[Dict[str, Any]] = []
+    seen: Set[str] = set()
+    unresolved: List[Dict[str, Any]] = []
+
+    for hit in hits:
+        file_path = hit.get("file", "")
+        try:
+            line = int(hit.get("line") or 0)
+        except (TypeError, ValueError):
+            line = 0
+
+        gap = gap_for_site(checklist, file_path, line) if line else None
+        if gap is None:
+            unresolved.append(hit)
+            continue
+
+        key = f"{gap['file']}:{gap['name']}"
+        if key in seen:
+            continue
+        # Skip the seed's own function: the rule was synthesised *from*
+        # it, so it is already a finding, not a new variant.
+        origin_file = hit.get("origin_file", "")
+        origin_function = hit.get("origin_function", "")
+        if origin_function and key == f"{origin_file}:{origin_function}":
+            continue
+        seen.add(key)
+
+        if hit.get("priority_score") is not None:
+            gap["priority_score"] = hit["priority_score"]
+        gap["from_synthesis"] = True
+        if hit.get("snippet"):
+            gap["synthesis_snippet"] = hit["snippet"]
+        gaps.append(gap)
+
+    if unresolved:
+        logger.info(
+            "synthesis pass: %d/%d hits did not resolve to a checklist "
+            "function — recorded as unresolved sites",
+            len(unresolved), len(hits),
+        )
+        if out_dir is not None:
+            _write_unresolved_synthesis_hits(unresolved, out_dir)
+
+    return gaps
+
+
+def _write_unresolved_synthesis_hits(
+    hits: List[Dict[str, Any]],
+    out_dir: Path,
+) -> None:
+    """Persist synthesis sites that have no enclosing reviewable function."""
+    path = out_dir / "unresolved-synthesis-hits.json"
+    tmp = None
+    # One non-fatal boundary around read, normalise, serialise and write.
+    # This is a diagnostic artifact: a malformed, mis-encoded or
+    # unserialisable one must never take the run down with it.
+    try:
+        existing: List[Dict[str, Any]] = []
+        if path.is_file():
+            try:
+                prior = json.loads(
+                    path.read_text(encoding="utf-8", errors="replace"),
+                )
+            except json.JSONDecodeError:
+                prior = None
+            # Tolerate any prior shape — a truncated write, a hand-edit,
+            # a bare list — and replace what can't be understood.
+            if isinstance(prior, dict) and isinstance(prior.get("hits"), list):
+                existing = prior["hits"]
+            elif isinstance(prior, list):
+                existing = prior
+            elif prior is not None:
+                logger.debug("replacing malformed %s", path.name)
+
+        existing = list(existing) + list(hits)
+        payload = json.dumps(
+            {"hits": existing, "count": len(existing)},
+            indent=2, default=str,
+        )
+
+        fd, tmp = tempfile.mkstemp(dir=str(out_dir), suffix=".tmp")
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fh.write(payload)
+        os.replace(tmp, str(path))
+    except (OSError, UnicodeError, TypeError, ValueError):
+        if tmp is not None:
+            try:
+                os.unlink(tmp)
+            except OSError:
+                pass
+        logger.debug("could not persist unresolved synthesis hits", exc_info=True)
 
 
 def _review_items(

--- a/core/audit/orchestrator.py
+++ b/core/audit/orchestrator.py
@@ -39,7 +39,7 @@ from .constraints import (
     save_constraints,
 )
 from .context import assemble_context
-from .gaps import compute_gaps, gap_for_site, load_checklist, load_context_map, mark_checked, write_gaps
+from .gaps import compute_gaps, gap_for_site, load_checklist, load_context_map, write_gaps
 from .priority import (
     group_by_subsystem, load_flow_traces, load_fuzz_coverage as _load_fuzz_coverage_from_runs,
     load_tool_failures, score_functions,

--- a/core/audit/tests/test_checker_synthesis.py
+++ b/core/audit/tests/test_checker_synthesis.py
@@ -210,13 +210,14 @@ class TestSynthesizeAndSweepDelegation:
         assert result.tool == "semgrep"
         assert result.cwe == "CWE-120"
         assert result.origin_file == "src/auth.c"
-        assert len(result.hits) == 1
-        assert result.hits[0]["file"] == "src/other.c"
+        # Both matches are emitted; the seed's own function is excluded
+        # downstream by function identity, not here by line.
+        assert [h["file"] for h in result.hits] == ["src/other.c", "src/auth.c"]
+        assert all(h["origin_function"] == "check_pw" for h in result.hits)
 
-    def test_dedup_against_seen_keys(self, tmp_path):
+    def _sweep_with_matches(self, tmp_path, matches, seen=None):
         from packages.checker_synthesis import (
             CheckerSynthesisResult,
-            Match,
             SynthesisedRule,
         )
 
@@ -226,7 +227,7 @@ class TestSynthesizeAndSweepDelegation:
                 rule=SynthesisedRule(
                     engine="semgrep", rule_id="synth.1", body="r",
                 ),
-                matches=[Match(file="src/already_seen.c", line=5)],
+                matches=list(matches),
                 positive_control=True,
             )
 
@@ -235,7 +236,6 @@ class TestSynthesizeAndSweepDelegation:
 
         o = _StubOutcome()
         c = _StubConfig(target_path=str(tmp_path), out_dir=str(tmp_path))
-        seen = {"src/already_seen.c:check_pw"}
 
         with patch(
             "core.audit.checker_synthesis._build_llm_callable",
@@ -244,10 +244,53 @@ class TestSynthesizeAndSweepDelegation:
             "packages.checker_synthesis.synthesise_with_refinement",
             side_effect=_fake_refinement,
         ):
-            result = synthesize_and_sweep(o, c, seen)
+            return synthesize_and_sweep(o, c, seen if seen is not None else set())
 
+    def test_sites_survive_a_prior_run_key(self, tmp_path):
+        """A site is not suppressed by `<file>:<seed function>`.
+
+        The old key paired the *matched* file with the *seed's* function
+        name, which identifies nothing, and `seen_keys` spans prior runs
+        — so a real variant could be dropped by coincidence. Sites are
+        function-less; dedup belongs downstream once each is resolved.
+        """
+        from packages.checker_synthesis import Match
+
+        result = self._sweep_with_matches(
+            tmp_path,
+            [Match(file="src/already_seen.c", line=5)],
+            seen={"src/already_seen.c:check_pw"},
+        )
         assert result is not None
-        assert len(result.hits) == 0
+        assert [h["file"] for h in result.hits] == ["src/already_seen.c"]
+
+    def test_same_file_sibling_is_kept(self, tmp_path):
+        """A second vulnerable function in the seed's own file counts.
+
+        `m.file != file_path` used to discard every same-file match.
+        """
+        from packages.checker_synthesis import Match
+
+        result = self._sweep_with_matches(
+            tmp_path, [Match(file="src/auth.c", line=99)],
+        )
+        assert [(h["file"], h["line"]) for h in result.hits] == [
+            ("src/auth.c", 99),
+        ]
+
+    def test_origin_is_attached_to_every_hit(self, tmp_path):
+        """Downstream excludes the seed by function identity, so each hit
+        must say which finding it came from."""
+        from packages.checker_synthesis import Match
+
+        result = self._sweep_with_matches(
+            tmp_path,
+            [Match(file="src/auth.c", line=42),
+             Match(file="src/other.c", line=99)],
+        )
+        assert [(h["origin_file"], h["origin_function"]) for h in result.hits] == [
+            ("src/auth.c", "check_pw"), ("src/auth.c", "check_pw"),
+        ]
 
     def test_synthesis_failure_returns_none(self, tmp_path):
         from packages.checker_synthesis import CheckerSynthesisResult

--- a/core/audit/tests/test_synthesis_hits.py
+++ b/core/audit/tests/test_synthesis_hits.py
@@ -1,0 +1,345 @@
+"""Tests for Mode-2 synthesis hits → reviewable gaps.
+
+Checker synthesis reports sites (file + line); the review loop is keyed
+on functions. These tests pin the resolution step, including the case
+that used to abort the whole run: a successful cross-file sweep hit.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from core.audit.gaps import gap_for_site
+from core.audit.orchestrator import _synthesis_hits_to_gaps
+from core.audit.task_graph import TaskGraph
+
+
+def _checklist():
+    return {
+        "files": [
+            {
+                "path": "src/parse.c",
+                "items": [
+                    {"name": "parse_header", "kind": "function",
+                     "line_start": 10, "line_end": 40},
+                    {"name": "parse_body", "kind": "function",
+                     "line_start": 45, "line_end": 90},
+                ],
+            },
+            {
+                "path": "src/util.c",
+                "items": [
+                    {"name": "copy_field", "kind": "function",
+                     "line_start": 5, "line_end": 20},
+                    {"name": "MAX_LEN", "kind": "macro",
+                     "line_start": 1, "line_end": 1},
+                ],
+            },
+        ],
+    }
+
+
+def _hit(file_path, line, snippet="memcpy(dst, src, len);"):
+    """The exact shape core.audit.checker_synthesis emits."""
+    return {
+        "file": file_path,
+        "line": line,
+        "function": "",
+        "snippet": snippet,
+        "priority_score": 0.8,
+    }
+
+
+class TestGapForSite:
+    def test_resolves_enclosing_function(self):
+        gap = gap_for_site(_checklist(), "src/parse.c", 30)
+        assert gap is not None
+        assert gap["name"] == "parse_header"
+        assert gap["line_start"] == 10
+        assert gap["line_end"] == 40
+        assert gap["sloc"] == 31
+
+    def test_picks_the_right_function_of_several(self):
+        gap = gap_for_site(_checklist(), "src/parse.c", 50)
+        assert gap["name"] == "parse_body"
+
+    def test_line_outside_any_function_is_unresolved(self):
+        assert gap_for_site(_checklist(), "src/parse.c", 42) is None
+
+    def test_unknown_file_is_unresolved(self):
+        assert gap_for_site(_checklist(), "src/nope.c", 10) is None
+
+    def test_non_reviewable_kind_is_skipped(self):
+        assert gap_for_site(_checklist(), "src/util.c", 1) is None
+
+    def test_zero_line_is_unresolved(self):
+        assert gap_for_site(_checklist(), "src/parse.c", 0) is None
+
+    def test_gap_shape_matches_compute_gaps(self):
+        gap = gap_for_site(_checklist(), "src/parse.c", 30)
+        for key in ("file", "name", "line_start", "line_end",
+                    "priority", "strategies", "is_stale", "sloc"):
+            assert key in gap, key
+
+
+class TestSynthesisHitsToGaps:
+    def test_hits_become_reviewable_gaps(self):
+        gaps = _synthesis_hits_to_gaps(
+            [_hit("src/parse.c", 30), _hit("src/util.c", 12)],
+            _checklist(),
+        )
+        assert [g["name"] for g in gaps] == ["parse_header", "copy_field"]
+
+    def test_result_is_safe_for_task_graph(self):
+        """The regression: a successful cross-file hit aborted the run.
+
+        Hits carry ``function``; TaskGraph.from_workqueue dereferences
+        ``gap['name']``, so raw hits raised KeyError after the entire
+        review loop had already run.
+        """
+        hits = [_hit("src/parse.c", 30)]
+
+        with pytest.raises(KeyError):
+            TaskGraph.from_workqueue(hits, [])
+
+        gaps = _synthesis_hits_to_gaps(hits, _checklist())
+        graph = TaskGraph.from_workqueue(gaps, [])
+        assert graph is not None
+
+    def test_unresolvable_hits_are_dropped_not_fatal(self):
+        gaps = _synthesis_hits_to_gaps(
+            [_hit("src/parse.c", 42), _hit("generated/blob.c", 7),
+             _hit("src/parse.c", 30)],
+            _checklist(),
+        )
+        assert [g["name"] for g in gaps] == ["parse_header"]
+
+    def test_duplicate_hits_in_one_function_collapse(self):
+        gaps = _synthesis_hits_to_gaps(
+            [_hit("src/parse.c", 12), _hit("src/parse.c", 30)],
+            _checklist(),
+        )
+        assert len(gaps) == 1
+
+    def test_previously_reviewed_functions_are_NOT_skipped(self):
+        """A synthesized checker encodes a pattern nobody knew about when
+        those functions were first reviewed — that is exactly when
+        re-review pays, so prior coverage must not suppress the hit."""
+        gaps = _synthesis_hits_to_gaps(
+            [_hit("src/parse.c", 30), _hit("src/util.c", 12)],
+            _checklist(),
+        )
+        assert [g["name"] for g in gaps] == ["parse_header", "copy_field"]
+
+    def test_unresolved_hits_are_persisted_not_discarded(self, tmp_path):
+        out_dir = tmp_path / "out"
+        out_dir.mkdir()
+        gaps = _synthesis_hits_to_gaps(
+            [_hit("src/parse.c", 42), _hit("src/parse.c", 30)],
+            _checklist(),
+            out_dir,
+        )
+        assert [g["name"] for g in gaps] == ["parse_header"]
+
+        import json
+        record = json.loads(
+            (out_dir / "unresolved-synthesis-hits.json").read_text()
+        )
+        assert record["count"] == 1
+        assert record["hits"][0]["line"] == 42
+
+    def test_malformed_line_is_survivable(self):
+        assert _synthesis_hits_to_gaps(
+            [{"file": "src/parse.c", "line": "not-a-number"}], _checklist(),
+        ) == []
+
+    def test_synthesis_provenance_is_carried(self):
+        gaps = _synthesis_hits_to_gaps([_hit("src/parse.c", 30)], _checklist())
+        assert gaps[0]["from_synthesis"] is True
+        assert gaps[0]["priority_score"] == 0.8
+        assert gaps[0]["synthesis_snippet"] == "memcpy(dst, src, len);"
+
+    def test_empty_input(self):
+        assert _synthesis_hits_to_gaps([], _checklist()) == []
+
+    def test_missing_line_key_is_survivable(self):
+        assert _synthesis_hits_to_gaps([{"file": "src/parse.c"}], _checklist()) == []
+
+
+class TestGapForSiteNestedSpans:
+    """Innermost span wins — a nested def is where the site really lives."""
+
+    def _nested_checklist(self):
+        return {
+            "files": [
+                {
+                    "path": "app/mod.py",
+                    "items": [
+                        {"name": "outer", "kind": "function",
+                         "line_start": 1, "line_end": 100},
+                        {"name": "inner", "kind": "function",
+                         "line_start": 30, "line_end": 50},
+                    ],
+                },
+            ],
+        }
+
+    def test_innermost_wins_when_outer_listed_first(self):
+        gap = gap_for_site(self._nested_checklist(), "app/mod.py", 35)
+        assert gap["name"] == "inner"
+
+    def test_innermost_wins_when_inner_listed_first(self):
+        cl = self._nested_checklist()
+        cl["files"][0]["items"].reverse()
+        gap = gap_for_site(cl, "app/mod.py", 35)
+        assert gap["name"] == "inner"
+
+    def test_outer_still_resolves_outside_the_nested_span(self):
+        gap = gap_for_site(self._nested_checklist(), "app/mod.py", 80)
+        assert gap["name"] == "outer"
+
+    def test_missing_line_end_infers_from_next_definition(self):
+        cl = {
+            "files": [
+                {
+                    "path": "app/mod.py",
+                    "items": [
+                        {"name": "first", "kind": "function", "line_start": 10},
+                        {"name": "second", "kind": "function", "line_start": 40},
+                    ],
+                },
+            ],
+        }
+        first = gap_for_site(cl, "app/mod.py", 25)
+        assert first["name"] == "first"
+        assert first["line_end"] == 39
+        assert first["span_inferred"] is True
+
+    def test_trailing_definition_without_end_stays_unresolved(self):
+        """No derivable upper bound — better unresolved than truncated.
+
+        Inventing an end either cuts the function short (review and
+        hydration miss its tail) or claims lines belonging to nothing.
+        These land in unresolved-synthesis-hits.json instead.
+        """
+        cl = {
+            "files": [
+                {
+                    "path": "app/mod.py",
+                    "items": [
+                        {"name": "first", "kind": "function", "line_start": 10},
+                        {"name": "second", "kind": "function", "line_start": 40},
+                    ],
+                },
+            ],
+        }
+        assert gap_for_site(cl, "app/mod.py", 45) is None
+
+    def test_task_graph_keys_match_resolved_functions(self):
+        gaps = _synthesis_hits_to_gaps(
+            [_hit("src/parse.c", 30), _hit("src/util.c", 12)], _checklist(),
+        )
+        graph = TaskGraph.from_workqueue(gaps, [])
+        keys = set(graph.nodes) if hasattr(graph, "nodes") else None
+        if keys is not None:
+            assert keys == {"src/parse.c:parse_header", "src/util.c:copy_field"}
+
+
+class TestSeedFunctionExclusion:
+    """The seed's own function is already a finding, not a new variant."""
+
+    def _hit_with_origin(self, file_path, line, origin_fn):
+        h = _hit(file_path, line)
+        h["origin_file"] = "src/parse.c"
+        h["origin_function"] = origin_fn
+        return h
+
+    def test_seed_function_is_excluded_by_identity_not_line(self):
+        """`outcome.line` is the function's line_start, not the bug line,
+        so a line test excluded the wrong site — or nothing at all."""
+        gaps = _synthesis_hits_to_gaps(
+            [self._hit_with_origin("src/parse.c", 35, "parse_header"),
+             self._hit_with_origin("src/parse.c", 50, "parse_header")],
+            _checklist(),
+        )
+        assert [g["name"] for g in gaps] == ["parse_body"]
+
+    def test_same_file_sibling_of_the_seed_survives(self):
+        gaps = _synthesis_hits_to_gaps(
+            [self._hit_with_origin("src/parse.c", 50, "parse_header")],
+            _checklist(),
+        )
+        assert [g["name"] for g in gaps] == ["parse_body"]
+
+    def test_hits_without_origin_are_unaffected(self):
+        gaps = _synthesis_hits_to_gaps([_hit("src/parse.c", 30)], _checklist())
+        assert [g["name"] for g in gaps] == ["parse_header"]
+
+
+class TestSecondPassIsNonFatal:
+    """The synthesis second pass must never cost the run its results.
+
+    It executes after the main review loop but before the state
+    sync-back and the single one-shot ``collector.flush()``. Any
+    exception escaping it discards the run's findings and its buffered
+    audit log — the exact failure the ``KeyError: 'name'`` above caused.
+    Resolution is the most likely source, so it must be total: hostile
+    or malformed hits produce fewer gaps, never an exception.
+    """
+
+    @pytest.mark.parametrize("bad", [
+        {},                                              # no keys at all
+        {"file": "src/parse.c"},                         # no line
+        {"line": 30},                                    # no file
+        {"file": "", "line": 30},                        # empty file
+        {"file": "src/parse.c", "line": None},           # null line
+        {"file": "src/parse.c", "line": "30"},           # line as string
+        {"file": "src/parse.c", "line": -1},             # negative line
+        {"file": "src/parse.c", "line": 0},              # zero line
+        {"file": "src/parse.c", "line": True},           # bool masquerading as int
+        {"file": None, "line": 30},                      # null file
+        {"file": "../../etc/passwd", "line": 1},         # traversal-shaped path
+        {"file": "src/parse.c", "line": 10**12},         # absurd line
+    ])
+    def test_malformed_hit_does_not_raise(self, bad):
+        gaps = _synthesis_hits_to_gaps([bad], _checklist())
+        assert isinstance(gaps, list)
+
+    def test_malformed_hits_do_not_suppress_good_ones(self):
+        """One bad hit must not discard the batch."""
+        gaps = _synthesis_hits_to_gaps(
+            [{}, _hit("src/parse.c", 30), {"file": None, "line": 1}],
+            _checklist(),
+        )
+        assert [g["name"] for g in gaps] == ["parse_header"]
+
+    @pytest.mark.parametrize("cl", [
+        {},                                                   # no files key
+        {"files": None},                                      # null files
+        {"files": []},                                        # empty files
+        {"files": [None]},                                    # null entry
+        {"files": ["nonsense"]},                              # non-dict entry
+        {"files": [{}]},                                      # entry with no path
+        {"files": [{"path": "src/parse.c", "items": None}]},  # null items
+        {"files": [{"path": "src/parse.c", "items": "x"}]},   # items not a list
+        {"files": [{"path": "src/parse.c",
+                    "items": [None, "x", 5]}]},               # junk items
+        None,                                                 # checklist itself null
+        [],                                                   # checklist not a dict
+    ])
+    def test_malformed_checklist_does_not_raise(self, cl):
+        assert _synthesis_hits_to_gaps([_hit("src/parse.c", 30)], cl) == []
+
+    def test_resolved_gaps_always_build_a_graph(self):
+        """Whatever resolution returns must be graph-safe.
+
+        ``TaskGraph.from_workqueue`` dereferences ``gap['name']``
+        unguarded; that is what turned a successful sweep into a
+        run-killing KeyError.
+        """
+        gaps = _synthesis_hits_to_gaps(
+            [_hit("src/parse.c", 30), {}, _hit("src/parse.c", 50)],
+            _checklist(),
+        )
+        TaskGraph.from_workqueue(gaps, {})
+        assert all("name" in g and g["name"] for g in gaps)


### PR DESCRIPTION
Split out of #892 so it can land independently of the evidence-contract work there, which is now contested and which this does not depend on. Branched from current `main`.

## The bug

Checker synthesis is one of the better ideas in `/audit` — confirm a bug once, generalise it to a rule, sweep the codebase. The payoff is currently unreachable, because the failure fires on **success**.

Synthesis hits are *sites*, carrying `function` (`checker_synthesis.py:204`). `TaskGraph.from_workqueue` dereferences `gap['name']` unguarded (`task_graph.py:197`), and the second-pass graph construction sits outside the synthesis `try/except` — `run_orchestrator` has only a `finally` for Joern cleanup. So a confirmed finding whose synthesized rule matched in another file raises `KeyError: 'name'` **after the entire review loop has run**, before state sync-back and before `collector.flush()` — losing the run's findings and its buffered audit log.

Reproduced against current `main`:

```
1) raw hits -> TaskGraph.from_workqueue   KeyError('name')
2) after this patch                        resolved -> [('src/a.c','parse_hdr')], graph builds
3) unresolvable site                       0 gaps, dropped cleanly
```

## The fix

`_synthesis_hits_to_gaps` resolves each site to its enclosing checklist function via a new `gaps.gap_for_site`, mirroring the resolution already used by `understand_bridge._find_containing_function`: strict smallest-containing-span first, so a nested function or closure is attributed to the innermost match rather than the enclosing one; then a closest-preceding-`line_start` fallback bounded by the next definition, for inventories that record only the definition line. A trailing definition with no next start has no derivable bound, so those sites stay unresolved rather than being given a fabricated span that would truncate review.

Two deliberate choices:

- Sites that resolve to no reviewable function (a top-level initializer, a macro, generated code) can't become review tasks, but they're still tool signal — they go to `unresolved-synthesis-hits.json` rather than being dropped silently.
- Functions reviewed in an earlier round or run are deliberately **not** skipped. A synthesized checker encodes a pattern nobody knew about when those functions were first reviewed, which is exactly when re-review pays.

This also removes the two filters in `checker_synthesis.py` that dropped real variants: the dedup key was `<matched file>:<seed function>` — a seed function name paired with a different file, which identifies nothing and matched `seen_keys` only by accident — and `m.file != file_path` discarded every same-file sibling, so a second vulnerable function in the same source file was lost. Both belong downstream, once a site has been resolved to a function. Excluding by line in `checker_synthesis` would be wrong anyway, since `outcome.line` is the function's `line_start` rather than the vulnerable line, and is `0` when the inventory recorded none.

Incidentally this restores the intent of 92cd8a85, which changed that dedup key and was then reverted by the bulk-land in aea9d17d — `main` currently has the pre-92cd8a85 form. Worth a look independently of this PR.

## Durability

Fixing the `KeyError` removes the known crash but not the class. The second pass is optional enrichment that runs after the main review loop and before the state sync-back and the single one-shot `collector.flush()`, so **any** exception in resolution, graph construction or the executor still discards the run's output.

It is now wrapped: the pass degrades to "second pass skipped" with a warning, main-pass results are kept and buffered state is flushed. `gap_for_site` is also made total — a malformed checklist yields fewer resolved gaps rather than an exception, which is the correct degradation for something holding the run's results hostage.

## Testing

`test_synthesis_hits.py` asserts `pytest.raises(KeyError)` on the raw hits *before* showing the resolved gaps work, so it fails loudly if the resolution is ever removed. Added on top: 12 malformed hit shapes and 11 malformed checklist shapes assert resolution never raises, that one bad hit doesn't discard the batch, and that whatever resolution returns is always safe to hand to `TaskGraph.from_workqueue`.
