### PR TITLE
fix(analysis): route the Java finding-resolver read through the containment guard

### DIFF
--- a/core/analysis/finding_resolver.py
+++ b/core/analysis/finding_resolver.py
@@ -886,11 +886,13 @@ def _resolve_from_parsed_java(parsed: _ParsedFinding) -> Resolution:
         find_enclosing_method,
     )
 
-    file_path = Path(parsed.file)
-    try:
-        source_text = file_path.read_text(encoding="utf-8")
-    except (OSError, UnicodeDecodeError) as e:
-        return ResolutionFailure(reason=f"cannot read {parsed.file}: {e}")
+    # Route through the ..-containment guard the Python (_resolve_from_
+    # parsed_python) and C++ (_resolve_from_parsed_cpp) branches already
+    # use; the Java branch previously read the untrusted finding path
+    # directly, skipping the check (00092 residual).
+    source_text = _read_finding_source(parsed.file)
+    if isinstance(source_text, ResolutionFailure):
+        return source_text
 
     fn_name, fn_start = find_enclosing_method(
         source_text, parsed.source_lineno, parsed.sink_lineno,

--- a/core/analysis/tests/test_finding_resolver.py
+++ b/core/analysis/tests/test_finding_resolver.py
@@ -396,6 +396,16 @@ class TestTraversalGuard:
         assert isinstance(result, ResolutionFailure)
         assert "'..'" in result.reason
 
+    def test_dotdot_refused_for_java_branch(self):
+        # 00092 residual: the Java branch read the file directly, skipping
+        # the ..-containment guard the Python and C++ branches route through.
+        finding = _raptor_native("../escape.java", 1, 3, language="java")
+        result = resolve_finding(finding)
+        assert isinstance(result, ResolutionFailure)
+        assert "'..'" in result.reason
+        # Refused by the guard, not by a failed read.
+        assert "cannot read" not in result.reason
+
     def test_sarif_uri_with_dotdot_refused(self):
         result = resolve_finding(_sarif_result("../../x.py", 1, 3))
         assert isinstance(result, ResolutionFailure)


### PR DESCRIPTION
`_resolve_from_parsed_java` read `Path(parsed.file).read_text()` directly, skipping the
`..`-containment guard `_read_finding_source()` that the Python (`_resolve_from_parsed_python`)
and C++ (`_resolve_from_parsed_cpp`) branches already route through. `parsed.file` comes from
externally-produced analyser output (SARIF/Semgrep/native), so an untrusted finding path with a
`..` segment reached the read on the Java branch alone.

Route the Java branch through the same guard. Absolute-path support (deliberate — see the guard
docstring; RAPTOR-native findings carry absolute in-repo paths) is preserved, so callers that
pass an absolute path are unaffected.

Test: `test_dotdot_refused_for_java_branch` (mirrors the existing C++ case) fails pre-fix
(returns "cannot read", i.e. the read was attempted) and passes post-fix (refused on `..`);
`test_absolute_path_still_allowed` still passes. After the change every `read_text` in the
resolver is inside `_read_finding_source`; no unguarded reader remains.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Security-sensitive path handling for untrusted analyser output; the change is a small, existing-guard alignment rather than new auth logic, but it sits on the file-read boundary.
> 
> **Overview**
> Closes a residual path-traversal hole in `_resolve_from_parsed_java`: untrusted finding paths (SARIF/Semgrep/native) were read with `Path.read_text` instead of `_read_finding_source`, so a `..` segment could skip the containment check that Python and C++ already use.
> 
> Java resolution now fails closed on `..` via the same guard. Absolute in-repo paths remain allowed. Adds `test_dotdot_refused_for_java_branch` to assert refusal happens at the guard, not after a failed read.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c8fa49d2040f412a08bf9ce5b0f49068a2c4914. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->