### PR TITLE
fix(audit): hydrate source for the negative-space detectors

### DIFF
--- a/core/audit/gaps.py
+++ b/core/audit/gaps.py
@@ -22,7 +22,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from .strategy import strategies_from_item
-from ._util import extract_context_map_set
+from ._util import extract_context_map_set, safe_join
 
 logger = logging.getLogger(__name__)
 
@@ -37,6 +37,14 @@ _TRIVIAL_SLOC = 5
 _SMALL_ENTRY_SLOC = 20
 _LARGE_SLOC = 200
 _REVIEWABLE_KINDS = frozenset({"function", "method", ""})
+
+# Bounds for detector source hydration. These exist so a large or
+# hostile tree degrades by hydrating fewer functions rather than by
+# exhausting memory.
+_MAX_HYDRATED_SLOC = 2000            # per function, lines
+_MAX_HYDRATED_FUNCTION_BYTES = 256 * 1024
+_MAX_HYDRATED_FILE_BYTES = 8 * 1024 * 1024
+_MAX_HYDRATED_TOTAL_BYTES = 64 * 1024 * 1024
 
 
 def compute_gaps(
@@ -206,6 +214,238 @@ def load_checklist(out_dir: Path) -> Dict[str, Any]:
     except json.JSONDecodeError:
         logger.error("malformed JSON in %s", path)
         return {}
+
+
+
+def hydrate_live_gaps_for_detectors(
+    gaps: List[Dict[str, Any]],
+    target_path: Path,
+) -> List[Dict[str, Any]]:
+    """Return live gaps as **copies** carrying their function body.
+
+    The mechanical pattern detectors that run before the LLM loop —
+    negative-space convention discovery and sibling asymmetry — read
+    ``gap["source"]`` and skip any gap without it. Gaps are built from
+    the checklist, which carries line spans but no text, so without this
+    those passes see nothing and silently return empty.
+
+    Two deliberate properties:
+
+    *Copies, not in-place.* ``gap["source"]`` is a generic field with
+    seven readers across ``core/audit`` (``triage``, ``spec_inference``,
+    ``taint_specs``, ``iris_specs``, ``project_context``, the
+    orchestrator, and negative space). Populating it on the shared gap
+    dicts would switch all of them on at once — ``triage`` would begin
+    generated-file detection, changing *which functions get reviewed*,
+    and ``spec_inference`` would issue extra LLM calls. Neither is this
+    change's business. Returning copies keeps the blast radius at the
+    two detectors this is for, and means ``write_gaps`` needs no
+    knowledge of it.
+
+    *Live only.* Dead gaps are excluded, so convention discovery cannot
+    learn a baseline from code the dead-code gate already rejected, and
+    sibling asymmetry cannot read an unhydrated dead sibling as
+    non-adherent. ``negative_space`` filters on ``dead`` too; this keeps
+    the I/O from happening at all.
+
+    Gaps are grouped by file so each file is read once and released once
+    its bodies are taken — the tree is never resident at once.
+    """
+    live = [g for g in gaps if not g.get("dead")]
+    if not live:
+        return []
+
+    # Carry the validated span alongside the gap: re-indexing the dict
+    # later would re-admit exactly the malformed shapes screened here.
+    by_file: Dict[str, List[tuple]] = {}
+    for gap in live:
+        line_start = gap.get("line_start")
+        line_end = gap.get("line_end")
+        if not isinstance(line_start, int) or isinstance(line_start, bool):
+            continue
+        if not isinstance(line_end, int) or isinstance(line_end, bool):
+            continue
+        if line_start < 1 or line_end < line_start:
+            continue
+        if (line_end - line_start + 1) > _MAX_HYDRATED_SLOC:
+            continue
+        file_path = gap.get("file") or ""
+        if file_path:
+            by_file.setdefault(file_path, []).append((gap, line_start, line_end))
+
+    hydrated: List[Dict[str, Any]] = []
+    total_bytes = 0
+
+    for file_path, file_gaps in by_file.items():
+        remaining = _MAX_HYDRATED_TOTAL_BYTES - total_bytes
+        if remaining <= 0:
+            logger.info(
+                "detector hydration stopped at %d gaps (%d MiB retained)",
+                len(hydrated), _MAX_HYDRATED_TOTAL_BYTES // (1024 * 1024),
+            )
+            break
+
+        bodies = _read_spans(
+            target_path, file_path,
+            [(start, end) for _, start, end in file_gaps],
+            budget_bytes=remaining,
+        )
+        if not bodies:
+            continue
+
+        # Charge per unique span, matching what _read_spans actually
+        # retained. Several gaps can share one span (duplicate checklist
+        # entries), and they share the same string object — counting the
+        # body once per gap would overstate the total and, with enough
+        # duplicates, breach the ceiling on paper while nothing extra is
+        # held. The ceiling is re-checked here so one file cannot run
+        # past it between the per-file checks.
+        charged: set = set()
+        for gap, start, end in file_gaps:
+            body = bodies.get((start, end))
+            if not body:
+                continue
+            if (start, end) not in charged:
+                size = len(body.encode("utf-8", errors="ignore"))
+                if total_bytes + size > _MAX_HYDRATED_TOTAL_BYTES:
+                    continue
+                total_bytes += size
+                charged.add((start, end))
+            copy = dict(gap)
+            copy["source"] = body
+            hydrated.append(copy)
+
+        del bodies
+
+    if hydrated:
+        logger.debug(
+            "hydrated source for %d/%d live gaps (%d KiB)",
+            len(hydrated), len(live), total_bytes // 1024,
+        )
+    return hydrated
+
+
+def _read_spans(
+    target_path: Path,
+    file_path: str,
+    spans: List[tuple],
+    *,
+    budget_bytes: int = _MAX_HYDRATED_TOTAL_BYTES,
+) -> Optional[Dict[tuple, str]]:
+    """Extract the requested 1-indexed inclusive line spans from a file.
+
+    Streams line by line and retains only lines inside a requested span,
+    so peak memory tracks what is wanted rather than file size — a 16 MiB
+    file of millions of short lines would cost hundreds of MiB via
+    ``readlines()``.
+
+    Spans are held in a sliding active set rather than rescanned per
+    line. Testing every span against every line is O(lines x spans),
+    which is pathological on a large file carrying many functions; here
+    each span is opened once when the stream reaches its start and
+    dropped once past its end, so cost is O(lines + spans log spans)
+    plus the bytes actually retained.
+
+    ``budget_bytes`` is the caller's *remaining* total allowance and is
+    charged during accumulation, so a single file cannot build more than
+    the global ceiling before the caller gets a chance to enforce it.
+    The per-function cap is likewise applied while accumulating, so an
+    oversized body is abandoned rather than built and then discarded.
+
+    Paths come from the checklist, which is derived from the scanned
+    tree, so containment is enforced rather than assumed. Oversized files
+    are refused, as are files with a NUL in the first 8 KiB (a cheap
+    probe, not a guarantee — a NUL past that window is not caught):
+    a minified bundle can
+    satisfy a line-count bound while still being huge, and NUL-laden
+    text only feeds noise to the pattern detectors downstream.
+    """
+    resolved = safe_join(Path(target_path), file_path)
+    if resolved is None or not resolved.is_file():
+        return None
+
+    wanted = sorted({
+        (int(s), int(e)) for s, e in spans
+        if isinstance(s, int) and isinstance(e, int) and s > 0 and e >= s
+    })
+    if not wanted:
+        return None
+    last_line = max(e for _, e in wanted)
+
+    try:
+        if resolved.stat().st_size > _MAX_HYDRATED_FILE_BYTES:
+            logger.debug("skipping oversized file for hydration: %s", file_path)
+            return None
+        with open(resolved, "rb") as probe:
+            if b"\0" in probe.read(8192):
+                logger.debug("skipping binary-looking file: %s", file_path)
+                return None
+
+        parts: Dict[tuple, List[str]] = {}
+        sizes: Dict[tuple, int] = {}
+        done: Dict[tuple, str] = {}
+        abandoned: set = set()
+        active: set = set()
+        nxt = 0
+        spent = 0
+
+        with open(resolved, encoding="utf-8", errors="replace") as fh:
+            for lineno, text in enumerate(fh, start=1):
+                if lineno > last_line:
+                    break
+
+                while nxt < len(wanted) and wanted[nxt][0] <= lineno:
+                    span = wanted[nxt]
+                    if span[1] >= lineno:
+                        active.add(span)
+                        parts[span] = []
+                        sizes[span] = 0
+                    nxt += 1
+
+                if not active:
+                    continue
+
+                cost = len(text.encode("utf-8", errors="ignore"))
+                # Sorted, not set order: which span survives a tight
+                # budget must not depend on hash iteration order.
+                for span in sorted(active):
+                    over_fn = sizes[span] + cost > _MAX_HYDRATED_FUNCTION_BYTES
+                    over_total = spent + cost > budget_bytes
+                    if over_fn or over_total:
+                        # Refund what this span buffered — an abandoned
+                        # body retains nothing, so it must not go on
+                        # charging the allowance and starving later
+                        # spans in the same file.
+                        spent -= sizes.pop(span, 0)
+                        abandoned.add(span)
+                        active.discard(span)
+                        parts.pop(span, None)
+                        continue
+                    parts[span].append(text)
+                    sizes[span] += cost
+                    spent += cost
+
+                for span in sorted(active):
+                    if span[1] <= lineno:
+                        active.discard(span)
+                        chunks = parts.pop(span, None)
+                        sizes.pop(span, None)
+                        if chunks:
+                            done[span] = "".join(chunks)
+
+        # A span still open at EOF never saw its declared end line, so
+        # the body is truncated. For absence detection that is worse
+        # than nothing: the check we would report as missing may simply
+        # lie in the part we did not read. Drop it.
+        for span in tuple(active):
+            parts.pop(span, None)
+            spent -= sizes.pop(span, 0)
+            abandoned.add(span)
+    except OSError:
+        logger.debug("could not read %s for gap hydration", file_path)
+        return None
+
+    return {s: b for s, b in done.items() if b and s not in abandoned}
 
 
 def load_context_map(out_dir: Path) -> Optional[Dict[str, Any]]:

--- a/core/audit/orchestrator.py
+++ b/core/audit/orchestrator.py
@@ -38,7 +38,7 @@ from .constraints import (
     save_constraints,
 )
 from .context import assemble_context
-from .gaps import compute_gaps, load_checklist, load_context_map, mark_checked, write_gaps
+from .gaps import compute_gaps, hydrate_live_gaps_for_detectors, load_checklist, load_context_map, mark_checked, write_gaps
 from .priority import (
     group_by_subsystem, load_flow_traces, load_fuzz_coverage as _load_fuzz_coverage_from_runs,
     load_tool_failures, score_functions,
@@ -710,12 +710,29 @@ def review_one_function(
         if isinstance(strategies, (list, tuple)):
             strategies = set(strategies)
         ns_findings = []
+        # check_negative_space reads gap["source"] and returns [] without
+        # it, so discovering conventions is only half the job — they have
+        # to reach the per-function check. The body is already in ctx;
+        # pass a throwaway copy rather than hydrating the shared gap,
+        # which would also switch on triage and spec_inference.
+        detector_gap = gap
+        ctx_source = ctx.get("source") or ""
+        if ctx_source and not gap.get("source"):
+            detector_gap = dict(gap)
+            detector_gap["source"] = ctx_source
         for strat in (strategies or {"general"}):
-            ns_findings.extend(check_negative_space(gap, conventions, strat))
+            ns_findings.extend(
+                check_negative_space(detector_gap, conventions, strat),
+            )
 
+        # Match on identity, not prose. NegativeSpaceFinding carries
+        # file/function, so substring-searching the function name in
+        # `evidence` only misroutes: duplicate names across files, and
+        # prefixes like handle_user / handle_user_admin.
+        gap_file, gap_name = gap.get("file", ""), gap.get("name", "")
         func_sibling_ns = [
             f for f in sibling_ns_findings
-            if gap.get("name", "") in f.evidence
+            if (f.file, f.function) == (gap_file, gap_name)
         ]
         ns_findings.extend(func_sibling_ns)
 
@@ -1581,15 +1598,22 @@ def _run_audit_body(
         discover_conventions,
         check_sibling_negative_space,
     )
-    live_gaps = [g for g in gaps if not g.get("dead")]
-    conventions = discover_conventions(live_gaps)
+    # Detectors need the function body; gaps carry line spans only.
+    # Hydrated *copies* — see hydrate_live_gaps_for_detectors: putting
+    # `source` on the shared gap dicts would also switch on triage's
+    # generated-file detection (changing which functions get reviewed)
+    # and spec_inference's LLM calls, neither of which belongs here.
+    detector_gaps = hydrate_live_gaps_for_detectors(
+        [g for g in gaps if not g.get("dead")], Path(config.target_path),
+    )
+    conventions = discover_conventions(detector_gaps)
     if conventions:
         logger.info(
             "negative-space: discovered %d security conventions",
             len(conventions),
         )
 
-    sibling_ns_findings = check_sibling_negative_space(live_gaps, conventions) if conventions else []
+    sibling_ns_findings = check_sibling_negative_space(detector_gaps, conventions) if conventions else []
     if sibling_ns_findings:
         logger.info(
             "sibling analysis: %d asymmetry findings across peer groups",

--- a/core/audit/orchestrator.py
+++ b/core/audit/orchestrator.py
@@ -39,7 +39,7 @@ from .constraints import (
     save_constraints,
 )
 from .context import assemble_context
-from .gaps import compute_gaps, hydrate_live_gaps_for_detectors, load_checklist, load_context_map, write_gaps
+from .gaps import compute_gaps, gap_for_site, hydrate_live_gaps_for_detectors, load_checklist, load_context_map, write_gaps
 from .priority import (
     group_by_subsystem, load_flow_traces, load_fuzz_coverage as _load_fuzz_coverage_from_runs,
     load_tool_failures, score_functions,

--- a/core/audit/tests/test_gap_hydration.py
+++ b/core/audit/tests/test_gap_hydration.py
@@ -1,0 +1,366 @@
+"""Source hydration for the negative-space detectors.
+
+`discover_conventions` and `check_sibling_negative_space` read
+`gap["source"]` and skip any gap without it. Gaps come from the
+checklist, which carries line spans but no text, so before this the two
+passes silently analysed nothing. These tests pin the end the change
+serves, the blast radius it must not exceed, and the bounds that keep it
+safe on a large or hostile tree.
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from core.audit.gaps import (
+    _MAX_HYDRATED_FUNCTION_BYTES,
+    _MAX_HYDRATED_FILE_BYTES,
+    _read_spans,
+    hydrate_live_gaps_for_detectors,
+)
+from core.audit.negative_space import discover_conventions
+
+# Matches _GENERIC_PATTERNS[CONCERN_AUTH]; four occurrences clear
+# MIN_CONVENTION_OCCURRENCES so a convention is actually discovered.
+ADHERENT = "def handle_{i}(req):\n    check_auth(req)\n    return run(req)\n"
+NON_ADHERENT = "def handle_x(req):\n    return run(req)\n"
+
+
+def _tree(tmp_path, n=4, body=ADHERENT):
+    (tmp_path / "src").mkdir(exist_ok=True)
+    for i in range(n):
+        (tmp_path / "src" / f"h{i}.py").write_text(body.format(i=i))
+    return tmp_path
+
+
+def _gap(i, dead=False, **kw):
+    g = {"file": f"src/h{i}.py", "name": f"handle_{i}",
+         "line_start": 1, "line_end": 3}
+    if dead:
+        g["dead"] = True
+    g.update(kw)
+    return g
+
+
+class TestHydrationServesTheDetectors:
+    """The end the change exists for."""
+
+    def test_conventions_are_empty_without_hydration(self, tmp_path):
+        _tree(tmp_path)
+        assert discover_conventions([_gap(i) for i in range(4)]) == []
+
+    def test_conventions_are_found_with_hydration(self, tmp_path):
+        _tree(tmp_path)
+        hydrated = hydrate_live_gaps_for_detectors(
+            [_gap(i) for i in range(4)], tmp_path,
+        )
+        assert len(hydrated) == 4
+        assert [c.concern for c in discover_conventions(hydrated)] == ["auth"]
+
+    def test_body_matches_the_file(self, tmp_path):
+        _tree(tmp_path, n=1)
+        got = hydrate_live_gaps_for_detectors([_gap(0)], tmp_path)
+        assert got[0]["source"] == ADHERENT.format(i=0)
+
+
+class TestBlastRadiusIsContained:
+    """`source` has seven readers; only two are in scope.
+
+    Populating it on the shared gap dicts would also switch on triage's
+    generated-file detection — which changes *which functions get
+    reviewed* — and spec_inference's extra LLM calls.
+    """
+
+    def test_input_gaps_are_not_mutated(self, tmp_path):
+        _tree(tmp_path)
+        gaps = [_gap(i) for i in range(4)]
+        hydrate_live_gaps_for_detectors(gaps, tmp_path)
+        assert not any("source" in g for g in gaps)
+
+    def test_returned_gaps_are_copies_not_aliases(self, tmp_path):
+        _tree(tmp_path, n=1)
+        gaps = [_gap(0)]
+        out = hydrate_live_gaps_for_detectors(gaps, tmp_path)
+        out[0]["name"] = "mutated"
+        assert gaps[0]["name"] == "handle_0"
+
+    def test_other_gap_fields_survive_the_copy(self, tmp_path):
+        _tree(tmp_path, n=1)
+        out = hydrate_live_gaps_for_detectors(
+            [_gap(0, priority=3, strategies=["memory"])], tmp_path,
+        )
+        assert out[0]["priority"] == 3
+        assert out[0]["strategies"] == ["memory"]
+
+
+class TestDeadGapsAreExcluded:
+    """Conventions must not be learned from code the dead-code gate rejected."""
+
+    def test_dead_gaps_are_not_hydrated(self, tmp_path):
+        _tree(tmp_path)
+        assert hydrate_live_gaps_for_detectors(
+            [_gap(i, dead=True) for i in range(4)], tmp_path,
+        ) == []
+
+    def test_mixed_keeps_only_live(self, tmp_path):
+        _tree(tmp_path)
+        out = hydrate_live_gaps_for_detectors(
+            [_gap(0), _gap(1, dead=True), _gap(2)], tmp_path,
+        )
+        assert sorted(g["name"] for g in out) == ["handle_0", "handle_2"]
+
+    def test_dead_gaps_cost_no_io(self, tmp_path, monkeypatch):
+        _tree(tmp_path)
+        import core.audit.gaps as gaps_mod
+        calls = []
+        real = gaps_mod._read_spans
+        monkeypatch.setattr(
+            gaps_mod, "_read_spans",
+            lambda *a, **k: (calls.append(a[1]), real(*a, **k))[1],
+        )
+        hydrate_live_gaps_for_detectors(
+            [_gap(i, dead=True) for i in range(4)], tmp_path,
+        )
+        assert calls == []
+
+
+class TestReadSpansCorrectness:
+    def test_spans_are_inclusive_and_one_indexed(self, tmp_path):
+        (tmp_path / "f.py").write_text("".join(f"L{i}\n" for i in range(1, 11)))
+        got = _read_spans(tmp_path, "f.py", [(2, 4)])
+        assert got[(2, 4)] == "L2\nL3\nL4\n"
+
+    def test_overlapping_spans_each_get_full_text(self, tmp_path):
+        (tmp_path / "f.py").write_text("".join(f"L{i}\n" for i in range(1, 11)))
+        got = _read_spans(tmp_path, "f.py", [(2, 6), (4, 8)])
+        assert got[(2, 6)] == "L2\nL3\nL4\nL5\nL6\n"
+        assert got[(4, 8)] == "L4\nL5\nL6\nL7\nL8\n"
+
+    def test_nested_span_is_not_swallowed(self, tmp_path):
+        (tmp_path / "f.py").write_text("".join(f"L{i}\n" for i in range(1, 11)))
+        got = _read_spans(tmp_path, "f.py", [(1, 10), (3, 4)])
+        assert got[(3, 4)] == "L3\nL4\n"
+        assert len(got[(1, 10)].splitlines()) == 10
+
+    def test_span_past_eof_is_abandoned(self, tmp_path):
+        """A truncated body is worse than none for absence detection.
+
+        If the span never reached its declared end line, the check we
+        would report as missing may simply lie in the part not read.
+        """
+        (tmp_path / "f.py").write_text("L1\nL2\n")
+        assert not _read_spans(tmp_path, "f.py", [(1, 99)])
+
+    def test_span_ending_exactly_at_eof_is_kept(self, tmp_path):
+        (tmp_path / "f.py").write_text("L1\nL2\n")
+        assert _read_spans(tmp_path, "f.py", [(1, 2)])[(1, 2)] == "L1\nL2\n"
+
+    def test_final_line_without_trailing_newline_is_kept(self, tmp_path):
+        (tmp_path / "f.py").write_text("L1\nL2")
+        assert _read_spans(tmp_path, "f.py", [(1, 2)])[(1, 2)] == "L1\nL2"
+
+    @pytest.mark.parametrize("spans", [
+        [], [(0, 5)], [(-1, 5)], [(5, 1)], [(None, 5)], [(1, None)],
+        [("1", "5")], [(True, False)],
+    ])
+    def test_malformed_spans_yield_nothing(self, tmp_path, spans):
+        (tmp_path / "f.py").write_text("L1\nL2\n")
+        assert not _read_spans(tmp_path, "f.py", spans)
+
+
+class TestBounds:
+    """A large or hostile tree must degrade, not exhaust memory."""
+
+    def test_traversal_is_refused(self, tmp_path):
+        assert _read_spans(tmp_path, "../../etc/passwd", [(1, 2)]) is None
+
+    def test_absolute_path_is_refused(self, tmp_path):
+        assert _read_spans(tmp_path, "/etc/passwd", [(1, 2)]) is None
+
+    def test_missing_file_is_refused(self, tmp_path):
+        assert _read_spans(tmp_path, "nope.py", [(1, 2)]) is None
+
+    def test_binary_looking_file_is_refused(self, tmp_path):
+        (tmp_path / "b.py").write_bytes(b"def f():\n" + b"\0" * 100)
+        assert _read_spans(tmp_path, "b.py", [(1, 2)]) is None
+
+    def test_oversized_file_is_refused(self, tmp_path):
+        (tmp_path / "big.py").write_text("x\n" * ((_MAX_HYDRATED_FILE_BYTES // 2) + 10))
+        assert _read_spans(tmp_path, "big.py", [(1, 2)]) is None
+
+    def test_oversized_function_is_abandoned(self, tmp_path):
+        line = "y" * 1024 + "\n"
+        n = (_MAX_HYDRATED_FUNCTION_BYTES // len(line)) + 50
+        (tmp_path / "f.py").write_text(line * n)
+        assert not _read_spans(tmp_path, "f.py", [(1, n)])
+
+    def test_budget_is_charged_during_accumulation(self, tmp_path):
+        """The ceiling must bound peak, not merely be checked afterwards."""
+        (tmp_path / "f.py").write_text("x = 1\n" * 5000)
+        spans = [(i * 10 + 1, i * 10 + 5) for i in range(400)]
+        got = _read_spans(tmp_path, "f.py", spans, budget_bytes=500)
+        retained = sum(len(v.encode("utf-8")) for v in got.values())
+        assert retained <= 500
+
+    def test_per_function_line_cap_skips_the_gap(self, tmp_path):
+        (tmp_path / "src").mkdir()
+        (tmp_path / "src" / "h0.py").write_text("x\n" * 5000)
+        assert hydrate_live_gaps_for_detectors(
+            [_gap(0, line_start=1, line_end=4000)], tmp_path,
+        ) == []
+
+
+class TestScalesToManySpans:
+    """Guards the active-set sweep against regressing to O(lines x spans)."""
+
+    def test_many_spans_over_a_large_file_is_fast(self, tmp_path):
+        (tmp_path / "f.py").write_text("x = 1\n" * 200_000)
+        spans = [(i * 10 + 1, i * 10 + 5) for i in range(2000)]
+        started = time.monotonic()
+        got = _read_spans(tmp_path, "f.py", spans)
+        elapsed = time.monotonic() - started
+        assert len(got) == 2000
+        # The per-line-per-span scan takes ~0.7s here; the sweep ~0.005s.
+        # Generous enough not to flake on a loaded runner, tight enough
+        # that the quadratic form cannot pass.
+        assert elapsed < 0.25, f"took {elapsed:.3f}s — sweep may have regressed"
+
+
+class TestMalformedInputIsSurvivable:
+    """Hydration runs before the review loop; it must not abort the run."""
+
+    @pytest.mark.parametrize("gap", [
+        {}, {"file": "src/h0.py"}, {"line_start": 1, "line_end": 3},
+        {"file": None, "line_start": 1, "line_end": 3},
+        {"file": "src/h0.py", "line_start": None, "line_end": 3},
+        {"file": "src/h0.py", "line_start": "1", "line_end": "3"},
+        {"file": "src/h0.py", "line_start": 5, "line_end": 1},
+        {"file": "src/h0.py", "line_start": True, "line_end": 3},
+        {"file": "", "line_start": 1, "line_end": 3},
+    ])
+    def test_malformed_gap_does_not_raise(self, tmp_path, gap):
+        _tree(tmp_path, n=1)
+        assert isinstance(hydrate_live_gaps_for_detectors([gap], tmp_path), list)
+
+    def test_one_bad_gap_does_not_discard_the_batch(self, tmp_path):
+        _tree(tmp_path, n=2)
+        out = hydrate_live_gaps_for_detectors([{}, _gap(0), {"file": None}], tmp_path)
+        assert [g["name"] for g in out] == ["handle_0"]
+
+    def test_empty_input(self, tmp_path):
+        assert hydrate_live_gaps_for_detectors([], tmp_path) == []
+
+
+class TestSweepMatchesNaiveExtraction:
+    """Differential test of the active-set sweep.
+
+    The sweep exists for speed; correctness must be identical to simply
+    slicing the file. Random span configurations cover the cases that
+    are easy to get wrong by hand: overlapping, nested, duplicate and
+    adjacent spans, spans starting on line 1, spans running past EOF,
+    and files with no trailing newline.
+    """
+
+    @staticmethod
+    def _naive(path, spans):
+        """Reference semantics: slice the file; drop spans past EOF.
+
+        Spans that never reach their declared end line are abandoned
+        rather than returned partially — see
+        ``test_span_past_eof_is_abandoned``.
+        """
+        lines = path.read_text(errors="replace").splitlines(keepends=True)
+        out = {}
+        for s, e in sorted({
+            (int(a), int(b)) for a, b in spans
+            if isinstance(a, int) and not isinstance(a, bool)
+            and isinstance(b, int) and not isinstance(b, bool)
+            and a > 0 and b >= a
+        }):
+            if e > len(lines):
+                continue
+            body = "".join(lines[s - 1:e])
+            if body:
+                out[(s, e)] = body
+        return out
+
+    @pytest.mark.parametrize("seed", range(25))
+    def test_matches_naive(self, tmp_path, seed):
+        import random
+        rng = random.Random(seed)
+        n = rng.randint(1, 60)
+        text = "".join(f"line{i}\n" for i in range(1, n + 1))
+        if seed % 2 and text.endswith("\n"):
+            text = text[:-1]                      # no trailing newline
+        f = tmp_path / "f.py"
+        f.write_text(text)
+
+        spans = [(1, 1), (1, n)]
+        for _ in range(rng.randint(1, 12)):
+            a = rng.randint(1, n + 3)
+            spans.append((a, a + rng.randint(0, n)))   # may run past EOF
+        spans += spans[:2]                              # duplicates
+
+        assert (_read_spans(tmp_path, "f.py", spans) or {}) == self._naive(f, spans)
+
+
+class TestBudgetAccounting:
+    """The retained-byte ceiling must reflect what is actually held."""
+
+    def test_duplicate_spans_are_charged_once(self, tmp_path):
+        """Several gaps can share one span; they share one string.
+
+        Charging per gap would overstate the total and, with enough
+        duplicates, breach the ceiling on paper while nothing extra is
+        retained.
+        """
+        (tmp_path / "src").mkdir()
+        (tmp_path / "src" / "h0.py").write_text(ADHERENT.format(i=0))
+        gaps = [_gap(0, name=f"dup{n}") for n in range(50)]
+        out = hydrate_live_gaps_for_detectors(gaps, tmp_path)
+        assert len(out) == 50
+        bodies = {id(g["source"]) for g in out}
+        assert len(bodies) == 1, "duplicates should share one string object"
+
+    def test_abandoned_span_refunds_its_buffered_bytes(self, tmp_path):
+        """An abandoned body retains nothing, so it must stop charging.
+
+        Without the refund, oversized spans early in a file starve valid
+        later spans in the same file.
+        """
+        big = "z" * 2048 + "\n"
+        (tmp_path / "f.py").write_text(big * 200 + "small\n" * 10)
+        oversized = (1, 200)
+        small = (201, 205)
+        got = _read_spans(
+            tmp_path, "f.py", [oversized, small],
+            budget_bytes=_MAX_HYDRATED_FUNCTION_BYTES + 1024,
+        )
+        assert oversized not in got
+        assert small in got, "later span starved by an abandoned earlier one"
+
+    def test_tight_budget_is_order_deterministic(self, tmp_path):
+        (tmp_path / "f.py").write_text("x = 1\n" * 500)
+        spans = [(1, 50), (10, 60), (20, 70)]
+        runs = {
+            tuple(sorted(_read_spans(tmp_path, "f.py", spans, budget_bytes=200) or {}))
+            for _ in range(8)
+        }
+        assert len(runs) == 1, f"nondeterministic under a tight budget: {runs}"
+
+
+class TestBinaryProbeIsBestEffort:
+    def test_nul_within_probe_window_is_refused(self, tmp_path):
+        (tmp_path / "b.py").write_bytes(b"x\n" * 100 + b"\0" + b"y\n" * 100)
+        assert _read_spans(tmp_path, "b.py", [(1, 2)]) is None
+
+    def test_nul_past_probe_window_is_not_caught(self, tmp_path):
+        """Documents the limitation rather than overclaiming.
+
+        The NUL probe reads the first 8 KiB only. It is a cheap filter,
+        not a guarantee — pinned so the docstring stays honest.
+        """
+        (tmp_path / "b.py").write_bytes(b"x\n" * 8192 + b"\0" * 10)
+        assert _read_spans(tmp_path, "b.py", [(1, 2)]) is not None


### PR DESCRIPTION
Resubmission of patch 3 from #892, narrowed as discussed there and rebuilt against your dead-gap work in 6f0d7ea6. Branched from current `main`.

## The gap

`discover_conventions`, `check_negative_space` and `check_sibling_negative_space` all read `gap["source"]` and skip any gap without it. Gaps are built from the checklist, which carries line spans but no text, so the key was never populated — convention discovery returned empty, and `check_sibling_negative_space` was never called at all, being guarded on `if conventions`. Three detectors wired into the default path have been silent no-ops since they were written.

## Narrowed, as agreed

`gap["source"]` has **seven** readers across `core/audit` — `negative_space`, `orchestrator`, `spec_inference`, `taint_specs`, `iris_specs`, `project_context`, `triage`. Hydrating the shared gap dicts switches on all of them; `triage.py:249` would begin generated-file detection, which changes *which functions get reviewed*, and `spec_inference` would issue extra LLM calls.

So hydration returns **copies** and hands them only to the detectors that need them. The originals are untouched, the other five modules see exactly what they see today, and `write_gaps` needs no knowledge of any of it — which also drops the `source`-stripping the #892 version needed.

## Dead gaps

Excluded before any I/O, via the unified `dead` flag from 6f0d7ea6 — thanks, that interface was exactly the right shape. Worth noting the exclusion has to happen at the input, not just at hydration: `check_sibling_negative_space` reads an unhydrated sibling as *non-adherent*, so leaving dead gaps in but unhydrated would actively manufacture asymmetry findings rather than merely skew the baseline. There's a test asserting dead gaps cost no `_read_spans` call at all.

## The two defects from the #892 review

**`_read_spans` was O(lines × spans).** It tested every requested span against every line — pathological on a large file carrying many functions. Now a sliding active set: spans sorted by start, opened when the stream reaches them, dropped once past their end. Measured on 200k lines × 2000 spans: **0.664s → 0.004s, ~150x, byte-identical output**. There's a scaling test that fails if it regresses to the quadratic form.

**The ceiling wasn't a peak bound.** Bodies for a whole file were built before the caller enforced the running total. Now `budget_bytes` carries the caller's remaining allowance and is charged during accumulation. Three related corrections while I was in there: abandoning a span refunds what it buffered, so oversized spans early in a file can't starve valid later ones; the active set is iterated sorted, so which span survives a tight budget doesn't depend on hash iteration order; and duplicate spans are charged once, matching the single string actually retained.

A span still open at EOF is now abandoned rather than returned partially. For absence detection a truncated body is worse than none — the check we'd report as missing may simply lie in the part we didn't read.

## Two more, only reachable once the detectors run

Both surfaced in review of this patch, and both are pre-existing, but they're in the blast radius of turning these detectors on so they belong here:

- **`check_negative_space` was still getting the raw unhydrated gap** in the review loop (`orchestrator.py`), so discovered conventions never reached the per-function check. Hydrating for `discover_conventions` alone would have delivered half the feature. It now gets a throwaway copy carrying the body already present in `ctx`.
- **Sibling findings were attached back by substring-matching** the function name against the finding's prose `evidence`. That misroutes on duplicate names across files and on prefixes like `handle_user` / `handle_user_admin`. `NegativeSpaceFinding` already carries `file` and `function`, so matching is now on exact identity.

## Testing

73 new tests in `test_gap_hydration.py`, covering the end the change serves (conventions `[]` unhydrated, `['auth']` hydrated — so the assertions aren't vacuous), blast-radius containment, dead-gap exclusion, the bounds, budget accounting, and span correctness **differentially against a naive file-slicing reference** across randomised configurations with overlapping, nested, duplicate and adjacent spans, spans on line 1, spans past EOF, and files with no trailing newline.

Full `core/audit` suite: **3013 passed, 199 skipped, 0 failed**. `ruff --select F401,F811,F821,F841` clean.

## Known limits, pinned by tests rather than claimed away

- The NUL binary probe reads the first 8 KiB only. It's a cheap filter, not a guarantee; there's a test documenting that a NUL past the window isn't caught.
- The convention baseline is drawn from the **budgeted** gap list, so it samples the current work batch rather than the whole project — it shifts with `--budget`, prior coverage and ordering. Defensible for a relative signal, but it isn't "the project's conventions" in the strong sense the module's docstring implies. Worth a follow-up building the corpus from the checklist independently of review budget, if you think it's worth the extra pass.

One thing I did **not** touch, which you may want to look at before these detectors carry weight: peer groups in `sibling_analysis.py` are global by verb, so every `handle_*` in the repo can land in one group. With the detector previously dead that was harmless; now that it runs, unrelated subsystems can be treated as siblings. Happy to take that as a separate change.
