### PR TITLE
fix(sandbox): retain namespace isolation when bind mounts fail

### DIFF
--- a/.github/scripts/vocab_baseline.json
+++ b/.github/scripts/vocab_baseline.json
@@ -1641,6 +1641,11 @@
     "count": 10,
     "kind": "literal"
   },
+  "libexec/raptor-seatbelt-shim::_strip": {
+    "count": 10,
+    "kind": "literal",
+    "note": "target environment-strip tuple mirrored from core.config.TARGET_ENV_STRIP_SET for the isolated macOS shim, not a learned name vocabulary"
+  },
   "libexec/raptor-self-test::_LLM_ENV_VARS": {
     "count": 10,
     "kind": "literal",

--- a/core/config/__init__.py
+++ b/core/config/__init__.py
@@ -862,7 +862,9 @@ class RaptorConfig:
     # on the platform (e.g. some Windows builds).
     GIT_ENV_VARS: ClassVar[dict] = {
         "GIT_TERMINAL_PROMPT": "0",
-        "GIT_ASKPASS": "true",
+        # Absolute so Git cannot resolve an operator-controlled executable
+        # through PATH inside a sandbox.
+        "GIT_ASKPASS": "/usr/bin/true",
         "GIT_CONFIG_GLOBAL": "/dev/null",
         "GIT_CONFIG_SYSTEM": "/dev/null",
         "GIT_CONFIG_NOSYSTEM": "1",

--- a/core/config/__init__.py
+++ b/core/config/__init__.py
@@ -561,6 +561,11 @@ class RaptorConfig:
         # TARGET_ENV_STRIP_SET (sandboxed code never sees the
         # credential; see core/sandbox/context.py).
         "RAPTOR_SESSION_PID", "RAPTOR_SESSION_TOKEN",
+        # Host-level consent for RAPTOR's reduced untrusted sandbox tier.
+        # RAPTOR-owned workers must inherit it so the decision made at the
+        # launcher boundary is not silently lost.  Target-bound envs strip it
+        # below, preventing scanned code from changing sandbox policy.
+        "RAPTOR_ALLOW_DEGRADED_UNTRUSTED",
     })
 
     # Variables that must NEVER reach code executed on behalf of a
@@ -577,6 +582,7 @@ class RaptorConfig:
     TARGET_ENV_STRIP_SET = frozenset({
         "CLAUDECODE", "_RAPTOR_TRUSTED",
         "RAPTOR_SESSION_PID", "RAPTOR_SESSION_TOKEN",
+        "RAPTOR_ALLOW_DEGRADED_UNTRUSTED",
         # Framework-identity values: each one names RAPTOR (or its
         # checkout / output layout) to any target that runs `env`,
         # defeating the anti-fingerprint posture in one getenv. No

--- a/core/config/tests/test_config.py
+++ b/core/config/tests/test_config.py
@@ -92,6 +92,13 @@ class TestGetSafeEnv:
         env = RaptorConfig.get_safe_env()
         assert env.get("PYTHONUNBUFFERED") == "1"
 
+    def test_degraded_untrusted_consent_reaches_raptor_workers(self):
+        with patch.dict(os.environ, {
+            "RAPTOR_ALLOW_DEGRADED_UNTRUSTED": "1",
+        }):
+            env = RaptorConfig.get_safe_env()
+        assert env.get("RAPTOR_ALLOW_DEGRADED_UNTRUSTED") == "1"
+
     def test_ef_benign_knobs_survive_scrub(self):
         """Numeric/boolean feasibility knobs must reach scrub-spawned
         children (the loader runs inside them); the exec-path class

--- a/core/config/tests/test_config.py
+++ b/core/config/tests/test_config.py
@@ -156,7 +156,7 @@ class TestGetGitEnv:
 
     def test_sets_askpass(self):
         env = RaptorConfig.get_git_env()
-        assert env.get("GIT_ASKPASS") == "true"
+        assert env.get("GIT_ASKPASS") == "/usr/bin/true"
 
     def test_also_strips_dangerous_vars(self):
         injected = {var: "bad" for var in RaptorConfig.DANGEROUS_ENV_VARS}

--- a/core/git/clone.py
+++ b/core/git/clone.py
@@ -20,7 +20,7 @@ Both wrap their ``git`` subprocess in ``core.sandbox.run_untrusted_networked``
     the target / repo directory;
   - sanitised env (``RaptorConfig.get_git_env()`` — clears
     HTTP_PROXY / NO_PROXY etc., sets GIT_TERMINAL_PROMPT=0 and
-    GIT_ASKPASS=true so a malformed-credential prompt can't hang
+    GIT_ASKPASS=/usr/bin/true so a malformed-credential prompt can't hang
     the run);
   - bounded timeout (``RaptorConfig.GIT_CLONE_TIMEOUT``).
 

--- a/core/sandbox/_macos_spawn.py
+++ b/core/sandbox/_macos_spawn.py
@@ -587,7 +587,11 @@ def run_sandboxed(cmd: list[str], *,
         child_env = dict(env)
         if strict_env:
             from core.config import RaptorConfig
-            child_env = {k: v for k, v in child_env.items() if k not in RaptorConfig.DANGEROUS_ENV_VARS}
+            child_env = {
+                k: v for k, v in child_env.items()
+                if (k not in RaptorConfig.DANGEROUS_ENV_VARS
+                    or RaptorConfig.GIT_ENV_VARS.get(k) == v)
+            }
     else:
         from core.config import RaptorConfig
         child_env = RaptorConfig.get_safe_env()

--- a/core/sandbox/_spawn.py
+++ b/core/sandbox/_spawn.py
@@ -2533,9 +2533,11 @@ def run_sandboxed(
                     if strict_env:
                         from core.config import RaptorConfig
                         _dangerous = set(RaptorConfig.DANGEROUS_ENV_VARS)
+                        _safe_git = RaptorConfig.GIT_ENV_VARS
                         exec_env = {
                             k: v for k, v in exec_env.items()
-                            if k not in _dangerous
+                            if (k not in _dangerous
+                                or _safe_git.get(k) == v)
                         }
                 else:
                     # env=None → scrubbed allowlist env, NOT the full

--- a/core/sandbox/context.py
+++ b/core/sandbox/context.py
@@ -2338,14 +2338,13 @@ def sandbox(block_network=_UNSET, target: str | None = None, output: str | None 
     # channel — is withdrawn per call via omit_proc_reads; the
     # per-call warning at the run_untrusted entry names the tool
     # breakage this trades for.
-    effective_read_paths: list | None = None
-    if restrict_reads:
-        effective_read_paths = [
+    def _restricted_read_allowlist() -> list[str]:
+        paths = [
             "/usr", "/lib", "/lib64", "/bin", "/sbin",
             "/etc", "/proc", "/sys",
         ]
         if omit_proc_reads:
-            effective_read_paths.remove("/proc")
+            paths.remove("/proc")
         if omit_etc_reads:
             # Swap the wholesale /etc grant for the loader/TLS minimum.
             # Host-identity files (/etc/passwd, /etc/hosts,
@@ -2354,8 +2353,8 @@ def sandbox(block_network=_UNSET, target: str | None = None, output: str | None 
             # narrows /etc for the child. Existing paths only:
             # Landlock rules bind to inodes and the preexec treats a
             # missing grant path as a setup failure.
-            effective_read_paths.remove("/etc")
-            effective_read_paths.extend(
+            paths.remove("/etc")
+            paths.extend(
                 p for p in _ETC_MINIMAL_READS if os.path.exists(p))
         # The pid-1 shim file ONLY (not the whole libexec/ dir).
         # Without this, execvp of the shim fails with EACCES (rc=126)
@@ -2368,15 +2367,20 @@ def sandbox(block_network=_UNSET, target: str | None = None, output: str | None 
         from pathlib import Path as _Path
         _shim = _Path(__file__).resolve().parents[2] / "libexec" / "raptor-pid1-shim"
         if _shim.is_file():
-            effective_read_paths.append(str(_shim))
+            paths.append(str(_shim))
         if target:
-            effective_read_paths.append(target)
+            paths.append(target)
         if readable_paths:
-            effective_read_paths.extend(readable_paths)
+            paths.extend(readable_paths)
         if etc_overlay:
             for ns_path in etc_overlay:
-                if isinstance(ns_path, str) and ns_path not in effective_read_paths:
-                    effective_read_paths.append(ns_path)
+                if isinstance(ns_path, str) and ns_path not in paths:
+                    paths.append(ns_path)
+        return paths
+
+    effective_read_paths: list | None = None
+    if restrict_reads:
+        effective_read_paths = _restricted_read_allowlist()
     elif readable_paths:
         logger.warning(
             "Sandbox: readable_paths=%s ignored because restrict_reads=False "
@@ -2776,6 +2780,11 @@ def sandbox(block_network=_UNSET, target: str | None = None, output: str | None 
         env_caller_filtered = kwargs.pop("env_caller_filtered", False)
         _skip_pid_ns = kwargs.pop("skip_pid_ns", False)
         _skip_mount_ns = kwargs.pop("skip_mount_ns", False)
+        # Kept separate from require_fresh_procfs: the operator's degraded
+        # untrusted opt-in relaxes the fresh-procfs requirement, but it must
+        # not erase the fact that the workload is untrusted. The mountless
+        # ABI safety gate below still applies to every untrusted workload.
+        _untrusted_workload = kwargs.pop("_untrusted_workload", False)
         # Untrusted-target contract knob (set by run_untrusted*): the
         # grandchild's fresh-procfs mount stops being best-effort —
         # a failure aborts the spawn (status byte 'F') instead of
@@ -3035,10 +3044,25 @@ def sandbox(block_network=_UNSET, target: str | None = None, output: str | None 
                     " ".join(cmd[:_CMD_DISPLAY_MAX_ARGS]) or repr(cmd),
                 )
             if strict_env:
-                _stripped = [k for k in kwargs["env"] if k in RaptorConfig.DANGEROUS_ENV_VARS]
+                # Preserve only RAPTOR's exact inert Git neutralisers. They
+                # are classified as dangerous because caller-controlled
+                # alternate paths can load config, but get_safe_env() resets
+                # them to /dev/null before this second-stage scrub. Removing
+                # those safe values makes git fall back to an unreadable real
+                # HOME and abort under Landlock instead of treating config as
+                # absent.
+                _safe_git = RaptorConfig.GIT_ENV_VARS
+                _stripped = [
+                    k for k, v in kwargs["env"].items()
+                    if k in RaptorConfig.DANGEROUS_ENV_VARS
+                    and _safe_git.get(k) != v
+                ]
                 if _stripped:
-                    kwargs["env"] = {k: v for k, v in kwargs["env"].items()
-                                     if k not in RaptorConfig.DANGEROUS_ENV_VARS}
+                    kwargs["env"] = {
+                        k: v for k, v in kwargs["env"].items()
+                        if (k not in RaptorConfig.DANGEROUS_ENV_VARS
+                            or _safe_git.get(k) == v)
+                    }
                     logger.info(
                         "Sandbox: strict_env=True — stripped DANGEROUS_ENV_VARS from caller env: %s", sorted(_stripped)
                     )
@@ -3166,6 +3190,51 @@ def sandbox(block_network=_UNSET, target: str | None = None, output: str | None 
                 k: v for k, v in _env_for_target.items()
                 if k != _ENV_RESTORE_KEY
             }
+
+        _mountless_call_writable: list[str] | None = None
+        _mountless_private_scratch: str | None = None
+
+        def _mountless_write_policy() -> tuple[list[str], dict]:
+            """Return write grants and env for a host-visible filesystem.
+
+            Construction assumes the mount backend has private tmpfs mounts at
+            /tmp and /dev/shm. If this call later uses a mountless lane under
+            read restriction, replace those host-shared grants with the same
+            private scratch policy used by the legacy demotion path.
+            """
+            nonlocal _env_for_target
+            nonlocal _mountless_call_writable
+            nonlocal _mountless_private_scratch
+
+            if _mountless_call_writable is not None:
+                return _mountless_call_writable, _env_for_target
+            if (not use_mount or rootfs is not None
+                    or sys.platform != "linux" or effectively_disabled
+                    or not restrict_reads or exclude_tmp_baseline):
+                return list(writable_paths or []), _env_for_target
+
+            import tempfile as _tempfile_mountless
+            scratch = _tempfile_mountless.mkdtemp(prefix=".scr-")
+            _demoted_scratch_dirs.append(scratch)
+            from core.run.scratch import keepalive_register
+            keepalive_register(scratch)
+            shared = {
+                "/tmp", "/dev/shm",
+                os.path.realpath(_tempfile_mountless.gettempdir()),
+            }
+            _mountless_call_writable = [scratch] + [
+                path for path in (writable_paths or [])
+                if path not in shared and os.path.realpath(path) not in shared
+            ]
+            _mountless_private_scratch = scratch
+            scratch_env = {"TMPDIR": scratch, "TEMP": scratch, "TMP": scratch}
+            kwargs["env"] = {**kwargs["env"], **scratch_env}
+            _env_for_target = {**_env_for_target, **scratch_env}
+            logger.debug(
+                "Sandbox: read-restricted mountless execution replaces "
+                "host-shared /tmp and /dev/shm grants with private scratch.",
+            )
+            return _mountless_call_writable, _env_for_target
 
         def _shim_hop_env() -> dict:
             # Env for the unshare/prlimit/pid1-shim BOOTSTRAP hops on
@@ -3818,6 +3887,8 @@ def sandbox(block_network=_UNSET, target: str | None = None, output: str | None 
         # operators understand WHY audit didn't engage.
         _b_fallback_reason = None
         _b_fallback_instr = None
+        _prefer_mountless_spawn = False
+        _spawn_without_mount = _skip_mount_ns
         # Per-call check that cmd[0] is visible inside the mount-ns
         # bind tree. The bind tree is fixed: standard system dirs,
         # target/output, /tmp (per-sandbox tmpfs), and the union of
@@ -3830,8 +3901,8 @@ def sandbox(block_network=_UNSET, target: str | None = None, output: str | None 
         # macOS sandbox-exec doesn't change the filesystem view, so
         # this check + the speculative-C cache it feeds are skipped
         # on Darwin (use_mount is always False there).
-        # Both per-cmd Landlock-only demotions below (B fallback,
-        # speculative-C cache) reason about the HOST-mode bind tree;
+        # Both per-command mountless selections below (B fallback and the
+        # speculative-C cache) reason about the host-mode bind tree;
         # in rootfs mode cmd[0] resolves inside the IMAGE filesystem
         # (its /bin/sh, its entrypoint script), so the host visibility
         # check would demote perfectly valid commands — and demotion
@@ -3843,17 +3914,17 @@ def sandbox(block_network=_UNSET, target: str | None = None, output: str | None 
             # mount-ns directly.
             if not _cmd_visible_in_mount_tree(cmd, target, output, _all_extra):
                 logger.debug(
-                    "Sandbox: Landlock-only for cmd[0]=%r "
+                    "Sandbox: mountless namespace backend for cmd[0]=%r "
                     "(resolved=%r, outside mount-ns bind tree). "
                     "Install under a system dir (/usr/local/bin) "
                     "or pass tool_paths=[<dir>] to engage mount-ns.",
                     cmd[0], _resolved,
                 )
-                spawn_eligible = False
+                _prefer_mountless_spawn = True
                 _b_fallback_reason = (
                     f"cmd[0]={cmd[0]!r} (resolved={_resolved!r}) is "
-                    f"outside the mount-ns bind tree — sandbox used "
-                    f"Landlock-only, tracer cannot attach")
+                    f"outside the mount-ns bind tree; sandbox used the "
+                    f"mountless namespace backend")
                 _b_fallback_instr = (
                     "install the tool under a system dir "
                     "(/usr/local/bin) or pass tool_paths=[<bin_dir>] "
@@ -3864,21 +3935,63 @@ def sandbox(block_network=_UNSET, target: str | None = None, output: str | None 
             # attempt entirely — saves ~100-300ms per call.
             elif _resolved in state._speculative_failure_cache:
                 logger.debug(
-                    "Sandbox: Landlock-only for cmd[0]=%r — known "
+                    "Sandbox: mountless namespace backend for cmd[0]=%r; "
                     "speculative-failure cache hit (mount-ns "
                     "previously failed at exec for this binary)",
                     cmd[0],
                 )
-                spawn_eligible = False
+                _prefer_mountless_spawn = True
                 _b_fallback_reason = (
                     f"cmd[0]={cmd[0]!r} previously failed mount-ns at "
-                    f"exec — cached as known-Landlock-only; tracer "
-                    f"cannot attach for cached binaries")
+                    f"exec; cached for the mountless namespace backend")
                 _b_fallback_instr = (
                     "the binary's native exec deps are outside any "
                     "reasonable mount-ns bind set; audit can't engage "
                     "for this tool. Other tools in the same workflow "
                     "still audit normally.")
+
+        def _require_mountless_opt_in(
+                reason: str, setup_category: str = "M") -> None:
+            """Refuse a lesser filesystem tier for untrusted workloads."""
+            if _require_fresh_procfs:
+                from .errors import SandboxSetupError
+                raise SandboxSetupError(
+                    "sandbox mount isolation is unavailable for an "
+                    f"untrusted run ({reason}); refusing the mountless "
+                    "namespace backend.",
+                    "fix the bind-tree/tool-path failure, or set "
+                    "RAPTOR_ALLOW_DEGRADED_UNTRUSTED=1 to explicitly "
+                    "accept host-path visibility with Landlock read/write "
+                    "enforcement.",
+                    setup_category=setup_category,
+                )
+            if ((_untrusted_workload or restrict_reads)
+                    and check_landlock_available()
+                    and _get_landlock_abi() < 3):
+                from .errors import SandboxSetupError
+                raise SandboxSetupError(
+                    "sandbox mount isolation is unavailable and Landlock "
+                    "ABI is below 3; refusing the mountless backend because "
+                    "truncate operations outside the write allowlist cannot "
+                    "be blocked.",
+                    "use a kernel with Landlock ABI 3 or newer, or restore "
+                    "mount-namespace bind support.",
+                    setup_category=setup_category,
+                )
+
+        if _prefer_mountless_spawn:
+            _require_mountless_opt_in(
+                _b_fallback_reason or "command is outside the bind tree",
+                "X",
+            )
+            if state.warn_once("_mountless_backend_warned"):
+                logger.warning(
+                    "Sandbox: bind-tree isolation unavailable for %r; using "
+                    "the mountless namespace backend. Host paths remain "
+                    "visible by name; Landlock enforces the requested read "
+                    "and write policy. Later cache hits log at debug level.",
+                    cmd[0],
+                )
         # Persona fail-closed gate (pre-spawn arm): every route that
         # abandons the mount-ns spawn path — pass_fds/input= kwarg
         # compat, the B fallback (cmd[0] outside the bind tree), a
@@ -3889,7 +4002,8 @@ def sandbox(block_network=_UNSET, target: str | None = None, output: str | None 
         # not a silent host-real run. Mirrors rootfs gate #2 above;
         # the post-spawn M/X arm is gated separately below.
         if (_persona is not None and require_sanitisation
-                and (not spawn_eligible or _skip_mount_ns)):
+                and (not spawn_eligible or _skip_mount_ns
+                     or _prefer_mountless_spawn)):
             from .errors import SandboxSetupError
             _reason = (
                 _b_fallback_reason
@@ -3901,7 +4015,7 @@ def sandbox(block_network=_UNSET, target: str | None = None, output: str | None 
             msg_0 = (
                 f"sandbox(require_sanitisation=True).run() cannot "
                 f"engage the mount-ns spawn backend for this call "
-                f"({_reason}) — refusing the Landlock-only path, "
+                f"({_reason}) — refusing the reduced filesystem path, "
                 f"which cannot apply the fingerprint persona."
             )
             raise SandboxSetupError(
@@ -4137,7 +4251,14 @@ def sandbox(block_network=_UNSET, target: str | None = None, output: str | None 
                     exclude_tmp_baseline=exclude_tmp_baseline,
                     map_root=map_root,
                     start_new_session=_start_new_session,
-                    strict_env=strict_env,
+                    # The public wrapper has already filtered the caller's
+                    # environment above, before adding RAPTOR-owned HOME,
+                    # proxy, and scratch overrides.  Reapplying strict_env in
+                    # the backend would remove those trusted overrides (most
+                    # importantly TMPDIR) and send grandchildren back to the
+                    # host /tmp.  Direct backend callers still retain the
+                    # backend's defence-in-depth filtering.
+                    strict_env=False,
                 )
                 used_spawn = True
                 # Fail-loud parity with the Linux exec-status pipe. The macOS
@@ -4223,7 +4344,7 @@ def sandbox(block_network=_UNSET, target: str | None = None, output: str | None 
                         # skip_mount_ns: no bind-tree, host FS visible.
                         # Landlock enforces the read allowlist directly —
                         # effective_read_paths already enumerates the same
-                        # system-dirs floor the Landlock-only fallback path
+                        # system-dirs floor the reduced filesystem path
                         # uses (/usr, /lib, /etc, /proc, /sys, target,
                         # tool_paths), so restrict_reads works without a
                         # mount tree. Pre-fix this branch forced
@@ -4253,21 +4374,29 @@ def sandbox(block_network=_UNSET, target: str | None = None, output: str | None 
                                         _proxy_unix_path, pid):
                                     _lane_peer_pids.append(pid)
 
-                        try:
-                            result = _spawn_mod.run_sandboxed(
+                        def _run_spawn_backend(
+                                *, skip_mount: bool,
+                        ) -> subprocess.CompletedProcess:
+                            _call_writable = list(writable_paths or [])
+                            _call_env = _env_for_target
+                            if skip_mount:
+                                _call_writable, _call_env = (
+                                    _mountless_write_policy()
+                                )
+                            return _spawn_mod.run_sandboxed(
                                 cmd,
                                 target=target, output=output,
                                 rootfs=rootfs,
                                 block_network=block_network,
                                 nproc_limit=nproc_limit,
                                 limits=effective_limits,
-                                writable_paths=writable_paths or [],
+                                writable_paths=_call_writable,
                                 readable_paths=_spawn_readable,
                                 allowed_tcp_ports=list(allowed_tcp_ports)
                                 if allowed_tcp_ports else None,
                                 seccomp_profile=seccomp_profile,
                                 seccomp_block_udp=seccomp_block_udp,
-                                env=_env_for_target,
+                                env=_call_env,
                                 cwd=kwargs.get("cwd"),
                                 timeout=kwargs.get("timeout"),
                                 capture_output=kwargs.get("capture_output", False),
@@ -4284,7 +4413,12 @@ def sandbox(block_network=_UNSET, target: str | None = None, output: str | None 
                                            if observe and nonlocal_audit_mode
                                            else None),
                                 restrict_reads=_spawn_restrict_reads,
-                                strict_env=strict_env,
+                                # _env_for_target/run_env is already filtered
+                                # by this wrapper.  It also contains trusted
+                                # sandbox-generated overrides such as the
+                                # private mountless TMPDIR; do not strip those
+                                # a second time in the lower backend.
+                                strict_env=False,
                                 persona=_persona,
                                 etc_overlay=etc_overlay,
                                 # Default True here even though subprocess.run
@@ -4301,7 +4435,7 @@ def sandbox(block_network=_UNSET, target: str | None = None, output: str | None 
                                 start_new_session=_start_new_session,
                                 inherit_netns=_inherit_netns,
                                 skip_pid_ns=_skip_pid_ns,
-                                skip_mount_ns=_skip_mount_ns,
+                                skip_mount_ns=skip_mount,
                                 require_fresh_procfs=_require_fresh_procfs,
                                 proxy_unix_socket=_proxy_unix_path if _use_proxy_netns else None,
                                 proxy_forwarder_port=_proxy_forwarder_port if _use_proxy_netns else None,
@@ -4313,6 +4447,42 @@ def sandbox(block_network=_UNSET, target: str | None = None, output: str | None 
                                 ),
                                 exec_pid_callback=_exec_pid_callback,
                                 child_pid_callback=_register_lane_peer,
+                            )
+
+                        def _grant_path_identities() -> dict[str, tuple]:
+                            identities = {}
+                            grant_paths = [
+                                target, output,
+                                *(writable_paths or []),
+                                *(_spawn_readable or []),
+                            ]
+                            for grant_path in grant_paths:
+                                if not grant_path:
+                                    continue
+                                absolute = os.path.abspath(grant_path)
+                                try:
+                                    resolved = os.path.realpath(absolute)
+                                    path_stat = os.stat(resolved)
+                                except OSError:
+                                    continue
+                                identities[absolute] = (
+                                    resolved, path_stat.st_dev,
+                                    path_stat.st_ino,
+                                )
+                            return identities
+
+                        _spawn_without_mount = (
+                            _skip_mount_ns or _prefer_mountless_spawn)
+                        if (_prefer_mountless_spawn
+                                and _b_fallback_reason):
+                            _mount_ns_degraded = _b_fallback_reason
+                        _grant_ids_before = (
+                            _grant_path_identities()
+                            if not _spawn_without_mount else None
+                        )
+                        try:
+                            result = _run_spawn_backend(
+                                skip_mount=_spawn_without_mount,
                             )
                         finally:
                             for _pp in _lane_peer_pids:
@@ -4329,13 +4499,13 @@ def sandbox(block_network=_UNSET, target: str | None = None, output: str | None 
                         #   P     → a bind source stopped resolving to its
                         #           validation-time inode (tamper signal from
                         #           the pinned mount setup) → fail loud; the
-                        #           M-degrade below would re-run via the
-                        #           Landlock-only tier, where the planted
+                        #           M-degrade below would re-run without the
+                        #           bind tree, where the planted
                         #           symlink resolves on the host filesystem
                         #           and the refused steering would succeed.
                         #   M/X   → mount-ns setup, or exec inside the
-                        #           sandbox, failed → degrade to Landlock-only
-                        #           (handled by the block below).
+                        #           sandbox, failed → retry with namespaces
+                        #           intact but without the bind tree.
                         _setup_status = getattr(result, "_setup_status", None)
                         if _setup_status is not None and _setup_status[0] == "P":
                             from .errors import SandboxSetupError
@@ -4401,15 +4571,14 @@ def sandbox(block_network=_UNSET, target: str | None = None, output: str | None 
                                 _instr,
                                 setup_category=_setup_status[0],
                             )
-                        # Degrade-to-Landlock-only on a mount-ns ('M') or
+                        # Retry without the bind tree on a mount-ns ('M') or
                         # in-sandbox exec ('X') failure reported by the exec-
                         # status pipe. 'X' is the common tool_paths case: the
                         # bind set was insufficient (typical Python tool: bin
                         # dir bound but stdlib at sys.prefix/lib was not), so
                         # the target couldn't exec inside the mount-ns view.
-                        # Re-run via the Landlock-only subprocess path (works
-                        # without mount-ns bind-tree visibility) — worst-case
-                        # isolation matches the Landlock-only outcome. The
+                        # Re-run through the namespace backend without
+                        # mount-ns bind-tree visibility. The
                         # signal is authoritative and unspoofable (a tool can
                         # no longer defeat OR forge this via stderr; the old
                         # rc==126/127 + empty-stderr heuristic could be both).
@@ -4417,7 +4586,7 @@ def sandbox(block_network=_UNSET, target: str | None = None, output: str | None 
                             # Rootfs fail-closed gate #4: an M/X status
                             # for a rootfs run means the image pivot or
                             # the exec inside the image failed. The
-                            # Landlock-only retry below would re-run the
+                            # mountless retry below would re-run the
                             # command against the HOST filesystem —
                             # forbidden. Raise with the child's detail;
                             # 'X' usually means cmd[0] doesn't exist in
@@ -4429,8 +4598,8 @@ def sandbox(block_network=_UNSET, target: str | None = None, output: str | None 
                                     f"sandbox(rootfs=...): mount-ns "
                                     f"setup or exec inside the image "
                                     f"rootfs failed: {_setup_status[1]} "
-                                    f"— refusing the Landlock-only "
-                                    f"host-filesystem fallback."
+                                    f"— refusing the mountless "
+                                    f"host-filesystem retry."
                                 )
                                 raise SandboxSetupError(
                                     msg_0,
@@ -4440,8 +4609,8 @@ def sandbox(block_network=_UNSET, target: str | None = None, output: str | None 
                                     "that exists INSIDE the image.",
                                     setup_category=_setup_status[0],
                                 )
-                            # Persona fail-closed gate: the Landlock-
-                            # only retry below runs WITHOUT mount-ns,
+                            # Persona fail-closed gate: the mountless
+                            # retry below runs WITHOUT the bind tree,
                             # so the fingerprint persona (bind-mounts
                             # + UTS) silently does not apply — the
                             # exact half-state require_sanitisation
@@ -4455,7 +4624,7 @@ def sandbox(block_network=_UNSET, target: str | None = None, output: str | None 
                                     f"True): mount-ns setup or exec "
                                     f"failed ({_setup_status[0]}: "
                                     f"{_setup_status[1]}) — refusing "
-                                    f"the Landlock-only fallback, "
+                                    f"the mountless fallback, "
                                     f"which cannot apply the "
                                     f"fingerprint persona."
                                 )
@@ -4468,52 +4637,32 @@ def sandbox(block_network=_UNSET, target: str | None = None, output: str | None 
                                     "surfaces on degrade.",
                                     setup_category=_setup_status[0],
                                 )
-                            # Fresh-procfs fail-closed gate: the
-                            # Landlock-only retry below runs with NO
-                            # pid namespace and the HOST /proc — the
-                            # exact posture require_fresh_procfs
-                            # exists to refuse. Without this gate an
-                            # untrusted run whose mount-ns setup (or
-                            # in-ns exec) failed silently re-ran with
-                            # the full host process table visible,
-                            # never consulting the operator override
-                            # that governs every other degraded-
-                            # untrusted shape.
-                            if _require_fresh_procfs:
+                            # Keep the namespace backend and retry without
+                            # the bind tree. This still enters a PID namespace,
+                            # mounts a fresh /proc, applies Landlock + seccomp,
+                            # and retains the isolated network/proxy lane. It
+                            # avoids the host-pid /proc exposure of the legacy
+                            # subprocess fallback on kernels/filesystems that
+                            # reject one of the bind mounts with EINVAL.
+                            _failed_setup_status = _setup_status
+                            _require_mountless_opt_in(
+                                f"{_setup_status[0]}: {_setup_status[1]}",
+                                _setup_status[0],
+                            )
+                            if (_grant_ids_before is not None
+                                    and _grant_path_identities()
+                                    != _grant_ids_before):
                                 from .errors import SandboxSetupError
-                                msg_0 = (
-                                    f"sandbox mount-ns setup or exec "
-                                    f"failed ({_setup_status[0]}: "
-                                    f"{_setup_status[1]}) on an "
-                                    f"untrusted run — refusing the "
-                                    f"Landlock-only fallback, which "
-                                    f"exposes the host-pid /proc."
-                                )
                                 raise SandboxSetupError(
-                                    msg_0,
-                                    "fix the mount-ns failure (see the "
-                                    "child diagnostic above; for 'X' "
-                                    "the usual cause is a tool outside "
-                                    "the bind set — tool_paths= / "
-                                    "--sandbox-tool-path). "
-                                    + _fresh_procfs_override_hint(),
-                                    setup_category=_setup_status[0],
+                                    "sandbox grant-source pin violation "
+                                    "during bind-tree fallback",
+                                    "a target, output, writable, or readable "
+                                    "path changed while the first sandbox "
+                                    "backend was starting; refusing to grant "
+                                    "the replacement path to the retry.",
+                                    setup_category="P",
                                 )
-                            # Populate the per-cmd cache so future
-                            # calls for the same binary skip mount-ns
-                            # directly (saves the doubled subprocess
-                            # setup cost for every Semgrep rule etc).
-                            # First-time-per-binary fires INFO so
-                            # operators see what's happening; cache-
-                            # hits on subsequent calls are silent.
-                            #
-                            # Lock around the populate so two
-                            # concurrent first-failures for the same
-                            # binary don't double-log. Lock scope is
-                            # tight (dict insert + log-once decision)
-                            # — held for microseconds.
-                            _resolved_cmd0 = (shutil.which(cmd[0])
-                                              or cmd[0])
+                            _resolved_cmd0 = shutil.which(cmd[0]) or cmd[0]
                             with state._cache_lock:
                                 _first_seen = (
                                     _resolved_cmd0
@@ -4523,87 +4672,48 @@ def sandbox(block_network=_UNSET, target: str | None = None, output: str | None 
                                     state._speculative_failure_cache[
                                         _resolved_cmd0] = True
                             if _first_seen:
-                                # ONE-TIME INFO per binary — concise.
-                                # The "why" detail (mount-ns failed
-                                # at exec, native-deps mismatch, etc.)
-                                # belongs in DEBUG, not in operator
-                                # output. Operator just needs to
-                                # know which binary and what isolation.
                                 logger.info(
-                                    "Sandbox: %r runs at Landlock-only "
-                                    "isolation.",
+                                    "Sandbox: %r bind tree is unusable; "
+                                    "future runs will use the reduced "
+                                    "namespace backend.",
                                     cmd[0],
-                                )
-                                if _use_proxy_netns:
-                                    logger.warning(
-                                        "Sandbox: proxy netns enforcement "
-                                        "lost in Landlock-only fallback "
-                                        "— child has no network connectivity.",
-                                    )
-                                # Companion DEBUG with the diagnostic
-                                # detail for operators investigating.
-                                logger.debug(
-                                    "Sandbox: %r mount-ns setup/exec "
-                                    "failed (exec-status=%s — e.g. tools "
-                                    "whose native deps live outside the "
-                                    "tool_paths bind set: Python with "
-                                    "sys.prefix/lib not bound, semgrep "
-                                    "with semgrep-core outside install "
-                                    "root; or a host where the mount op "
-                                    "is denied). Cached so subsequent "
-                                    "calls to this binary skip mount-ns "
-                                    "directly.",
-                                    cmd[0], _setup_status,
                                 )
                             else:
                                 logger.debug(
-                                    "Sandbox: speculative-C cache "
-                                    "hit on cmd[0]=%r (rc=%d) — "
-                                    "Landlock-only fallback.",
-                                    cmd[0], result.returncode,
+                                    "Sandbox: bind-tree failure cache hit "
+                                    "for cmd[0]=%r.",
+                                    cmd[0],
                                 )
-                            # Audit-mode signal lost: the retry routes
-                            # through subprocess+preexec which has no
-                            # tracer attachment. Write the marker so
-                            # operators see explicitly that audit
-                            # didn't fully engage for this call —
-                            # absent records would otherwise be
-                            # misread as "nothing to audit". Marker
-                            # location: audit_run_dir takes precedence
-                            # (canonical "where audit signal lands"),
-                            # fall back to output. Codeql analyze etc.
-                            # pass audit_run_dir without output — the
-                            # marker still fires there.
-                            _retry_marker_dir = audit_run_dir or output
-                            if nonlocal_audit_mode:
-                                _audit_no_engage_reason = (
-                                    f"cmd[0]={cmd[0]!r} mount-ns "
-                                    f"failed at exec (rc="
-                                    f"{result.returncode}, no "
-                                    f"stderr) — speculative-C "
-                                    f"retry routed via Landlock-"
-                                    f"only; tracer didn't attach")
-                                _audit_no_engage_instr = (
-                                    "the binary's deps are outside "
-                                    "the tool_paths bind set; "
-                                    "audit can't engage. Other "
-                                    "tools in the workflow still "
-                                    "audit normally.")
-                            if nonlocal_audit_mode and _retry_marker_dir:
-                                from pathlib import Path as _Path
-
-                                from . import summary as _summary_mod
-                                _summary_mod.record_audit_degraded(
-                                    _Path(_retry_marker_dir),
-                                    reason=_audit_no_engage_reason,
-                                    instructions=_audit_no_engage_instr,
+                            result = _run_spawn_backend(skip_mount=True)
+                            _retry_status = getattr(
+                                result, "_setup_status", None)
+                            if _retry_status is not None:
+                                from .errors import SandboxSetupError
+                                raise SandboxSetupError(
+                                    "sandbox bind-tree fallback failed "
+                                    f"({_retry_status[0]}: "
+                                    f"{_retry_status[1]})",
+                                    "the reduced mount backend could not "
+                                    "engage Landlock, seccomp, namespaces, "
+                                    "fresh procfs, or execute the target; "
+                                    "the target was not run.",
+                                    setup_category=_retry_status[0],
                                 )
-                            used_spawn = False
                             _mount_ns_degraded = (
-                                f"exec failed in mount-ns (rc="
-                                f"{result.returncode}); retried via "
-                                "Landlock-only path")
-                            # Fall through to subprocess path below.
+                                "bind-tree setup failed "
+                                f"({_failed_setup_status[0]}: "
+                                f"{_failed_setup_status[1]}); retried with "
+                                "Landlock + PID namespace + fresh procfs")
+                            _spawn_without_mount = True
+                            used_spawn = True
+                            if state.warn_once("_mountless_backend_warned"):
+                                logger.warning(
+                                    "Sandbox: bind-tree isolation unavailable "
+                                    "for %r; using Landlock + PID namespace + "
+                                    "fresh procfs. Later cache hits log at "
+                                    "debug level.",
+                                    cmd[0],
+                                )
                 except (FileNotFoundError, RuntimeError, OSError,
                         _errors.SandboxSetupError) as _spawn_err:
                     # _spawn raised mid-setup (uidmap uninstalled,
@@ -4863,29 +4973,9 @@ def sandbox(block_network=_UNSET, target: str | None = None, output: str | None 
                             "silently downgrade for you.",
                         )
                     if restrict_reads and not exclude_tmp_baseline:
-                        import tempfile as _tempfile_dem
-                        _demoted_scratch = _tempfile_dem.mkdtemp(
-                            prefix=".scr-")
-                        # Reaper-listed prefix: keep the per-call
-                        # scratch registered while the (possibly
-                        # multi-day) call runs; unregistered with the
-                        # context teardown. Appended to the teardown
-                        # list FIRST so a register failure can never
-                        # strand a dir the teardown loop won't see.
-                        _demoted_scratch_dirs.append(_demoted_scratch)
-                        from core.run.scratch import keepalive_register
-                        keepalive_register(_demoted_scratch)
-                        _shared_scratch = {
-                            "/tmp", "/dev/shm",
-                            os.path.realpath(
-                                _tempfile_dem.gettempdir()),
-                        }
-                        _demoted_call_writable = [_demoted_scratch] + [
-                            w for w in (writable_paths or [])
-                            if w not in _shared_scratch
-                            and os.path.realpath(w)
-                            not in _shared_scratch
-                        ]
+                        _demoted_call_writable, _demoted_env = (
+                            _mountless_write_policy()
+                        )
                         _dem_preexec = _make_preexec_fn(
                             effective_limits,
                             writable_paths=_demoted_call_writable,
@@ -4905,20 +4995,7 @@ def sandbox(block_network=_UNSET, target: str | None = None, output: str | None 
                             kwargs["preexec_fn"] = _dem_combined
                         else:
                             kwargs["preexec_fn"] = _dem_preexec
-                        _dem_env = {
-                            "TMPDIR": _demoted_scratch,
-                            "TEMP": _demoted_scratch,
-                            "TMP": _demoted_scratch,
-                        }
-                        kwargs["env"] = {**kwargs["env"], **_dem_env}
-                        _env_for_target = {**_env_for_target,
-                                           **_dem_env}
-                        logger.info(
-                            "Sandbox: mount-ns demotion under "
-                            "restrict_reads — host-shared /tmp and "
-                            "/dev/shm grants replaced by a per-call "
-                            "private scratch dir for this run.",
-                        )
+                        kwargs["env"] = dict(_demoted_env)
                 if _exec_pid_callback is not None:
                     logger.debug(
                         "Sandbox: exec_pid_callback supplied but this "
@@ -5360,8 +5437,14 @@ def sandbox(block_network=_UNSET, target: str | None = None, output: str | None 
         # would tell forensic readers the child had fs isolation it
         # didn't have.
         result.sandbox_info["mount_ns_active"] = bool(
-            used_spawn and use_mount and not _skip_mount_ns
+            used_spawn and use_mount
+            and not _spawn_without_mount
         )
+        if (used_spawn
+                and _spawn_without_mount):
+            result.sandbox_info["backend"] = "landlock-pidns"
+            if _require_fresh_procfs:
+                result.sandbox_info["fresh_procfs"] = True
         # Fresh-procfs posture for pid-ns runs. When the host refuses
         # the grandchild's procfs remount (static kernel policy —
         # probed once, warned once per process by _spawn), stamp the
@@ -5395,6 +5478,8 @@ def sandbox(block_network=_UNSET, target: str | None = None, output: str | None 
                     mount_ns_active=bool(
                         result.sandbox_info["mount_ns_active"]),
                     restrict_reads=bool(restrict_reads),
+                    mountless_backend=bool(
+                        used_spawn and _spawn_without_mount),
                 )
             except Exception:  # noqa: BLE001 — best-effort telemetry posture
                 logger.debug("run posture record failed",
@@ -5405,13 +5490,10 @@ def sandbox(block_network=_UNSET, target: str | None = None, output: str | None 
         # the bind tree + Landlock, skip_mount_ns and Landlock-only via
         # the Landlock read allowlist alone.
         result.sandbox_info["restrict_reads"] = bool(restrict_reads)
-        if _private_scratch_dir or (
-                not used_spawn
-                and locals().get("_demoted_call_writable") is not None):
-            # Restricted Landlock-only posture: the host-shared /tmp
-            # and /dev/shm grants were replaced by a 0700 scratch dir
-            # (TMPDIR-steered) — per-context, or per-call when this
-            # run was demoted from the mount-ns backend.
+        if _private_scratch_dir or _mountless_private_scratch:
+            # Restricted host-visible posture: the host-shared /tmp and
+            # /dev/shm grants were replaced by a 0700 TMPDIR-steered scratch
+            # directory, whether namespaces remain active or not.
             result.sandbox_info["private_scratch"] = True
         if _reaper_cell is not None and not _audit_landlock_engaged:
             # No-namespace posture: teardown containment came from the
@@ -6563,6 +6645,7 @@ def run_untrusted(cmd: list[str], *, target: str | None = None, output: str | No
                    omit_proc_reads=_degraded_no_pidns,
                    strict_env=True,
                    strip_trust_markers=True,
+                   _untrusted_workload=True,
                    # Untrusted contract: the fresh-procfs mount is
                    # mandatory (host-procfs visibility exposes the
                    # spawn chain's pre-strip environ image) unless the
@@ -6739,6 +6822,7 @@ def run_untrusted_networked(
         omit_proc_reads=_degraded_no_pidns,
         strict_env=True,
         strip_trust_markers=not keep_trust_markers,
+        _untrusted_workload=True,
         # Same untrusted contract as run_untrusted(): mandatory
         # fresh-procfs mount unless the operator accepted the
         # degraded posture. Applies to the keep-trust dispatch lane

--- a/core/sandbox/state.py
+++ b/core/sandbox/state.py
@@ -153,6 +153,9 @@ _pidns_proc_mount_unavailable_warned = False
 # level mount probe); this flag is for the user-facing warning emitted from
 # the public sandbox() path that names the practical posture and remediation.
 _sandbox_landlock_only_warned = False
+# Namespace-preserving bind-tree fallback. The posture is static enough for a
+# process-level warning; per-call reporting still records every affected run.
+_mountless_backend_warned = False
 _bare_run_posture_warned = False
 _net_and_tcp_allowlist_warned = False
 # Degraded-mode Landlock TCP-connect deny (block_network without a

--- a/core/sandbox/summary.py
+++ b/core/sandbox/summary.py
@@ -434,7 +434,8 @@ def get_proxy_persist_state(run_dir: Path) -> "dict | None":
 
 
 def record_run_posture(run_dir: Path, *, mount_ns_active: bool,
-                       restrict_reads: bool) -> None:
+                       restrict_reads: bool,
+                       mountless_backend: bool = False) -> None:
     """Record whether a sandbox invocation's posture could hide the
     telemetry-MAC key from the sandboxed child.
 
@@ -468,12 +469,16 @@ def record_run_posture(run_dir: Path, *, mount_ns_active: bool,
                 "restrict_reads": bool(restrict_reads),
                 "mac_key_hidden": hidden,
             }
+            if mountless_backend:
+                _run_postures[run_key]["mountless_backend"] = True
         else:
             cur["mount_ns_active"] = (cur["mount_ns_active"]
                                       and bool(mount_ns_active))
             cur["restrict_reads"] = (cur["restrict_reads"]
                                      and bool(restrict_reads))
             cur["mac_key_hidden"] = cur["mac_key_hidden"] and hidden
+            if mountless_backend:
+                cur["mountless_backend"] = True
 
 
 def get_run_posture(run_dir: Path) -> dict[str, bool] | None:

--- a/core/sandbox/tests/conftest.py
+++ b/core/sandbox/tests/conftest.py
@@ -90,6 +90,7 @@ def _sandbox_state_guard():
         "_landlock_warned_unavailable", "_landlock_warned_abi_v4",
         "_landlock_warned_abi_v3", "_landlock_warned_abi_v2",
         "_sandbox_unavailable_warned", "_sandbox_landlock_only_warned",
+        "_mountless_backend_warned",
         "_bare_run_posture_warned",
         "_net_and_tcp_allowlist_warned",
         "_degraded_tcp_deny_warned",

--- a/core/sandbox/tests/test_audit_filter.py
+++ b/core/sandbox/tests/test_audit_filter.py
@@ -121,12 +121,14 @@ class TestAuditSystemRoMatchesContext:
         assert spawn_m, "could not find _system_ro literal in _spawn"
         spawn_paths = re.findall(r'"([^"]+)"', spawn_m.group(1))
 
-        # Extract effective_read_paths default in context.
+        # Extract the restricted-read default from its helper in context.
         ctx_m = re.search(
-            r"effective_read_paths\s*=\s*\[\s*((?:\"[^\"]+\"[,\s]*)+)\]",
+            r"def _restricted_read_allowlist\(\).*?"
+            r"paths\s*=\s*\[\s*((?:\"[^\"]+\"[,\s]*)+)\]",
             ctx_src,
+            re.DOTALL,
         )
-        assert ctx_m, "could not find effective_read_paths in context"
+        assert ctx_m, "could not find restricted read allowlist in context"
         ctx_paths = re.findall(r'"([^"]+)"', ctx_m.group(1))
 
         assert set(spawn_paths) == set(ctx_paths), (

--- a/core/sandbox/tests/test_child_isolation_matrix.py
+++ b/core/sandbox/tests/test_child_isolation_matrix.py
@@ -219,6 +219,9 @@ class TestLiveIsolationMatrix:
             "print('MP-OK')\n"
         )
         r = self._run(tmp_path, code)
+        if not r.sandbox_info.get("mount_ns_active"):
+            pytest.skip(
+                "AF_UNIX scoping needs the bind-tree backend on this host")
         assert r.returncode == 0, r.stderr[-500:] if r.stderr else r
         assert "MP-OK" in (r.stdout or "")
 

--- a/core/sandbox/tests/test_e2e_sandbox.py
+++ b/core/sandbox/tests/test_e2e_sandbox.py
@@ -966,6 +966,26 @@ class TestE2EEgressProxy(unittest.TestCase):
             self.assertIn("GIT_CONFIG_SYSTEM=/dev/null", r.stdout)
             self.assertIn("MY_LEGITIMATE_VAR=kept", r.stdout)
 
+    def test_strict_env_keeps_only_exact_git_neutralisers(self):
+        """Strict filtering keeps /dev/null pins but rejects overrides."""
+        with TemporaryDirectory() as out:
+            r = sandbox_run(
+                ["env"], target=out, output=out,
+                env={
+                    "PATH": "/usr/bin",
+                    "HOME": out,
+                    "GIT_CONFIG_GLOBAL": "/dev/null",
+                    "GIT_CONFIG_SYSTEM": "/tmp/attacker-config",
+                    "LD_PRELOAD": "/tmp/attacker.so",
+                },
+                strict_env=True,
+                capture_output=True, text=True, timeout=5,
+            )
+            self.assertEqual(r.returncode, 0)
+            self.assertIn("GIT_CONFIG_GLOBAL=/dev/null", r.stdout)
+            self.assertNotIn("GIT_CONFIG_SYSTEM=", r.stdout)
+            self.assertNotIn("LD_PRELOAD=", r.stdout)
+
     def test_run_untrusted_detaches_controlling_tty(self):
         """run_untrusted must put the child in a new session (setsid) so
         it has no controlling tty.

--- a/core/sandbox/tests/test_fresh_procfs_contract.py
+++ b/core/sandbox/tests/test_fresh_procfs_contract.py
@@ -419,18 +419,16 @@ def test_require_fresh_procfs_reaches_the_spawn_layer(tmp_path, monkeypatch):
 
 @pytest.mark.integration
 @pytest.mark.skipif(sys.platform != "linux", reason="namespace sandbox")
-def test_mount_ns_failure_refuses_landlock_only_for_untrusted(
+def test_mount_ns_failure_refuses_mountless_untrusted_without_opt_in(
         tmp_path, monkeypatch):
-    """A mount-ns setup failure ('M' status) on an untrusted run must
-    NOT silently degrade to the Landlock-only retry — that fallback
-    runs with no pid namespace and the host /proc, the exact posture
-    the fresh-procfs contract refuses. The operator override restores
-    the old degrade."""
+    """Untrusted work does not lose bind-tree isolation automatically."""
     from core.sandbox import _spawn as _spawn_mod
     from core.sandbox import context as _ctx
     from core.sandbox.errors import SandboxSetupError
+    calls = []
 
     def fake_spawn(cmd, **kwargs):
+        calls.append(kwargs)
         cp = subprocess.CompletedProcess(cmd, returncode=126,
                                          stdout="", stderr="")
         cp._setup_status = ("M", "forced mount-ns failure")
@@ -438,23 +436,254 @@ def test_mount_ns_failure_refuses_landlock_only_for_untrusted(
 
     monkeypatch.setattr(_spawn_mod, "run_sandboxed", fake_spawn)
     monkeypatch.delenv("RAPTOR_ALLOW_DEGRADED_UNTRUSTED", raising=False)
+    with pytest.raises(SandboxSetupError) as excinfo:
+        _ctx.run_untrusted(
+            ["sh", "-c", "test $$ -eq 1 && test -r /proc/1/status"],
+            target=str(tmp_path), output=str(tmp_path), timeout=60,
+            capture_output=True, text=True)
+    assert len(calls) == 1
+    assert calls[0]["skip_mount_ns"] is False
+    assert excinfo.value.setup_category == "M"
+    assert "RAPTOR_ALLOW_DEGRADED_UNTRUSTED=1" in str(excinfo.value)
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(sys.platform != "linux", reason="namespace sandbox")
+def test_mount_ns_failure_preserves_trusted_policy_and_tmp_baseline(
+        tmp_path, monkeypatch):
+    """Trusted fallback keeps the caller's reads and documented /tmp."""
+    from core.sandbox import _spawn as _spawn_mod
+    from core.sandbox import context as _ctx
+    calls = []
+
+    def fake_spawn(cmd, **kwargs):
+        calls.append(kwargs)
+        cp = subprocess.CompletedProcess(cmd, returncode=0,
+                                         stdout="", stderr="")
+        cp._setup_status = (
+            ("M", "forced mount-ns failure")
+            if len(calls) == 1 else None)
+        return cp
+
+    monkeypatch.setattr(_spawn_mod, "run_sandboxed", fake_spawn)
     try:
-        with pytest.raises(SandboxSetupError, match="host-pid /proc"):
-            _ctx.run_untrusted(["true"], target=str(tmp_path),
-                               output=str(tmp_path), timeout=60)
+        with _ctx.sandbox(
+                block_network=True, target=str(tmp_path),
+                output=str(tmp_path), restrict_reads=False) as run:
+            result = run(["true"], timeout=60)
     except (pytest.skip.Exception, pytest.fail.Exception):
         raise
-    except Exception as e:  # noqa: BLE001 — host can't reach the lane
-        pytest.skip(f"mount-ns lane unavailable: {e}")
+    except Exception as exc:  # noqa: BLE001 - host capability gate
+        pytest.skip(f"mount-ns lane unavailable: {exc}")
+    assert result.returncode == 0
+    assert len(calls) == 2
+    assert calls[0]["restrict_reads"] is False
+    assert calls[1]["restrict_reads"] is False
+    assert "/tmp" in calls[1]["writable_paths"]
+    # context.sandbox() already scrubbed the caller environment. The lower
+    # backend must not strip wrapper-owned environment values a second time.
+    assert calls[1]["strict_env"] is False
 
+
+@pytest.mark.skipif(sys.platform != "linux", reason="namespace sandbox")
+def test_read_restricted_mountless_retry_and_cache_use_private_scratch(
+        tmp_path, monkeypatch, caplog):
+    """Every host-visible namespace lane replaces shared temporary grants."""
+    from core.sandbox import _spawn as _spawn_mod
+    from core.sandbox import context as _ctx
+    from core.sandbox import state as _state
+    calls = []
+
+    def fake_spawn(cmd, **kwargs):
+        calls.append(kwargs)
+        cp = subprocess.CompletedProcess(cmd, returncode=0,
+                                         stdout="", stderr="")
+        cp._setup_status = (
+            ("M", "forced mount-ns failure")
+            if len(calls) == 1 else None)
+        return cp
+
+    monkeypatch.setattr(_spawn_mod, "run_sandboxed", fake_spawn)
+    monkeypatch.setattr(_ctx, "check_mount_available", lambda: True)
+    monkeypatch.setattr(_ctx, "check_landlock_available", lambda: True)
+    monkeypatch.setattr(_ctx, "_get_landlock_abi", lambda: 6)
+    monkeypatch.setattr(_state, "_speculative_failure_cache", {})
+    monkeypatch.setattr(_state, "_mountless_backend_warned", False)
+    scratch_paths = []
+    with _ctx.sandbox(
+            block_network=True, target=str(tmp_path),
+            output=str(tmp_path), restrict_reads=True) as run:
+        first = run(["true"], timeout=60)
+        second = run(["true"], timeout=60)
+        assert first.sandbox_info["private_scratch"] is True
+        assert second.sandbox_info["private_scratch"] is True
+
+        assert [call["skip_mount_ns"] for call in calls] == [
+            False, True, True,
+        ]
+        for call in calls[1:]:
+            scratch = call["env"]["TMPDIR"]
+            scratch_paths.append(scratch)
+            assert call["env"]["TEMP"] == scratch
+            assert call["env"]["TMP"] == scratch
+            assert call["writable_paths"][0] == scratch
+            assert "/tmp" not in call["writable_paths"]
+            assert "/dev/shm" not in call["writable_paths"]
+            assert Path(scratch).stat().st_mode & 0o777 == 0o700
+        assert scratch_paths[0] != scratch_paths[1]
+
+    assert all(not Path(path).exists() for path in scratch_paths)
+    warnings = [
+        record for record in caplog.records
+        if "bind-tree isolation unavailable" in record.getMessage()
+    ]
+    assert len(warnings) == 1
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="namespace sandbox")
+@pytest.mark.parametrize("selection", ["outside-bind-tree", "explicit-skip"])
+def test_read_restricted_direct_mountless_selection_uses_private_scratch(
+        tmp_path, monkeypatch, selection):
+    """Every direct mountless selection gets the same private write policy."""
+    from core.sandbox import _spawn as _spawn_mod
+    from core.sandbox import context as _ctx
+    from core.sandbox import state as _state
+    calls = []
+
+    def fake_spawn(cmd, **kwargs):
+        calls.append(kwargs)
+        cp = subprocess.CompletedProcess(cmd, returncode=0,
+                                         stdout="", stderr="")
+        cp._setup_status = None
+        return cp
+
+    monkeypatch.setattr(_spawn_mod, "run_sandboxed", fake_spawn)
+    monkeypatch.setattr(_ctx, "check_mount_available", lambda: True)
+    monkeypatch.setattr(_ctx, "check_landlock_available", lambda: True)
+    monkeypatch.setattr(_ctx, "_get_landlock_abi", lambda: 6)
+    if selection == "outside-bind-tree":
+        monkeypatch.setattr(
+            _ctx, "_cmd_visible_in_mount_tree", lambda *args: False,
+        )
+    monkeypatch.setattr(_state, "_mountless_backend_warned", False)
+    scratch = None
+    with _ctx.sandbox(
+            block_network=True, target=str(tmp_path),
+            output=str(tmp_path), restrict_reads=True) as run:
+        result = run(
+            ["true"], timeout=60,
+            skip_mount_ns=(selection == "explicit-skip"),
+        )
+        assert result.sandbox_info["private_scratch"] is True
+        assert len(calls) == 1
+        assert calls[0]["skip_mount_ns"] is True
+        scratch = calls[0]["env"]["TMPDIR"]
+        assert calls[0]["writable_paths"][0] == scratch
+        assert "/tmp" not in calls[0]["writable_paths"]
+        assert "/dev/shm" not in calls[0]["writable_paths"]
+
+    assert scratch is not None
+    assert not Path(scratch).exists()
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(sys.platform != "linux", reason="namespace sandbox")
+@pytest.mark.parametrize("restrict_reads", [True, False])
+def test_mountless_untrusted_refuses_landlock_abi_below_three(
+        tmp_path, monkeypatch, restrict_reads):
+    """ABI 1/2 cannot safely contain any mountless untrusted run."""
+    from core.sandbox import _spawn as _spawn_mod
+    from core.sandbox import context as _ctx
+    from core.sandbox.errors import SandboxSetupError
+    calls = []
+
+    def fail_bind(cmd, **kwargs):
+        calls.append(kwargs)
+        cp = subprocess.CompletedProcess(cmd, returncode=126,
+                                         stdout="", stderr="")
+        cp._setup_status = ("M", "forced mount-ns failure")
+        return cp
+
+    monkeypatch.setattr(_spawn_mod, "run_sandboxed", fail_bind)
+    monkeypatch.setattr(_ctx, "check_landlock_available", lambda: True)
+    monkeypatch.setattr(_ctx, "_get_landlock_abi", lambda: 2)
+    monkeypatch.setenv("RAPTOR_ALLOW_DEGRADED_UNTRUSTED", "1")
+    with pytest.raises(SandboxSetupError) as excinfo:
+        _ctx.run_untrusted(
+            ["true"], target=str(tmp_path), output=str(tmp_path), timeout=60,
+            restrict_reads=restrict_reads,
+        )
+    assert len(calls) == 1
+    assert "ABI is below 3" in str(excinfo.value)
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(sys.platform != "linux", reason="namespace sandbox")
+def test_mountless_retry_blocks_home_credentials(tmp_path, monkeypatch):
+    """An opted-in read-restricted fallback blocks home credentials."""
+    from core.sandbox import _spawn as _spawn_mod
+    from core.sandbox import context as _ctx
+    real_spawn = _spawn_mod.run_sandboxed
+    calls = []
+    secret = Path.home() / f".raptor_mountless_read_test_{os.getpid()}"
+    secret.write_text("SECRET-CREDENTIAL\n")
+
+    def fail_first_bind(cmd, **kwargs):
+        calls.append(kwargs)
+        if len(calls) == 1:
+            cp = subprocess.CompletedProcess(cmd, returncode=126,
+                                             stdout="", stderr="")
+            cp._setup_status = ("M", "forced mount-ns failure")
+            return cp
+        return real_spawn(cmd, **kwargs)
+
+    monkeypatch.setattr(_spawn_mod, "run_sandboxed", fail_first_bind)
     monkeypatch.setenv("RAPTOR_ALLOW_DEGRADED_UNTRUSTED", "1")
     try:
-        r = _ctx.run_untrusted(["true"], target=str(tmp_path),
-                               output=str(tmp_path), timeout=60)
-    except Exception as e:  # noqa: BLE001
-        pytest.skip(f"override lane unavailable: {e}")
-    assert r.returncode == 0, (
-        "operator override did not restore the Landlock-only degrade")
+        try:
+            result = _ctx.run_untrusted(
+                ["cat", str(secret)], target=str(tmp_path),
+                output=str(tmp_path), timeout=60,
+                capture_output=True, text=True)
+        except Exception as exc:  # noqa: BLE001 - host capability gate
+            pytest.skip(f"mount-ns lane unavailable: {exc}")
+        assert len(calls) == 2
+        assert calls[1]["restrict_reads"] is True
+        assert result.returncode != 0
+        assert "SECRET-CREDENTIAL" not in result.stdout
+        assert result.sandbox_info["restrict_reads"] is True
+        assert result.sandbox_info["mount_ns_active"] is False
+    finally:
+        secret.unlink(missing_ok=True)
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(sys.platform != "linux", reason="namespace sandbox")
+def test_secure_namespace_retry_fails_closed(tmp_path, monkeypatch):
+    """The target never runs when the reduced backend cannot engage."""
+    from core.sandbox import _spawn as _spawn_mod
+    from core.sandbox import context as _ctx
+    from core.sandbox.errors import SandboxSetupError
+    calls = []
+
+    def fake_spawn(cmd, **kwargs):
+        calls.append(kwargs)
+        cp = subprocess.CompletedProcess(cmd, returncode=126,
+                                         stdout="", stderr="")
+        cp._setup_status = (
+            "M" if len(calls) == 1 else "F",
+            "forced setup failure",
+        )
+        return cp
+
+    monkeypatch.setattr(_spawn_mod, "run_sandboxed", fake_spawn)
+    with pytest.raises(SandboxSetupError) as excinfo:
+        with _ctx.sandbox(
+                block_network=True, target=str(tmp_path),
+                output=str(tmp_path), restrict_reads=False) as run:
+            run(["true"], timeout=60)
+    assert excinfo.value.setup_category == "F"
+    assert [call["skip_mount_ns"] for call in calls] == [False, True]
 
 
 @pytest.mark.integration

--- a/core/sandbox/tests/test_target_env_strip.py
+++ b/core/sandbox/tests/test_target_env_strip.py
@@ -36,6 +36,7 @@ def test_constant_contents():
     assert "_RAPTOR_TRUSTED" in STRIP_SET
     assert "RAPTOR_SESSION_PID" in STRIP_SET
     assert "RAPTOR_SESSION_TOKEN" in STRIP_SET
+    assert "RAPTOR_ALLOW_DEGRADED_UNTRUSTED" in STRIP_SET
 
 
 def test_session_credential_is_allowlisted_but_stripped():
@@ -44,6 +45,13 @@ def test_session_credential_is_allowlisted_but_stripped():
     combination, not a contradiction."""
     assert "RAPTOR_SESSION_PID" in RaptorConfig.SAFE_ENV_ALLOWLIST
     assert "RAPTOR_SESSION_TOKEN" in RaptorConfig.SAFE_ENV_ALLOWLIST
+
+
+def test_degraded_untrusted_consent_is_allowlisted_but_stripped():
+    """RAPTOR workers inherit consent, but scanned code cannot change it."""
+    assert "RAPTOR_ALLOW_DEGRADED_UNTRUSTED" in (
+        RaptorConfig.SAFE_ENV_ALLOWLIST
+    )
 
 
 def test_pid1_shim_tuple_in_sync():

--- a/core/sandbox/tests/test_telemetry_key_posture.py
+++ b/core/sandbox/tests/test_telemetry_key_posture.py
@@ -73,6 +73,14 @@ class TestPostureRecording:
     def test_unknown_run_is_none(self, tmp_path):
         assert summary_mod.get_run_posture(tmp_path) is None
 
+    def test_mountless_backend_is_reported(self, tmp_path):
+        summary_mod.record_run_posture(
+            tmp_path, mount_ns_active=False, restrict_reads=True,
+            mountless_backend=True,
+        )
+        assert summary_mod.get_run_posture(
+            tmp_path)["mountless_backend"] is True
+
     def test_key_hidden_needs_mount_ns_or_restrict_reads(self, tmp_path):
         summary_mod.record_run_posture(
             tmp_path, mount_ns_active=False, restrict_reads=False)

--- a/core/security/THREAT_MODEL.md
+++ b/core/security/THREAT_MODEL.md
@@ -49,6 +49,26 @@ The `core.sandbox` stack composes three filesystem-isolation layers:
    With `restrict_reads=False` (the historic default), only writes
    are restricted; reads are allowed everywhere visible.
 
+If the bind tree fails after namespaces are available, the sandbox retries
+without bind mounts. This `landlock-pidns` backend keeps the user, PID, IPC,
+and network namespaces, mounts a fresh `/proc`, and applies Landlock and
+seccomp. Reads can be limited, but Landlock cannot control metadata-only
+operations such as `chmod`, `chown`, and `utimensat`. Host paths remain
+visible by name, so a child can distinguish a missing path (`ENOENT`) from a
+denied path (`EACCES`), which exposes a filesystem-existence oracle. The
+fallback preserves the caller's read policy: `restrict_reads=False` keeps the
+historic read-everywhere behaviour, while `restrict_reads=True` limits reads
+to the declared allowlist. Read-restricted mountless calls also replace
+host-shared `/tmp` and `/dev/shm` write grants with a private mode-`0700`
+scratch directory. Explicit non-shared writable paths are retained. Calls with
+`restrict_reads=False` retain the historical writable baseline, including
+host-shared temporary paths when the bind tree is absent. Untrusted execution
+refuses this lesser filesystem tier unless the operator sets
+`RAPTOR_ALLOW_DEGRADED_UNTRUSTED=1`. The
+mountless backend refuses every untrusted run on Landlock ABI below 3 because
+those kernels cannot block `truncate()` outside the write allowlist. It also
+refuses read-restricted trusted runs on those kernels.
+
 **Critical fallback property** — `mount namespace` engagement requires
 unprivileged user namespaces (`kernel.apparmor_restrict_unprivileged_userns=0`).
 On Ubuntu 24.04+, hardened containers, and similar host configurations

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -102,12 +102,11 @@ namespace-capable hosts: untrusted runs mount a pid-namespace-local
 `/proc` inside the sandbox (hiding the host process table and the
 spawn chain's own environ images). The requirement binds everywhere
 the contract would otherwise silently degrade: a failed fresh-proc
-mount aborts instead of warning, a mount-ns setup failure refuses
-the Landlock-only retry, hosts whose mount-namespace backend cannot
+mount aborts instead of warning, a mount-ns setup failure refuses the
+mountless retry, hosts whose namespace backend cannot
 engage at all (`newuidmap` missing) refuse untrusted runs up front,
-and so do the pre-flight demotions (a tool resolving outside the
-mount-ns bind tree — pass `tool_paths=` — a speculative-failure
-cache hit, `skip_mount_ns=`, and `pass_fds=`) — each with a
+and so do pre-flight demotions (a tool outside the bind tree, a cached
+bind-tree failure, `skip_mount_ns=`, and `pass_fds=`), each with a
 `SandboxSetupError` naming this override. Witness bytes passed via
 `input=` do NOT degrade the lane: they convert to a private unlinked
 stdin spool and ride the fork backend. `--sandbox none` remains
@@ -723,7 +722,8 @@ seam and scanned for drift.
 - **`PROXY_ENV_VARS`** — both cases of the proxy family; stripped by
   default, preserved + normalised on opt-in (see above).
 - **`GIT_ENV_VARS`** — git-config isolation applied to *every*
-  sanitised subprocess env: `GIT_TERMINAL_PROMPT=0`, `GIT_ASKPASS=true`,
+  sanitised subprocess env: `GIT_TERMINAL_PROMPT=0`,
+  `GIT_ASKPASS=/usr/bin/true`,
   `GIT_CONFIG_GLOBAL=/dev/null`, `GIT_CONFIG_SYSTEM=/dev/null`,
   `GIT_CONFIG_NOSYSTEM=1` — operator gitconfig (gpg signing,
   credential helpers, fsmonitor) never influences internal git.

--- a/docs/sandbox.md
+++ b/docs/sandbox.md
@@ -75,6 +75,10 @@ process.
    copied). **Disabled on Ubuntu 24.04 by
    default** (AppArmor gates unprivileged user namespaces); see
    [Troubleshooting](#troubleshooting).
+   If namespace creation succeeds but the bind tree cannot be built,
+   trusted tool runs can keep the network, PID, IPC, fresh-proc, Landlock,
+   seccomp, and rlimit layers through the mountless backend. Untrusted runs
+   require the existing `RAPTOR_ALLOW_DEGRADED_UNTRUSTED=1` opt-in.
 6. **Landlock + seccomp-bpf + rlimits** -- always applied when
    available, even when namespaces fall back.
 
@@ -136,18 +140,32 @@ parse time; the flags are rejected alongside `--sandbox none` /
 
 **Tool visibility:** the mount-namespace sandbox bind-mounts a fixed
 set of system dirs; a tool installed anywhere else (`~/.local/bin/`,
-`/opt/homebrew/bin/`) would be invisible (exit 127). The sandbox
-auto-falls back to Landlock-only isolation when the command resolves
-outside the bind tree, and callers can opt tool directories in
+`/opt/homebrew/bin/`) would be invisible (exit 127). The sandbox retries
+through its namespace backend without the bind tree when a bind mount or
+in-tree exec fails. This keeps the PID, user, IPC, and network namespaces,
+fresh procfs, Landlock, seccomp, limits, and proxy bridge active. The result
+reports `backend=landlock-pidns` and `mount_ns_active=false`; tracked runs also
+write `posture.mountless_backend=true` in `sandbox-summary.json`. Callers can opt
+tool directories in
 (`--sandbox-tool-path`, or `tool_paths=` programmatically — with
 `python_runtime_tool_paths()` auto-discovering the running Python's
-runtime roots for Python tools). If a bind set turns out insufficient,
-the call automatically retries at Landlock-only and caches the result
-for the rest of the process — provided Landlock can actually enforce
-the call's declared policy: on a kernel without Landlock, a demoted
-call that requested target/output/allowed_tcp_ports/restrict_reads
-refuses (`SandboxSetupError`) instead of retrying, because the
-Landlock-only path would enforce none of it.
+runtime roots for Python tools). If the reduced namespace backend cannot
+mount fresh procfs or apply Landlock, seccomp, or namespaces, the call fails
+closed before the target executes. The fallback preserves the caller's read
+policy. Host paths remain visible by name, including an `ENOENT` versus
+`EACCES` filesystem-existence oracle. Landlock cannot block metadata changes
+such as `chmod` outside the write allowlist. For read-restricted calls, every
+mountless lane replaces the construction-time `/tmp` and `/dev/shm` write
+grants with a private mode-`0700` scratch directory and points `TMPDIR`,
+`TEMP`, and `TMP` at it. Explicit non-shared writable paths remain available.
+Calls with
+`restrict_reads=False` retain their historical writable baseline, which means
+host `/tmp` and `/dev/shm` are writable when the bind tree is absent.
+Untrusted runs therefore
+require `RAPTOR_ALLOW_DEGRADED_UNTRUSTED=1`; read-restricted runs also refuse
+the fallback on Landlock ABI below 3, where `truncate()` is not controlled.
+Every untrusted run refuses that backend on ABI below 3, even when the caller
+explicitly disabled read restriction.
 
 Declaring a directory via `tool_paths` is also how `$HOME`-resident
 toolchains stay runnable: the sandboxed child's environment scrub
@@ -576,13 +594,13 @@ sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
 sudo apt install uidmap
 ```
 
-Without both, the sandbox falls back to Landlock-only. Landlock alone
-already covers the main threat model (no writes outside the output
-dir, no credential reads under the read restriction). Exception: when
-the user-namespace tier is unavailable entirely, untrusted execution
-refuses to fall back — set `RAPTOR_ALLOW_DEGRADED_UNTRUSTED=1` to
-explicitly accept Landlock/seccomp-only containment for untrusted code
-(see [environment.md](environment.md)).
+If user, network, PID, and IPC namespaces are available but bind mounts
+fail, the sandbox retains those namespaces and uses Landlock read/write
+rules in place of the bind tree for trusted tool runs. Host paths remain
+visible by name and metadata-only operations are outside Landlock's control.
+Untrusted execution refuses both this tier and the namespace-less fallback.
+Set `RAPTOR_ALLOW_DEGRADED_UNTRUSTED=1` only to explicitly accept the reduced
+containment for untrusted code (see [environment.md](environment.md)).
 
 ### A target binary fails with EACCES reading `/home/<user>/...`
 

--- a/libexec/raptor-pid1-shim
+++ b/libexec/raptor-pid1-shim
@@ -376,6 +376,7 @@ def main() -> int:
                 ("_RAPTOR_DEATH_FD",) if keep_trust_markers
                 else ("_RAPTOR_DEATH_FD", "_RAPTOR_TRUSTED", "CLAUDECODE",
                       "RAPTOR_SESSION_PID", "RAPTOR_SESSION_TOKEN",
+                      "RAPTOR_ALLOW_DEGRADED_UNTRUSTED",
                       # Framework-identity values (checkout path,
                       # output layout, target-kind override) are pure
                       # "inside RAPTOR" tells — no target consumes

--- a/libexec/raptor-seatbelt-shim
+++ b/libexec/raptor-seatbelt-shim
@@ -396,6 +396,7 @@ def main() -> int:
             else ("_RAPTOR_STATUS_FD", "_RAPTOR_DEATH_FD",
                   "_RAPTOR_TRUSTED", "CLAUDECODE",
                   "RAPTOR_SESSION_PID", "RAPTOR_SESSION_TOKEN",
+                  "RAPTOR_ALLOW_DEGRADED_UNTRUSTED",
                   "RAPTOR_DIR", "RAPTOR_OUT_DIR", "RAPTOR_TARGET_KIND")
         )
         for _m in _strip:

--- a/packages/sca/tests/test_agentic_sca_gate.py
+++ b/packages/sca/tests/test_agentic_sca_gate.py
@@ -16,7 +16,10 @@ REPO_ROOT = Path(__file__).resolve().parents[3]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
-from raptor_agentic import _should_run_mechanical_sca
+from raptor_agentic import (
+    _persist_redacted_sca_stderr,
+    _should_run_mechanical_sca,
+)
 
 
 class TestMechanicalScaGate(unittest.TestCase):
@@ -32,6 +35,20 @@ class TestMechanicalScaGate(unittest.TestCase):
     def test_skipped_when_agent_missing(self):
         self.assertFalse(_should_run_mechanical_sca(None, False))
         self.assertFalse(_should_run_mechanical_sca(None, True))
+
+    def test_sca_stderr_redaction_is_shared_by_log_and_file(self):
+        with self.subTest("terminal text and file sink use one redaction"):
+            from tempfile import TemporaryDirectory
+
+            with TemporaryDirectory() as tmp:
+                output = Path(tmp)
+                safe = _persist_redacted_sca_stderr(
+                    "request failed token=secret-value-123\n", output,
+                )
+                persisted = (output / "stderr.log").read_text(
+                    encoding="utf-8")
+                self.assertEqual(persisted, safe)
+                self.assertNotIn("secret-value-123", safe)
 
 
 if __name__ == "__main__":

--- a/raptor_agentic.py
+++ b/raptor_agentic.py
@@ -1258,6 +1258,22 @@ def _should_run_mechanical_sca(sca_agent, deep_sca_requested: bool) -> bool:
     return bool(sca_agent) and not deep_sca_requested
 
 
+def _persist_redacted_sca_stderr(stderr: str, output_dir: Path) -> str:
+    """Persist and return the same redacted SCA diagnostic text."""
+    from core.security.redaction import redact_secrets
+
+    safe_stderr = redact_secrets(stderr)
+    retained_stderr = safe_stderr[-1024 * 1024:]
+    if len(retained_stderr) != len(safe_stderr):
+        retained_stderr = (
+            "[earlier SCA stderr truncated]\n" + retained_stderr
+        )
+    stderr_path = output_dir / "stderr.log"
+    stderr_path.write_text(retained_stderr, encoding="utf-8")
+    stderr_path.chmod(0o600)
+    return safe_stderr
+
+
 def _build_completion_manifest(orch_meta, import_result, import_sarif_files,
                                reanalyze_dir=None):
     manifest = {
@@ -3236,12 +3252,17 @@ Examples:
             # Route via sandbox egress proxy so SCA's HTTP calls are
             # hostname-allowlisted when --sandbox is active. The allowlist
             # is SCA_ALLOWED_HOSTS (vuln feeds + registries + archives).
-            rc, sca_stdout, _sca_stderr = run_sca_subprocess(
+            rc, sca_stdout, sca_stderr = run_sca_subprocess(
                 sca_agent,
                 original_repo_path,
                 sca_out,
                 sandbox_args=sandbox_passthrough,
             )
+            safe_stderr = ""
+            if sca_stderr:
+                safe_stderr = _persist_redacted_sca_stderr(
+                    sca_stderr, sca_out,
+                )
             if rc == 0:
                 sca_sarif = sca_out / "findings.sarif"
                 if sca_sarif.exists():
@@ -3301,6 +3322,12 @@ Examples:
                 except Exception:
                     logger.debug("SAGE SCA store skipped", exc_info=True)
             else:
+                detail = (
+                    safe_stderr.strip().splitlines()[-1]
+                    if safe_stderr.strip()
+                    else "no stderr"
+                )
+                logger.warning("SCA stderr: %s", detail)
                 logger.warning("SCA failed (rc=%d) — continuing without dep findings", rc)
                 sca_findings_count = 0
         except Exception as e:  # noqa: BLE001


### PR DESCRIPTION
## Summary

Keep RAPTOR's namespace sandbox active when a Linux host supports namespaces but rejects the bind-mount tree.

WSL is one affected environment. Bind-mounting `/usr` can return `EINVAL` even though PID, network, Landlock, and seccomp isolation are available.

The reduced backend is a lesser filesystem-isolation tier. Untrusted runs must opt in through the existing `RAPTOR_ALLOW_DEGRADED_UNTRUSTED=1` control. No new consent mechanism is added.

## Behavior

When bind-tree setup or in-tree execution fails, RAPTOR retries through the existing spawn backend with mount setup disabled. The retry retains:

- user, PID, IPC, and network namespaces;
- fresh procfs;
- Landlock read and write enforcement;
- seccomp and resource limits;
- audit tracing;
- proxy-controlled network access.

The caller's read policy is preserved. RAPTOR does not force read restriction onto calls that use the historical read-everywhere default, so venv, pipx, and user-installed tools keep working without per-consumer grants.

The result records `backend=landlock-pidns`, `mount_ns_active=false`, and the reduced posture in `sandbox-summary.json`. Repeated demotions warn once per process; later cache hits and per-call scratch diagnostics log at debug level.

## Untrusted-run gates

An untrusted run refuses the reduced backend unless `RAPTOR_ALLOW_DEGRADED_UNTRUSTED=1` was set by the operator. The consent value is retained across RAPTOR-owned worker environments, then stripped at target execution seams by both the Linux PID 1 shim and the macOS seatbelt shim.

Mountless untrusted execution also refuses Landlock ABI below 3. Older ABIs cannot block `truncate()` outside the write allowlist.

Modes that require bind mounts, including rootfs and fingerprint-persona execution, continue to fail closed. The retry also fails closed if its remaining isolation layers cannot engage.

## Temporary storage

Read-restricted host-visible execution must not inherit writable host-shared `/tmp` or `/dev/shm` grants. Every such mountless path now uses the same private-scratch policy:

- direct mountless selection;
- explicit per-call mount skipping;
- the first bind-tree retry;
- speculative-cache retries;
- the legacy subprocess demotion.

RAPTOR creates a private mode-`0700` scratch directory, steers `TMPDIR`, `TEMP`, and `TMP` to it, and removes host-shared `/tmp` and `/dev/shm` from that call's write grants. Explicit non-shared writable paths remain available. Unrestricted calls retain the documented host temporary-directory baseline.

## Residual exposure

The bind-tree backend remains the stronger default. In mountless mode host paths remain visible by name. Landlock limits requested reads and writes, but it cannot mediate metadata-only operations such as `chmod`. `ENOENT` versus `EACCES` also exposes a filesystem-existence oracle. These limits are documented in `docs/sandbox.md` and the threat model.

## SCA diagnostics

Agentic SCA failures now redact captured stderr once, persist a bounded mode-`0600` diagnostic, and log the final line from the same redacted value. SCA execution and model-triage behavior are unchanged. The earlier global `--no-llm` change is not part of this PR.

## Compatibility

- Hosts with working bind mounts continue to use the preferred bind-tree backend.
- Caller read policy and unrestricted `/tmp` behavior remain unchanged.
- No calibration, SCA, or CodeQL compensating path grants are added.
- `GIT_ASKPASS` uses the absolute inert path `/usr/bin/true`.
- Context-built child environments are already wrapper-scrubbed before the lower backend receives them.
- Upstream's fresh-procfs demotion fixes are inherited from current `main`; this PR does not duplicate them.
- The seatbelt shim's environment-strip tuple is recorded in the vocabulary baseline as policy data, not learned name vocabulary.

## Commits

- `f58bd1049` retains namespaces when bind mounts fail, adds the security gates, private-scratch policy, reporting, documentation, and tests.
- `dd6ffaee9` adds bounded redacted SCA failure diagnostics.
- `4737ffcf0` propagates degraded-run consent through RAPTOR workers, strips it at Linux and macOS target seams, and records the seatbelt policy tuple in the vocabulary baseline.

## Validation

Local validation on the affected WSL host:

- reviewer-focused sandbox and vocabulary suite: 48 passed;
- wider sandbox/config/SCA set from the previous revision: 136 passed, 4 skipped;
- vocabulary checker, Ruff, `py_compile`, and `git diff --check`: passed;
- live reduced-backend probe: host `/tmp` write denied, private-scratch tempfile creation succeeded.

One low-level audit test fails on this host because it invokes the mount backend directly and `/usr` is not bind-mountable. It bypasses the context retry changed by this PR. Linux and macOS PR jobs provide the mount-capable and seatbelt coverage.
