### PR TITLE
feat(dispatcher): add OrcaRouter as a named provider

### DIFF
--- a/core/config/__init__.py
+++ b/core/config/__init__.py
@@ -849,6 +849,7 @@ class RaptorConfig:
         "GROQ_API_KEY",         # aggregator + family stem (batch 067)
         "TOGETHER_API_KEY",     # aggregator
         "OPENROUTER_API_KEY",   # aggregator
+        "ORCAROUTER_API_KEY",   # aggregator
         "FIREWORKS_API_KEY",    # aggregator
         "DEEPINFRA_API_KEY",    # aggregator
         "PERPLEXITY_API_KEY",   # aggregator

--- a/core/llm/dispatcher/auth.py
+++ b/core/llm/dispatcher/auth.py
@@ -245,6 +245,7 @@ class CredentialStore:
             "groq":       _read_env("GROQ_API_KEY"),
             "together":   _read_env("TOGETHER_API_KEY"),
             "openrouter": _read_env("OPENROUTER_API_KEY"),
+            "orcarouter": _read_env("ORCAROUTER_API_KEY"),
             "fireworks":  _read_env("FIREWORKS_API_KEY"),
             "deepinfra":  _read_env("DEEPINFRA_API_KEY"),
             "perplexity": _read_env("PERPLEXITY_API_KEY"),
@@ -1044,6 +1045,15 @@ def build_rules(creds: CredentialStore) -> dict[str, ProviderRule]:
             # is preserved end-to-end through the dispatcher.
             upstream_base_url="https://openrouter.ai",
             inject_headers=_bearer_headers("openrouter"),
+        ),
+        "orcarouter": ProviderRule(
+            name="orcarouter",
+            # OrcaRouter's API is rooted at ``/v1`` (OpenAI-compatible
+            # gateway). The SDK's path component (``/v1/chat/completions``
+            # etc.) is preserved end-to-end through the dispatcher, so the
+            # bare host is the correct upstream — same shape as OpenRouter.
+            upstream_base_url="https://api.orcarouter.ai",
+            inject_headers=_bearer_headers("orcarouter"),
         ),
         "fireworks": ProviderRule(
             name="fireworks",

--- a/core/llm/dispatcher/server.py
+++ b/core/llm/dispatcher/server.py
@@ -632,6 +632,7 @@ _PROVIDER_FROM_PATH_PREFIX = {
     "/groq/":         "groq",
     "/together/":     "together",
     "/openrouter/":   "openrouter",
+    "/orcarouter/":   "orcarouter",
     "/fireworks/":    "fireworks",
     "/deepinfra/":    "deepinfra",
     "/perplexity/":   "perplexity",

--- a/core/llm/dispatcher/tests/test_providers.py
+++ b/core/llm/dispatcher/tests/test_providers.py
@@ -35,6 +35,7 @@ def all_providers_creds():
         "groq":        "gsk-groq-real-NOT-LEAKED",
         "together":    "together-real-NOT-LEAKED",
         "openrouter":  "sk-or-real-NOT-LEAKED",
+        "orcarouter":  "sk-orca-real-NOT-LEAKED",
         "fireworks":   "fw-fireworks-real-NOT-LEAKED",
         "deepinfra":   "deepinfra-real-NOT-LEAKED",
         "perplexity":  "pplx-perplexity-real-NOT-LEAKED",
@@ -256,6 +257,7 @@ _BEARER_PROVIDERS = [
     ("groq",       "openai/v1/chat/completions", "gsk-groq-real-NOT-LEAKED"),
     ("together",   "v1/chat/completions",    "together-real-NOT-LEAKED"),
     ("openrouter", "api/v1/chat/completions", "sk-or-real-NOT-LEAKED"),
+    ("orcarouter", "v1/chat/completions", "sk-orca-real-NOT-LEAKED"),
     ("fireworks",  "inference/v1/chat/completions", "fw-fireworks-real-NOT-LEAKED"),
     ("deepinfra",  "v1/openai/chat/completions", "deepinfra-real-NOT-LEAKED"),
     ("perplexity", "chat/completions",       "pplx-perplexity-real-NOT-LEAKED"),
@@ -392,6 +394,7 @@ class TestNewProvidersUnconfiguredKeyReturns503:
             ("groq",         "/groq/openai/v1/chat/completions"),
             ("together",     "/together/v1/chat/completions"),
             ("openrouter",   "/openrouter/api/v1/chat/completions"),
+            ("orcarouter",   "/orcarouter/v1/chat/completions"),
             ("fireworks",    "/fireworks/inference/v1/chat/completions"),
             ("deepinfra",    "/deepinfra/v1/openai/chat/completions"),
             ("perplexity",   "/perplexity/chat/completions"),
@@ -406,6 +409,7 @@ class TestNewProvidersUnconfiguredKeyReturns503:
         creds._keys = {p: None for p in [
             "anthropic", "openai", "gemini",
             "mistral", "groq", "together", "openrouter",
+            "orcarouter",
             "fireworks", "deepinfra", "perplexity",
             "cohere", "replicate",
             "azure_openai", "azure_openai_endpoint",
@@ -439,6 +443,7 @@ class TestCredentialStoreReadsAggregatorEnvs:
             "GROQ_API_KEY":       "groq-test",
             "TOGETHER_API_KEY":   "together-test",
             "OPENROUTER_API_KEY": "openrouter-test",
+            "ORCAROUTER_API_KEY": "orcarouter-test",
             "FIREWORKS_API_KEY":  "fireworks-test",
             "DEEPINFRA_API_KEY":  "deepinfra-test",
             "PERPLEXITY_API_KEY": "perplexity-test",
@@ -455,6 +460,7 @@ class TestCredentialStoreReadsAggregatorEnvs:
         assert creds.get("groq") == "groq-test"
         assert creds.get("together") == "together-test"
         assert creds.get("openrouter") == "openrouter-test"
+        assert creds.get("orcarouter") == "orcarouter-test"
         assert creds.get("fireworks") == "fireworks-test"
         assert creds.get("deepinfra") == "deepinfra-test"
         assert creds.get("perplexity") == "perplexity-test"

--- a/core/llm/dispatcher/tests/test_seed_from_config.py
+++ b/core/llm/dispatcher/tests/test_seed_from_config.py
@@ -28,6 +28,7 @@ def _make_empty_store() -> CredentialStore:
         "groq": None,
         "together": None,
         "openrouter": None,
+        "orcarouter": None,
         "fireworks": None,
         "deepinfra": None,
         "perplexity": None,

--- a/core/security/llm_family.py
+++ b/core/security/llm_family.py
@@ -69,6 +69,7 @@ _AGGREGATOR_PREFIXES: tuple[str, ...] = (
     "together/",
     "groq/",
     "openrouter/",
+    "orcarouter/",
     "fireworks/",
     "deepinfra/",
     "perplexity/",

--- a/core/security/tests/test_llm_family.py
+++ b/core/security/tests/test_llm_family.py
@@ -27,6 +27,7 @@ def test_bare_model_id_peels_aggregator_then_provider():
     # both peel; the lookup in models.json sees just ``claude-haiku-4-5``.
     assert bare_model_id("together/anthropic/claude-haiku-4-5") == "claude-haiku-4-5"
     assert bare_model_id("openrouter/openai/gpt-5") == "gpt-5"
+    assert bare_model_id("orcarouter/openai/gpt-5") == "gpt-5"
 
 
 def test_bare_model_id_leaves_unknown_prefixes_alone():


### PR DESCRIPTION
## Summary

Adds **[OrcaRouter](https://www.orcarouter.ai)** as a named LLM provider in the dispatcher, mirroring the existing OpenRouter wiring exactly. OrcaRouter is an OpenAI-compatible gateway (base URL `https://api.orcarouter.ai`, API rooted at `/v1`) that fronts a broad model catalog under namespaced IDs (e.g. `openai/gpt-5.5`, `anthropic/claude-sonnet-4.6`).

## What this changes

- `core/llm/dispatcher/auth.py` — new `ProviderRule` for `orcarouter` (`upstream_base_url="https://api.orcarouter.ai"`, Bearer auth via `ORCAROUTER_API_KEY`), plus the credential read in `CredentialStore` (read-and-erased like every other key).
- `core/llm/dispatcher/server.py` — route prefix `/orcarouter/` → `orcarouter`, so an OpenAI SDK pointed at `<dispatcher>/orcarouter/v1` forwards `/v1/chat/completions` etc. to the OrcaRouter upstream.
- `core/config/__init__.py` — `ORCAROUTER_API_KEY` added to the LLM env allowlist.
- `core/security/llm_family.py` — `orcarouter/` treated as an aggregator prefix for model-family detection (cross-family retry safety).
- Tests — provider-injection, unconfigured-503, env read-and-erase, seed-from-config, and family-detection coverage for the new provider (all mirroring the openrouter cases).

## Why a separate provider

The dispatcher already treats OpenAI-compatible aggregators as first-class named providers (OpenRouter, Groq, Together, Fireworks, ...), each with its own key, upstream URL, and path prefix. OrcaRouter is the same shape, so routing it through the generic OpenAI passthrough would silently skip the credential management, env erasure, and audit-path guarantees every other aggregator gets. Keeping it as a named rule preserves those guarantees.

## How to use it

```bash
export ORCAROUTER_API_KEY=sk-orca-...
# point an OpenAI-compatible client at the dispatcher:
# base_url = http://<dispatcher>/orcarouter/v1, model = openai/gpt-5.5
```

## Verification

- `pytest core/llm/dispatcher/tests/test_providers.py core/llm/dispatcher/tests/test_seed_from_config.py core/security/tests/test_llm_family.py` — 63 passed (the dispatcher server-socket cases require `AF_UNIX` and are skipped on this Windows host; they fail identically on `main` without these changes).
- L3 live: `POST https://api.orcarouter.ai/v1/chat/completions` with a real key and `openai/gpt-5.5` → HTTP 200, `content: "ORCA-OK"` — confirming the exact upstream URL the dispatcher constructs (`bare host` + `/v1/chat/completions`).

## Disclosure

I'm an engineer on the OrcaRouter team. OrcaRouter is an API gateway that never inspects or stores prompt/response content in plaintext; credentials are forwarded only to the upstream model provider chosen for the request.
