### PR TITLE
fix(dataflow): apply the rebind-KILL to the non-Python value-reach in the charset prescreen

### DIFF
--- a/core/dataflow/injection_prescreen.py
+++ b/core/dataflow/injection_prescreen.py
@@ -56,6 +56,7 @@ from core.dataflow.smt_barrier import (
     ValidatorSpec,
     _crosses_function_boundary,
     _python_chain_reaches_sink,
+    _lexical_var_reaches_sink,
     extract_validator_from_line,
     extractor_languages,
     prove_neutralizes,
@@ -327,9 +328,10 @@ def _step_refutes_path(
             tree, spec.var_name, step_line, sink_line, sink_line_text,
         )
     else:
-        var_reaches = bool(_re.search(
-            rf"\b{_re.escape(spec.var_name)}\b", sink_line_text,
-        ))
+        var_reaches = _lexical_var_reaches_sink(
+            spec.var_name, source_text, step_line, sink_line,
+            sink_line_text,
+        )
     if not var_reaches:
         return False, (
             f"validated variable {spec.var_name!r} not in the sink's "

--- a/core/dataflow/smt_barrier.py
+++ b/core/dataflow/smt_barrier.py
@@ -1297,6 +1297,42 @@ def _python_chain_reaches_sink(
     return False
 
 
+def _lexical_var_reaches_sink(
+    var: str, source_text: str, validator_line: int,
+    sink_line: int, sink_line_text: str,
+) -> bool:
+    """AST-free analogue of ``_python_chain_reaches_sink``'s rebind-KILL,
+    for languages without a parsed tree (JS/TS/Java).
+
+    Returns ``True`` iff ``var`` appears at the sink line AND is not
+    rebound between the validator and the sink. Previously the non-Python
+    path was a bare ``\\bvar\\b`` match at the sink with NO rebind-KILL
+    (a204f309): ``x = validate(raw); x = req.query.evil; sink(x)`` left
+    ``x`` "validated" at the sink and the charset prescreen suppressed a
+    live flow. A reassignment ``var = <expr not referencing var>`` between
+    validator and sink rebinds it to a value the validator never
+    constrained, so it must KILL the reach.
+
+    Conservative by design: it detects reassignments lexically and errs
+    toward KILL (declining the suppression → the finding falls through to
+    LLM validation), which is the sound direction for a false-negative
+    fix. Member/index writes (``var.f = …``, ``var[i] = …``) and
+    comparisons (``==``/``!=``/``<=``/``>=``) do not count as rebinds.
+    """
+    if not _re.search(rf"\b{_re.escape(var)}\b", sink_line_text):
+        return False
+    lines = source_text.splitlines()
+    assign_re = _re.compile(rf"\b{_re.escape(var)}\b\s*=(?!=)")
+    self_re = _re.compile(rf"\b{_re.escape(var)}\b")
+    for lineno in range(validator_line + 1, sink_line):
+        if 1 <= lineno <= len(lines):
+            text = lines[lineno - 1]
+            m = assign_re.search(text)
+            if m and not self_re.search(text[m.end():]):
+                return False  # rebind from a non-self RHS -> KILL
+    return True
+
+
 def substitution_dominates_sink(
     source_text: str,
     validator_line: int,
@@ -1699,9 +1735,9 @@ def try_tier0(
                 chain_tree, spec.var_name, line, sink_line, sink_line_text,
             )
     else:
-        var_reaches = bool(_re.search(
-            rf"\b{_re.escape(spec.var_name)}\b", sink_line_text,
-        ))
+        var_reaches = _lexical_var_reaches_sink(
+            spec.var_name, source_text, line, sink_line, sink_line_text,
+        )
     if not var_reaches:
         return Tier0Result(
             Tier0Status.NOT_APPLICABLE,

--- a/core/dataflow/tests/test_injection_prescreen.py
+++ b/core/dataflow/tests/test_injection_prescreen.py
@@ -17,6 +17,7 @@ import pytest
 pytest.importorskip("z3")
 
 from core.dataflow import injection_prescreen as ip
+from core.dataflow.smt_barrier import ValidatorSpec
 from core.dataflow.injection_prescreen import (
     PrescreenVerdict,
     prescreen_finding,
@@ -414,3 +415,48 @@ class TestGatesAndTelemetry:
         after_miss = snapshot_stats()
         assert after_miss["no_signal"] == after_refute["no_signal"] + 1
         assert after_miss["refuted"] == after_refute["refuted"]
+
+
+class TestNonPythonRebindKill:
+    """a204f309: the non-Python value-reach must apply the rebind-KILL, so
+    a charset guard whose variable is re-tainted after the guard does NOT
+    suppress a live JS/TS/Java finding."""
+
+    _SPEC = ValidatorSpec(
+        kind="charset", var_name="p", charset="A-Za-z0-9",
+        source_line="+  p = p.replace(/[^A-Za-z0-9]/g, '')", forbidden=0,
+    )
+
+    def _refute(self, src, step_line, sink_line):
+        return ip._step_refutes_path(
+            spec=self._SPEC, step_file="app.js", step_line=step_line,
+            sink_file="app.js", sink_line=sink_line, source_text=src,
+            language="javascript", sink_classes=frozenset({"pathtrav"}),
+        )
+
+    def test_no_rebind_still_refutes(self):
+        # legitimate guard, value flows straight to the sink -> suppressed
+        src = (
+            "function h(req){\n"
+            "  let p = req.query.name;\n"
+            "  p = p.replace(/[^A-Za-z0-9]/g, '');\n"   # 3 validator
+            "  fs.readFile('/data/'+p);\n"              # 4 sink
+            "}\n"
+        )
+        refuted, _reason, _conf = self._refute(src, 3, 4)
+        assert refuted is True
+
+    def test_rebind_to_attacker_data_does_not_refute(self):
+        # p re-tainted after the guard -> the charset proof is stale -> the
+        # finding must fall through to LLM validation, not be suppressed.
+        src = (
+            "function h(req){\n"
+            "  let p = req.query.name;\n"
+            "  p = p.replace(/[^A-Za-z0-9]/g, '');\n"   # 3 validator
+            "  p = req.query.evil;\n"                   # 4 rebind
+            "  fs.readFile('/data/'+p);\n"              # 5 sink
+            "}\n"
+        )
+        refuted, reason, _conf = self._refute(src, 3, 5)
+        assert refuted is False
+        assert "value chain" in reason

--- a/core/dataflow/tests/test_lexical_var_reaches_sink.py
+++ b/core/dataflow/tests/test_lexical_var_reaches_sink.py
@@ -1,0 +1,85 @@
+"""Unit tests for _lexical_var_reaches_sink (a204f309 rebind-KILL).
+
+The non-Python value-reach in the charset prescreen / SMT tier-0 path used
+a bare `\\bvar\\b` match at the sink with no rebind-KILL, so a decoy
+charset guard on a variable that was later re-tainted still suppressed a
+live JS/TS/Java finding. This helper mirrors the Python AST rebind-KILL
+lexically.
+"""
+from __future__ import annotations
+
+from core.dataflow.smt_barrier import _lexical_var_reaches_sink
+
+
+def _reaches(src, var, validator_line, sink_line):
+    lines = src.splitlines()
+    sink_text = lines[sink_line - 1]
+    return _lexical_var_reaches_sink(var, src, validator_line, sink_line, sink_text)
+
+
+def test_no_rebind_reaches():
+    # validated value flows straight to the sink -> still a valid guard
+    src = (
+        "function h(req){\n"          # 1
+        "  let p = validate(req.q);\n"  # 2 validator
+        "  exec(p);\n"                  # 3 sink
+        "}\n"
+    )
+    assert _reaches(src, "p", 2, 3) is True
+
+
+def test_rebind_from_nonself_rhs_kills():
+    # a204f309: p is re-tainted after the guard -> must NOT reach validated
+    src = (
+        "function h(req){\n"          # 1
+        "  let p = validate(req.q);\n"  # 2 validator
+        "  p = req.query.evil;\n"       # 3 rebind from attacker data
+        "  exec(p);\n"                  # 4 sink
+        "}\n"
+    )
+    assert _reaches(src, "p", 2, 4) is False
+
+
+def test_self_referencing_rebind_does_not_kill():
+    # p = p + '/' keeps p's validated constraint tie -> not a KILL
+    src = (
+        "function h(req){\n"
+        "  let p = validate(req.q);\n"  # 2
+        "  p = p + '/x';\n"             # 3 self-referencing
+        "  exec(p);\n"                  # 4
+        "}\n"
+    )
+    assert _reaches(src, "p", 2, 4) is True
+
+
+def test_member_and_index_writes_are_not_rebinds():
+    src = (
+        "function h(req){\n"
+        "  let p = validate(req.q);\n"  # 2
+        "  p.field = req.query.evil;\n"  # 3 member write, p still validated
+        "  p[0] = 9;\n"                  # 4 index write
+        "  exec(p);\n"                   # 5
+        "}\n"
+    )
+    assert _reaches(src, "p", 2, 5) is True
+
+
+def test_comparison_is_not_a_rebind():
+    src = (
+        "function h(req){\n"
+        "  let p = validate(req.q);\n"  # 2
+        "  if (p == 'x') {}\n"          # 3 comparison, not assignment
+        "  exec(p);\n"                  # 4
+        "}\n"
+    )
+    assert _reaches(src, "p", 2, 4) is True
+
+
+def test_absent_at_sink_does_not_reach():
+    src = (
+        "function h(req){\n"
+        "  let p = validate(req.q);\n"  # 2
+        "  exec(other);\n"              # 3 sink uses a different var
+        "}\n"
+    )
+    assert _reaches(src, "p", 2, 3) is False

--- a/core/dataflow/tier1_llm.py
+++ b/core/dataflow/tier1_llm.py
@@ -54,6 +54,7 @@ from core.dataflow.smt_barrier import (
     _crosses_function_boundary,
     _function_containing,
     _python_chain_reaches_sink,
+    _lexical_var_reaches_sink,
     _same_function_in_order,
     prove_neutralizes,
     substitution_dominates_sink,
@@ -375,9 +376,10 @@ def _try_known_safe_call(
             tree, spec.variable_name, validator_line, sink_line, sink_line_text,
         )
     elif spec.variable_name:
-        chain_ok = bool(_re.search(
-            rf"\b{_re.escape(spec.variable_name)}\b", sink_line_text,
-        ))
+        chain_ok = _lexical_var_reaches_sink(
+            spec.variable_name, source_text, validator_line, sink_line,
+            sink_line_text,
+        )
     else:
         chain_ok = False
     if not chain_ok:
@@ -526,9 +528,10 @@ def try_tier1b(
                 tree, mech.var_name, validator_line, sink_line, sink_line_text,
             )
         else:
-            chain_ok = bool(_re.search(
-                rf"\b{_re.escape(mech.var_name)}\b", sink_line_text,
-            ))
+            chain_ok = _lexical_var_reaches_sink(
+                mech.var_name, source_text, validator_line, sink_line,
+                sink_line_text,
+            )
         if not chain_ok:
             return Tier0Result(
                 Tier0Status.NOT_APPLICABLE,


### PR DESCRIPTION
The Python value-reach uses `_python_chain_reaches_sink`, whose rebind-KILL drops a variable
reassigned from a non-chain RHS between validator and sink. The non-Python (JS/TS/Java) path was
a bare `\bvar\b` match at the sink line with NO rebind-KILL, so
`p = validate(raw); p = req.query.evil; sink(p)` left `p` "validated" and the zero-LLM charset
prescreen UNSAT-proof suppressed a live flow (induced false-negative: a real CWE-22/78/79/89
finding demoted to `is_exploitable=False`, skipping LLM validation).

Add a shared lexical helper `_lexical_var_reaches_sink` (beside `_python_chain_reaches_sink`)
that keeps the reach check but KILLs it when the var is rebound in the validator->sink window;
member/index writes (`p.f = ...`, `p[i] = ...`) and comparisons (`==`/`!=`/`<=`/`>=`) are not
rebinds. Conservative by design: it errs toward KILL, which only DECLINES a suppression (the
finding falls through to LLM validation) — the sound direction for a false-negative fix. Wire
all four non-Python fallback sites: `injection_prescreen`, `smt_barrier`, and two in `tier1_llm`.

Tests: unit tests for the helper (rebind kills, self-referencing rebind and member/index/compare
do not, absent-at-sink does not) + an integration test through `_step_refutes_path` (a JS decoy
charset guard + rebind was `refuted=True` pre-fix, `refuted=False` post-fix; a legit no-rebind
guard still refutes). Full dataflow suite passes; no bare `\bvar\b` fallback remains.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches security-critical sanitizer/prescreen logic that can demote real CWE-22/78/79/89 findings. The change is small and conservative (errs toward not suppressing), but a bug in the lexical rebind heuristic could still over- or under-kill reach.
> 
> **Overview**
> Stops a **false-negative suppression** of live JS/TS/Java injection findings: a charset guard on a variable that was later re-tainted (`p = validate(raw); p = req.query.evil; sink(p)`) used to still count as validated because the non-Python path only checked that the name appeared at the sink.
> 
> Adds `_lexical_var_reaches_sink` as an AST-free analogue of Python’s rebind-KILL. Reach is killed on `var = <expr that does not mention var>` between validator and sink; member/index writes and comparisons are not rebinds. Conservative: a kill only declines suppression so the finding falls through to LLM validation.
> 
> Wired at all four non-Python fallbacks (`injection_prescreen`, `smt_barrier` Tier 0, two `tier1_llm` chain checks). Tests cover helper cases plus a JS `_step_refutes_path` integration that no longer refutes after re-taint.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b044b0788b00129114cce52a40aa067f1716a39. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->