### PR TITLE
release: v3.1.0

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -11,8 +11,8 @@ abstract: >-
   disclosure bundles, for defensive security research, education, and
   authorized penetration testing.
 type: software
-version: "3.0.0"
-date-released: "2026-05-22"
+version: "3.1.0"
+date-released: "2026-09-07"
 license: MIT
 url: "https://github.com/gadievron/raptor"
 repository-code: "https://github.com/gadievron/raptor"

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 ║             ╚═╝  ╚═╝╚═╝  ╚═╝╚═╝        ╚═╝    ╚═════╝ ╚═╝  ╚═╝            ║
 ║                                                                           ║
 ║             Autonomous Offensive/Defensive Research Framework             ║
-║             Based on Claude Code (v3.0.0)                                 ║
+║             Based on Claude Code (v3.1.0)                                 ║
 ║                                                                           ║
 ║             Gadi Evron, Daniel Cuthbert, Thomas Dullien (Halvar Flake)    ║
 ║             Michael Bargury, John Cartwright                              ║

--- a/core/config/__init__.py
+++ b/core/config/__init__.py
@@ -73,7 +73,7 @@ class RaptorConfig:
     # commits past a release never masquerades as that clean release. It falls
     # back to ``VERSION`` when there is no usable git checkout (archive,
     # exported copy, git absent).
-    VERSION = "3.0.0"
+    VERSION = "3.1.0"
 
     @classmethod
     def effective_version(cls) -> str:

--- a/packages/sca/calibration/tests/test_refit_joint_gate.py
+++ b/packages/sca/calibration/tests/test_refit_joint_gate.py
@@ -94,7 +94,8 @@ def test_joint_strictly_better_stays_joint_proposed(
     the joint values (not the single-pass ones)."""
     _tiny_corpus(tmp_path)
     from packages.sca.risk import current_constants
-    kev_cur = current_constants()["_KEV_FLOOR"]
+    constants = current_constants()
+    kev_cur = constants["_KEV_FLOOR"]
 
     def _metric(
         samples: list, *, overrides: dict | None = None,
@@ -117,9 +118,13 @@ def test_joint_strictly_better_stays_joint_proposed(
         out_path=tmp_path / "joint.json",
     )
     assert report.status == "proposed"
-    assert report.proposed_values.get("_KEV_FLOOR") == pytest.approx(
-        kev_cur * 0.9,
-    )
+    proposed = report.proposed_values.get("_KEV_FLOOR")
+    assert proposed is not None
+    # The metric rewards lowering KEV_FLOOR, but the joint search must
+    # respect the cross-constraint that it stays at or above the exploit-
+    # evidence floor. A refit may move that floor, so do not pin the old
+    # assumption that the exact -10% bracket edge is admissible.
+    assert constants["_EXPLOIT_EVIDENCE_FLOOR"] <= proposed < kev_cur
 
 
 def test_joint_rejected_when_single_pass_also_failed_gate(

--- a/packages/sca/tests/test_risk.py
+++ b/packages/sca/tests/test_risk.py
@@ -91,16 +91,10 @@ def test_log4shell_kev_reachable_direct_scores_high():
     )
     score, comps = compute_risk_estimate(f, f.dependency)
     assert 90 <= score <= 100, f"got {score}"
-    # KEV multiplier history: 1.20 (pre-refit) → 1.32 (2026-05-09
-    # wider-grid refit) → 1.452 (2026-05-21 first ρ-aware refit
-    # after Vulnrichment integration) → 1.5972 (2026-05-22 second
-    # ρ-aware refit after SSVC decoupling + CVSS-from-severity
-    # fallback + RUSTSEC informational filter + SSVC Automatable
-    # wiring) → 1.7569 (2026-05-22 third ρ-aware refit after
-    # round-9 CPM + Gradle catalog corpus expansion; joint refit
-    # confirmed per-constant is at the basin floor on this corpus,
-    # making the +6pp ρ jump the right move to ship).
-    assert comps["kev_multiplier"] == 1.7569
+    # The value is calibration-owned and can move after a successful
+    # refit; the breakdown must report the live value that was applied.
+    from packages.sca.risk import current_constants
+    assert comps["kev_multiplier"] == current_constants()["_KEV_MULTIPLIER"]
 
 
 def test_log4shell_but_not_reachable_drops_to_low():
@@ -128,29 +122,29 @@ def test_log4shell_but_not_reachable_drops_to_low():
         reach_verdict="imported", exposure=1.0, depth=0,
     )
     s_reach, _ = compute_risk_estimate(reachable, reachable.dependency)
-    assert score < s_reach * 0.40, (
-        f"not_reachable={score} should be <40% of reachable={s_reach}"
+    assert score < s_reach * 0.45, (
+        f"not_reachable={score} should be <45% of reachable={s_reach}"
     )
 
 
 def test_log4shell_at_transitive_depth_3():
-    """Same vuln, but at depth 3 — geometric decay (0.7^3 ≈ 0.343)
-    on top of KEV-tier base. The expected range bumped 2026-05-22
-    after the ρ-aware refit lifted KEV_MULT to 1.5972; the broader
-    range now covers the new floor of ~45 down to ~30 (refit may
-    drift either direction in future). The structural intent —
-    depth-3 transitive still surfaces clearly above background
-    hygiene noise but well below depth-0 reachable — is what
-    matters; the band is wide enough to absorb modest weight
-    drift without false-failing."""
+    """Depth-3 transitive risk decays geometrically below direct risk."""
+    from packages.sca.risk import current_constants
     transitive = _dep(direct=False)
     f = _finding(
         dep=transitive,
         cvss=10.0, in_kev=True, epss=0.97,
         reach_verdict="imported", exposure=1.0, depth=3,
     )
-    score, _ = compute_risk_estimate(f, transitive)
-    assert 30 <= score <= 55, f"got {score}"
+    score, comps = compute_risk_estimate(f, transitive)
+    direct = _finding(
+        cvss=10.0, in_kev=True, epss=0.97,
+        reach_verdict="imported", exposure=1.0, depth=0,
+    )
+    direct_score, _ = compute_risk_estimate(direct, direct.dependency)
+    decay = current_constants()["_DEPTH_DECAY_BASE"]
+    assert comps["depth_multiplier"] == pytest.approx(decay ** 3)
+    assert 0 < score < direct_score
 
 
 def test_background_hygiene_finding_scores_low():
@@ -317,12 +311,15 @@ def test_not_reachable_low_confidence_smaller_reduction():
 
 
 def test_depth_decay_geometric():
-    """Depth 1 → 0.7×; depth 2 → 0.49×; depth 3 → 0.343×."""
+    """Each transitive level applies the live calibrated decay base."""
+    from packages.sca.risk import current_constants
     base_dep = _dep(direct=True)
     direct = _finding(dep=base_dep, depth=0)
     s0, _ = compute_risk_estimate(direct, direct.dependency)
 
-    for depth, expected_ratio in [(1, 0.70), (2, 0.49), (3, 0.343)]:
+    decay = current_constants()["_DEPTH_DECAY_BASE"]
+    for depth in (1, 2, 3):
+        expected_ratio = decay ** depth
         td = _dep(direct=False)
         f = _finding(dep=td, depth=depth)
         s, _ = compute_risk_estimate(f, td)
@@ -678,10 +675,10 @@ class TestRefitConstraintGate:
     candidates from the per-constant grid search."""
 
     def test_inadmissible_candidate_dropped_from_search(self, tmp_path):
-        """At ±50% delta the search would propose
+        """At ±75% delta the search would propose
         _REACH_NOT_EVALUATED_MULTIPLIER above 1.0; with constraint-
         aware refit, that candidate must be dropped and the
-        constant left at its current value."""
+        selected value must remain within the penalty bound."""
         # Build a tiny corpus: 5 findings, 1 exploited.
         import json
         signal_dir = tmp_path / "kev_signals.json"
@@ -722,7 +719,7 @@ class TestRefitConstraintGate:
 
         from packages.sca.calibration.refit import grid_search_refit
         report = grid_search_refit(
-            tmp_path, max_delta=0.50,
+            tmp_path, max_delta=0.75,
             min_samples=1,
         )
         # _REACH_NOT_EVALUATED_MULTIPLIER must NOT have been moved

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "raptor"
-version = "3.0.0"
+version = "3.1.0"
 requires-python = ">=3.10,<4.0"
 license = "MIT"
 


### PR DESCRIPTION
## Summary

- stamp RAPTOR version metadata to 3.1.0
- update CITATION.cff release date to 2026-09-07
- realign stale SCA risk tests with the calibration constants applied by #942

## Verification

- bash .github/tests/test_release_workflow.sh (61 passed)
- python3 -m pytest core/startup/tests/test_banner.py core/startup/tests/test_version_newer.py core/annotations/tests/test_versioning.py -q (19 passed)
- python3 -m pytest packages/sca/tests/test_risk.py packages/sca/calibration/tests/test_refit_joint_gate.py -q (39 passed)
- ruff check on both modified SCA test files
- git diff --check
- pyproject.toml parses with project.version = 3.1.0

Main context: the automated calibration refit in #942 intentionally changed nine production weights, but left six deterministic assertions pinned to the prior calibration. Main's tests run 34058822709 and this PR's first run failed on those same assertions. The production constants are unchanged here.

After this PR merges, the annotated v3.1.0 tag will trigger the release workflow.