### PR TITLE
fix(sandbox): fail closed on the degraded egress tier for untrusted-code callers

### DIFF
--- a/core/sandbox/context.py
+++ b/core/sandbox/context.py
@@ -450,6 +450,7 @@ def sandbox(block_network=_UNSET, target: str | None = None, output: str | None 
             degraded_net_deny: bool = True,
             loopback_unix_bridges: dict | None = None,
             omit_proc_reads: bool = False,
+            require_proxy_netns: bool = False,
             rootfs: str | None = None):
     """Context manager for sandboxed subprocess execution.
 
@@ -950,6 +951,42 @@ def sandbox(block_network=_UNSET, target: str | None = None, output: str | None 
                 "ABI %d < 4 (no TCP allowlist) — egress proxy "
                 "allowlist is advisory only on this host.",
                 _proxy_abi,
+            )
+
+        # 00015: fail closed when an untrusted-egress caller requires
+        # the netns tier but only the port-scoped Landlock tier is
+        # available. On a Linux net-yes/mount-no host the child would
+        # silently degrade to a Landlock port pin, where a direct
+        # connect() on the proxy port reaches ANY host (the hostname
+        # allowlist is bypassed). Refuse unless the operator explicitly
+        # accepts the weaker tier.
+        #
+        # Scoped to non-darwin: this is the Linux Landlock Tier-2 gap.
+        # macOS uses a different enforcement path (seatbelt SBPL, which
+        # can express address-scoped loopback egress) where _use_proxy_netns
+        # is always False, so an unscoped guard would wrongly refuse every
+        # macOS untrusted-egress caller. macOS egress scoping is out of
+        # this finding's scope and unchanged here.
+        _degraded_ok = os.environ.get(
+            'RAPTOR_ALLOW_DEGRADED_UNTRUSTED', '',
+        ).strip().lower() in ('1', 'true', 'yes', 'on')
+        if (
+            sys.platform != 'darwin'
+            and use_egress_proxy
+            and require_proxy_netns
+            and not _use_proxy_netns
+            and not _degraded_ok
+        ):
+            from .errors import SandboxSetupError
+            raise SandboxSetupError(
+                'use_egress_proxy with require_proxy_netns=True needs the '
+                'netns egress tier, but it is unavailable on this host '
+                '(mount-ns / user-ns capability missing). The port-scoped '
+                'Landlock fallback does not enforce the hostname allowlist '
+                '(a direct connect on the proxy port reaches any host). '
+                'Install uidmap / enable unprivileged user namespaces to '
+                'restore the netns tier, or set '
+                'RAPTOR_ALLOW_DEGRADED_UNTRUSTED=1 to accept the weaker tier.'
             )
 
         if _use_proxy_netns:
@@ -3634,6 +3671,7 @@ def run(cmd: list[str], block_network: bool = True, target: str | None = None,
         profile: str | None = None, disabled: bool = False, limits: dict | None = None,
         map_root: bool = False,
         use_egress_proxy: bool = False, proxy_hosts: list | None = None,
+        require_proxy_netns: bool = False,
         restrict_reads=_UNSET, readable_paths: list | None = None,
         caller_label: str | None = None,
         fake_home=_UNSET,
@@ -3667,6 +3705,7 @@ def run(cmd: list[str], block_network: bool = True, target: str | None = None,
                  disabled=disabled, limits=limits, map_root=map_root,
                  use_egress_proxy=use_egress_proxy,
                  proxy_hosts=proxy_hosts,
+                 require_proxy_netns=require_proxy_netns,
                  restrict_reads=restrict_reads,
                  readable_paths=readable_paths,
                  caller_label=caller_label,
@@ -4073,6 +4112,7 @@ def run_untrusted_networked(
         writable_paths=writable_paths,
         fake_home=fake_home,
         use_egress_proxy=True,
+        require_proxy_netns=True,
         proxy_hosts=list(proxy_hosts),
         allowed_tcp_ports=[443],
         omit_proc_reads=_degraded_no_pidns,

--- a/core/sandbox/tests/test_proxy_netns_enforcement.py
+++ b/core/sandbox/tests/test_proxy_netns_enforcement.py
@@ -514,6 +514,87 @@ class TestProxyNetnsContextWiring:
         assert (self._enforcement_with(abi=3, net=True, mount=False)
                 == "landlock_tcp")
 
+    def _egress_with(self, *, abi, net, mount, require_proxy_netns):
+        """Like _enforcement_with but lets the caller set
+        require_proxy_netns; returns the chosen proxy_enforcement."""
+        from core.sandbox import sandbox
+        with mock.patch(
+            "core.sandbox.context._get_landlock_abi", return_value=abi,
+        ), mock.patch(
+            "core.sandbox.context.check_landlock_available", return_value=True,
+        ), mock.patch(
+            "core.sandbox.context.check_net_available", return_value=net,
+        ), mock.patch(
+            "core.sandbox.context.check_mount_available", return_value=mount,
+        ), sandbox(
+            target=self.out, output=self.out, use_egress_proxy=True,
+            proxy_hosts=["example.com"], require_proxy_netns=require_proxy_netns,
+        ) as run:
+            result = run(["echo", "x"], capture_output=True, text=True, timeout=15)
+            return result.sandbox_info.get("proxy_enforcement")
+
+    def _enter_egress(self, *, platform, net, mount, require, env=None, monkeypatch=None):
+        """Enter sandbox() with the probe/platform surface pinned and exit
+        WITHOUT running a child — exercises the 00015 setup-time guard,
+        which fires (or not) at __enter__ before any child executes."""
+        import core.sandbox.context as ctx
+        from core.sandbox import sandbox
+        if env and monkeypatch:
+            monkeypatch.setenv("RAPTOR_ALLOW_DEGRADED_UNTRUSTED", env)
+        with mock.patch.object(ctx.sys, "platform", platform), mock.patch(
+            "core.sandbox.context._get_landlock_abi", return_value=4,
+        ), mock.patch(
+            "core.sandbox.context.check_landlock_available", return_value=True,
+        ), mock.patch(
+            "core.sandbox.context.check_net_available", return_value=net,
+        ), mock.patch(
+            "core.sandbox.context.check_mount_available", return_value=mount,
+        ):
+            with sandbox(
+                target=self.out, output=self.out, use_egress_proxy=True,
+                proxy_hosts=["example.com"], require_proxy_netns=require,
+            ):
+                pass
+
+    @pytest.mark.usefixtures("_fresh_tier2_latch")
+    def test_require_proxy_netns_fails_closed_on_linux_degraded(self):
+        """00015: on a Linux net-yes/mount-no host, an untrusted-egress
+        caller requiring the netns tier is REFUSED (not silently port-pinned)."""
+        from core.sandbox.errors import SandboxSetupError
+        with pytest.raises(SandboxSetupError, match="netns egress tier"):
+            self._enter_egress(platform="linux", net=True, mount=False, require=True)
+
+    @pytest.mark.usefixtures("_fresh_tier2_latch")
+    def test_require_proxy_netns_override_bypasses_guard_on_linux(self, monkeypatch):
+        """The operator override lets the degraded tier through explicitly
+        (the setup-time guard does not fire)."""
+        # No SandboxSetupError('netns egress tier') should be raised.
+        self._enter_egress(platform="linux", net=True, mount=False, require=True,
+                           env="1", monkeypatch=monkeypatch)
+
+    @pytest.mark.usefixtures("_fresh_tier2_latch")
+    def test_require_proxy_netns_falsey_override_keeps_guard(self, monkeypatch):
+        """A falsey override value (0/false/off) must NOT bypass the guard —
+        the guard uses strict truthiness, matching _require_userns_or_optin."""
+        from core.sandbox.errors import SandboxSetupError
+        for val in ("0", "false", "off", "no", ""):
+            with pytest.raises(SandboxSetupError, match="netns egress tier"):
+                self._enter_egress(platform="linux", net=True, mount=False,
+                                   require=True, env=val, monkeypatch=monkeypatch)
+
+    @pytest.mark.usefixtures("_fresh_tier2_latch")
+    def test_require_proxy_netns_not_enforced_on_darwin(self):
+        """Regression (macOS blocker): macOS uses seatbelt (a different
+        enforcement path) where _use_proxy_netns is always False; the guard
+        must NOT fire there, or every macOS untrusted-egress caller breaks."""
+        # net/mount irrelevant on darwin; the guard is scoped out entirely.
+        self._enter_egress(platform="darwin", net=True, mount=False, require=True)
+
+    @pytest.mark.usefixtures("_fresh_tier2_latch")
+    def test_require_proxy_netns_flag_off_does_not_fire_on_linux(self):
+        """Without the flag (trusted egress callers), the guard never fires."""
+        self._enter_egress(platform="linux", net=True, mount=False, require=False)
+
     def test_tcp_path_when_netns_unavailable(self):
         """Without netns capability, ABI >= 4 falls back to the
         Landlock TCP pin tier — the pre-generalisation posture."""

--- a/packages/sca/agent.py
+++ b/packages/sca/agent.py
@@ -152,6 +152,7 @@ def run_sca_subprocess(
         result = sandbox_run(
             cmd,
             use_egress_proxy=True,
+            require_proxy_netns=True,  # 00015
             proxy_hosts=_compose_proxy_hosts(target),
             caller_label="sca-agent",
             target=str(target),
@@ -291,6 +292,7 @@ def _run_sandboxed(
         output=str(output_dir),
         profile=profile,
         use_egress_proxy=True,
+        require_proxy_netns=True,  # 00015
         proxy_hosts=_compose_proxy_hosts(target),
         caller_label="sca-agent",
         audit=audit,

--- a/packages/sca/resolvers/__init__.py
+++ b/packages/sca/resolvers/__init__.py
@@ -274,6 +274,7 @@ def _run(
             sandbox_kwargs["block_network"] = True
         else:
             sandbox_kwargs["use_egress_proxy"] = True
+            sandbox_kwargs["require_proxy_netns"] = True  # 00015: untrusted egress must use the netns tier
             sandbox_kwargs["proxy_hosts"] = list(proxy_hosts)
 
         return sandbox_run(cmd, **sandbox_kwargs)


### PR DESCRIPTION
On a Linux net-yes / mount-no host the egress-proxy admission (`_require_userns_or_optin`) checks
only `check_net_available()`, never `check_mount_available()`, while the tier selector additionally
requires mount-ns. So an untrusted networked child silently degrades to the port-scoped Landlock
tier (`allowed_tcp_ports=[proxy port]`, no address dimension), where a direct `connect()` on the
proxy port reaches ANY host — the hostname allowlist is bypassed and seccomp does not block TCP
connect.

Add `require_proxy_netns` to `sandbox()`/`run()`: an untrusted-code caller that sets it is refused
(`SandboxSetupError`) when the netns tier is unavailable, unless the operator sets
`RAPTOR_ALLOW_DEGRADED_UNTRUSTED` (strict truthiness: `1/true/yes/on`; `0/false/off` keep the guard
active). Gated at the single egress-proxy chokepoint — NOT in the shared admission helper, which
`run_untrusted` also uses with no proxy (patching it there would regress the non-networked path).
Scoped to non-darwin: macOS uses a different enforcement path (seatbelt SBPL emits address-scoped
`localhost:PROXY_PORT`), where `_use_proxy_netns` is structurally False, so an unscoped guard would
wrongly refuse every macOS caller.

Flag set at the untrusted-code-execution entries that run the target's own package managers /
sandboxed children: `run_untrusted_networked`, `packages/sca/agent` (2 sites),
`packages/sca/resolvers`. Trusted egress callers and `run_untrusted` (non-networked) are unaffected
(default `require_proxy_netns=False`).

SCOPE NOTE FOR REVIEWERS: `core/build/build_detector.py` and `packages/codeql/query_runner.py` also
run with `use_egress_proxy=True` but invoke RAPTOR's OWN trusted binaries (the `claude` CLI /
`codeql`) over untrusted target content — a different threat class. They are deliberately NOT
flagged here: extending fail-closed to them would hard-fail build-detection / pack resolution on
degraded hosts, a product decision left to the maintainer.

BEHAVIOR CHANGE: on a Linux net-yes/mount-no host, untrusted-code egress that previously ran on
the weaker Landlock port-pin now hard-fails with `SandboxSetupError` until uidmap/userns is
enabled or `RAPTOR_ALLOW_DEGRADED_UNTRUSTED=1` is set. This is the intended fail-closed direction;
flagged as a product decision for the maintainer.

Tests: the fail-closed raise on Linux-degraded (via mocked platform/probes at context entry),
the strict-truthiness override, darwin non-enforcement (the earlier macOS-blocker regression
guard), and flag-off. Enforcement suite + broad sandbox sweep pass.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes sandbox network isolation for untrusted code: fail-closed vs a hostname-allowlist bypass. Behavior change on degraded Linux hosts (hard fail unless operator opt-in).
> 
> **Overview**
> Untrusted egress no longer silently falls back to Landlock port-pinning on Linux hosts that have net-ns but not mount-ns. That weaker tier lets a child `connect()` the proxy port to **any** host, bypassing the hostname allowlist.
> 
> `sandbox()` / `run()` gain `require_proxy_netns`. When set and the netns proxy tier is unavailable, setup raises `SandboxSetupError` unless `RAPTOR_ALLOW_DEGRADED_UNTRUSTED` is truthy (`1`/`true`/`yes`/`on`). The guard is Linux-only so macOS seatbelt callers are not refused.
> 
> The flag is enabled at untrusted networked entries: `run_untrusted_networked`, SCA agent, and SCA resolvers. Trusted egress (build detector, CodeQL) is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f468343adc314c71b0aeb7142c044fad52d3cb81. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->