### PR TITLE
Bunch of bug fixes

### DIFF
--- a/core/audit/tests/test_agentic_audit_postpass.py
+++ b/core/audit/tests/test_agentic_audit_postpass.py
@@ -21,6 +21,7 @@ from raptor_agentic import (
     _audit_run_status,
     _build_audit_postpass_cmd,
     _discover_codeql_dbs,
+    _workflow_cost_summary,
     run_audit_postpass,
 )
 
@@ -236,6 +237,25 @@ class TestRunAuditPostpass:
         assert tail["deferred"] == ["validate", "feedback"]
         assert tail["parent_run"] == str(out_dir)
 
+    def test_success_reads_completeness_and_reconciled_cost(
+        self, tmp_path, _postpass_env,
+    ):
+        audit_dir, _calls, _fails = _postpass_env
+        save_json(audit_dir / "audit-report.json", {
+            "stats": {},
+            "completeness": {"partial": True, "run_status": "completed"},
+        })
+        save_json(audit_dir / "cost-breakdown.json", {
+            "totals": {"total_spend_usd": 69.1884},
+        })
+        out_dir = tmp_path / "agentic_out"
+        out_dir.mkdir()
+
+        phase = run_audit_postpass(_args(), tmp_path / "target", out_dir)
+
+        assert phase["partial"] is True
+        assert phase["cost_usd"] == 69.1884
+
     def test_failure_backstops_lifecycle(self, tmp_path, _postpass_env):
         audit_dir, calls, fails = _postpass_env
         calls["rc"] = 2
@@ -283,6 +303,33 @@ class TestRunAuditPostpass:
         phase = run_audit_postpass(_args(), tmp_path, tmp_path)
         assert phase["completed"] is False
         assert phase["skipped_reason"] == "lifecycle start failed"
+
+
+class TestWorkflowCostSummary:
+    def test_combines_analysis_passes_and_audit(self):
+        class PassResult:
+            def __init__(self, cost):
+                self.cost_usd = cost
+
+        summary = _workflow_cost_summary(
+            {"orchestration": {"cost": {
+                "total_cost": 17.24,
+                "thinking_tokens": 123,
+                "cost_by_model": {"model-a": 17.24},
+            }}},
+            {"cost_usd": 69.1884},
+            PassResult(2.0),
+            PassResult(3.0),
+        )
+
+        assert summary["total_cost"] == 91.4284
+        assert summary["cost_by_phase"] == {
+            "analysis": 17.24,
+            "understand": 2.0,
+            "validate": 3.0,
+            "audit": 69.1884,
+        }
+        assert summary["thinking_tokens"] == 123
 
 
 class TestReportSection:

--- a/core/llm/providers.py
+++ b/core/llm/providers.py
@@ -1153,7 +1153,13 @@ def _normalize_schema(schema: dict[str, Any]) -> dict[str, Any]:
     Returns the schema unchanged if already in JSON Schema format.
     """
     if "properties" in schema:
-        return schema  # Already JSON Schema
+        # ``properties`` without a top-level object type is valid JSON
+        # Schema, but Claude Code validates with AJV strictTypes and rejects
+        # it. Preserve complete schemas unchanged and complete this common
+        # partial form at the provider-independent normalization boundary.
+        if "type" in schema:
+            return schema
+        return {"type": "object", **schema}
 
     type_aliases = {
         "bool": "boolean", "str": "string", "int": "integer",
@@ -1204,7 +1210,11 @@ def _normalize_schema(schema: dict[str, Any]) -> dict[str, Any]:
         desc_lower = str(field_desc).lower()
         if "optional" not in desc_lower and "or null" not in desc_lower:
             required.append(field_name)
-    return {"properties": properties, "required": required}
+    return {
+        "type": "object",
+        "properties": properties,
+        "required": required,
+    }
 
 
 def _schema_to_gemini(schema: dict[str, Any]) -> dict[str, Any]:
@@ -4262,12 +4272,19 @@ class ClaudeCodeLLMProvider(LLMProvider):
         # converts into a `--system-prompt-file` flag).
         call_timeout = self._effective_timeout_s(kwargs.pop("timeout_s", None))
 
+        # Consumers may use RAPTOR's compact schema form, for example
+        # {"reasoning": "string", "verdict": "string"}.  Claude Code's
+        # --json-schema flag accepts JSON Schema only, so normalise before
+        # crossing the subprocess boundary.  Other native structured-output
+        # providers already do this at their respective boundaries.
+        normalized_schema = _normalize_schema(schema)
+
         cc_config = CCDispatchConfig(
             claude_bin=self._claude_bin,
             tools="",                                # see generate() comment
             budget_usd=self._budget_usd,
             timeout_s=call_timeout,
-            json_schema=schema,
+            json_schema=normalized_schema,
             capture_json_envelope=False,
             stream_json=True,
             system_prompt=system_prompt,

--- a/core/llm/tests/test_cc_adapter.py
+++ b/core/llm/tests/test_cc_adapter.py
@@ -66,7 +66,6 @@ class TestBuildCCCommand:
         idx = cmd.index("--json-schema")
         assert json.loads(cmd[idx + 1]) == schema
 
-
 class TestSystemPromptArgvHygiene:
     """System prompts must never ride argv in-repo: argv is
     world-readable via /proc/<pid>/cmdline on multi-user hosts, and

--- a/core/llm/tests/test_claude_code_llm_provider.py
+++ b/core/llm/tests/test_claude_code_llm_provider.py
@@ -430,6 +430,34 @@ def test_generate_structured_passes_schema_to_subprocess(monkeypatch) -> None:
     assert json.loads(raw)["answer"] == 42
 
 
+def test_generate_structured_normalizes_compact_schema(monkeypatch) -> None:
+    import core.llm.cc_adapter as _cc_adapter
+    captured: dict[str, Any] = {}
+
+    def fake_stream(cmd, prompt, *, env, timeout_s):
+        captured["cmd"] = cmd
+        return _stream_result({"reasoning": "direct data flow"})
+
+    monkeypatch.setattr(_cc_adapter, "run_cc_streaming", fake_stream)
+    p = ClaudeCodeLLMProvider(_config())
+    result, _raw = p.generate_structured(
+        "analyse", {"reasoning": "string - evidence-based explanation"},
+    )
+
+    schema_idx = captured["cmd"].index("--json-schema") + 1
+    assert json.loads(captured["cmd"][schema_idx]) == {
+        "type": "object",
+        "properties": {
+            "reasoning": {
+                "type": "string",
+                "description": "evidence-based explanation",
+            },
+        },
+        "required": ["reasoning"],
+    }
+    assert result == {"reasoning": "direct data flow"}
+
+
 def test_generate_structured_prefers_structured_output(monkeypatch) -> None:
     """CLI >= 2.1.x delivers --json-schema output via a StructuredOutput
     tool call: assistant text is empty, the object arrives on the result

--- a/core/orchestration/agentic_passes.py
+++ b/core/orchestration/agentic_passes.py
@@ -90,6 +90,7 @@ class PrepassResult:
     context_map_path: Path | None = None
     checklist_enriched: bool = False          # priority markers written to agentic checklist?
     duration_s: float = 0.0
+    cost_usd: float = 0.0
 
 
 @dataclass
@@ -101,6 +102,7 @@ class PostpassResult:
     validate_dir: Path | None = None
     report_path: Path | None = None
     duration_s: float = 0.0
+    cost_usd: float = 0.0
 
 
 @dataclass
@@ -201,7 +203,8 @@ def _run_understand_prepass_unsafe(
         return PrepassResult(ran=False,
                              skipped_reason=dispatch.skipped_reason,
                              understand_dir=dispatch.run_dir,
-                             duration_s=dispatch.duration_s)
+                             duration_s=dispatch.duration_s,
+                             cost_usd=dispatch.cost_usd)
 
     context_map = dispatch.run_dir / "context-map.json"
 
@@ -226,6 +229,7 @@ def _run_understand_prepass_unsafe(
         context_map_path=context_map,
         checklist_enriched=enriched,
         duration_s=dispatch.duration_s,
+        cost_usd=dispatch.cost_usd,
     )
 
 
@@ -401,14 +405,16 @@ def _run_validate_postpass_unsafe(
                               selected_count=len(selected) + len(audit_selected),
                               validate_dir=dispatch.run_dir,
                               skipped_reason=dispatch.skipped_reason,
-                              duration_s=dispatch.duration_s)
+                              duration_s=dispatch.duration_s,
+                              cost_usd=dispatch.cost_usd)
 
     report_path = dispatch.run_dir / "validation-report.md"
     return PostpassResult(ran=True,
                           selected_count=len(selected) + len(audit_selected),
                           validate_dir=dispatch.run_dir,
                           report_path=report_path if report_path.exists() else None,
-                          duration_s=dispatch.duration_s)
+                          duration_s=dispatch.duration_s,
+                          cost_usd=dispatch.cost_usd)
 
 
 def _provision_understand_checklist(target: Path, agentic_out_dir: Path,

--- a/core/orchestration/agentic_passes.py
+++ b/core/orchestration/agentic_passes.py
@@ -399,6 +399,10 @@ def _run_validate_postpass_unsafe(
         context_dirs=(agentic_out_dir,),
         preflight=_preflight,
         stage=_stage,
+        validate_outputs=lambda validate_dir: (
+            None if (validate_dir / "findings.json").is_file()
+            else "findings.json missing after validate run"
+        ),
     )
     if not dispatch.ran:
         return PostpassResult(ran=False,

--- a/core/orchestration/skill_dispatch.py
+++ b/core/orchestration/skill_dispatch.py
@@ -264,6 +264,56 @@ class SkillDispatchResult:
     cost_usd: float = 0.0
 
 
+def _decode_stream(raw: str | bytes | None) -> str:
+    """Normalise a captured stream to text.
+
+    ``subprocess.run(text=True)`` decodes on the happy path, but the
+    ``TimeoutExpired`` it raises carries the partial output as RAW BYTES
+    (CPython builds the exception inside ``Popen._communicate``, before
+    the text-mode decode). Both shapes reach the replay below.
+    """
+    if raw is None:
+        return ""
+    if isinstance(raw, (bytes, bytearray)):
+        return raw.decode("utf-8", errors="replace")
+    return raw
+
+
+def _replay_cc_output(raw_stdout: str | bytes | None,
+                      raw_stderr: str | bytes | None) -> float:
+    """Replay a captured Claude Code dispatch to the operator's console
+    and return the spend the CLI reported.
+
+    stdout is the ``--output-format json`` envelope: the model's final
+    text goes to stdout, ``total_cost_usd`` becomes the pass's cost. A
+    stdout that doesn't parse (a child killed mid-write, a CLI error
+    printed outside the envelope) is echoed verbatim rather than
+    swallowed — losing it would leave the operator with no record of a
+    pass that already charged them.
+    """
+    cost_usd = 0.0
+    stdout = _decode_stream(raw_stdout)
+    stderr = _decode_stream(raw_stderr)
+    if stdout:
+        try:
+            envelope = json.loads(stdout)
+        except (TypeError, json.JSONDecodeError):
+            envelope = None
+        if isinstance(envelope, dict):
+            raw_cost = envelope.get("total_cost_usd")
+            if isinstance(raw_cost, (int, float)):
+                cost_usd = float(raw_cost)
+            final_text = envelope.get("result")
+            if isinstance(final_text, str) and final_text:
+                print(final_text)
+        else:
+            print(stdout, end="" if stdout.endswith("\n") else "\n")
+    if stderr:
+        print(stderr, file=sys.stderr,
+              end="" if stderr.endswith("\n") else "\n")
+    return cost_usd
+
+
 class StageError(Exception):
     """Raised by a caller's ``stage`` callback to abort the dispatch
     with a specific reason (the lifecycle is marked failed with it)."""
@@ -739,31 +789,22 @@ def run_skill_dispatch(
                     ),
                     caller_label=caller_label,
                 )
-            cc_cost_usd = 0.0
-            stdout = proc.stdout or ""
-            stderr = proc.stderr or ""
-            if stdout:
-                try:
-                    envelope = json.loads(stdout)
-                except (TypeError, json.JSONDecodeError):
-                    print(stdout, end="" if stdout.endswith("\n") else "\n")
-                else:
-                    raw_cost = envelope.get("total_cost_usd")
-                    if isinstance(raw_cost, (int, float)):
-                        cc_cost_usd = float(raw_cost)
-                    final_text = envelope.get("result")
-                    if isinstance(final_text, str) and final_text:
-                        print(final_text)
-            if stderr:
-                print(stderr, file=sys.stderr,
-                      end="" if stderr.endswith("\n") else "\n")
-        except subprocess.TimeoutExpired:
+            cc_cost_usd = _replay_cc_output(proc.stdout, proc.stderr)
+        except subprocess.TimeoutExpired as e:
+            # A pass that ran until the deadline still spent money, and
+            # whatever the CLI managed to emit is the operator's only
+            # window into what it was doing. Replay both before failing:
+            # `--output-format json` buffers everything to the end, so a
+            # killed child usually leaves a truncated envelope — the
+            # replay falls back to printing it raw.
+            cc_cost_usd = _replay_cc_output(e.stdout, e.stderr)
             lifecycle_settled = True
             fail_lifecycle(run_dir, f"timeout after {timeout_s}s")
             logger.warning("%s timed out after %ds", log_label, timeout_s)
             return SkillDispatchResult(
                 ran=False, skipped_reason=f"timeout after {timeout_s}s",
-                run_dir=run_dir, duration_s=time.monotonic() - t0)
+                run_dir=run_dir, duration_s=time.monotonic() - t0,
+                cost_usd=cc_cost_usd)
         except OSError as e:
             lifecycle_settled = True
             fail_lifecycle(run_dir, f"launch failed: {e}")

--- a/core/orchestration/skill_dispatch.py
+++ b/core/orchestration/skill_dispatch.py
@@ -27,10 +27,12 @@ what the prompt says, and what happens with the artefacts afterwards
 
 from __future__ import annotations
 
+import json
 import logging
 import math
 import os
 import subprocess
+import sys
 import tempfile
 import time
 from dataclasses import dataclass
@@ -259,6 +261,7 @@ class SkillDispatchResult:
     skipped_reason: str | None = None
     run_dir: Path | None = None
     duration_s: float = 0.0
+    cost_usd: float = 0.0
 
 
 class StageError(Exception):
@@ -612,7 +615,10 @@ def run_skill_dispatch(
                       *(str(d) for d in context_dirs), str(run_dir)),
             budget_usd=budget_usd,
             timeout_s=timeout_s,
-            capture_json_envelope=False,
+            # Capture the CLI envelope so the parent workflow can account for
+            # this pass's real spend.  The model's final text is replayed
+            # below; tools still stream through Claude internally.
+            capture_json_envelope=True,
         )
         # env: proxy mode hands the child a credential-FREE env whose
         # only auth is the scoped dispatcher token; env mode keeps the
@@ -679,6 +685,7 @@ def run_skill_dispatch(
                         system_prompt_file=_sys_prompt_path,
                     ),
                     text=True,
+                    capture_output=True,
                     **stdin_kwargs,
                     timeout=timeout_s,
                     target=str(target), output=str(run_dir),
@@ -732,6 +739,24 @@ def run_skill_dispatch(
                     ),
                     caller_label=caller_label,
                 )
+            cc_cost_usd = 0.0
+            stdout = proc.stdout or ""
+            stderr = proc.stderr or ""
+            if stdout:
+                try:
+                    envelope = json.loads(stdout)
+                except (TypeError, json.JSONDecodeError):
+                    print(stdout, end="" if stdout.endswith("\n") else "\n")
+                else:
+                    raw_cost = envelope.get("total_cost_usd")
+                    if isinstance(raw_cost, (int, float)):
+                        cc_cost_usd = float(raw_cost)
+                    final_text = envelope.get("result")
+                    if isinstance(final_text, str) and final_text:
+                        print(final_text)
+            if stderr:
+                print(stderr, file=sys.stderr,
+                      end="" if stderr.endswith("\n") else "\n")
         except subprocess.TimeoutExpired:
             lifecycle_settled = True
             fail_lifecycle(run_dir, f"timeout after {timeout_s}s")
@@ -770,7 +795,8 @@ def run_skill_dispatch(
             return SkillDispatchResult(
                 ran=False,
                 skipped_reason=f"subprocess returned {proc.returncode}",
-                run_dir=run_dir, duration_s=time.monotonic() - t0)
+                run_dir=run_dir, duration_s=time.monotonic() - t0,
+                cost_usd=cc_cost_usd)
 
         if validate_outputs is not None:
             error = validate_outputs(run_dir)
@@ -780,13 +806,15 @@ def run_skill_dispatch(
                 logger.warning("%s: %s", log_label, error)
                 return SkillDispatchResult(
                     ran=False, skipped_reason=error, run_dir=run_dir,
-                    duration_s=time.monotonic() - t0)
+                    duration_s=time.monotonic() - t0,
+                    cost_usd=cc_cost_usd)
 
         complete_lifecycle(run_dir)
         lifecycle_settled = True
 
         return SkillDispatchResult(ran=True, run_dir=run_dir,
-                                   duration_s=time.monotonic() - t0)
+                                   duration_s=time.monotonic() - t0,
+                                   cost_usd=cc_cost_usd)
 
     except Exception:
         # Make sure the lifecycle is marked failed before propagating.

--- a/core/orchestration/tests/test_agentic_passes.py
+++ b/core/orchestration/tests/test_agentic_passes.py
@@ -574,7 +574,10 @@ class ValidatePostpassTests(unittest.TestCase):
                 {"finding_id": "FINDING-F3", "is_exploitable": False, "confidence": "low"},
             ])
             validate_dir = tmp / "validate_run"
-            dispatcher = _make_lifecycle_dispatcher(start_dir=validate_dir)
+            dispatcher = _make_lifecycle_dispatcher(
+                start_dir=validate_dir,
+                claude_writes={"findings.json": "[]"},
+            )
             with _patch_passes(dispatcher) as mock_run:
                 result = run_validate_postpass(
                     target=tmp, agentic_out_dir=tmp, analysis_report=report,
@@ -603,6 +606,22 @@ class ValidatePostpassTests(unittest.TestCase):
             self.assertNotIn("FINDING-F2", prompt)
             self.assertNotIn("FINDING-F3", prompt)
 
+    def test_successful_process_without_findings_is_a_failed_postpass(self):
+        with TemporaryDirectory() as tmp:
+            tmp = Path(tmp)
+            report = self._make_report(
+                tmp, [{"finding_id": "FINDING-F1", "is_exploitable": True}],
+            )
+            validate_dir = tmp / "validate_run"
+            dispatcher = _make_lifecycle_dispatcher(start_dir=validate_dir)
+            with _patch_passes(dispatcher):
+                result = run_validate_postpass(
+                    target=tmp, agentic_out_dir=tmp, analysis_report=report,
+                    claude_bin="/fake/claude",
+                )
+            self.assertFalse(result.ran)
+            self.assertIn("findings.json missing", result.skipped_reason)
+
     def test_validate_dispatch_uses_sandbox_with_egress_proxy(self):
         with TemporaryDirectory() as tmp:
             tmp = Path(tmp)
@@ -610,7 +629,10 @@ class ValidatePostpassTests(unittest.TestCase):
                 {"finding_id": "FINDING-F1", "is_exploitable": True},
             ])
             validate_dir = tmp / "validate_run"
-            dispatcher = _make_lifecycle_dispatcher(start_dir=validate_dir)
+            dispatcher = _make_lifecycle_dispatcher(
+                start_dir=validate_dir,
+                claude_writes={"findings.json": "[]"},
+            )
             sandbox_calls = []
 
             def _sandbox_capture(cmd, *args, **kwargs):
@@ -676,7 +698,10 @@ class ValidatePostpassTests(unittest.TestCase):
                     for i in range(_MAX_VALIDATE_FINDINGS + 10)]
             report = self._make_report(tmp, many)
             validate_dir = tmp / "validate_run"
-            dispatcher = _make_lifecycle_dispatcher(start_dir=validate_dir)
+            dispatcher = _make_lifecycle_dispatcher(
+                start_dir=validate_dir,
+                claude_writes={"findings.json": "[]"},
+            )
             with _patch_passes(dispatcher):
                 result = run_validate_postpass(
                     target=tmp, agentic_out_dir=tmp, analysis_report=report,
@@ -819,7 +844,10 @@ class NaNScoreTests(unittest.TestCase):
             import json as _json
             report.write_text(_json.dumps({"results": findings}))
             validate_dir = tmp / "validate_run"
-            dispatcher = _make_lifecycle_dispatcher(start_dir=validate_dir)
+            dispatcher = _make_lifecycle_dispatcher(
+                start_dir=validate_dir,
+                claude_writes={"findings.json": "[]"},
+            )
             with _patch_passes(dispatcher):
                 result = run_validate_postpass(
                     target=tmp, agentic_out_dir=tmp, analysis_report=report,
@@ -951,7 +979,10 @@ class SortKeyTypeSafetyTests(unittest.TestCase):
             report = tmp / "report.json"
             report.write_text(json.dumps({"results": findings}))
             validate_dir = tmp / "validate_run"
-            dispatcher = _make_lifecycle_dispatcher(start_dir=validate_dir)
+            dispatcher = _make_lifecycle_dispatcher(
+                start_dir=validate_dir,
+                claude_writes={"findings.json": "[]"},
+            )
             with _patch_passes(dispatcher):
                 # Must not raise — backstop would catch it but the user would
                 # see "unexpected ValueError" instead of a clean post-pass.

--- a/core/orchestration/tests/test_agentic_passes_audit_merge.py
+++ b/core/orchestration/tests/test_agentic_passes_audit_merge.py
@@ -122,7 +122,12 @@ class MergedSelectionTests(unittest.TestCase):
             ])
             audit_dir = self._make_audit_dir(tmp, 2)
             validate_dir = tmp / "validate_run"
-            dispatcher = _make_lifecycle_dispatcher(start_dir=validate_dir)
+            # The post-pass now asserts findings.json exists before
+            # calling the run a success — the stub must produce it.
+            dispatcher = _make_lifecycle_dispatcher(
+                start_dir=validate_dir,
+                claude_writes={"findings.json": "[]"},
+            )
             with _patch_passes(dispatcher):
                 result = run_validate_postpass(
                     target=tmp, agentic_out_dir=tmp, analysis_report=report,
@@ -144,7 +149,12 @@ class MergedSelectionTests(unittest.TestCase):
             tmp = Path(tmp)
             audit_dir = self._make_audit_dir(tmp, 1)
             validate_dir = tmp / "validate_run"
-            dispatcher = _make_lifecycle_dispatcher(start_dir=validate_dir)
+            # The post-pass now asserts findings.json exists before
+            # calling the run a success — the stub must produce it.
+            dispatcher = _make_lifecycle_dispatcher(
+                start_dir=validate_dir,
+                claude_writes={"findings.json": "[]"},
+            )
             with _patch_passes(dispatcher):
                 result = run_validate_postpass(
                     target=tmp, agentic_out_dir=tmp,
@@ -175,7 +185,12 @@ class MergedSelectionTests(unittest.TestCase):
             ])
             audit_dir = self._make_audit_dir(tmp, 3)
             validate_dir = tmp / "validate_run"
-            dispatcher = _make_lifecycle_dispatcher(start_dir=validate_dir)
+            # The post-pass now asserts findings.json exists before
+            # calling the run a success — the stub must produce it.
+            dispatcher = _make_lifecycle_dispatcher(
+                start_dir=validate_dir,
+                claude_writes={"findings.json": "[]"},
+            )
             old_cap = agentic_passes._MAX_VALIDATE_FINDINGS
             agentic_passes._MAX_VALIDATE_FINDINGS = 4
             try:

--- a/core/orchestration/tests/test_agentic_passes_integration.py
+++ b/core/orchestration/tests/test_agentic_passes_integration.py
@@ -340,7 +340,10 @@ class PostpassIntegrationTests(unittest.TestCase):
             ])
             sub_disp2, sbx_disp2 = _selective_subprocess(
                 real_subprocess_run,
-                claude_writes={"validation-report.md": "# Validation\n"},
+                claude_writes={
+                    "validation-report.md": "# Validation\n",
+                    "findings.json": "[]",
+                },
             )
             with env_patch, \
                  patch("core.orchestration.skill_dispatch.subprocess.run",

--- a/core/orchestration/tests/test_skill_dispatch.py
+++ b/core/orchestration/tests/test_skill_dispatch.py
@@ -7,6 +7,7 @@ contract: gate order, StageError abort, output validation, truncation
 policy, and the settled-lifecycle pattern.
 """
 
+import os
 import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -266,6 +267,17 @@ class DispatchFlowTests(unittest.TestCase):
             run_dir = Path(tmp) / "run"
             result = _run(tmp, run_dir, validate_outputs=lambda d: None)
         self.assertTrue(result.ran)
+
+    def test_json_envelope_cost_is_returned(self):
+        def _sandbox(cmd, *args, **kwargs):
+            return _ok(stdout=(
+                '{"result":"done","total_cost_usd":1.2345}'
+            ))
+
+        with TemporaryDirectory() as tmp:
+            result = _run(tmp, Path(tmp) / "run", sandbox=_sandbox)
+        self.assertTrue(result.ran)
+        self.assertEqual(result.cost_usd, 1.2345)
 
     def test_keyboard_interrupt_marks_lifecycle_failed(self):
         with TemporaryDirectory() as tmp:

--- a/core/orchestration/tests/test_skill_dispatch.py
+++ b/core/orchestration/tests/test_skill_dispatch.py
@@ -7,7 +7,10 @@ contract: gate order, StageError abort, output validation, truncation
 policy, and the settled-lifecycle pattern.
 """
 
+import contextlib
+import io
 import os
+import subprocess
 import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -278,6 +281,46 @@ class DispatchFlowTests(unittest.TestCase):
             result = _run(tmp, Path(tmp) / "run", sandbox=_sandbox)
         self.assertTrue(result.ran)
         self.assertEqual(result.cost_usd, 1.2345)
+
+    def test_timeout_reports_partial_spend_and_output(self):
+        """A pass killed at the deadline still charged the operator, and
+        CPython hands the partial output back as BYTES on the exception
+        even in text mode."""
+        def _sandbox(cmd, *args, **kwargs):
+            raise subprocess.TimeoutExpired(
+                cmd, 60,
+                output=b'{"result":"partial work","total_cost_usd":0.75}',
+                stderr=b"cc: deadline\n",
+            )
+
+        with TemporaryDirectory() as tmp:
+            with contextlib.redirect_stdout(io.StringIO()) as out:
+                result = _run(tmp, Path(tmp) / "run", sandbox=_sandbox)
+        self.assertFalse(result.ran)
+        self.assertEqual(result.skipped_reason, "timeout after 60s")
+        self.assertEqual(result.cost_usd, 0.75)
+        self.assertIn("partial work", out.getvalue())
+
+    def test_timeout_with_unparseable_output_is_echoed_verbatim(self):
+        def _sandbox(cmd, *args, **kwargs):
+            raise subprocess.TimeoutExpired(
+                cmd, 60, output='{"result":"truncated mid-wr')
+
+        with TemporaryDirectory() as tmp:
+            with contextlib.redirect_stdout(io.StringIO()) as out:
+                result = _run(tmp, Path(tmp) / "run", sandbox=_sandbox)
+        self.assertFalse(result.ran)
+        self.assertEqual(result.cost_usd, 0.0)
+        self.assertIn("truncated mid-wr", out.getvalue())
+
+    def test_timeout_without_any_output_is_quiet(self):
+        def _sandbox(cmd, *args, **kwargs):
+            raise subprocess.TimeoutExpired(cmd, 60)
+
+        with TemporaryDirectory() as tmp:
+            result = _run(tmp, Path(tmp) / "run", sandbox=_sandbox)
+        self.assertFalse(result.ran)
+        self.assertEqual(result.cost_usd, 0.0)
 
     def test_keyboard_interrupt_marks_lifecycle_failed(self):
         with TemporaryDirectory() as tmp:

--- a/packages/sca/agent.py
+++ b/packages/sca/agent.py
@@ -160,6 +160,11 @@ def run_sca_subprocess(
             caller_label="sca-agent",
             target=str(target),
             output=str(output_dir),
+            # Keep every relative cache/output path beneath the directory
+            # Landlock grants writable.  Inheriting the launcher's cwd made
+            # the child resolve ``out/llm_cache`` beside the target run and
+            # fail with EACCES before dependency analysis completed.
+            cwd=str(output_dir),
             writable_paths=[str(log_dir)],
             env=env if env is not None else RaptorConfig.get_safe_env(),
             env_caller_filtered=True,

--- a/packages/sca/tests/test_agentic_sca_report_wiring.py
+++ b/packages/sca/tests/test_agentic_sca_report_wiring.py
@@ -1,0 +1,98 @@
+"""The SCA artefact pointers must survive from producer to consumer.
+
+``sca_findings_path`` is set by whichever SCA mode runs (mechanical or
+deep) and read twice, far downstream: ``run_validation_phase`` merges the
+dependency findings, and the final report publishes the path. A second
+``= None`` initialiser sitting between the mechanical producer and those
+consumers silently dropped every mechanical-mode dependency finding out
+of validation and left ``outputs.sca_findings`` null on the default path.
+
+The clobber is invisible in a 4000-line ``main()``, so guard it
+structurally rather than by re-running the whole workflow.
+"""
+
+from __future__ import annotations
+
+import ast
+import sys
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from raptor_agentic import _sca_mode
+
+_POINTERS = ("sca_findings_path", "sca_report_path")
+
+
+def _main_function() -> ast.FunctionDef:
+    tree = ast.parse((REPO_ROOT / "raptor_agentic.py").read_text("utf-8"))
+    for node in tree.body:
+        if isinstance(node, ast.FunctionDef) and node.name == "main":
+            return node
+    msg = "raptor_agentic.main() not found"
+    raise AssertionError(msg)
+
+
+def _assignments(name: str) -> list[tuple[int, bool]]:
+    """``(lineno, assigns_none)`` for every binding of ``name`` in main()."""
+    found = []
+    for node in ast.walk(_main_function()):
+        if not isinstance(node, ast.Assign):
+            continue
+        for target in node.targets:
+            if isinstance(target, ast.Name) and target.id == name:
+                found.append((
+                    node.lineno,
+                    isinstance(node.value, ast.Constant)
+                    and node.value.value is None,
+                ))
+    return sorted(found)
+
+
+class TestScaPointerWiring(unittest.TestCase):
+
+    def test_pointers_are_initialised_exactly_once(self):
+        for name in _POINTERS:
+            with self.subTest(pointer=name):
+                assignments = _assignments(name)
+                self.assertTrue(assignments, f"{name} is never assigned")
+                none_inits = [ln for ln, is_none in assignments if is_none]
+                self.assertEqual(
+                    len(none_inits), 1,
+                    f"{name} is re-initialised to None at lines "
+                    f"{none_inits} — a second initialiser clobbers whatever "
+                    f"an earlier SCA phase produced",
+                )
+
+    def test_the_only_none_init_precedes_every_producer(self):
+        for name in _POINTERS:
+            with self.subTest(pointer=name):
+                assignments = _assignments(name)
+                none_init = next(ln for ln, is_none in assignments if is_none)
+                producers = [ln for ln, is_none in assignments if not is_none]
+                self.assertTrue(producers, f"{name} is never given a value")
+                self.assertLess(none_init, min(producers))
+
+
+class TestScaMode(unittest.TestCase):
+
+    def test_deep_wins_over_mechanical(self):
+        self.assertEqual(_sca_mode(True, False), "deep")
+        # The gate makes this combination unreachable, but "deep"
+        # remains the honest answer if it ever occurs.
+        self.assertEqual(_sca_mode(True, True), "deep")
+
+    def test_mechanical_when_the_subprocess_phase_ran(self):
+        self.assertEqual(_sca_mode(False, True), "mechanical")
+
+    def test_none_when_no_sca_phase_ran(self):
+        # No agent installed: reporting "mechanical" named a phase that
+        # never existed.
+        self.assertEqual(_sca_mode(False, False), "none")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/packages/sca/tests/test_sca_egress.py
+++ b/packages/sca/tests/test_sca_egress.py
@@ -181,6 +181,7 @@ class TestRunScaSubprocess:
         proxy_hosts = captured_kwargs.get("proxy_hosts", [])
         assert set(SCA_ALLOWED_HOSTS) <= set(proxy_hosts)
         assert captured_kwargs.get("caller_label") == "sca-agent"
+        assert captured_kwargs.get("cwd") == str(tmp_path / "out")
 
     def test_passes_sandbox_args(self, tmp_path):
         """Extra --sandbox / --audit flags are forwarded to the command."""

--- a/raptor_agentic.py
+++ b/raptor_agentic.py
@@ -1563,12 +1563,72 @@ def run_audit_postpass(args: argparse.Namespace, target: Path, out_dir: Path) ->
             for key in ("findings_count", "gaps_remaining"):
                 if isinstance(report.get(key), int):
                     phase[key] = report[key]
+            completeness = report.get("completeness")
+            if isinstance(completeness, dict):
+                phase["completeness"] = completeness
+                phase["partial"] = bool(completeness.get("partial"))
+
+        # The reconciled audit ledger is authoritative. Audit can spend most
+        # of the workflow budget, so excluding it makes the parent total
+        # materially misleading.
+        cost_breakdown = load_json(audit_dir / "cost-breakdown.json")
+        if isinstance(cost_breakdown, dict):
+            totals = cost_breakdown.get("totals")
+            if isinstance(totals, dict):
+                spend = totals.get("total_spend_usd")
+                if isinstance(spend, (int, float)):
+                    phase["cost_usd"] = float(spend)
         return phase
     except Exception as e:
         logger.exception("audit post-pass crashed unexpectedly")
         phase["skipped_reason"] = f"unexpected {type(e).__name__}: {e}"
         phase.setdefault("duration_seconds", round(time.time() - t0, 1))
         return phase
+
+
+def _workflow_cost_summary(
+    orchestration_result: dict | None,
+    audit_postpass: dict | None,
+    prepass_result=None,
+    postpass_result=None,
+) -> dict:
+    """Combine every paid phase into one operator-facing total."""
+    by_phase: dict[str, float] = {}
+
+    orchestration = (
+        orchestration_result.get("orchestration", {})
+        if isinstance(orchestration_result, dict) else {}
+    )
+    main_cost = orchestration.get("cost", {})
+    if isinstance(main_cost, dict):
+        value = main_cost.get("total_cost")
+        if isinstance(value, (int, float)) and value > 0:
+            by_phase["analysis"] = float(value)
+
+    for name, result in (("understand", prepass_result),
+                         ("validate", postpass_result)):
+        value = getattr(result, "cost_usd", 0.0) if result else 0.0
+        if isinstance(value, (int, float)) and value > 0:
+            by_phase[name] = float(value)
+
+    audit_cost = (
+        audit_postpass.get("cost_usd", 0.0)
+        if isinstance(audit_postpass, dict) else 0.0
+    )
+    if isinstance(audit_cost, (int, float)) and audit_cost > 0:
+        by_phase["audit"] = float(audit_cost)
+
+    summary = {
+        "total_cost": round(sum(by_phase.values()), 4),
+        "cost_by_phase": by_phase,
+    }
+    # Retain the useful token/model detail from the main analysis ledger while
+    # making clear that its dollar subtotal is only one workflow phase.
+    if isinstance(main_cost, dict):
+        for key in ("thinking_tokens", "cost_by_model"):
+            if key in main_cost:
+                summary[key] = main_cost[key]
+    return summary
 
 
 def main() -> int:
@@ -3890,10 +3950,15 @@ Examples:
                 "to review the residual."
             )
 
+    workflow_cost = _workflow_cost_summary(
+        orchestration_result, audit_postpass, prepass_result, postpass_result,
+    )
+
     final_report = {
         "timestamp": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
         "repository": str(original_repo_path),
         "duration_seconds": workflow_duration,
+        "cost": workflow_cost,
         "tools_used": {
             "semgrep": not args.codeql_only,
             "codeql": args.codeql or args.codeql_only,
@@ -4323,27 +4388,37 @@ Examples:
     )
     from core.reporting.formatting import format_elapsed
     print(f"   Duration: {format_elapsed(workflow_duration)}")
-    if orchestration_result:
-        cost_summary = orchestration_result.get("orchestration", {}).get("cost", {})
-        cost = cost_summary.get("total_cost", 0)
-        if cost > 0:
-            thinking = cost_summary.get("thinking_tokens", 0)
-            cost_str = f"   Cost: ${cost:.2f}"
-            if thinking > 0:
-                cost_str += f" ({thinking:,} thinking tokens)"
-            print(cost_str)
-            # Per-model breakdown if multiple models used
-            by_model = cost_summary.get("cost_by_model", {})
-            if len(by_model) > 1:
-                for model, mcost in by_model.items():
-                    print(f"     {model}: ${mcost:.2f}")
+    # Gated on spend, not on the orchestrator: the understand / validate /
+    # audit passes cost money in --sequential runs too, where
+    # orchestration_result is None.
+    cost_summary = final_report.get("cost", {})
+    cost = cost_summary.get("total_cost", 0)
+    if cost > 0:
+        thinking = cost_summary.get("thinking_tokens", 0)
+        cost_str = f"   Cost: ${cost:.2f}"
+        if thinking > 0:
+            cost_str += f" ({thinking:,} thinking tokens)"
+        print(cost_str)
+        by_phase = cost_summary.get("cost_by_phase", {})
+        if len(by_phase) > 1:
+            for phase_name, phase_cost in by_phase.items():
+                print(f"     {phase_name}: ${phase_cost:.2f}")
+        # Per-model breakdown if multiple models used. Only the analysis
+        # ledger has one, so it stays sourced from the orchestration block.
+        by_model = (
+            orchestration_result.get("orchestration", {}).get("cost", {})
+            .get("cost_by_model", {}) if orchestration_result else {}
+        )
+        if len(by_model) > 1:
+            for model, mcost in by_model.items():
+                print(f"     {model}: ${mcost:.2f}")
         # Fast-tier scorecard savings — surface concrete behaviour
         # of the prefilter (full ANALYSE calls skipped on findings
         # the cheap tier confidently classified as FPs and the
         # scorecard trusted).
         short_circuits = orchestration_result.get("orchestration", {}).get(
             "fast_tier_short_circuits", 0
-        )
+        ) if orchestration_result else 0
         if short_circuits > 0:
             plural = "s" if short_circuits != 1 else ""
             print(f"   Fast-tier saved: {short_circuits} full ANALYSE call{plural}")
@@ -4489,7 +4564,7 @@ Examples:
         extra_summary["Exploits generated"] = exploits_count
     if patches_count > 0:
         extra_summary["Patches generated"] = patches_count
-    cost_summary = orch_phase.get("cost", {})
+    cost_summary = final_report.get("cost", {})
     cost = cost_summary.get("total_cost", 0)
     if cost > 0:
         extra_summary["Cost"] = f"${cost:.2f}"

--- a/raptor_agentic.py
+++ b/raptor_agentic.py
@@ -1258,6 +1258,18 @@ def _should_run_mechanical_sca(sca_agent, deep_sca_requested: bool) -> bool:
     return bool(sca_agent) and not deep_sca_requested
 
 
+def _sca_mode(deep_sca_requested: bool, mechanical_sca_ran: bool) -> str:
+    """Which dependency-analysis mode the run actually used.
+
+    ``"none"`` matters: with no SCA agent installed neither phase runs,
+    and reporting ``"mechanical"`` there described a phase that never
+    existed.
+    """
+    if deep_sca_requested:
+        return "deep"
+    return "mechanical" if mechanical_sca_ran else "none"
+
+
 def _build_completion_manifest(orch_meta, import_result, import_sarif_files,
                                reanalyze_dir=None):
     manifest = {
@@ -3274,6 +3286,13 @@ Examples:
     sca_metrics = {}
     mechanical_sca_error = None
     sca_out = out_dir / "sca"
+    # Artefact pointers for whichever SCA mode actually runs (mechanical
+    # here, deep in PHASE 1b below). They are declared once, at the first
+    # phase that can set them, and MUST NOT be re-initialised later: a
+    # second `= None` between the producer and the consumer silently drops
+    # the mechanical run's findings out of validation and the report.
+    sca_findings_path = None
+    sca_report_path = None
     try:
         from packages.sca.agent import _find_sca_agent, run_sca_subprocess
         sca_agent = _find_sca_agent()
@@ -3319,6 +3338,8 @@ Examples:
                         break
                 sca_findings_count = sca_metrics.get("vuln_findings", 0) + \
                                      sca_metrics.get("supply_chain_findings", 0)
+                sca_findings_path = sca_out / "findings.json"
+                sca_report_path = sca_out / "report.md"
                 print("\n✓ SCA complete:")
                 print(f"  - Dependencies: {sca_metrics.get('deps_analysed', 0)}")
                 print(f"  - Vulnerability findings: {sca_metrics.get('vuln_findings', 0)}")
@@ -3328,7 +3349,6 @@ Examples:
                 # SAGE: store SCA vulnerability findings for cross-run learning
                 try:
                     from core.sage.hooks import store_sca_outcomes
-                    sca_findings_path = sca_out / "findings.json"
                     if sca_findings_path.exists():
                         import json as _sca_json
                         sca_data = _sca_json.loads(
@@ -3475,7 +3495,6 @@ Examples:
     # PHASE 1b: SCA — DEPENDENCY ANALYSIS (opt-in via --sca)
     # ========================================================================
     sca_result = None
-    sca_findings_path = None
     if args.sca:
         print("\n" + "=" * 70)
         print("SCA — DEPENDENCY ANALYSIS")
@@ -3497,6 +3516,7 @@ Examples:
                 options=sca_options,
             )
             sca_findings_path = sca_deep_out / "findings.json"
+            sca_report_path = sca_deep_out / "report.md"
 
             print("\n✓ SCA complete:")
             print(f"  - Dependencies analysed: {sca_result.deps_analysed}")
@@ -3950,9 +3970,21 @@ Examples:
                 "to review the residual."
             )
 
+    effective_analysis = dict(orchestration_result or analysis or {})
+    dataflow_result = effective_analysis.get("dataflow_validation")
+    if isinstance(dataflow_result, dict):
+        validated_count = dataflow_result.get("n_validated")
+        if isinstance(validated_count, int):
+            # The orchestrator's legacy scalar can remain zero even after the
+            # IRIS stage validates eligible paths. Its structured telemetry is
+            # the authoritative result rendered elsewhere in the report.
+            effective_analysis["dataflow_validated"] = validated_count
     workflow_cost = _workflow_cost_summary(
         orchestration_result, audit_postpass, prepass_result, postpass_result,
     )
+    mechanical_sca_completed = bool(run_mechanical_sca and sca_metrics)
+    deep_sca_completed = sca_result is not None
+    sca_completed = mechanical_sca_completed or deep_sca_completed
 
     final_report = {
         "timestamp": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
@@ -3962,7 +3994,7 @@ Examples:
         "tools_used": {
             "semgrep": not args.codeql_only,
             "codeql": args.codeql or args.codeql_only,
-            "sca": bool(sca_agent and sca_metrics),
+            "sca": sca_completed,
         },
         "phases": {
             "scanning": {
@@ -3982,12 +4014,14 @@ Examples:
             },
             "threat_model": threat_model_phase,
             "sca": {
-                "enabled": args.sca,
-                "completed": sca_result is not None,
-                "deps_analysed": sca_result.deps_analysed if sca_result else 0,
-                "vuln_findings": sca_result.vuln_findings if sca_result else 0,
-                "hygiene_findings": sca_result.hygiene_findings if sca_result else 0,
-                "supply_chain_findings": sca_result.supply_chain_findings if sca_result else 0,
+                "enabled": bool(run_mechanical_sca or args.sca),
+                "completed": sca_completed,
+                "mode": _sca_mode(args.sca, run_mechanical_sca),
+                "skipped_reason": mechanical_sca_error,
+                "deps_analysed": sca_result.deps_analysed if sca_result else sca_metrics.get("deps_analysed", 0),
+                "vuln_findings": sca_result.vuln_findings if sca_result else sca_metrics.get("vuln_findings", 0),
+                "hygiene_findings": sca_result.hygiene_findings if sca_result else sca_metrics.get("hygiene_findings", 0),
+                "supply_chain_findings": sca_result.supply_chain_findings if sca_result else sca_metrics.get("supply_chain_findings", 0),
                 "llm_reviews": sca_result.llm_reviews_run if sca_result else 0,
                 "triage_run": sca_result.triage_run if sca_result else False,
             },
@@ -3999,18 +4033,25 @@ Examples:
                 "noise_reduction_percent": ((total_findings - validated_findings) / total_findings * 100) if total_findings > 0 else 0,
             },
             "autonomous_analysis": {
-                "completed": bool(analysis),
+                "completed": bool(effective_analysis),
                 "skipped": not llm_env.llm_available,
-                "exploitable": analysis.get('exploitable', 0),
-                "exploits_generated": analysis.get('exploits_generated', 0),
-                "patches_generated": analysis.get('patches_generated', 0),
-                "dataflow_validated": analysis.get('dataflow_validated', 0) if (args.codeql or args.codeql_only) else 0,
+                "exploitable": effective_analysis.get('exploitable', 0),
+                "exploits_generated": effective_analysis.get('exploits_generated', 0),
+                "patches_generated": effective_analysis.get('patches_generated', 0),
+                "dataflow_validated": effective_analysis.get('dataflow_validated', 0) if (args.codeql or args.codeql_only) else 0,
             },
             "orchestration": orchestration_result.get("orchestration", {}) if orchestration_result else {
                 "completed": False,
                 "mode": "none",
             },
             "audit": audit_postpass,
+            "validation_postpass": {
+                "enabled": bool(args.validate),
+                "completed": bool(postpass_result and postpass_result.ran),
+                "selected_count": postpass_result.selected_count if postpass_result else 0,
+                "skipped_reason": postpass_result.skipped_reason if postpass_result else None,
+                "cost_usd": postpass_result.cost_usd if postpass_result else 0.0,
+            },
         },
         "outputs": {
             "sarif_files": [str(f) for f in sarif_files],
@@ -4023,7 +4064,7 @@ Examples:
             "threat_model_summary": str(out_dir / "threat-model-summary.json") if threat_model_phase.get("completed") else None,
             "threat_model_candidates": threat_model_phase.get("candidate_sarif"),
             "sca_findings": str(sca_findings_path) if sca_findings_path and sca_findings_path.exists() else None,
-            "sca_report": str(out_dir / "sca" / "report.md") if sca_result else None,
+            "sca_report": str(sca_report_path) if sca_report_path and sca_report_path.exists() else None,
             "validation_report": str(out_dir / "validation" / "findings.json") if validation_result else None,
             "autonomous_report": str(analysis_report) if analysis_report and analysis_report.exists() else None,
             "orchestrated_report": str(out_dir / "orchestrated_report.json") if orchestration_result else None,

--- a/raptor_agentic.py
+++ b/raptor_agentic.py
@@ -3212,6 +3212,7 @@ Examples:
     # PHASE 1b: SOFTWARE COMPOSITION ANALYSIS
     # ========================================================================
     sca_metrics = {}
+    mechanical_sca_error = None
     sca_out = out_dir / "sca"
     try:
         from packages.sca.agent import _find_sca_agent, run_sca_subprocess
@@ -3236,7 +3237,7 @@ Examples:
             # Route via sandbox egress proxy so SCA's HTTP calls are
             # hostname-allowlisted when --sandbox is active. The allowlist
             # is SCA_ALLOWED_HOSTS (vuln feeds + registries + archives).
-            rc, sca_stdout, _sca_stderr = run_sca_subprocess(
+            rc, sca_stdout, sca_stderr = run_sca_subprocess(
                 sca_agent,
                 original_repo_path,
                 sca_out,
@@ -3301,11 +3302,20 @@ Examples:
                 except Exception:
                     logger.debug("SAGE SCA store skipped", exc_info=True)
             else:
-                logger.warning("SCA failed (rc=%d) — continuing without dep findings", rc)
+                detail = (sca_stderr or "").strip()[-1000:]
+                mechanical_sca_error = (
+                    f"SCA subprocess exited {rc}"
+                    + (f": {detail}" if detail else "")
+                )
+                logger.warning(
+                    "SCA failed (rc=%d) — continuing without dep findings: %s",
+                    rc, detail or "no stderr captured",
+                )
                 sca_findings_count = 0
         except Exception as e:  # noqa: BLE001
             print(f"⚠️  SCA failed: {e}", file=sys.stderr)
             logger.warning("SCA failed — continuing without dep findings: %s", e)
+            mechanical_sca_error = f"{type(e).__name__}: {e}"
             sca_findings_count = 0
     else:
         sca_findings_count = 0


### PR DESCRIPTION
Seperators ahoy!

## 1. `fix(agentic): make Claude skill dispatch reliable`

Three separate reasons the dispatched skill passes died before doing any work:

- **Schema rejected by AJV.** Callers pass RAPTOR's compact schema form
  (`{"reasoning": "string", ...}`), and `_normalize_schema` emitted
  `properties` without a top-level `type`. Claude Code validates
  `--json-schema` with AJV `strictTypes` and rejects it. Normalisation now
  completes both the compact form and this partial-JSON-Schema form, at the
  provider-independent boundary, and `ClaudeCodeLLMProvider` normalises before
  crossing the subprocess boundary like every other native structured-output
  provider.

## 3. `fix(reporting): include every paid workflow phase`

`orchestration.cost.total_cost` was reported as *the* workflow cost, but the
`/understand` pre-pass, `/validate` post-pass, and `--gap-audit` post-pass all
spend real money through their own Claude Code subprocesses. On audit-heavy
runs the audit phase alone can dominate the budget, so the headline number was
materially misleading.

- `run_skill_dispatch` captures the CLI JSON envelope and returns its
  `total_cost_usd` as `SkillDispatchResult.cost_usd`; `PrepassResult` /
  `PostpassResult` carry it through. The model's final text is replayed to
  stdout and stderr to stderr, so operator-visible output is preserved.
- The **timeout path** replays the partial output and reports the spend too. A
  pass killed at the deadline still charged the operator, and whatever the CLI
  emitted is the only window into what it was doing. Note
  `TimeoutExpired.stdout` arrives as raw bytes even in text mode (CPython
  builds the exception before the text-mode decode), and `--output-format
  json` buffers to the end, so a killed child usually leaves a truncated
  envelope — that is echoed verbatim rather than swallowed.
- The audit post-pass reads the reconciled `cost-breakdown.json` ledger, which
  is authoritative, plus the report's `completeness` block so a partial audit
  is reported as partial.
- New `_workflow_cost_summary` combines analysis + understand + validate +
  audit into `final_report["cost"]` with a `cost_by_phase` breakdown, printed
  per phase when more than one phase spent. The console `Cost:` line is gated
  on spend rather than on the orchestrator's presence, so `--sequential` runs
  whose only spend is in the skill passes now report it. The per-model
  breakdown still comes from the analysis ledger — the only phase that has
  one.

## 4. `fix(reporting): reflect completed agentic phase results`

The final report contradicted what the run actually did:

- **Analysis results read from the wrong object.** In orchestrated mode the
  report read `exploitable` / `exploits_generated` / `patches_generated` from
  the prep-only `analysis` dict — always zero — instead of the orchestrator
  result that carries them. Now reads `orchestration_result or analysis`.
- **Dataflow validation always zero.** The orchestrator's legacy scalar can
  stay 0 after the IRIS stage validates paths; its structured
  `dataflow_validation.n_validated` telemetry is authoritative and is rendered
  elsewhere in the same report. The scalar is now derived from it.
- **Mechanical SCA reported as "not run".** `tools_used.sca` and
  `phases.sca.*` were computed exclusively from the deep-SCA result object, so
  the default mechanical path — which does run, and does print findings —
  reported `completed: false` with all-zero counts. The phase block now covers
  both modes and falls back to the mechanical metrics, and gained `mode` and
  `skipped_reason`. `mode` distinguishes `none` (no SCA agent installed, so
  neither phase ran) from `mechanical`.
- **Mechanical SCA findings never reached validation.** `sca_findings_path` was
  set by the mechanical phase and then re-initialised to `None` before the
  deep-SCA block. Since the two modes are mutually exclusive, on the *default*
  path the pointer was always `None` by the time it reached
  `run_validation_phase(sca_findings_path=...)` and `outputs.sca_findings`:
  dependency findings were counted and printed, then silently dropped from
  dedup/validation, with a null pointer in the report. Both artefact pointers
  are now declared once, before any producer, and a test guards the
  invariant (see below).
- **`outputs.sca_report` pointed at the wrong file.** It was hardcoded to
  `<out>/sca/report.md`, but deep mode writes to `<out>/sca_deep/`. It now
  follows the mode that ran and is existence-guarded like every sibling entry.
- **Validate post-pass had no report entry at all.** Added
  `phases.validation_postpass` with enabled / completed / selected_count /
  skipped_reason / cost.
- The validate post-pass now asserts `findings.json` exists before declaring
  success, so a pass that dies mid-pipeline fails its lifecycle instead of
  being recorded as a clean run. This is safe because the pass never
  dispatches when the selection is empty.