### PR TITLE
Fix devcontainer build: remove stale yarn apt repo

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -11,7 +11,11 @@ FROM mcr.microsoft.com/devcontainers/python:1-3.12-bookworm
 # Organized by component that needs them
 # ============================================================================
 
-RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+# The base image ships an unused yarn apt repo whose signing key has rotated,
+# which breaks `apt-get update` (NO_PUBKEY / repository not signed). RAPTOR
+# installs Node via nodesource + npm and never uses yarn, so remove the repo.
+RUN rm -f /etc/apt/sources.list.d/yarn.list \
+    && apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && apt-get install -y --no-install-recommends \
     #
     # --- Core Tools (all scripts, packages) ---


### PR DESCRIPTION
## Problem

The devcontainer fails to build at the first `apt-get` layer (`Dockerfile` line 14) with `exit code: 100`:

```
E: The repository 'https://dl.yarnpkg.com/debian stable InRelease' is not signed.
```

The base image `mcr.microsoft.com/devcontainers/python:1-3.12-bookworm` ships a preconfigured yarn apt repo (`/etc/apt/sources.list.d/yarn.list`) pinned to a bundled keyring. Yarn rotated its signing key to `62D54FD4003F6525`, which is absent from the stale bundled keyring, so `apt-get update` rejects the repo as unsigned and exits non-zero — failing the entire install layer even though no RAPTOR package comes from yarn.

## Fix

Remove the unused yarn repo before `apt-get update`. RAPTOR installs Node via nodesource + npm and never uses yarn, so the repo is dead weight.

```dockerfile
RUN rm -f /etc/apt/sources.list.d/yarn.list \
    && apt-get update && export DEBIAN_FRONTEND=noninteractive \
    && apt-get install -y --no-install-recommends \
    ...
```

## Verification

Full image build completes (exit 0). Confirmed inside the resulting container:

- semgrep 1.176.0
- CodeQL 2.15.5
- Node v20.20.2
- Claude Code CLI 2.1.197
- gdb 13.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)